### PR TITLE
[miele] Clean up properties and improve reliability and performance

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
@@ -63,13 +63,4 @@ public class DeviceUtil {
         int temperature = Integer.parseInt(s);
         return new QuantityType<>(temperature, SIUnits.CELSIUS);
     }
-
-    /**
-     * Get device class from fully qualified string
-     */
-    public static String getDeviceClassFromFullyQualifiedString(String fullString) {
-        // com.miele.xgw3000.gateway.hdm.deviceclasses.MieleWashingMachine
-        // Position of "WashingMachine" in above string:
-        return fullString.substring(49);
-    }
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
@@ -14,6 +14,7 @@ package org.openhab.binding.miele.internal;
 
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.types.State;
@@ -62,5 +63,13 @@ public class DeviceUtil {
         }
         int temperature = Integer.parseInt(s);
         return new QuantityType<>(temperature, SIUnits.CELSIUS);
+    }
+
+    /**
+     * Get device class from fully qualified string
+     */
+    public static String getDeviceClassFromFullyQualifiedString(String fullString) {
+        return StringUtils.right(fullString,
+                fullString.length() - new String("com.miele.xgw3000.gateway.hdm.deviceclasses.Miele").length());
     }
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
@@ -20,12 +20,12 @@ import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
 /**
- * The {@link ExtendedDeviceStateUtil} class contains utility methods for parsing
- * ExtendedDeviceState information
+ * The {@link DeviceUtil} class contains utility methods for extracting
+ * and parsing device information, for example from ExtendedDeviceState.
  *
  * @author Jacob Laursen - Initial contribution
  */
-public class ExtendedDeviceStateUtil {
+public class DeviceUtil {
     private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
     private static final String TEMPERATURE_UNDEFINED = "32768";
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
@@ -14,7 +14,6 @@ package org.openhab.binding.miele.internal;
 
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.types.State;
@@ -69,7 +68,8 @@ public class DeviceUtil {
      * Get device class from fully qualified string
      */
     public static String getDeviceClassFromFullyQualifiedString(String fullString) {
-        return StringUtils.right(fullString,
-                fullString.length() - new String("com.miele.xgw3000.gateway.hdm.deviceclasses.Miele").length());
+        // com.miele.xgw3000.gateway.hdm.deviceclasses.MieleWashingMachine
+        // Position of "WashingMachine" in above string:
+        return fullString.substring(49);
     }
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
@@ -23,7 +23,7 @@ import org.openhab.core.types.UnDefType;
  * The {@link ExtendedDeviceStateUtil} class contains utility methods for parsing
  * ExtendedDeviceState information
  *
- * @author Jacob Laursen - Added power/water consumption channels
+ * @author Jacob Laursen - Initial contribution
  */
 public class ExtendedDeviceStateUtil {
     private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifier.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifier.java
@@ -16,7 +16,7 @@ package org.openhab.binding.miele.internal;
  * The {@link FullyQualifiedApplianceIdentifier} class represents a fully qualified appliance identifier.
  * Example: "hdm:ZigBee:0123456789abcdef#210"
  *
- * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ * @author Jacob Laursen - Initial contribution
  */
 public class FullyQualifiedApplianceIdentifier {
     private String uid;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -67,8 +67,14 @@ public class MieleBindingConstants {
 
     // Miele devices classes
     public static final String MIELE_DEVICE_CLASS_COFFEE_SYSTEM = "CoffeeSystem";
+    public static final String MIELE_DEVICE_CLASS_DISHWASHER = "Dishwasher";
     public static final String MIELE_DEVICE_CLASS_FRIDGE = "Fridge";
     public static final String MIELE_DEVICE_CLASS_FRIDGE_FREEZER = "FridgeFreezer";
+    public static final String MIELE_DEVICE_CLASS_HOB = "Hob";
+    public static final String MIELE_DEVICE_CLASS_HOOD = "Hood";
+    public static final String MIELE_DEVICE_CLASS_OVEN = "Oven";
+    public static final String MIELE_DEVICE_CLASS_TUMBLE_DRYER = "TumbleDryer";
+    public static final String MIELE_DEVICE_CLASS_WASHING_MACHINE = "WashingMachine";
 
     // Miele appliance states
     public static final int STATE_UNKNOWN = 0;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -29,6 +29,7 @@ public class MieleBindingConstants {
     public static final String BINDING_ID = "miele";
     public static final String APPLIANCE_ID = "uid";
     public static final String DEVICE_CLASS = "dc";
+    public static final String MODEL_PROPERTY_NAME = "model";
     public static final String PROTOCOL_ADAPTER_PROPERTY_NAME = "protocolAdapter";
     public static final String CONNECTION_TYPE_PROPERTY_NAME = "connectionType";
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -30,6 +30,7 @@ public class MieleBindingConstants {
     public static final String APPLIANCE_ID = "uid";
     public static final String DEVICE_CLASS = "dc";
     public static final String PROTOCOL_ADAPTER_PROPERTY_NAME = "protocolAdapter";
+    public static final String CONNECTION_TYPE_PROPERTY_NAME = "connectionType";
 
     // JSON-RPC property names
     public static final String SERIAL_NUMBER_PROPERTY_NAME = "serialNumber";

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -28,7 +28,7 @@ public class MieleBindingConstants {
 
     public static final String BINDING_ID = "miele";
     public static final String APPLIANCE_ID = "uid";
-    public static final String DEVICE_CLASS = "dc";
+    public static final String DEVICE_CLASS = "deviceClass";
     public static final String MODEL_PROPERTY_NAME = "model";
     public static final String PROTOCOL_ADAPTER_PROPERTY_NAME = "protocolAdapter";
     public static final String CONNECTION_TYPE_PROPERTY_NAME = "connectionType";

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -29,7 +29,7 @@ public class MieleBindingConstants {
     public static final String BINDING_ID = "miele";
     public static final String APPLIANCE_ID = "uid";
     public static final String DEVICE_CLASS = "dc";
-    public static final String PROTOCOL_PROPERTY_NAME = "protocol";
+    public static final String PROTOCOL_ADAPTER_PROPERTY_NAME = "protocolAdapter";
 
     // JSON-RPC property names
     public static final String SERIAL_NUMBER_PROPERTY_NAME = "serialNumber";

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -104,6 +104,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
             Map<String, Object> properties = new HashMap<>(2);
 
             FullyQualifiedApplianceIdentifier applianceIdentifier = appliance.getApplianceIdentifier();
+            properties.put(MODEL_PROPERTY_NAME, appliance.getApplianceModel());
             properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(APPLIANCE_ID, applianceIdentifier.getApplianceId());
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -107,6 +107,10 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
             properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(APPLIANCE_ID, applianceIdentifier.getApplianceId());
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
+            String connectionType = appliance.getConnectionType();
+            if (connectionType != null) {
+                properties.put(CONNECTION_TYPE_PROPERTY_NAME, connectionType);
+            }
 
             for (JsonElement dc : appliance.DeviceClasses) {
                 String dcStr = dc.getAsString();

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -104,7 +104,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
             Map<String, Object> properties = new HashMap<>(2);
 
             FullyQualifiedApplianceIdentifier applianceIdentifier = appliance.getApplianceIdentifier();
-            properties.put(PROTOCOL_PROPERTY_NAME, applianceIdentifier.getProtocol());
+            properties.put(PROTOCOL_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(APPLIANCE_ID, applianceIdentifier.getApplianceId());
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -35,8 +35,6 @@ import org.openhab.core.thing.ThingUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.JsonElement;
-
 /**
  * The {@link MieleApplianceDiscoveryService} tracks appliances that are
  * associated with the Miele@Home gateway
@@ -46,9 +44,6 @@ import com.google.gson.JsonElement;
  * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class MieleApplianceDiscoveryService extends AbstractDiscoveryService implements ApplianceStatusListener {
-
-    private static final String MIELE_APPLIANCE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.MieleAppliance";
-    private static final String MIELE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.Miele";
 
     private final Logger logger = LoggerFactory.getLogger(MieleApplianceDiscoveryService.class);
 
@@ -105,20 +100,16 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
 
             FullyQualifiedApplianceIdentifier applianceIdentifier = appliance.getApplianceIdentifier();
             properties.put(MODEL_PROPERTY_NAME, appliance.getApplianceModel());
+            String deviceClass = appliance.getDeviceClass();
+            if (deviceClass != null) {
+                properties.put(DEVICE_CLASS, deviceClass);
+            }
             properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(APPLIANCE_ID, applianceIdentifier.getApplianceId());
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
             String connectionType = appliance.getConnectionType();
             if (connectionType != null) {
                 properties.put(CONNECTION_TYPE_PROPERTY_NAME, connectionType);
-            }
-
-            for (JsonElement dc : appliance.DeviceClasses) {
-                String dcStr = dc.getAsString();
-                if (dcStr.contains(MIELE_CLASS) && !dcStr.equals(MIELE_APPLIANCE_CLASS)) {
-                    properties.put(DEVICE_CLASS, dcStr.substring(MIELE_CLASS.length()));
-                    break;
-                }
             }
 
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
@@ -158,15 +149,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
 
     private ThingUID getThingUID(HomeDevice appliance) {
         ThingUID bridgeUID = mieleBridgeHandler.getThing().getUID();
-        String modelId = null;
-
-        for (JsonElement dc : appliance.DeviceClasses) {
-            String dcStr = dc.getAsString();
-            if (dcStr.contains(MIELE_CLASS) && !dcStr.equals(MIELE_APPLIANCE_CLASS)) {
-                modelId = dcStr.substring(MIELE_CLASS.length());
-                break;
-            }
-        }
+        String modelId = appliance.getDeviceClass();
 
         if (modelId != null) {
             ThingTypeUID thingTypeUID = getThingTypeUidFromModelId(modelId);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -142,11 +142,6 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
         // nothing to do
     }
 
-    @Override
-    public void onAppliancePropertyChanged(String serialNumber, DeviceProperty dp) {
-        // nothing to do
-    }
-
     private ThingUID getThingUID(HomeDevice appliance) {
         ThingUID bridgeUID = mieleBridgeHandler.getThing().getUID();
         String modelId = appliance.getDeviceClass();
@@ -171,7 +166,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
          * coffeemachine. At least until it is known if any models are actually reported
          * as CoffeeMachine, we need this special mapping.
          */
-        if (modelId.equals(MIELE_DEVICE_CLASS_COFFEE_SYSTEM)) {
+        if (MIELE_DEVICE_CLASS_COFFEE_SYSTEM.equals(modelId)) {
             return THING_TYPE_COFFEEMACHINE;
         }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -104,7 +104,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
             Map<String, Object> properties = new HashMap<>(2);
 
             FullyQualifiedApplianceIdentifier applianceIdentifier = appliance.getApplianceIdentifier();
-            properties.put(PROTOCOL_PROPERTY_NAME, appliance.ProtocolAdapterName);
+            properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(APPLIANCE_ID, applianceIdentifier.getApplianceId());
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
@@ -26,7 +26,6 @@ import org.openhab.binding.miele.internal.MieleBindingConstants;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
-import org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
@@ -44,14 +44,6 @@ public interface ApplianceStatusListener {
     void onAppliancePropertyChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceProperty dp);
 
     /**
-     * This method is called whenever a "property" of the given appliance has changed.
-     *
-     * @param serialNumber The serial number of the appliance that has changed
-     * @param dco the POJO containing the new state of the property
-     */
-    void onAppliancePropertyChanged(String serialNumber, DeviceProperty dp);
-
-    /**
      * This method is called whenever an appliance is removed.
      *
      * @param appliance The XGW homedevice definition of the appliance that was removed

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
@@ -86,9 +86,9 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
 
     private final Logger logger = LoggerFactory.getLogger(CoffeeMachineChannelSelector.class);
 
-    private final static Map<String, String> programs = Collections.<String, String> emptyMap();
+    private static final Map<String, String> programs = Collections.<String, String> emptyMap();
 
-    private final static Map<String, String> phases = Collections.<String, String> emptyMap();
+    private static final Map<String, String> phases = Collections.<String, String> emptyMap();
 
     private final String mieleID;
     private final String channelID;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
@@ -42,8 +42,6 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
@@ -71,7 +71,7 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
@@ -14,9 +14,7 @@ package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_COFFEE_SYSTEM;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -49,8 +47,6 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         CoffeeMachineChannelSelector selector = (CoffeeMachineChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -60,9 +56,9 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOn");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "switchOn");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOff");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "switchOff");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -14,12 +14,10 @@ package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
 
 import java.math.BigDecimal;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
@@ -60,8 +58,6 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         DishwasherChannelSelector selector = (DishwasherChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -71,9 +67,9 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "start");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -82,7 +82,7 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_DISHWASHER;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
 
@@ -49,7 +50,7 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
     private final Logger logger = LoggerFactory.getLogger(DishWasherHandler.class);
 
     public DishWasherHandler(Thing thing) {
-        super(thing, DishwasherChannelSelector.class, "Dishwasher");
+        super(thing, DishwasherChannelSelector.class, MIELE_DEVICE_CLASS_DISHWASHER);
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -150,12 +150,12 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
 
     private final Logger logger = LoggerFactory.getLogger(DishwasherChannelSelector.class);
 
-    private final static Map<String, String> programs = Map.ofEntries(entry("26", "Pots & Pans"),
+    private static final Map<String, String> programs = Map.ofEntries(entry("26", "Pots & Pans"),
             entry("27", "Clean Machine"), entry("28", "Economy"), entry("30", "Normal"), entry("32", "Sensor Wash"),
             entry("34", "Energy Saver"), entry("35", "China & Crystal"), entry("36", "Extra Quiet"),
             entry("37", "SaniWash"), entry("38", "QuickPowerWash"), entry("42", "Tall items"));
 
-    private final static Map<String, String> phases = Map.ofEntries(entry("2", "Pre-Wash"), entry("3", "Main Wash"),
+    private static final Map<String, String> phases = Map.ofEntries(entry("2", "Pre-Wash"), entry("3", "Main Wash"),
             entry("4", "Rinses"), entry("6", "Final rinse"), entry("7", "Drying"), entry("8", "Finished"));
 
     private final String mieleID;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -48,8 +48,6 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true, false),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true, false),
-    BRAND_ID("brandId", "brandId", StringType.class, true, false),
-    COMPANY_ID("companyId", "companyId", StringType.class, true, false),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false, false) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -42,8 +42,6 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     SUPERCOOL(null, SUPERCOOL_CHANNEL_ID, OnOffType.class, false),

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -17,7 +17,7 @@ import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 import java.lang.reflect.Method;
 import java.util.Map.Entry;
 
-import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
+import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -146,7 +146,7 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
 
     public State getTemperatureState(String s) {
         try {
-            return ExtendedDeviceStateUtil.getTemperatureState(s);
+            return DeviceUtil.getTemperatureState(s);
         } catch (NumberFormatException e) {
             logger.warn("An exception occurred while converting '{}' into a State", s);
             return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -43,8 +43,6 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     FREEZERSTATE("freezerState", "freezerstate", StringType.class, false),

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -17,7 +17,7 @@ import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 import java.lang.reflect.Method;
 import java.util.Map.Entry;
 
-import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
+import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -163,7 +163,7 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
 
     public State getTemperatureState(String s) {
         try {
-            return ExtendedDeviceStateUtil.getTemperatureState(s);
+            return DeviceUtil.getTemperatureState(s);
         } catch (NumberFormatException e) {
             logger.warn("An exception occurred while converting '{}' into a State", s);
             return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
@@ -77,7 +77,7 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
@@ -91,7 +91,7 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
     protected void onAppliancePropertyChanged(DeviceProperty dp) {
         super.onAppliancePropertyChanged(dp);
 
-        if (!dp.Name.equals(STATE_PROPERTY_NAME)) {
+        if (!STATE_PROPERTY_NAME.equals(dp.Name)) {
             return;
         }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
@@ -14,7 +14,6 @@ package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceProperty;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
@@ -48,8 +47,6 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         FridgeFreezerChannelSelector selector = (FridgeFreezerChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -59,17 +56,17 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
                 switch (selector) {
                     case SUPERCOOL: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "startSuperCooling");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stopSuperCooling");
                         }
                         break;
                     }
                     case SUPERFREEZE: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperFreezing");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "startSuperFreezing");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperFreezing");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stopSuperFreezing");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -92,7 +92,7 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
     protected void onAppliancePropertyChanged(DeviceProperty dp) {
         super.onAppliancePropertyChanged(dp);
 
-        if (!dp.Name.equals(STATE_PROPERTY_NAME)) {
+        if (!STATE_PROPERTY_NAME.equals(dp.Name)) {
             return;
         }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -14,7 +14,6 @@ package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceProperty;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
@@ -49,8 +48,6 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         FridgeChannelSelector selector = (FridgeChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -60,15 +57,15 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
                 switch (selector) {
                     case SUPERCOOL: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "startSuperCooling");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stopSuperCooling");
                         }
                         break;
                     }
                     case START: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "start");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -78,7 +78,7 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
@@ -37,8 +37,6 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     PLATES("plateNumbers", "plates", DecimalType.class, true),

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobHandler.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
+import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_HOB;
+
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -26,7 +28,7 @@ import org.openhab.core.types.Command;
 public class HobHandler extends MieleApplianceHandler<HobChannelSelector> {
 
     public HobHandler(Thing thing) {
-        super(thing, HobChannelSelector.class, "Hob");
+        super(thing, HobChannelSelector.class, MIELE_DEVICE_CLASS_HOB);
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
@@ -39,8 +39,6 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     VENTILATION("ventilationPower", "ventilation", DecimalType.class, false),

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_HOOD;
 
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
@@ -37,7 +38,7 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
     private final Logger logger = LoggerFactory.getLogger(HoodHandler.class);
 
     public HoodHandler(Thing thing) {
-        super(thing, HoodChannelSelector.class, "Hood");
+        super(thing, HoodChannelSelector.class, MIELE_DEVICE_CLASS_HOOD);
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
@@ -13,9 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -48,8 +46,6 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         HoodChannelSelector selector = (HoodChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -59,15 +55,15 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
                 switch (selector) {
                     case LIGHT: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startLighting");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "startLighting");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopLighting");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stopLighting");
                         }
                         break;
                     }
                     case STOP: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
@@ -74,7 +74,7 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -319,6 +319,10 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
         if (applianceId.equals(applianceIdentifier.getApplianceId())) {
             Map<String, String> properties = editProperties();
             properties.put(MODEL_PROPERTY_NAME, appliance.getApplianceModel());
+            String deviceClass = appliance.getDeviceClass();
+            if (deviceClass != null) {
+                properties.put(DEVICE_CLASS, deviceClass);
+            }
             properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
             String connectionType = appliance.getConnectionType();

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -161,11 +161,6 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             return;
         }
 
-        String modelID = DeviceUtil.getDeviceClassFromFullyQualifiedString(dco.DeviceClass);
-        if (!modelID.equals(this.modelID)) {
-            return;
-        }
-
         for (JsonElement prop : dco.Properties.getAsJsonArray()) {
             try {
                 DeviceProperty dp = gson.fromJson(prop, DeviceProperty.class);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -343,6 +343,9 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     }
 
     protected boolean isResultProcessable(JsonElement result) {
-        return result != null && !result.isJsonNull();
+        if (result == null) {
+            throw new IllegalArgumentException("Provided result is null");
+        }
+        return !result.isJsonNull();
     }
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -184,15 +184,6 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     }
 
     @Override
-    public void onAppliancePropertyChanged(String serialNumber, DeviceProperty dp) {
-        String mySerialNumber = getThing().getProperties().get(SERIAL_NUMBER_PROPERTY_NAME);
-        if (mySerialNumber == null || !mySerialNumber.equals(serialNumber)) {
-            return;
-        }
-        this.onAppliancePropertyChanged(dp);
-    }
-
-    @Override
     public void onAppliancePropertyChanged(FullyQualifiedApplianceIdentifier applicationIdentifier, DeviceProperty dp) {
         String myApplianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -318,7 +318,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
         if (applianceId.equals(applianceIdentifier.getApplianceId())) {
             Map<String, String> properties = editProperties();
-            properties.put(PROTOCOL_PROPERTY_NAME, appliance.ProtocolAdapterName);
+            properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
             updateProperties(properties);
             updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -246,7 +246,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                     } else {
                         updateState(theChannelUID, UnDefType.UNDEF);
                     }
-                } else if (dpValue != null) {
+                } else {
                     logger.debug("Updating the property '{}' of '{}' to '{}'", selector.getChannelID(),
                             getThing().getUID(), selector.getState(dpValue, dmd).toString());
                     Map<String, String> properties = editProperties();

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -318,6 +318,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
         if (applianceId.equals(applianceIdentifier.getApplianceId())) {
             Map<String, String> properties = editProperties();
+            properties.put(MODEL_PROPERTY_NAME, appliance.getApplianceModel());
             properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
             String connectionType = appliance.getConnectionType();

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -318,7 +318,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
         if (applianceId.equals(applianceIdentifier.getApplianceId())) {
             Map<String, String> properties = editProperties();
-            properties.put(PROTOCOL_PROPERTY_NAME, applianceIdentifier.getProtocol());
+            properties.put(PROTOCOL_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
             updateProperties(properties);
             updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -320,6 +320,10 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             Map<String, String> properties = editProperties();
             properties.put(PROTOCOL_ADAPTER_PROPERTY_NAME, appliance.ProtocolAdapterName);
             properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
+            String connectionType = appliance.getConnectionType();
+            if (connectionType != null) {
+                properties.put(CONNECTION_TYPE_PROPERTY_NAME, connectionType);
+            }
             updateProperties(properties);
             updateStatus(ThingStatus.ONLINE);
         }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceClassObject;
@@ -263,7 +264,8 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                 } else {
                     logger.debug("Updating the property '{}' of '{}' to '{}'", selector.getChannelID(),
                             getThing().getUID(), selector.getState(dpValue, dmd).toString());
-                    Map<String, String> properties = editProperties();
+                    @NonNull
+                    Map<@NonNull String, @NonNull String> properties = editProperties();
                     properties.put(selector.getChannelID(), selector.getState(dpValue, dmd).toString());
                     updateProperties(properties);
                 }
@@ -329,7 +331,8 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
         FullyQualifiedApplianceIdentifier applianceIdentifier = appliance.getApplianceIdentifier();
 
         if (applianceId.equals(applianceIdentifier.getApplianceId())) {
-            Map<String, String> properties = editProperties();
+            @NonNull
+            Map<@NonNull String, @NonNull String> properties = editProperties();
             properties.put(MODEL_PROPERTY_NAME, appliance.getApplianceModel());
             String deviceClass = appliance.getDeviceClass();
             if (deviceClass != null) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
+import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceClassObject;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
@@ -217,9 +217,9 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
             if (dp.Name.equals(EXTENDED_DEVICE_STATE_PROPERTY_NAME)) {
                 if (!dp.Value.isEmpty()) {
-                    byte[] extendedStateBytes = ExtendedDeviceStateUtil.stringToBytes(dp.Value);
+                    byte[] extendedStateBytes = DeviceUtil.stringToBytes(dp.Value);
                     logger.trace("Extended device state for {}: {}", getThing().getUID(),
-                            ExtendedDeviceStateUtil.bytesToHex(extendedStateBytes));
+                            DeviceUtil.bytesToHex(extendedStateBytes));
                     if (this instanceof ExtendedDeviceStateListener) {
                         ((ExtendedDeviceStateListener) this).onApplianceExtendedStateChanged(extendedStateBytes);
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -149,8 +149,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     public void onApplianceStateChanged(FullyQualifiedApplianceIdentifier applicationIdentifier,
             DeviceClassObject dco) {
         String myApplianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String modelID = StringUtils.right(dco.DeviceClass,
-                dco.DeviceClass.length() - new String("com.miele.xgw3000.gateway.hdm.deviceclasses.Miele").length());
+        String modelID = DeviceUtil.getDeviceClassFromFullyQualifiedString(dco.DeviceClass);
 
         if (myApplianceId.equals(applicationIdentifier.getApplianceId())) {
             if (modelID.equals(this.modelID)) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceClassObject;
@@ -157,8 +156,8 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                     try {
                         DeviceProperty dp = gson.fromJson(prop, DeviceProperty.class);
                         if (!dp.Name.equals(EXTENDED_DEVICE_STATE_PROPERTY_NAME)) {
-                            dp.Value = StringUtils.trim(dp.Value);
-                            dp.Value = StringUtils.strip(dp.Value);
+                            dp.Value = dp.Value.trim();
+                            dp.Value = dp.Value.strip();
                         }
 
                         onAppliancePropertyChanged(applicationIdentifier, dp);
@@ -208,7 +207,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                 }
             }
             if (dp.Metadata != null) {
-                String metadata = StringUtils.replace(dp.Metadata.toString(), "enum", "MieleEnum");
+                String metadata = dp.Metadata.toString().replace("enum", "MieleEnum");
                 JsonObject jsonMetaData = (JsonObject) JsonParser.parseString(metadata);
                 dmd = gson.fromJson(jsonMetaData, DeviceMetaData.class);
                 metaDataCache.put(new StringBuilder().append(dp.Name).toString().trim(), metadata);
@@ -233,7 +232,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                 logger.trace("{} is not a valid channel for a {}", dp.Name, modelID);
             }
 
-            String dpValue = StringUtils.trim(StringUtils.strip(dp.Value));
+            String dpValue = dp.Value.strip().trim();
 
             if (selector != null) {
                 if (!selector.isProperty()) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -334,7 +334,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                     DeviceClassObject dco = gson.fromJson(obj, DeviceClassObject.class);
 
                                     // Skip com.prosyst.mbs.services.zigbee.hdm.deviceclasses.ReportingControl
-                                    if (!dco.DeviceClass.startsWith(MIELE_CLASS)) {
+                                    if (dco == null || !dco.DeviceClass.startsWith(MIELE_CLASS)) {
                                         continue;
                                     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -82,6 +82,8 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     @NonNull
     public static final Set<@NonNull ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_XGW3000);
 
+    private static final String MIELE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.Miele";
+
     private static final Pattern IP_PATTERN = Pattern
             .compile("^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
@@ -112,7 +114,6 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     public class HomeDevice {
 
         private static final String MIELE_APPLIANCE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.MieleAppliance";
-        private static final String MIELE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.Miele";
 
         public String Name;
         public String Status;
@@ -331,6 +332,11 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                 try {
                                     DeviceClassObject dco = gson.fromJson(obj, DeviceClassObject.class);
 
+                                    // Skip com.prosyst.mbs.services.zigbee.hdm.deviceclasses.ReportingControl
+                                    if (!dco.DeviceClass.startsWith(MIELE_CLASS)) {
+                                        continue;
+                                    }
+
                                     for (ApplianceStatusListener listener : applianceStatusListeners) {
                                         listener.onApplianceStateChanged(applianceIdentifier, dco);
                                     }
@@ -523,7 +529,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
 
         Object[] args = new Object[4];
         args[0] = applianceIdentifier.getUid();
-        args[1] = "com.miele.xgw3000.gateway.hdm.deviceclasses.Miele" + modelID;
+        args[1] = MIELE_CLASS + modelID;
         args[2] = methodName;
         args[3] = null;
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.common.NamedThreadFactory;
@@ -423,16 +422,16 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                 DeviceProperty dp = new DeviceProperty();
                                 String id = null;
 
-                                String[] parts = StringUtils.split(event, "&");
+                                String[] parts = event.split("&");
                                 for (String p : parts) {
-                                    String[] subparts = StringUtils.split(p, "=");
+                                    String[] subparts = p.split("=");
                                     switch (subparts[0]) {
                                         case "property": {
                                             dp.Name = subparts[1];
                                             break;
                                         }
                                         case "value": {
-                                            dp.Value = StringUtils.trim(StringUtils.strip(subparts[1]));
+                                            dp.Value = subparts[1].strip().trim();
                                             break;
                                         }
                                         case "id": {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -134,6 +134,14 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         public String getSerialNumber() {
             return Properties.get("serial.number").getAsString();
         }
+
+        public String getConnectionType() {
+            JsonElement connectionType = Properties.get("connection.type");
+            if (connectionType == null) {
+                return null;
+            }
+            return connectionType.getAsString();
+        }
     }
 
     public class DeviceClassObject {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -111,6 +111,9 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     // Data structures to de-JSONify whatever Miele appliances are sending us
     public class HomeDevice {
 
+        private static final String MIELE_APPLIANCE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.MieleAppliance";
+        private static final String MIELE_CLASS = "com.miele.xgw3000.gateway.hdm.deviceclasses.Miele";
+
         public String Name;
         public String Status;
         public String ParentUID;
@@ -151,6 +154,16 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                 return "";
             }
             return model.getAsString();
+        }
+
+        public String getDeviceClass() {
+            for (JsonElement dc : DeviceClasses) {
+                String dcStr = dc.getAsString();
+                if (dcStr.contains(MIELE_CLASS) && !dcStr.equals(MIELE_APPLIANCE_CLASS)) {
+                    return dcStr.substring(MIELE_CLASS.length());
+                }
+            }
+            return null;
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -131,6 +131,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
             return new FullyQualifiedApplianceIdentifier(this.UID);
         }
 
+        @NonNull
         public String getSerialNumber() {
             return Properties.get("serial.number").getAsString();
         }
@@ -141,6 +142,15 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                 return null;
             }
             return connectionType.getAsString();
+        }
+
+        @NonNull
+        public String getApplianceModel() {
+            JsonElement model = Properties.get("miele.model");
+            if (model == null) {
+                return "";
+            }
+            return model.getAsString();
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -306,6 +306,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                         for (ApplianceStatusListener listener : applianceStatusListeners) {
                             listener.onApplianceRemoved(cachedHomeDevice);
                         }
+                        cachedHomeDevicesByRemoteUid.remove(cachedHomeDevice.getRemoteUid());
                         iterator.remove();
                     }
                 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
-import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
+import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
@@ -239,7 +239,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
 
     public State getTemperatureState(String s) {
         try {
-            return ExtendedDeviceStateUtil.getTemperatureState(s);
+            return DeviceUtil.getTemperatureState(s);
         } catch (NumberFormatException e) {
             logger.warn("An exception occurred while converting '{}' into a State", s);
             return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -49,8 +49,6 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false),

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -165,7 +165,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
 
     private final Logger logger = LoggerFactory.getLogger(OvenChannelSelector.class);
 
-    private final static Map<String, String> phases = Map.ofEntries(entry("1", "Heating"), entry("2", "Temp. hold"),
+    private static final Map<String, String> phases = Map.ofEntries(entry("1", "Heating"), entry("2", "Temp. hold"),
             entry("3", "Door Open"), entry("4", "Pyrolysis"), entry("7", "Lighting"), entry("8", "Searing phase"),
             entry("10", "Defrost"), entry("11", "Cooling down"), entry("12", "Energy save phase"));
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
@@ -77,7 +77,7 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
@@ -13,9 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -49,8 +47,6 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         OvenChannelSelector selector = (OvenChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -60,15 +56,15 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOn");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "switchOn");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOff");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "switchOff");
                         }
                         break;
                     }
                     case STOP: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_OVEN;
 
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
@@ -38,7 +39,7 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
     private final Logger logger = LoggerFactory.getLogger(OvenHandler.class);
 
     public OvenHandler(Thing thing) {
-        super(thing, OvenChannelSelector.class, "Oven");
+        super(thing, OvenChannelSelector.class, MIELE_DEVICE_CLASS_OVEN);
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
@@ -153,7 +153,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
 
     private final Logger logger = LoggerFactory.getLogger(TumbleDryerChannelSelector.class);
 
-    private final static Map<String, String> programs = Map.ofEntries(entry("10", "Automatic Plus"),
+    private static final Map<String, String> programs = Map.ofEntries(entry("10", "Automatic Plus"),
             entry("23", "Cottons hygiene"), entry("30", "Minimum iron"), entry("31", "Gentle minimum iron"),
             entry("40", "Woollens handcare"), entry("50", "Delicates"), entry("60", "Warm Air"),
             entry("70", "Cool air"), entry("80", "Express"), entry("90", "Cottons"), entry("100", "Gentle smoothing"),
@@ -163,7 +163,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
             entry("240", "Smoothing"), entry("65000", "Cottons, auto load control"),
             entry("65001", "Minimum iron, auto load control"));
 
-    private final static Map<String, String> phases = Map.ofEntries(entry("1", "Programme running"),
+    private static final Map<String, String> phases = Map.ofEntries(entry("1", "Programme running"),
             entry("2", "Drying"), entry("3", "Drying Machine iron"), entry("4", "Drying Hand iron"),
             entry("5", "Drying Normal"), entry("6", "Drying Normal+"), entry("7", "Cooling down"),
             entry("8", "Drying Hand iron"), entry("10", "Finished"));

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
@@ -47,8 +47,6 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
-    BRAND_ID("brandId", "brandId", StringType.class, true),
-    COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_TUMBLE_DRYER;
 
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
@@ -38,7 +39,7 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
     private final Logger logger = LoggerFactory.getLogger(TumbleDryerHandler.class);
 
     public TumbleDryerHandler(Thing thing) {
-        super(thing, TumbleDryerChannelSelector.class, "TumbleDryer");
+        super(thing, TumbleDryerChannelSelector.class, MIELE_DEVICE_CLASS_TUMBLE_DRYER);
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
@@ -13,9 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -49,8 +47,6 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         TumbleDryerChannelSelector selector = (TumbleDryerChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -60,9 +56,9 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "start");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
@@ -71,7 +71,7 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -50,8 +50,6 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
 
     PRODUCT_TYPE("productTypeId", "productType", StringType.class, true, false),
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true, false),
-    BRAND_ID("brandId", "brandId", StringType.class, true, false),
-    COMPANY_ID("companyId", "companyId", StringType.class, true, false),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false, false),
     STATE(null, STATE_CHANNEL_ID, DecimalType.class, false, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false, false) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DateTimeType;
@@ -96,7 +95,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(StringUtils.trim(s)) * 60000);
+                date.setTime(Long.valueOf(s.trim()) * 60000);
             } catch (Exception e) {
                 date.setTime(0);
             }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -172,7 +172,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
 
     private final Logger logger = LoggerFactory.getLogger(WashingMachineChannelSelector.class);
 
-    private final static Map<String, String> programs = Map.ofEntries(entry("1", "Cottons"), entry("3", "Minimum iron"),
+    private static final Map<String, String> programs = Map.ofEntries(entry("1", "Cottons"), entry("3", "Minimum iron"),
             entry("4", "Delicates"), entry("8", "Woollens"), entry("9", "Silks"), entry("17", "Starch"),
             entry("18", "Rinse"), entry("21", "Drain/Spin"), entry("22", "Curtains"), entry("23", "Shirts"),
             entry("24", "Denim"), entry("27", "Proofing"), entry("29", "Sportswear"), entry("31", "Automatic Plus"),
@@ -181,7 +181,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
             entry("95", "Down duvets"), entry("122", "Express 20"), entry("129", "Down filled items"),
             entry("133", "Cottons Eco"), entry("146", "QuickPowerWash"), entry("65532", "Mix"));
 
-    private final static Map<String, String> phases = Map.ofEntries(entry("1", "Pre-wash"), entry("4", "Washing"),
+    private static final Map<String, String> phases = Map.ofEntries(entry("1", "Pre-wash"), entry("4", "Washing"),
             entry("5", "Rinses"), entry("7", "Clean"), entry("9", "Drain"), entry("10", "Spin"),
             entry("11", "Anti-crease"), entry("12", "Finished"));
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -23,7 +23,7 @@ import java.util.Map.Entry;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.StringUtils;
-import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
+import org.openhab.binding.miele.internal.DeviceUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
@@ -258,7 +258,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
 
     public State getTemperatureState(String s) {
         try {
-            return ExtendedDeviceStateUtil.getTemperatureState(s);
+            return DeviceUtil.getTemperatureState(s);
         } catch (NumberFormatException e) {
             logger.warn("An exception occurred while converting '{}' into a State", s);
             return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_WASHING_MACHINE;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
 
@@ -49,7 +50,7 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
     private final Logger logger = LoggerFactory.getLogger(WashingMachineHandler.class);
 
     public WashingMachineHandler(Thing thing) {
-        super(thing, WashingMachineChannelSelector.class, "WashingMachine");
+        super(thing, WashingMachineChannelSelector.class, MIELE_DEVICE_CLASS_WASHING_MACHINE);
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -83,7 +83,7 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
                 }
             }
             // process result
-            if (isResultProcessable(result)) {
+            if (result != null && isResultProcessable(result)) {
                 logger.debug("Result of operation is {}", result.getAsString());
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -14,12 +14,10 @@ package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
 
 import java.math.BigDecimal;
 
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
@@ -60,8 +58,6 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
 
         String channelID = channelUID.getId();
         String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
-        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         WashingMachineChannelSelector selector = (WashingMachineChannelSelector) getValueSelectorFromChannelID(
                 channelID);
@@ -72,9 +68,9 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "start");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceId, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+		https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:miele:appliance">
+		<parameter name="uid" type="text" required="true">
+			<label>ID</label>
+			<description>The identifier identifies one certain appliance on the ZigBee network.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/config/config.xml
@@ -8,7 +8,7 @@
 	<config-description uri="thing-type:miele:appliance">
 		<parameter name="uid" type="text" required="true">
 			<label>ID</label>
-			<description>The identifier identifies one certain appliance on the ZigBee network.</description>
+			<description>Unique identifier for specific appliance on the gateway.</description>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele.properties
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele.properties
@@ -1,0 +1,107 @@
+# binding
+
+binding.miele.name = Miele Binding
+binding.miele.description = This is the binding for Miele@home appliances
+
+# thing types
+
+thing-type.miele.coffeemachine.label = Coffee Machine
+thing-type.miele.coffeemachine.description = This is a Miele@home compatible coffee machine
+thing-type.miele.dishwasher.label = Dishwasher
+thing-type.miele.dishwasher.description = This is a Miele@home compatible dishwasher
+thing-type.miele.fridge.label = Fridge
+thing-type.miele.fridge.description = This is a Miele@home compatible fridge
+thing-type.miele.fridgefreezer.label = Fridge Freezer
+thing-type.miele.fridgefreezer.description = This is a Miele@home compatible fridgefreezer
+thing-type.miele.hob.label = Hob
+thing-type.miele.hob.description = This is a Miele@home compatible hob
+thing-type.miele.hood.label = Hood
+thing-type.miele.hood.description = This is a Miele@home compatible hood
+thing-type.miele.oven.label = Oven
+thing-type.miele.oven.description = This is a Miele@home compatible oven
+thing-type.miele.tumbledryer.label = Tumbledryer
+thing-type.miele.tumbledryer.description = This is a Miele@home compatible tumbledryer
+thing-type.miele.washingmachine.label = Washing Machine
+thing-type.miele.washingmachine.description = This is a Miele@home compatible washing machine
+thing-type.miele.xgw3000.label = Miele XGW3000
+thing-type.miele.xgw3000.description = The Miele bridge represents the Miele@home XGW3000 gateway.
+
+# thing types config
+
+thing-type.config.miele.appliance.uid.label = ID
+thing-type.config.miele.appliance.uid.description = Unique identifier for specific appliance on the gateway.
+thing-type.config.miele.xgw3000.interface.label = Network Address of the Multicast Interface
+thing-type.config.miele.xgw3000.interface.description = Network address of openHAB host interface where the binding will listen for multicast events coming from the Miele@home gateway.
+thing-type.config.miele.xgw3000.ipAddress.label = Network Address
+thing-type.config.miele.xgw3000.ipAddress.description = Network address of the Miele@home gateway.
+thing-type.config.miele.xgw3000.password.label = Password
+thing-type.config.miele.xgw3000.password.description = Password for the registered Miele@home user.
+thing-type.config.miele.xgw3000.userName.label = Username
+thing-type.config.miele.xgw3000.userName.description = Name of a registered Miele@home user.
+
+# channel types
+
+channel-type.miele.currentTemperature.label = Current Temperature
+channel-type.miele.currentTemperature.description = Current temperature of the appliance
+channel-type.miele.door.label = Door
+channel-type.miele.door.description = Current state of the door of the appliance
+channel-type.miele.duration.label = Duration
+channel-type.miele.duration.description = Duration of the program running on the appliance
+channel-type.miele.duration.state.pattern = %1$tH:%1$tM
+channel-type.miele.elapsed.label = Elapsed Time
+channel-type.miele.elapsed.description = Time elapsed in the program running on the appliance
+channel-type.miele.elapsed.state.pattern = %1$tH:%1$tM
+channel-type.miele.finish.label = Finish Time
+channel-type.miele.finish.description = Time to finish the program running on the appliance
+channel-type.miele.finish.state.pattern = %1$tH:%1$tM
+channel-type.miele.freezerstate.label = Status
+channel-type.miele.freezerstate.description = Current status of the freezer compartment
+channel-type.miele.fridgestate.label = Status
+channel-type.miele.fridgestate.description = Current status of the fridge compartment
+channel-type.miele.heat.label = Remaining Heat
+channel-type.miele.heat.description = Remaining heat level of the heating zone/plate
+channel-type.miele.phase.label = Phase
+channel-type.miele.phase.description = Current phase of the program running on the appliance
+channel-type.miele.plates.label = Plates
+channel-type.miele.plates.description = Number of heating zones/plates on the hob
+channel-type.miele.power.label = Power Step
+channel-type.miele.power.description = Power level of the heating zone/plate
+channel-type.miele.powerConsumption.label = Power Consumption
+channel-type.miele.powerConsumption.description = Power consumption by the currently running program on the appliance
+channel-type.miele.program.label = Program
+channel-type.miele.program.description = Current program or function running on the appliance
+channel-type.miele.rawPhase.label = Raw Phase
+channel-type.miele.rawPhase.description = Current phase of the program running on the appliance as raw number
+channel-type.miele.rawProgram.label = Raw Program
+channel-type.miele.rawProgram.description = Current program or function running on the appliance as raw number
+channel-type.miele.rawState.label = Raw State
+channel-type.miele.rawState.description = Current status of the appliance as raw number
+channel-type.miele.spinningspeed.label = Spinning Speed
+channel-type.miele.spinningspeed.description = Spinning speed in the program running on the appliance
+channel-type.miele.start.label = Start Time
+channel-type.miele.start.description = Programmed start time of the program
+channel-type.miele.start.state.pattern = %1$tH:%1$tM
+channel-type.miele.state.label = State
+channel-type.miele.state.description = Current status of the appliance
+channel-type.miele.step.label = Step
+channel-type.miele.step.description = Current step in the program running on the appliance
+channel-type.miele.stop.label = Stop
+channel-type.miele.stop.description = Stop the appliance
+channel-type.miele.supercool.label = Super Cool
+channel-type.miele.supercool.description = Start or stop Super Cooling
+channel-type.miele.superfreeze.label = Super Freeze
+channel-type.miele.superfreeze.description = Start or stop Super Freezing
+channel-type.miele.switch.label = Switch
+channel-type.miele.switch.description = Switch the appliance on or off
+channel-type.miele.targetTemperature.label = Target Temperature
+channel-type.miele.targetTemperature.description = Target temperature to be reached by the appliance
+channel-type.miele.temperature.label = Temperature
+channel-type.miele.temperature.description = Temperature reported by the appliance
+channel-type.miele.time.label = Remaining Time
+channel-type.miele.time.description = Remaining time of the heating zone/plate
+channel-type.miele.type.label = Program Type
+channel-type.miele.type.description = Type of the program running on the appliance
+channel-type.miele.ventilation.label = Ventilation Power
+channel-type.miele.ventilation.description = Current ventilation power
+channel-type.miele.waterConsumption.label = Water Consumption
+channel-type.miele.waterConsumption.description = Water consumption by the currently running program on the appliance

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele_da.properties
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele_da.properties
@@ -1,0 +1,40 @@
+# binding
+
+binding.miele.name = Miele Binding
+binding.miele.description = Dette er bindingen til Miele@home-husholdningsapparater
+
+# thing types
+
+thing-type.miele.coffeemachine.label = Kaffemaskine
+thing-type.miele.coffeemachine.description = Dette er en Miele@home-kompatibel kaffemaskine
+thing-type.miele.dishwasher.label = Opvaskemaskine
+thing-type.miele.dishwasher.description = Dette er en Miele@home-kompatibel opvaskemaskine
+thing-type.miele.fridge.label = Køleskab
+thing-type.miele.fridge.description = Dette er et Miele@home-kompatibelt køleskab
+thing-type.miele.fridgefreezer.label = Kølefryseskab
+thing-type.miele.fridgefreezer.description = Dette er et Miele@home-kompatibelt kølefryseskab
+thing-type.miele.hob.label = Kogeplader
+thing-type.miele.hob.description = Dette er Miele@home-kompatible kogeplader
+thing-type.miele.hood.label = Emhætte
+thing-type.miele.hood.description = Dette er en Miele@home-kompatibel emhætte
+thing-type.miele.oven.label = Ovn
+thing-type.miele.oven.description = Dette er en Miele@home-kompatibel ovn
+thing-type.miele.tumbledryer.label = Tørretumbler
+thing-type.miele.tumbledryer.description = Dette er en Miele@home-kompatibel tørretumbler
+thing-type.miele.washingmachine.label = Vaskemaskine
+thing-type.miele.washingmachine.description = Dette er en Miele@home-kompatibel vaskemaskine
+thing-type.miele.xgw3000.label = Miele XGW3000
+thing-type.miele.xgw3000.description = Miele-bridgen repræsenterer Miele@home XGW3000-gateway'en.
+
+# thing types config
+
+thing-type.config.miele.appliance.uid.label = ID
+thing-type.config.miele.appliance.uid.description = Unik identifikator til specifikt husholdningsapparat på gateway'en.
+thing-type.config.miele.xgw3000.interface.label = Netværksadresse til multicast-interfacet
+thing-type.config.miele.xgw3000.interface.description = Netværksadresse til openHAB værts-interfacet hvor bindingen vil lytte på multicast-hændelser fra Miele@home-gateway'en.
+thing-type.config.miele.xgw3000.ipAddress.label = Netværksadresse
+thing-type.config.miele.xgw3000.ipAddress.description = Netværksadresse til Miele@home-gateway'en.
+thing-type.config.miele.xgw3000.password.label = Adgangskode
+thing-type.config.miele.xgw3000.password.description = Adgangskode til registreret Miele@home-bruger.
+thing-type.config.miele.xgw3000.userName.label = Brugernavn
+thing-type.config.miele.xgw3000.userName.description = Navn på en registeret Miele@home-bruger.

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/coffeemachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/coffeemachine.xml
@@ -27,12 +27,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
@@ -32,13 +32,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
-
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
@@ -29,13 +29,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
-
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
@@ -38,13 +38,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
-
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hob.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hob.xml
@@ -38,13 +38,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
-
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hood.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hood.xml
@@ -23,12 +23,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies the appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
@@ -47,13 +47,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
-
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/tumbledryer.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/tumbledryer.xml
@@ -32,13 +32,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
-
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -38,12 +38,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description>
-			<parameter name="uid" type="text" required="true">
-				<label>ID</label>
-				<description>The identifier identifies one certain appliance on the ZigBee network.</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:miele:appliance"/>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/xgw3000.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/xgw3000.xml
@@ -7,7 +7,7 @@
 	<!-- Miele Bridge -->
 	<bridge-type id="xgw3000">
 		<label>Miele XGW3000</label>
-		<description>The miele bridge represents the Miele@home XGW3000 gateway.</description>
+		<description>The Miele bridge represents the Miele@home XGW3000 gateway.</description>
 
 		<properties>
 			<property name="vendor">Miele</property>
@@ -25,7 +25,7 @@
 				<context>network-address</context>
 				<label>Network Address of the Multicast Interface</label>
 				<description>Network address of openHAB host interface where the binding will listen for multicast events coming
-					from the Miele@home gateway</description>
+					from the Miele@home gateway.</description>
 			</parameter>
 			<parameter name="userName" type="text" required="false">
 				<label>Username</label>
@@ -36,7 +36,7 @@
 			<parameter name="password" type="text" required="false">
 				<context>password</context>
 				<label>Password</label>
-				<description>Password for the registered Miele@home</description>
+				<description>Password for the registered Miele@home user.</description>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
@@ -22,17 +22,16 @@ import org.openhab.core.types.UnDefType;
 
 /**
  * This class provides test cases for {@link
- * org.openhab.binding.miele.internal.ExtendedDeviceStateUtil}
+ * org.openhab.binding.miele.internal.DeviceUtil}
  *
  * @author Jacob Laursen - Initial contribution
  */
 
-public class ExtendedDeviceStateUtilTest extends JavaTest {
+public class DeviceUtilTest extends JavaTest {
 
     @Test
     public void bytesToHexWhenTopBitIsUsedReturnsCorrectString() {
-        String actual = ExtendedDeviceStateUtil
-                .bytesToHex(new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef });
+        String actual = DeviceUtil.bytesToHex(new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef });
         assertEquals("DEADBEEF", actual);
     }
 
@@ -45,27 +44,27 @@ public class ExtendedDeviceStateUtilTest extends JavaTest {
     @Test
     public void stringToBytesWhenTopBitIsUsedReturnsSingleByte() {
         byte[] expected = new byte[] { (byte) 0x00, (byte) 0x80, (byte) 0x00 };
-        byte[] actual = ExtendedDeviceStateUtil.stringToBytes("\u0000\u0080\u0000");
+        byte[] actual = DeviceUtil.stringToBytes("\u0000\u0080\u0000");
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void getTemperatureStateWellFormedValueReturnsQuantityType() throws NumberFormatException {
-        assertEquals(new QuantityType<>(42, SIUnits.CELSIUS), ExtendedDeviceStateUtil.getTemperatureState("42"));
+        assertEquals(new QuantityType<>(42, SIUnits.CELSIUS), DeviceUtil.getTemperatureState("42"));
     }
 
     @Test
     public void getTemperatureStateMagicValueReturnsUndefined() throws NumberFormatException {
-        assertEquals(UnDefType.UNDEF, ExtendedDeviceStateUtil.getTemperatureState("32768"));
+        assertEquals(UnDefType.UNDEF, DeviceUtil.getTemperatureState("32768"));
     }
 
     @Test
     public void getTemperatureStateNonNumericValueThrowsNumberFormatException() {
-        assertThrows(NumberFormatException.class, () -> ExtendedDeviceStateUtil.getTemperatureState("A"));
+        assertThrows(NumberFormatException.class, () -> DeviceUtil.getTemperatureState("A"));
     }
 
     @Test
     public void getTemperatureStateNullValueThrowsNumberFormatException() {
-        assertThrows(NumberFormatException.class, () -> ExtendedDeviceStateUtil.getTemperatureState(null));
+        assertThrows(NumberFormatException.class, () -> DeviceUtil.getTemperatureState(null));
     }
 }

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
@@ -67,4 +67,10 @@ public class DeviceUtilTest extends JavaTest {
     public void getTemperatureStateNullValueThrowsNumberFormatException() {
         assertThrows(NumberFormatException.class, () -> DeviceUtil.getTemperatureState(null));
     }
+
+    @Test
+    public void getDeviceClassFromFullyQualifiedStringReturnsCorrectDeviceClass() {
+        assertEquals("WashingMachine", DeviceUtil.getDeviceClassFromFullyQualifiedString(
+                "com.miele.xgw3000.gateway.hdm.deviceclasses.MieleWashingMachine"));
+    }
 }

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/DeviceUtilTest.java
@@ -67,10 +67,4 @@ public class DeviceUtilTest extends JavaTest {
     public void getTemperatureStateNullValueThrowsNumberFormatException() {
         assertThrows(NumberFormatException.class, () -> DeviceUtil.getTemperatureState(null));
     }
-
-    @Test
-    public void getDeviceClassFromFullyQualifiedStringReturnsCorrectDeviceClass() {
-        assertEquals("WashingMachine", DeviceUtil.getDeviceClassFromFullyQualifiedString(
-                "com.miele.xgw3000.gateway.hdm.deviceclasses.MieleWashingMachine"));
-    }
 }

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
@@ -24,7 +24,7 @@ import org.openhab.core.types.UnDefType;
  * This class provides test cases for {@link
  * org.openhab.binding.miele.internal.ExtendedDeviceStateUtil}
  *
- * @author Jacob Laursen - Added power/water consumption channels
+ * @author Jacob Laursen - Initial contribution
  */
 
 public class ExtendedDeviceStateUtilTest extends JavaTest {

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifierTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifierTest.java
@@ -21,7 +21,7 @@ import org.openhab.core.test.java.JavaTest;
  * This class provides test cases for {@link
  * org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier}
  *
- * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ * @author Jacob Laursen - Initial contribution
  */
 public class FullyQualifiedApplianceIdentifierTest extends JavaTest {
 


### PR DESCRIPTION
Fixes #11422

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

### Reliability

#11244 introduced a dependency to the **protocol** property for correctly handling both ZigBee and Wi-Fi appliances. This had two drawbacks:
- The **protocol** property is a technical protocol prefix ("hdm:ZigBee:" or "hdm:LAN:"). #11244 did not change this, but it would make more sense to expose a user-oriented protocol name like "ZigBee" or "Wi-Fi". This is not possible with current technical dependency.
- In rare scenarios properties are not correctly set. This breaks channel updates as correct API calls cannot be made without protocol prefix. I'm not sure exactly when this happens, but it could be timing related if properties are not initialized before receiving state updates.

Similarly a dependency to the **serialNumber** property was introduced for correct handling multicast updates.

To fix both problems, two internal appliance caches are now used for fast lookup of UID from appliance id (i.e. "0123456789#0" -> "hdm:ZigBee:0123456789#0") as well as from remote UID/serial number. After removing this property dependency, the **protocol** property has been renamed to **protocolAdapter** which now contains only the actual protocol adapter name, i.e. **ZigBee** or **LAN**. Additionally, a new property, **connectionType**, has been introduced. For Wi-Fi devices protocolAdapter is **LAN** and connectionType is **WiFi**.

### Performance

Appliance cache has been changed from List to HashMap for faster lookups, and is also being used more actively now for looking up UID's.

### Property cleanup

Properties removed:
- **brandId** always containing value MI.
- **companyId** always containing value MI.

Properties renamed:
- **dc** renamed to **deviceClass**. Now also set for things configured in files, where previously only auto-discovered things had this property set.
- **protocol** renamed to **protocolAdapter** as this is more correct.

Properties added:
- **model** containing the appliance model.
- **connectionType** (not available for ZigBee appliances).

Before:
![image](https://user-images.githubusercontent.com/19519842/138553171-ed64c350-247a-4b56-b891-ca199efd431f.png)

After:
![image](https://user-images.githubusercontent.com/19519842/138553202-6d12a9f3-1c5a-4204-abe7-f5d17455d3d7.png)

### Refactoring

Refer to "gateway" instead of "ZigBee network" in configuration, since both ZigBee and LAN/Wi-Fi appliances are supported by the gateway.

Added constants for remaining handlers with hardcoded device classes.

Changed obscure string operations for skipping this result of the _getDeviceClassObjects_ response:
`"DeviceClass": "com.prosyst.mbs.services.zigbee.hdm.deviceclasses.ReportingControl"`

while processing only this result:
`"DeviceClass": "com.miele.xgw3000.gateway.hdm.deviceclasses.MieleWashingMachine"`
(or other device class name for appliance)

Fixed all warnings:
- Potential null pointer access
- Redundant null check
- Import never used

Fixed some Static Code Analysis issues:
- The package org.apache.commons.lang3.StringUtils should not be used.
- 'static' modifier out of order with the JLS suggestions.
- First javadoc author should have "Initial contribution" contribution description.

### Translation

Added default i18n properties file and partial Danish translation as baseline. Next steps will be adding custom strings for states, programs and phases so these can be provided in desired language. This is not planned within the context of this PR.