### PR TITLE
[linky] Add all default translations to properties file

### DIFF
--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/LinkyHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/LinkyHandler.java
@@ -184,7 +184,7 @@ public class LinkyHandler extends BaseThingHandler {
             });
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Username, password and authId are mandatory");
+                    "@text/offline.config-error-mandatory-settings");
         }
     }
 

--- a/bundles/org.openhab.binding.linky/src/main/resources/OH-INF/i18n/linky.properties
+++ b/bundles/org.openhab.binding.linky/src/main/resources/OH-INF/i18n/linky.properties
@@ -1,0 +1,46 @@
+# binding
+
+binding.linky.name = Linky Binding
+binding.linky.description = Retrieves your energy consumption data from Enedis website
+
+# thing types
+
+thing-type.linky.linky.label = Linky
+thing-type.linky.linky.description = Provides your energy consumption data. In order to receive the data, you must activate your account at https://espace-client-particuliers.enedis.fr/web/espace-particuliers/compteur-linky.
+
+# thing types config
+
+thing-type.config.linky.linky.internalAuthId.label = Auth ID
+thing-type.config.linky.linky.internalAuthId.description = Authentication ID delivered after the captcha (see documentation).
+thing-type.config.linky.linky.password.label = Password
+thing-type.config.linky.linky.password.description = Your Enedis Password
+thing-type.config.linky.linky.username.label = Username
+thing-type.config.linky.linky.username.description = Your Enedis Username
+
+# channel group types
+
+channel-group-type.linky.daily.label = Daily consumption
+channel-group-type.linky.daily.channel.timestamp.label = Peak Timestamp
+channel-group-type.linky.daily.channel.timestamp.description = Maximum power usage timestamp
+channel-group-type.linky.daily.channel.yesterday.label = Yesterday Consumption
+channel-group-type.linky.monthly.label = Monthly consumption
+channel-group-type.linky.monthly.channel.lastMonth.label = Last Month Consumption
+channel-group-type.linky.monthly.channel.thisMonth.label = This Month Consumption
+channel-group-type.linky.weekly.label = Weekly consumption
+channel-group-type.linky.weekly.channel.lastWeek.label = Last Week Consumption
+channel-group-type.linky.weekly.channel.thisWeek.label = This Week Consumption
+channel-group-type.linky.yearly.label = Yearly consumption
+channel-group-type.linky.yearly.channel.lastYear.label = Last Year Consumption
+channel-group-type.linky.yearly.channel.thisYear.label = This Year Consumption
+
+# channel types
+
+channel-type.linky.consumption.label = Total Consumption
+channel-type.linky.consumption.description = Consumption at given time interval
+channel-type.linky.power.label = Yesterday Peak Power
+channel-type.linky.power.description = Maximum power usage yesterday
+channel-type.linky.timestamp.label = Timestamp
+
+# Thing status descriptions
+
+offline.config-error-mandatory-settings = Username, password and authId are mandatory.

--- a/bundles/org.openhab.binding.linky/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.linky/src/main/resources/OH-INF/thing/thing-types.xml
@@ -43,9 +43,7 @@
 			<channel id="yesterday" typeId="consumption">
 				<label>Yesterday Consumption</label>
 			</channel>
-			<channel id="power" typeId="power">
-				<label>Maximum power usage yesterday</label>
-			</channel>
+			<channel id="power" typeId="power"/>
 			<channel id="timestamp" typeId="timestamp">
 				<label>Peak Timestamp</label>
 				<description>Maximum power usage timestamp</description>
@@ -99,7 +97,7 @@
 
 	<channel-type id="power">
 		<item-type>Number:Power</item-type>
-		<label>Peak Power</label>
+		<label>Yesterday Peak Power</label>
 		<description>Maximum power usage yesterday</description>
 		<state readOnly="true" pattern="%.3f %unit%"/>
 	</channel-type>


### PR DESCRIPTION
Allows translating the linky binding strings with Crowdin.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>