### PR TITLE
[homematic] Improve (re)connect handling to Homematic gateways

### DIFF
--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -160,8 +160,8 @@ The port number of the CUxD daemon (default = 8701)
 - **groupPort**
 The port number of the Group daemon (default = 9292)
 
-- **retryConnects**
-Maximum number of retries to connect to the Homematic Gateway and register a callback.
+- **callbackRegistrationRetries**
+Maximum number of retries to register a callback in the Homematic gateway.
 
 - **retryWaitTime**
 Time in seconds between two connection retries (default = 30s)

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -157,6 +157,12 @@ The port number of the HMIP server (default = 2010)
 - **cuxdPort**
 The port number of the CUxD daemon (default = 8701)
 
+- **retryConnects**
+Maximum number of retries to connect to the Homematic Gateway and register a callback.
+
+- **retryWaitTime**
+Time in seconds between two connection retries (default = 30s)
+
 - **installModeDuration**
 Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)
 

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -161,10 +161,10 @@ The port number of the CUxD daemon (default = 8701)
 The port number of the Group daemon (default = 9292)
 
 - **callbackRegistrationRetries**
-Maximum number of retries to register a callback in the Homematic gateway.
+Maximum number of retries to register a callback in the Homematic gateway (default = 20).
 
 - **retryWaitTime**
-Time in seconds between two connection retries (default = 30s)
+Time in seconds between two connection retries (default = 5s)
 
 - **installModeDuration**
 Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -160,11 +160,9 @@ The port number of the CUxD daemon (default = 8701)
 - **groupPort**
 The port number of the Group daemon (default = 9292)
 
-- **callbackRegistrationRetries**
-Maximum number of retries to register a callback in the Homematic gateway (default = 20).
-
-- **retryWaitTime**
-Time in seconds between two connection retries (default = 5s)
+- **callbackRegTimeout**
+Maximum time in seconds for callback registration in the Homematic gateway (default = 120s).
+For a CCU2, the value may need to be increased to 180s.
 
 - **installModeDuration**
 Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -157,6 +157,9 @@ The port number of the HMIP server (default = 2010)
 - **cuxdPort**
 The port number of the CUxD daemon (default = 8701)
 
+- **groupPort**
+The port number of the Group daemon (default = 9292)
+
 - **retryConnects**
 Maximum number of retries to connect to the Homematic Gateway and register a callback.
 

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -685,6 +685,13 @@ Examples: HmIP-BROLL, HmIP-FROLL, HmIP-BBL, HmIP-FBL and HmIP-DRBLI4
 | openHAB | 0%   | 100%   |
 | CCU     | 100% | 0%     |
 
+** The binding does not receive any status changes from the Homematic gateway**
+
+First of all, make sure that none of the ports needed to receive status changes from the gateway are blocked by firewall settings.
+
+If the computer running openHAB has more than one IP address, a wrong one may have been set as receiver for status changes.
+In this case change the setting for `callbackHost` to the correct address.
+
 ### Debugging and Tracing
 
 If you want to see what's going on in the binding, switch the log level to DEBUG in the Karaf console

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/HomematicBindingConstants.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/HomematicBindingConstants.java
@@ -24,6 +24,7 @@ import org.openhab.core.thing.ThingTypeUID;
 public class HomematicBindingConstants {
 
     public static final String BINDING_ID = "homematic";
+    public static final String GATEWAY_POOL_NAME = "homematicGateway";
     public static final ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");
     public static final String CONFIG_DESCRIPTION_URI_CHANNEL = "channel-type:homematic:config";
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -58,7 +58,7 @@ public class HomematicConfig {
     private int bufferSize = 2048;
 
     private HmGatewayInfo gatewayInfo;
-    private int retryConnects;
+    private int callbackRegistrationRetries;
     private int retryWaitTime;
 
     /**
@@ -120,15 +120,15 @@ public class HomematicConfig {
     /**
      * Sets the number of retry connects.
      */
-    public void setRetryConnects(int retryConnectCtr) {
-        this.retryConnects = retryConnectCtr;
+    public void setCallbackRegistrationRetries(int retries) {
+        this.callbackRegistrationRetries = retries;
     }
 
     /**
      * Returns the number of retry connects.
      */
-    public int getRetryConnects() {
-        return retryConnects;
+    public int getCallbackRegistrationRetries() {
+        return callbackRegistrationRetries;
     }
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -58,6 +58,8 @@ public class HomematicConfig {
     private int bufferSize = 2048;
 
     private HmGatewayInfo gatewayInfo;
+    private int retryConnects;
+    private int retryWaitTime;
 
     /**
      * Returns the Homematic gateway address.
@@ -113,6 +115,34 @@ public class HomematicConfig {
      */
     public void setBinCallbackPort(int binCallbackPort) {
         this.binCallbackPort = binCallbackPort;
+    }
+
+    /**
+     * Sets the number of retry connects.
+     */
+    public void setRetryConnects(int retryConnectCtr) {
+        this.retryConnects = retryConnectCtr;
+    }
+
+    /**
+     * Returns the number of retry connects.
+     */
+    public int getRetryConnects() {
+        return retryConnects;
+    }
+
+    /**
+     * Sets the wait time between two retries in seconds.
+     */
+    public void setRetryWaitTime(int retryWaitTime) {
+        this.retryWaitTime = retryWaitTime;
+    }
+
+    /**
+     * Returns the wait time between two retries in seconds.
+     */
+    public int getRetryWaitTime() {
+        return retryWaitTime;
     }
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/common/HomematicConfig.java
@@ -59,7 +59,7 @@ public class HomematicConfig {
 
     private HmGatewayInfo gatewayInfo;
     private int callbackRegistrationRetries;
-    private int retryWaitTime;
+    private int callbackRegTimeout;
 
     /**
      * Returns the Homematic gateway address.
@@ -118,31 +118,17 @@ public class HomematicConfig {
     }
 
     /**
-     * Sets the number of retry connects.
+     * Sets timeout for callback registration.
      */
-    public void setCallbackRegistrationRetries(int retries) {
-        this.callbackRegistrationRetries = retries;
+    public void setCallbackRegTimeout(int timeout) {
+        this.callbackRegTimeout = timeout;
     }
 
     /**
-     * Returns the number of retry connects.
+     * Returns timeout for callback registrations.
      */
-    public int getCallbackRegistrationRetries() {
-        return callbackRegistrationRetries;
-    }
-
-    /**
-     * Sets the wait time between two retries in seconds.
-     */
-    public void setRetryWaitTime(int retryWaitTime) {
-        this.retryWaitTime = retryWaitTime;
-    }
-
-    /**
-     * Returns the wait time between two retries in seconds.
-     */
-    public int getRetryWaitTime() {
-        return retryWaitTime;
+    public int getCallbackRegTimeout() {
+        return callbackRegTimeout;
     }
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -254,7 +254,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
             }
         }
         for (HmInterface hmInterface : availableInterfaces.keySet()) {
-            getRpcClient(hmInterface).init(hmInterface, hmInterface.toString() + "-" + id);
+            getRpcClient(hmInterface).init(hmInterface);
         }
     }
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractHomematicGateway implements RpcEventListener, HomematicGateway, VirtualGateway {
     private final Logger logger = LoggerFactory.getLogger(AbstractHomematicGateway.class);
     public static final double DEFAULT_DISABLE_DELAY = 2.0;
-    private static final long RESTART_DELAY = 30; 
+    private static final long RESTART_DELAY = 30;
     private static final long CONNECTION_TRACKER_INTERVAL_SECONDS = 15;
 
     private final Map<TransferMode, RpcClient<?>> rpcClients = new HashMap<>();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.homematic.internal.communicator;
 
+import static org.openhab.binding.homematic.internal.HomematicBindingConstants.*;
 import static org.openhab.binding.homematic.internal.misc.HomematicConstants.*;
 
 import java.io.IOException;
@@ -87,8 +88,8 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractHomematicGateway implements RpcEventListener, HomematicGateway, VirtualGateway {
     private final Logger logger = LoggerFactory.getLogger(AbstractHomematicGateway.class);
     public static final double DEFAULT_DISABLE_DELAY = 2.0;
+    private static final long RESTART_DELAY = 30; 
     private static final long CONNECTION_TRACKER_INTERVAL_SECONDS = 15;
-    private static final String GATEWAY_POOL_NAME = "homematicGateway";
 
     private final Map<TransferMode, RpcClient<?>> rpcClients = new HashMap<>();
     private final Map<TransferMode, RpcServer> rpcServers = new HashMap<>();
@@ -212,7 +213,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
         stopWatchdogs();
         sendDelayedExecutor.stop();
         receiveDelayedExecutor.stop();
-        stopServers();
+        stopServers(true);
         stopClients();
         devices.clear();
         echoEvents.clear();
@@ -265,17 +266,18 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
     /**
      * Stops the Homematic RPC server.
      */
-    private synchronized void stopServers() {
-        for (HmInterface hmInterface : availableInterfaces.keySet()) {
-            try {
-                getRpcClient(hmInterface).release(hmInterface);
-            } catch (IOException ex) {
-                // recoverable exception, therefore only debug
-                logger.debug("Unable to release the connection to the gateway with id '{}': {}", id, ex.getMessage(),
-                        ex);
+    private synchronized void stopServers(boolean releaseConnection) {
+        if (releaseConnection) {
+            for (HmInterface hmInterface : availableInterfaces.keySet()) {
+                try {
+                    getRpcClient(hmInterface).release(hmInterface);
+                } catch (IOException ex) {
+                    // recoverable exception, therefore only debug
+                    logger.debug("Unable to release the connection to the gateway with id '{}': {}", id,
+                            ex.getMessage(), ex);
+                }
             }
         }
-
         for (TransferMode mode : rpcServers.keySet()) {
             rpcServers.get(mode).shutdown();
         }
@@ -900,10 +902,14 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
      */
     private class ConnectionTrackerThread implements Runnable {
         private boolean connectionLost;
+        private boolean reStartPending = false;
 
         @Override
         public void run() {
             try {
+                if (reStartPending) {
+                    return;
+                }
                 ListBidcosInterfacesParser parser = getRpcClient(getDefaultInterface())
                         .listBidcosInterfaces(getDefaultInterface());
                 Integer dutyCycleRatio = parser.getDutyCycleRatio();
@@ -939,10 +945,19 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
                 logger.warn("Connection lost on gateway '{}', cause: \"{}\"", id, cause);
                 gatewayAdapter.onConnectionLost();
             }
-            stopServers();
+            stopServers(false);
             stopClients();
-            startClients();
-            startServers();
+            reStartPending = true;
+            logger.debug("Waiting {}s until restart attempt", RESTART_DELAY);
+            scheduler.schedule(() -> {
+                try {
+                    startClients();
+                    startServers();
+                } catch (IOException e) {
+                    logger.debug("Restart failed: {}", e.getMessage());
+                }
+                reStartPending = false;
+            }, RESTART_DELAY, TimeUnit.SECONDS);
         }
     }
 }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -189,6 +189,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
         logger.debug("Used Homematic transfer modes: {}", sb.toString());
         startClients();
         startServers();
+        registerCallbacks();
 
         if (!config.getGatewayInfo().isHomegear()) {
             // delay the newDevice event handling at startup, reduces some API calls
@@ -253,6 +254,9 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
                 rpcServer.start();
             }
         }
+    }
+
+    private void registerCallbacks() throws IOException {
         for (HmInterface hmInterface : availableInterfaces.keySet()) {
             getRpcClient(hmInterface).init(hmInterface);
         }
@@ -920,6 +924,11 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
             if (connectionLost) {
                 connectionLost = false;
                 logger.info("Connection resumed on gateway '{}'", id);
+                try {
+                    registerCallbacks();
+                } catch (IOException e) {
+                    logger.warn("Connection only partially restored. It is recommended to restart the binding");
+                }
                 gatewayAdapter.onConnectionResumed();
             }
         }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
@@ -40,6 +40,7 @@ public class BinRpcClient extends RpcClient<byte[]> {
 
     @Override
     public void dispose() {
+        super.dispose();
         socketHandler.flush();
     }
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/BinRpcClient.java
@@ -54,8 +54,8 @@ public class BinRpcClient extends RpcClient<byte[]> {
     }
 
     @Override
-    public void init(HmInterface hmInterface, String clientId) throws IOException {
-        super.init(hmInterface, clientId);
+    public void init(HmInterface hmInterface) throws IOException {
+        super.init(hmInterface);
         socketHandler.removeSocket(config.getRpcPort(hmInterface));
     }
 

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -74,11 +74,6 @@ public abstract class RpcClient<T> {
     }
 
     /**
-     * Disposes the client.
-     */
-    public abstract void dispose();
-
-    /**
      * Returns a RpcRequest for this client.
      */
     protected abstract RpcRequest<T> createRpcRequest(String methodName);
@@ -128,7 +123,16 @@ public abstract class RpcClient<T> {
                 logger.error("Callback registration for interface {} timed out", hmInterface.getName());
                 throw new IOException("Unable to reconnect in time");
             }
+            future = null;
         }
+    }
+
+    /**
+     * Disposes the client.
+     */
+    public void dispose() {
+        if (future != null)
+            future.cancel(true);
     }
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.openhab.binding.homematic.internal.HomematicBindingConstants;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
@@ -55,6 +56,7 @@ public abstract class RpcClient<T> {
     protected static final int RESP_BUFFER_SIZE = 8192;
 
     protected HomematicConfig config;
+    private String thisUID = UUID.randomUUID().toString();
 
     public RpcClient(HomematicConfig config) {
         this.config = config;
@@ -83,10 +85,10 @@ public abstract class RpcClient<T> {
     /**
      * Register a callback for the specified interface where the Homematic gateway can send its events.
      */
-    public void init(HmInterface hmInterface, String clientId) throws IOException {
+    public void init(HmInterface hmInterface) throws IOException {
         RpcRequest<T> request = createRpcRequest("init");
         request.addArg(getRpcCallbackUrl());
-        request.addArg(clientId);
+        request.addArg(thisUID);
         if (config.getGatewayInfo().isHomegear()) {
             request.addArg(Integer.valueOf(0x22));
         }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -20,6 +20,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.openhab.binding.homematic.internal.HomematicBindingConstants;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
@@ -42,6 +48,7 @@ import org.openhab.binding.homematic.internal.model.HmGatewayInfo;
 import org.openhab.binding.homematic.internal.model.HmInterface;
 import org.openhab.binding.homematic.internal.model.HmParamsetType;
 import org.openhab.binding.homematic.internal.model.HmRssiInfo;
+import org.openhab.core.common.ThreadPoolManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +61,13 @@ public abstract class RpcClient<T> {
     private final Logger logger = LoggerFactory.getLogger(RpcClient.class);
     protected static final int MAX_RPC_RETRY = 3;
     protected static final int RESP_BUFFER_SIZE = 8192;
+    private static final int INITIAL_CALLBACK_REG_DELAY = 20; // 20 s before first attempt
+    private static final int CALLBACK_REG_DELAY = 10; // 10 s between two attempts
 
     protected HomematicConfig config;
     private String thisUID = UUID.randomUUID().toString();
+    private ScheduledFuture<?> future = null;
+    private int attempt;
 
     public RpcClient(HomematicConfig config) {
         this.config = config;
@@ -86,32 +97,36 @@ public abstract class RpcClient<T> {
      * Register a callback for the specified interface where the Homematic gateway can send its events.
      */
     public void init(HmInterface hmInterface) throws IOException {
+        ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(GATEWAY_POOL_NAME);
         RpcRequest<T> request = createRpcRequest("init");
         request.addArg(getRpcCallbackUrl());
         request.addArg(thisUID);
         if (config.getGatewayInfo().isHomegear()) {
             request.addArg(Integer.valueOf(0x22));
         }
-        int maxRetryAttempts = config.getCallbackRegistrationRetries();
-        int waitTime = config.getRetryWaitTime() * 1000;
-        for (int attempt = 1; attempt <= maxRetryAttempts; attempt++) {
-            try {
-                logger.debug("Register callback for interface {}, attempt {}/{}", hmInterface.getName(), attempt,
-                        maxRetryAttempts);
-                sendMessage(config.getRpcPort(hmInterface), request);
-                break;
-            } catch (IOException e) {
-                if (attempt == maxRetryAttempts) {
-                    logger.warn(
-                            "All attempts to register a callback for interface '{}' failed, last exception message: {}",
-                            hmInterface.getName(), e.getMessage());
-                    throw (e);
-                }
+        logger.debug("Register callback for interface {}", hmInterface.getName());
+        try {
+            attempt = 1;
+            sendMessage(config.getRpcPort(hmInterface), request); // first attempt without delay
+        } catch (IOException e) {
+            future = scheduler.scheduleWithFixedDelay(() -> {
+                logger.debug("Register callback for interface {}, attempt {}", hmInterface.getName(), ++attempt);
                 try {
-                    Thread.sleep(waitTime);
-                } catch (InterruptedException e1) {
-                    // ignore
+                    sendMessage(config.getRpcPort(hmInterface), request);
+                    future.cancel(true);
+                } catch (IOException ex) {
+                    // Ignore, retry
                 }
+            }, INITIAL_CALLBACK_REG_DELAY, CALLBACK_REG_DELAY, TimeUnit.SECONDS);
+            try {
+                future.get(config.getCallbackRegTimeout(), TimeUnit.SECONDS);
+            } catch (CancellationException e1) {
+                logger.debug("Callback for interface {} successfully registered", hmInterface.getName());
+            } catch (InterruptedException | ExecutionException e1) {
+                throw new IOException("Callback reg. thread interrupted", e1);
+            } catch (TimeoutException e1) {
+                logger.error("Callback registration for interface {} timed out", hmInterface.getName());
+                throw new IOException("Unable to reconnect in time");
             }
         }
     }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -92,7 +92,7 @@ public abstract class RpcClient<T> {
         if (config.getGatewayInfo().isHomegear()) {
             request.addArg(Integer.valueOf(0x22));
         }
-        int maxRetryAttempts = config.getRetryConnects();
+        int maxRetryAttempts = config.getCallbackRegistrationRetries();
         int waitTime = config.getRetryWaitTime() * 1000;
         for (int attempt = 1; attempt <= maxRetryAttempts; attempt++) {
             try {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -87,10 +87,13 @@ public class XmlRpcClient extends RpcClient<String> {
                 throw new IOException(ex);
             } catch (IOException ex) {
                 reason = ex;
-                if ("init".equals(request.getMethodName())) { // no retries for "init" request
+                // no retries for "init" request or if connection is refused
+                if ("init".equals(request.getMethodName())
+                        || ex.getCause() != null && ex.getCause() instanceof ExecutionException) {
                     break;
                 }
-                logger.debug("XmlRpcMessage failed({}), sending message again {}/{}", ex.getMessage(), rpcRetryCounter, MAX_RPC_RETRY);
+                logger.debug("XmlRpcMessage failed({}), sending message again {}/{}", ex.getMessage(), rpcRetryCounter,
+                        MAX_RPC_RETRY);
             }
         }
         throw reason;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -90,7 +90,7 @@ public class XmlRpcClient extends RpcClient<String> {
                 if ("init".equals(request.getMethodName())) { // no retries for "init" request
                     break;
                 }
-                logger.debug("XmlRpcMessage failed, sending message again {}/{}", rpcRetryCounter, MAX_RPC_RETRY);
+                logger.debug("XmlRpcMessage failed({}), sending message again {}/{}", ex.getMessage(), rpcRetryCounter, MAX_RPC_RETRY);
             }
         }
         throw reason;

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -50,10 +50,6 @@ public class XmlRpcClient extends RpcClient<String> {
     }
 
     @Override
-    public void dispose() {
-    }
-
-    @Override
     public RpcRequest<String> createRpcRequest(String methodName) {
         return new XmlRpcRequest(methodName);
     }

--- a/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
@@ -95,6 +95,18 @@
 				<advanced>true</advanced>
 				<default>9292</default>
 			</parameter>
+			<parameter name="retryConnects" type="integer" min="1">
+				<label>Number of Connection Retries </label>
+				<description>Maximum number of retries to connect to the Homematic Gateway and register a callback.</description>
+				<advanced>true</advanced>
+				<default>20</default>
+			</parameter>
+			<parameter name="retryWaitTime" type="integer" min="1" unit="s">
+				<label>Retry Wait Time</label>
+				<description>Time in seconds between two connection retries.</description>
+				<advanced>true</advanced>
+				<default>3</default>
+			</parameter>
 			<parameter name="installModeDuration" type="integer" min="10" max="300" unit="s">
 				<label>Install Mode Duration</label>
 				<description>Time in seconds that the controller will be in install mode when a device discovery is initiated</description>

--- a/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
@@ -95,17 +95,17 @@
 				<advanced>true</advanced>
 				<default>9292</default>
 			</parameter>
-			<parameter name="retryConnects" type="integer" min="1">
-				<label>Number of Connection Retries </label>
-				<description>Maximum number of retries to connect to the Homematic Gateway and register a callback.</description>
+			<parameter name="callbackRegistrationRetries" type="integer" min="1">
+				<label>Number of Callback Registration Retries </label>
+				<description>Maximum number of retries to connect to register a callback in the Homematic gateway.</description>
 				<advanced>true</advanced>
 				<default>20</default>
 			</parameter>
 			<parameter name="retryWaitTime" type="integer" min="1" unit="s">
 				<label>Retry Wait Time</label>
-				<description>Time in seconds between two connection retries.</description>
+				<description>Time in seconds between two callback registration retries.</description>
 				<advanced>true</advanced>
-				<default>3</default>
+				<default>5</default>
 			</parameter>
 			<parameter name="installModeDuration" type="integer" min="10" max="300" unit="s">
 				<label>Install Mode Duration</label>

--- a/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
@@ -95,17 +95,11 @@
 				<advanced>true</advanced>
 				<default>9292</default>
 			</parameter>
-			<parameter name="callbackRegistrationRetries" type="integer" min="1">
-				<label>Callback Reg. Retries</label>
-				<description>Maximum number of retries to connect to register a callback in the Homematic gateway.</description>
+			<parameter name="callbackRegTimeout" type="integer" min="30">
+				<label>Callback Reg. Timeout</label>
+				<description>Maximum time in seconds for callback registration in the Homematic gateway.</description>
 				<advanced>true</advanced>
-				<default>20</default>
-			</parameter>
-			<parameter name="retryWaitTime" type="integer" min="1" unit="s">
-				<label>Retry Wait Time</label>
-				<description>Time in seconds between two callback registration retries.</description>
-				<advanced>true</advanced>
-				<default>5</default>
+				<default>120</default>
 			</parameter>
 			<parameter name="installModeDuration" type="integer" min="10" max="300" unit="s">
 				<label>Install Mode Duration</label>

--- a/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
@@ -96,7 +96,7 @@
 				<default>9292</default>
 			</parameter>
 			<parameter name="callbackRegistrationRetries" type="integer" min="1">
-				<label>Number of Callback Registration Retries </label>
+				<label>Callback Reg. Retries</label>
 				<description>Maximum number of retries to connect to register a callback in the Homematic gateway.</description>
 				<advanced>true</advanced>
 				<default>20</default>


### PR DESCRIPTION
The PR improves the connect and especially the re-connect handling to Homematic gateways through the following measures:

1. by using a global unique id for each bridge installation it is possible to use two or more OH installation with the same Homematic gateway in parallel.
2. the HmIP daemon normally need much longer than the HM daemon until it accepts event registration. Therefore a configurable retry mechanismn has been implemented.

Signed-off-by: Martin Herbst <develop@mherbst.de>
