### PR TITLE
[powermax] Add default translations to properties file

### DIFF
--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
@@ -133,13 +133,12 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
 
         String threadName = "OH-binding-" + getThing().getUID().getAsString();
 
-        String errorMsg = null;
+        String errorMsg = String.format("@text/offline.config-error-unexpected-thing-type [ \"%s\" ]",
+                getThing().getThingTypeUID().getAsString());
         if (getThing().getThingTypeUID().equals(BRIDGE_TYPE_SERIAL)) {
             errorMsg = initializeBridgeSerial(getConfigAs(PowermaxSerialConfiguration.class), threadName);
         } else if (getThing().getThingTypeUID().equals(BRIDGE_TYPE_IP)) {
             errorMsg = initializeBridgeIp(getConfigAs(PowermaxIpConfiguration.class), threadName);
-        } else {
-            errorMsg = "Unexpected thing type " + getThing().getThingTypeUID();
         }
 
         if (errorMsg == null) {
@@ -188,9 +187,9 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
                     serialPortManager, threadName, timeZoneProvider);
         } else {
             if (serialPort.startsWith("rfc2217")) {
-                errorMsg = "Please use the IP Connection thing type for a serial over IP connection.";
+                errorMsg = "@text/offline.config-error-invalid-thing-type";
             } else {
-                errorMsg = "serialPort setting must be defined in thing configuration";
+                errorMsg = "@text/offline.config-error-mandatory-serial-port";
             }
         }
         return errorMsg;
@@ -216,7 +215,7 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
             commManager = new PowermaxCommManager(ip, config.tcpPort, panelType, forceStandardMode, config.autoSyncTime,
                     threadName, timeZoneProvider);
         } else {
-            errorMsg = "ip and port settings must be defined in thing configuration";
+            errorMsg = "@text/offline.config-error-mandatory-ip-port";
         }
         return errorMsg;
     }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxThingHandler.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxThingHandler.java
@@ -83,23 +83,24 @@ public class PowermaxThingHandler extends BaseThingHandler implements PowermaxPa
         if (bridgeHandler != null && bridgeStatus != null) {
             if (bridgeStatus == ThingStatus.ONLINE) {
                 boolean validConfig = false;
-                String errorMsg = "Unexpected thing type " + getThing().getThingTypeUID();
+                String errorMsg = String.format("@text/offline.config-error-unexpected-thing-type [ \"%s\" ]",
+                        getThing().getThingTypeUID().getAsString());
 
                 if (getThing().getThingTypeUID().equals(THING_TYPE_ZONE)) {
                     PowermaxZoneConfiguration config = getConfigAs(PowermaxZoneConfiguration.class);
                     if (config.zoneNumber >= ZONE_NR_MIN && config.zoneNumber <= ZONE_NR_MAX) {
                         validConfig = true;
                     } else {
-                        errorMsg = "zoneNumber setting must be defined in thing configuration and set between "
-                                + ZONE_NR_MIN + " and " + ZONE_NR_MAX;
+                        errorMsg = String.format("@text/offline.config-error-invalid-zone-number [ \"%d\", \"%d\" ]",
+                                ZONE_NR_MIN, ZONE_NR_MAX);
                     }
                 } else if (getThing().getThingTypeUID().equals(THING_TYPE_X10)) {
                     PowermaxX10Configuration config = getConfigAs(PowermaxX10Configuration.class);
                     if (config.deviceNumber >= X10_NR_MIN && config.deviceNumber <= X10_NR_MAX) {
                         validConfig = true;
                     } else {
-                        errorMsg = "deviceNumber setting must be defined in thing configuration and set between "
-                                + X10_NR_MIN + " and " + X10_NR_MAX;
+                        errorMsg = String.format("@text/offline.config-error-invalid-device-number [ \"%d\", \"%d\" ]",
+                                X10_NR_MIN, X10_NR_MAX);
                     }
                 }
 
@@ -226,7 +227,7 @@ public class PowermaxThingHandler extends BaseThingHandler implements PowermaxPa
                 }
             } else if (deviceSettings == null || !deviceSettings.isEnabled()) {
                 if (getThing().getStatus() != ThingStatus.OFFLINE) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Disabled device");
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.disabled-device");
                     logger.debug("Set handler status to OFFLINE for thing {} (X10 device {} disabled)",
                             getThing().getUID(), config.deviceNumber);
                 }
@@ -256,7 +257,7 @@ public class PowermaxThingHandler extends BaseThingHandler implements PowermaxPa
                     }
                 } else if (zoneSettings == null) {
                     if (getThing().getStatus() != ThingStatus.OFFLINE) {
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Zone not paired");
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.zone-not-paired");
                         logger.debug("Set handler status to OFFLINE for thing {} (zone number {} not paired)",
                                 getThing().getUID(), config.zoneNumber);
                     }

--- a/bundles/org.openhab.binding.powermax/src/main/resources/OH-INF/i18n/powermax.properties
+++ b/bundles/org.openhab.binding.powermax/src/main/resources/OH-INF/i18n/powermax.properties
@@ -1,0 +1,129 @@
+# binding
+
+binding.powermax.name = Powermax Binding
+binding.powermax.description = The Powermax binding interfaces with Visonic PowerMax and PowerMaster alarm panel series.
+
+# thing types
+
+thing-type.powermax.ip.label = IP Connection
+thing-type.powermax.ip.description = This bridge represents the IP connection to the alarm system.
+thing-type.powermax.serial.label = Serial Connection
+thing-type.powermax.serial.description = This bridge represents the serial connection to the alarm system.
+thing-type.powermax.x10.label = X10 Device
+thing-type.powermax.x10.description = This thing represents a physical X10 device.
+thing-type.powermax.zone.label = Alarm Zone
+thing-type.powermax.zone.description = This thing represents a physical device such as a door, window or a motion sensor.
+
+# thing types config
+
+thing-type.config.powermax.ip.ip.label = IP Address
+thing-type.config.powermax.ip.ip.description = The IP address to use for connecting to the Ethernet interface of the alarm system.
+thing-type.config.powermax.ip.tcpPort.label = TCP Port
+thing-type.config.powermax.ip.tcpPort.description = The TCP port to use for connecting to the Ethernet interface of the alarm system.
+thing-type.config.powermax.serial.serialPort.label = Serial Port
+thing-type.config.powermax.serial.serialPort.description = The serial port to use for connecting to the serial interface of the alarm system e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.
+thing-type.config.powermax.x10.deviceNumber.label = Device Number
+thing-type.config.powermax.x10.deviceNumber.description = The device number.
+thing-type.config.powermax.zone.zoneNumber.label = Zone Number
+thing-type.config.powermax.zone.zoneNumber.description = The zone number.
+
+config.allowArming.label = Allow Arming
+config.allowArming.description = Enable or disable arming the alarm system from openHAB.
+config.allowDisarming.label = Allow Disarming
+config.allowDisarming.description = Enable or disable disarming the alarm system from openHAB.
+config.autoSyncTime.label = Sync Time
+config.autoSyncTime.description = Automatic sync time at openHAB startup.
+config.forceStandardMode.label = Force Standard Mode
+config.forceStandardMode.description = Force the standard mode rather than trying using the Powerlink mode.
+config.motionOffDelay.label = Motion Reset Delay
+config.motionOffDelay.description = The delay in minutes to reset a motion detection.
+config.panelType.label = Panel Type
+config.panelType.description = Define the panel type. Only required when forcing the standard mode.
+config.pinCode.label = PIN Code
+config.pinCode.description = The PIN code to use for arming/disarming the alarm system from openHAB. Not required except when Powerlink mode cannot be used.
+
+# channel types
+
+channel-type.powermax.active_alerts.label = Active Alarms and Alerts
+channel-type.powermax.active_alerts.description = List of active alarms and alerts
+channel-type.powermax.alarm_active.label = Alarm Active
+channel-type.powermax.alarm_active.description = Whether or not an alarm is active
+channel-type.powermax.alarmed.label = Zone Alarmed
+channel-type.powermax.alarmed.description = Whether or not the zone has an active alarm condition, or has had an active alarm since the memory was last cleared
+channel-type.powermax.alert_in_memory.label = Alert in Memory
+channel-type.powermax.alert_in_memory.description = Whether or not an alert is saved in system memory
+channel-type.powermax.arm_mode.label = System Arm Mode
+channel-type.powermax.arm_mode.state.option.Disarmed = Disarmed
+channel-type.powermax.arm_mode.state.option.Stay = Armed Home
+channel-type.powermax.arm_mode.state.option.Armed = Armed Away
+channel-type.powermax.arm_mode.state.option.StayInstant = Armed Home Instant
+channel-type.powermax.arm_mode.state.option.ArmedInstant = Armed Away Instant
+channel-type.powermax.arm_mode.state.option.Night = Armed Night
+channel-type.powermax.arm_mode.state.option.NightInstant = Armed Night Instant
+channel-type.powermax.arm_mode.state.option.EntryDelay = Entry Delay
+channel-type.powermax.arm_mode.state.option.ExitDelay = Exit Delay
+channel-type.powermax.arm_mode.state.option.NotReady = Not Ready
+channel-type.powermax.arm_mode.state.option.Ready = Ready
+channel-type.powermax.arm_mode.state.option.UserTest = User Test
+channel-type.powermax.arm_mode.state.option.Force = Bypass
+channel-type.powermax.armed.label = Zone Armed (Switch)
+channel-type.powermax.armed.description = Whether or not the zone is armed
+channel-type.powermax.bypassed.label = Zone Bypassed
+channel-type.powermax.bypassed.description = Whether or not the zone is bypassed
+channel-type.powermax.download_setup.label = Download Setup
+channel-type.powermax.download_setup.description = Switch command to download the setup
+channel-type.powermax.event_log.label = Event Log Entry
+channel-type.powermax.inactive.label = Zone Inactive
+channel-type.powermax.inactive.description = Whether or not the zone's sensor is inactive (loss of supervision)
+channel-type.powermax.last_message_time.label = Last Message Time
+channel-type.powermax.last_message_time.description = Timestamp when the most recent message of any kind was received from the panel
+channel-type.powermax.last_trip.label = Zone Last Trip
+channel-type.powermax.last_trip.description = Timestamp when the zone was last tripped
+channel-type.powermax.locked.label = Zone Armed (Contact)
+channel-type.powermax.locked.description = Whether or not the zone is armed (CLOSED when armed)
+channel-type.powermax.mode.label = System Mode
+channel-type.powermax.mode.description = Current mode can be Standard, Powerlink or Download
+channel-type.powermax.mode.state.option.Download = Download
+channel-type.powermax.mode.state.option.Powerlink = Powerlink
+channel-type.powermax.mode.state.option.Standard = Standard
+channel-type.powermax.pgm_status.label = PGM Status
+channel-type.powermax.ready.label = System Ready
+channel-type.powermax.ready.description = Whether or not the system is ready for arming
+channel-type.powermax.ringing.label = Ringing
+channel-type.powermax.ringing.description = Whether or not the alarm siren is currently ringing
+channel-type.powermax.system_armed.label = System Armed
+channel-type.powermax.system_armed.description = Whether or not the system is armed
+channel-type.powermax.system_status.label = System Status
+channel-type.powermax.system_status.description = A short status summary of the system
+channel-type.powermax.tamper_alarm.label = Zone Tamper Alarm
+channel-type.powermax.tamper_alarm.description = Whether or not the zone's sensor has an active tamper condition, or has had an active tamper condition since the memory was last cleared
+channel-type.powermax.tampered.label = Zone Tampered
+channel-type.powermax.tampered.description = Whether or not the zone's sensor is reporting a tamper condition
+channel-type.powermax.tripped.label = Zone Tripped
+channel-type.powermax.tripped.description = Whether or not the zone is tripped
+channel-type.powermax.trouble.label = Trouble Detected
+channel-type.powermax.trouble.description = Whether or not a trouble is detected
+channel-type.powermax.update_event_logs.label = Update Event Logs
+channel-type.powermax.update_event_logs.description = Switch command to update the event logs
+channel-type.powermax.with_zones_bypassed.label = With Zones Bypassed
+channel-type.powermax.with_zones_bypassed.description = Whether or not at least one zone is bypassed
+channel-type.powermax.x10_status.label = X10 Device Status
+channel-type.powermax.x10_status.state.option.ON = On
+channel-type.powermax.x10_status.state.option.OFF = Off
+channel-type.powermax.x10_status.state.option.DIM = Dim
+channel-type.powermax.x10_status.state.option.BRIGHT = Bright
+channel-type.powermax.zone_last_message.label = Zone Last Status Message
+channel-type.powermax.zone_last_message.description = The most recent status message reported by the zone
+channel-type.powermax.zone_last_message_time.label = Zone Last Status Time
+channel-type.powermax.zone_last_message_time.description = Timestamp when Zone Last Status Message was received
+
+# Thing status descriptions
+
+offline.config-error-mandatory-ip-port = ip and port settings must be defined in the thing configuration.
+offline.config-error-mandatory-serial-port = serialPort setting must be defined in the thing configuration.
+offline.config-error-invalid-thing-type = Please use the IP Connection thing type for a serial over IP connection.
+offline.config-error-unexpected-thing-type = Unexpected thing type {0}.
+offline.config-error-invalid-zone-number = zoneNumber setting must be defined in thing configuration and set between {0} and {1}.
+offline.config-error-invalid-device-number = deviceNumber setting must be defined in thing configuration and set between {0} and {1}.
+offline.disabled-device = Disabled device.
+offline.zone-not-paired = Zone not paired.

--- a/bundles/org.openhab.binding.powermax/src/main/resources/OH-INF/thing/ip.xml
+++ b/bundles/org.openhab.binding.powermax/src/main/resources/OH-INF/thing/ip.xml
@@ -51,36 +51,35 @@
 				<description>The TCP port to use for connecting to the Ethernet interface of the alarm system.</description>
 			</parameter>
 			<parameter name="motionOffDelay" type="integer" min="1" unit="min" required="false">
-				<label>Motion Reset Delay</label>
-				<description>The delay in minutes to reset a motion detection.</description>
+				<label>@text/config.motionOffDelay.label</label>
+				<description>@text/config.motionOffDelay.description</description>
 				<default>3</default>
 			</parameter>
 			<parameter name="allowArming" type="boolean" required="false">
-				<label>Allow Arming</label>
-				<description>Enable or disable arming the alarm system from openHAB.</description>
+				<label>@text/config.allowArming.label</label>
+				<description>@text/config.allowArming.description</description>
 				<default>false</default>
 			</parameter>
 			<parameter name="allowDisarming" type="boolean" required="false">
-				<label>Allow Disarming</label>
-				<description>Enable or disable disarming the alarm system from openHAB.</description>
+				<label>@text/config.allowDisarming.label</label>
+				<description>@text/config.allowDisarming.description</description>
 				<default>false</default>
 			</parameter>
 			<parameter name="pinCode" type="text" required="false">
 				<context>password</context>
-				<label>PIN Code</label>
-				<description>The PIN code to use for arming/disarming the alarm system from openHAB. Not required except when
-					Powerlink mode cannot be used.</description>
+				<label>@text/config.pinCode.label</label>
+				<description>@text/config.pinCode.description</description>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="forceStandardMode" type="boolean" required="false">
-				<label>Force Standard Mode</label>
-				<description>Force the standard mode rather than trying using the Powerlink mode.</description>
+				<label>@text/config.forceStandardMode.label</label>
+				<description>@text/config.forceStandardMode.description</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="panelType" type="text" required="false">
-				<label>Panel Type</label>
-				<description>Define the panel type. Only required when forcing the standard mode.</description>
+				<label>@text/config.panelType.label</label>
+				<description>@text/config.panelType.description</description>
 				<limitToOptions>true</limitToOptions>
 				<options>
 					<option value="PowerMax">PowerMax</option>
@@ -97,8 +96,8 @@
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="autoSyncTime" type="boolean" required="false">
-				<label>Sync Time</label>
-				<description>Automatic sync time at openHAB startup.</description>
+				<label>@text/config.autoSyncTime.label</label>
+				<description>@text/config.autoSyncTime.description</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>

--- a/bundles/org.openhab.binding.powermax/src/main/resources/OH-INF/thing/serial.xml
+++ b/bundles/org.openhab.binding.powermax/src/main/resources/OH-INF/thing/serial.xml
@@ -49,36 +49,35 @@
 					and /dev/ttyS0 or /dev/ttyUSB0 for Linux.</description>
 			</parameter>
 			<parameter name="motionOffDelay" type="integer" min="1" unit="min" required="false">
-				<label>Motion Reset Delay</label>
-				<description>The delay in minutes to reset a motion detection.</description>
+				<label>@text/config.motionOffDelay.label</label>
+				<description>@text/config.motionOffDelay.description</description>
 				<default>3</default>
 			</parameter>
 			<parameter name="allowArming" type="boolean" required="false">
-				<label>Allow Arming</label>
-				<description>Enable or disable arming the alarm system from openHAB.</description>
+				<label>@text/config.allowArming.label</label>
+				<description>@text/config.allowArming.description</description>
 				<default>false</default>
 			</parameter>
 			<parameter name="allowDisarming" type="boolean" required="false">
-				<label>Allow Disarming</label>
-				<description>Enable or disable disarming the alarm system from openHAB.</description>
+				<label>@text/config.allowDisarming.label</label>
+				<description>@text/config.allowDisarming.description</description>
 				<default>false</default>
 			</parameter>
 			<parameter name="pinCode" type="text" required="false">
 				<context>password</context>
-				<label>PIN Code</label>
-				<description>The PIN code to use for arming/disarming the alarm system from openHAB. Not required except when
-					Powerlink mode cannot be used.</description>
+				<label>@text/config.pinCode.label</label>
+				<description>@text/config.pinCode.description</description>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="forceStandardMode" type="boolean" required="false">
-				<label>Force Standard Mode</label>
-				<description>Force the standard mode rather than trying using the Powerlink mode.</description>
+				<label>@text/config.forceStandardMode.label</label>
+				<description>@text/config.forceStandardMode.description</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="panelType" type="text" required="false">
-				<label>Panel Type</label>
-				<description>Define the panel type. Only required when forcing the standard mode.</description>
+				<label>@text/config.panelType.label</label>
+				<description>@text/config.panelType.description</description>
 				<limitToOptions>true</limitToOptions>
 				<options>
 					<option value="PowerMax">PowerMax</option>
@@ -95,8 +94,8 @@
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="autoSyncTime" type="boolean" required="false">
-				<label>Sync Time</label>
-				<description>Automatic sync time at openHAB startup.</description>
+				<label>@text/config.autoSyncTime.label</label>
+				<description>@text/config.autoSyncTime.description</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>


### PR DESCRIPTION
Allows translating the powermax binding strings with Crowdin.

This is not a 100% internationalization of the binding, rather 95%.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>