### PR TITLE
[gce] Add all default translations to properties file

### DIFF
--- a/bundles/org.openhab.binding.gce/src/main/resources/OH-INF/i18n/gce.properties
+++ b/bundles/org.openhab.binding.gce/src/main/resources/OH-INF/i18n/gce.properties
@@ -1,0 +1,53 @@
+# binding
+
+binding.gce.name = GCE Electronics Binding
+binding.gce.description = Provides access to IPX800 PLC build by GCE.
+
+# thing types
+
+thing-type.gce.ipx800v3.label = IPX800v3
+thing-type.gce.ipx800v3.description = The GCE IPX800v3 device
+
+# thing types config
+
+thing-type.config.gce.ipx800v3Config.hostname.label = Network Address
+thing-type.config.gce.ipx800v3Config.hostname.description = Network/IP address of the IPX800 without http(s) prefix.
+thing-type.config.gce.ipx800v3Config.portNumber.label = Port Number
+thing-type.config.gce.ipx800v3Config.portNumber.description = TCP client connection port.
+thing-type.config.gce.ipx800v3Config.pullInterval.label = Pull Interval
+thing-type.config.gce.ipx800v3Config.pullInterval.description = Delay for pulling Analog and Counters info (in milliseconds).
+
+# channel group types
+
+channel-group-type.gce.analogs.label = Analog Inputs
+channel-group-type.gce.contacts.label = Digital Inputs
+channel-group-type.gce.counters.label = Counters
+channel-group-type.gce.relays.label = Digital Outputs
+
+# channel types
+
+channel-type.gce.analog.label = Analog Input
+channel-type.gce.analogAdvanced.label = Analog Input
+channel-type.gce.contact-trigger.label = Push Button Trigger Channel
+channel-type.gce.contact-triggerAdvanced.label = Push Button Trigger Channel
+channel-type.gce.contact.label = Digital Input
+channel-type.gce.contactAdvanced.label = Digital Input
+channel-type.gce.counter.label = Counter
+channel-type.gce.duration.label = Previous State Duration
+channel-type.gce.duration.description = Duration of previous state before state change.
+channel-type.gce.relay.label = Digital Output
+channel-type.gce.relayAdvanced.label = Digital Output
+channel-type.gce.voltage.label = Voltage
+channel-type.gce.voltage.description = Voltage
+
+# channel types config
+
+channel-type.config.gce.analogConfig.hysteresis.label = Hysteresis
+channel-type.config.gce.contactConfig.debouncePeriod.label = Debounce Time
+channel-type.config.gce.contactConfig.longPressTime.label = Long Press Time
+channel-type.config.gce.contactConfig.longPressTime.description = Long press time in milliseconds.
+channel-type.config.gce.contactConfig.pulsePeriod.label = Pulse Period
+channel-type.config.gce.contactConfig.pulsePeriod.description = Pulse period in milliseconds.
+channel-type.config.gce.contactConfig.pulseTimeout.label = Pulse Timeout
+channel-type.config.gce.contactConfig.pulseTimeout.description = Maximum period for sending pulses in milliseconds.
+channel-type.config.gce.relayConfig.pulse.label = Pulse Output


### PR DESCRIPTION
Allows translating the gce binding strings with Crowdin.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>