### PR TITLE
[digitalstrom] Fix: Remove excessive log statements for unknown Application Groups

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
@@ -278,9 +278,7 @@ public class DeviceImpl extends AbstractGeneralDeviceInformations implements Dev
      */
     private boolean addGroupToList(Short groupID) {
         ApplicationGroup group = ApplicationGroup.getGroup(groupID);
-        if (ApplicationGroup.UNDEFINED.equals(group)) {
-            logger.warn("Unknown application group with ID '{}' found! Ignoring group", groupID);
-        } else {
+        if (!ApplicationGroup.UNDEFINED.equals(group)) {
             if (!this.groupList.contains(group)) {
                 this.groupList.add(group);
             }


### PR DESCRIPTION
Fixes #10939, excessive log statements. The occurence of the unknown Application Groups is still unclear and a first try to squelch the logging messages failed.
The WARN log statement has been removed competely as there is no means of correcting the digitalSTROM configuration on the DSS or in the binding.

Signed-off-by: Rouven Schürch <r.schuerch@gmx.ch>

