### PR TITLE
[digitalstrom] Fix: NoSuchElementException when no functional groups set

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/DeviceHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/DeviceHandler.java
@@ -32,6 +32,7 @@ import org.openhab.binding.digitalstrom.internal.lib.structure.devices.Device;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.GeneralDeviceInformation;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.DeviceSceneSpec;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.DeviceStateUpdate;
+import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.ApplicationGroup;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.ChangeableDeviceConfigEnum;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.DeviceBinarayInputEnum;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.OutputModeEnum;
@@ -457,9 +458,11 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
                     checkOutputChannel();
                 } else if (this.device.isBlind()) {
                     // load channel for set the angle of jalousie devices
-                    String channelTypeID = DsChannelTypeProvider.getOutputChannelTypeID(
-                            ((Device) device).getFunctionalColorGroup().getColor(), ((Device) device).getOutputMode(),
-                            ((Device) device).getOutputChannels());
+                    ApplicationGroup.Color color = ((Device) device).getFunctionalColorGroup() != null
+                            ? ((Device) device).getFunctionalColorGroup().getColor()
+                            : null;
+                    String channelTypeID = DsChannelTypeProvider.getOutputChannelTypeID(color,
+                            ((Device) device).getOutputMode(), ((Device) device).getOutputChannels());
                     loadOutputChannel(new ChannelTypeUID(BINDING_ID, channelTypeID),
                             DsChannelTypeProvider.getItemType(channelTypeID));
                 }
@@ -713,8 +716,11 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         if (!device.isDeviceWithOutput()) {
             loadOutputChannel(null, null);
         }
-        String channelTypeID = DsChannelTypeProvider.getOutputChannelTypeID(device.getFunctionalColorGroup().getColor(),
-                device.getOutputMode(), device.getOutputChannels());
+        ApplicationGroup.Color color = device.getFunctionalColorGroup() != null
+                ? device.getFunctionalColorGroup().getColor()
+                : null;
+        String channelTypeID = DsChannelTypeProvider.getOutputChannelTypeID(color, device.getOutputMode(),
+                device.getOutputChannels());
         logger.debug("load channel: typeID={}, itemType={}",
                 DsChannelTypeProvider.getOutputChannelTypeID(device.getFunctionalColorGroup().getColor(),
                         device.getOutputMode(), device.getOutputChannels()),

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 
 import org.openhab.binding.digitalstrom.internal.DigitalSTROMBindingConstants;
@@ -407,7 +408,8 @@ public class DeviceImpl extends AbstractGeneralDeviceInformations implements Dev
 
     @Override
     public synchronized ApplicationGroup getFunctionalColorGroup() {
-        return groupList.stream().findFirst().get();
+        Optional<ApplicationGroup> applicationGroup = groupList.stream().findFirst();
+        return applicationGroup.isPresent() ? applicationGroup.get() : null;
     }
 
     @Override

--- a/bundles/org.openhab.binding.digitalstrom/src/test/java/org/openhab/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImplTest.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/test/java/org/openhab/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImplTest.java
@@ -14,15 +14,18 @@ package org.openhab.binding.digitalstrom.internal.lib.structure.devices.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.ApplicationGroup;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.OutputChannelEnum;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.OutputModeEnum;
 import org.openhab.binding.digitalstrom.internal.lib.util.JsonModel;
@@ -148,6 +151,24 @@ class DeviceImplTest {
         JsonObject jsonObject = createJsonObject(OutputModeEnum.POSITION_CON, MIXED_SHADE_CHANNEL);
         DeviceImpl deviceImpl = new DeviceImpl(jsonObject);
         assertThat(deviceImpl.isBlind(), is(true));
+    }
+
+    @Test
+    @DisplayName("No functional color group set, expect a null value returned")
+    void noFunctionalColorGroupSet() {
+        DeviceImpl deviceImpl = new DeviceImpl(new JsonObject());
+        ApplicationGroup functionalColorGroup = deviceImpl.getFunctionalColorGroup();
+        assertNull(functionalColorGroup);
+    }
+
+    @Test
+    @DisplayName("Multiple functional color groups set, expect the first group returned which had previously been added")
+    void multipleFunctionalColorGroupSet() {
+        DeviceImpl deviceImpl = new DeviceImpl(new JsonObject());
+        deviceImpl.addGroup(ApplicationGroup.JOKER.getId());
+        deviceImpl.addGroup(ApplicationGroup.ACCESS.getId());
+
+        assertThat(deviceImpl.getFunctionalColorGroup(), is(ApplicationGroup.JOKER));
     }
 
     private static JsonObject createJsonObject(OutputModeEnum outputMode, List<OutputChannel> channels) {


### PR DESCRIPTION
Fixes #11054, NoSuchElementException when retrieving the functional color group of a device. I was under the impression that every device should have a functional color group set, which is obviously not the case.

Signed-off-by: Rouven Schürch <r.schuerch@gmx.ch>
