### PR TITLE
[synopanalyzer] Add all default translations to properties file

### DIFF
--- a/bundles/org.openhab.binding.synopanalyzer/src/main/java/org/openhab/binding/synopanalyzer/internal/handler/SynopAnalyzerHandler.java
+++ b/bundles/org.openhab.binding.synopanalyzer/src/main/java/org/openhab/binding/synopanalyzer/internal/handler/SynopAnalyzerHandler.java
@@ -99,6 +99,8 @@ public class SynopAnalyzerHandler extends BaseThingHandler {
             discoverAttributes(stations, configuration.stationId);
         }
 
+        updateStatus(ThingStatus.UNKNOWN);
+
         executionJob = scheduler.scheduleWithFixedDelay(this::updateSynopChannels, 0, configuration.refreshInterval,
                 TimeUnit.MINUTES);
     }

--- a/bundles/org.openhab.binding.synopanalyzer/src/main/resources/OH-INF/i18n/synopanalyzer.properties
+++ b/bundles/org.openhab.binding.synopanalyzer/src/main/resources/OH-INF/i18n/synopanalyzer.properties
@@ -1,0 +1,55 @@
+# binding
+
+binding.synopanalyzer.name = Synop Analyzer Binding
+binding.synopanalyzer.description = This is the binding to download and interpret Synop messages
+
+# thing types
+
+thing-type.synopanalyzer.synopanalyzer.label = Synop Message
+thing-type.synopanalyzer.synopanalyzer.description = This is the interpretation of the last message of a given station.
+
+# thing types config
+
+thing-type.config.synopanalyzer.synopanalyzer.refreshInterval.label = Refresh Interval
+thing-type.config.synopanalyzer.synopanalyzer.refreshInterval.description = The refresh interval to poll Synop messages (in minutes).
+thing-type.config.synopanalyzer.synopanalyzer.stationId.label = Station Number
+
+# channel types
+
+channel-type.synopanalyzer.attenuation-factor.label = Mitigation Factor
+channel-type.synopanalyzer.attenuation-factor.description = Cloud layer mitigation factor
+channel-type.synopanalyzer.horizontal-visibility.label = Horizontal Visibility
+channel-type.synopanalyzer.horizontal-visibility.description = Horizontal visibility range
+channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_1 = Less than 1 km
+channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_10 = 1 to 10 km
+channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_50 = 10 to 50 km
+channel-type.synopanalyzer.horizontal-visibility.state.option.MORE_THAN_50 = More than 50 km
+channel-type.synopanalyzer.octa.label = Octa
+channel-type.synopanalyzer.octa.description = Cloud cover estimation.
+channel-type.synopanalyzer.overcast.label = Overcast
+channel-type.synopanalyzer.overcast.description = Overcast
+channel-type.synopanalyzer.overcast.state.option.CLEAR_SKY = Clear sky
+channel-type.synopanalyzer.overcast.state.option.CLOUDY = Cloudy
+channel-type.synopanalyzer.overcast.state.option.SKY_NOT_VISIBLE = Sky is not visible
+channel-type.synopanalyzer.time-utc.label = Observation Time
+channel-type.synopanalyzer.time-utc.description = Timestamp when data was observed
+channel-type.synopanalyzer.wind-direction.label = Wind Direction
+channel-type.synopanalyzer.wind-direction.description = Wind direction
+channel-type.synopanalyzer.wind-direction.state.option.N = N
+channel-type.synopanalyzer.wind-direction.state.option.NNE = NNE
+channel-type.synopanalyzer.wind-direction.state.option.NE = NE
+channel-type.synopanalyzer.wind-direction.state.option.ENE = ENE
+channel-type.synopanalyzer.wind-direction.state.option.E = E
+channel-type.synopanalyzer.wind-direction.state.option.ESE = ESE
+channel-type.synopanalyzer.wind-direction.state.option.SE = SE
+channel-type.synopanalyzer.wind-direction.state.option.SSE = SSE
+channel-type.synopanalyzer.wind-direction.state.option.S = S
+channel-type.synopanalyzer.wind-direction.state.option.SSW = SSW
+channel-type.synopanalyzer.wind-direction.state.option.SW = SW
+channel-type.synopanalyzer.wind-direction.state.option.WSW = WSW
+channel-type.synopanalyzer.wind-direction.state.option.W = W
+channel-type.synopanalyzer.wind-direction.state.option.WNW = WNW
+channel-type.synopanalyzer.wind-direction.state.option.NW = NW
+channel-type.synopanalyzer.wind-direction.state.option.NNW = NNW
+channel-type.synopanalyzer.wind-speed-beaufort.label = Beaufort
+channel-type.synopanalyzer.wind-speed-beaufort.description = Wind speed in Beaufort Scale

--- a/bundles/org.openhab.binding.synopanalyzer/src/main/resources/OH-INF/i18n/synopanalyzer_fr.properties
+++ b/bundles/org.openhab.binding.synopanalyzer/src/main/resources/OH-INF/i18n/synopanalyzer_fr.properties
@@ -1,18 +1,36 @@
 # binding
+
 binding.synopanalyzer.name = Extension Synop Analyzer
 binding.synopanalyzer.description = Synop Analyzer permet de télécharger et interpréter les messages SYNOP.
 
 # thing type
+
 thing-type.synopanalyzer.synopanalyzer.label = Message Synop
 thing-type.synopanalyzer.synopanalyzer.description = Décodage du dernier message d'une station Synop.
 
-# channel types
-channel-type.synopanalyzer.wind-speed-beaufort.label = Beaufort
-channel-type.synopanalyzer.wind-speed-beaufort.description = Force du vent sur l'échelle Beaufort.
+# thing types config
 
+# channel types
+
+channel-type.synopanalyzer.attenuation-factor.label = Coefficient d'atténuation
+channel-type.synopanalyzer.attenuation-factor.description = Atténuation générée par la couverture nuageuse.
+channel-type.synopanalyzer.horizontal-visibility.label = Visibilité horizontale
+channel-type.synopanalyzer.horizontal-visibility.description = Ordre de grandeur de la visibilité horizontale.
+channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_1 = Moins de 1 km
+channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_10 = Entre 1 et 10 km
+channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_50 = Entre 10 et 50 km
+channel-type.synopanalyzer.horizontal-visibility.state.option.MORE_THAN_50 = Plus de 50 km
+channel-type.synopanalyzer.octa.label = Octa
+channel-type.synopanalyzer.octa.description = Evaluation de la couverture nuageuse.
+channel-type.synopanalyzer.overcast.label = Couverture nuageuse
+channel-type.synopanalyzer.overcast.description = Appréciation de la couverture nuageuse.
+channel-type.synopanalyzer.overcast.state.option.CLEAR_SKY = Ciel dégagé
+channel-type.synopanalyzer.overcast.state.option.CLOUDY = Nuageux
+channel-type.synopanalyzer.overcast.state.option.SKY_NOT_VISIBLE = Ciel non visible
+channel-type.synopanalyzer.time-utc.label = Horodatage
+channel-type.synopanalyzer.time-utc.description = Heure d'observation des mesures relevées
 channel-type.synopanalyzer.wind-direction.label = Direction du vent
 channel-type.synopanalyzer.wind-direction.description = Equivalent cardinal de la direction du vent.
-# Only translating those that needs a french adaptation (containing "W")
 channel-type.synopanalyzer.wind-direction.state.option.SSW = SSO
 channel-type.synopanalyzer.wind-direction.state.option.SW = SO
 channel-type.synopanalyzer.wind-direction.state.option.WSW = OSO
@@ -20,25 +38,5 @@ channel-type.synopanalyzer.wind-direction.state.option.W = O
 channel-type.synopanalyzer.wind-direction.state.option.WNW = ONO
 channel-type.synopanalyzer.wind-direction.state.option.NW = NO
 channel-type.synopanalyzer.wind-direction.state.option.NNW = NNO
-
-channel-type.synopanalyzer.octa.label = Octa
-channel-type.synopanalyzer.octa.description = Evaluation de la couverture nuageuse.
-
-channel-type.synopanalyzer.attenuation-factor.label = Coefficient d'atténuation
-channel-type.synopanalyzer.attenuation-factor.description = Atténuation générée par la couverture nuageuse.
-
-channel-type.synopanalyzer.overcast.label = Couverture nuageuse
-channel-type.synopanalyzer.overcast.description = Appréciation de la couverture nuageuse.
-channel-type.synopanalyzer.overcast.state.option.CLEAR_SKY = Ciel dégagé
-channel-type.synopanalyzer.overcast.state.option.CLOUDY = Nuageux
-channel-type.synopanalyzer.overcast.state.option.SKY_NOT_VISIBLE = Ciel non visible
-
-channel-type.synopanalyzer.horizontal-visibility.label = Visibilité horizontale
-channel-type.synopanalyzer.horizontal-visibility.description = Ordre de grandeur de la visibilité horizontale.
-channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_1 = Moins de 1 km
-channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_10 = Entre 1 et 10 km
-channel-type.synopanalyzer.horizontal-visibility.state.option.LESS_THAN_50 = Entre 10 et 50 km
-channel-type.synopanalyzer.horizontal-visibility.state.option.MORE_THAN_50 = Plus de 50 km
-
-channel-type.synopanalyzer.time-utc.label = Horodatage
-channel-type.synopanalyzer.time-utc.description = Heure d'observation des mesures relevées
+channel-type.synopanalyzer.wind-speed-beaufort.label = Beaufort
+channel-type.synopanalyzer.wind-speed-beaufort.description = Force du vent sur l'échelle Beaufort.


### PR DESCRIPTION
Allows translating the synopanalyzer binding strings with Crowdin.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>