### PR TITLE
[unifi] Fix online/blocked channels after client is disconnected

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/cache/UniFiClientCache.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/cache/UniFiClientCache.java
@@ -26,12 +26,14 @@ import org.openhab.binding.unifi.internal.api.model.UniFiClient;
 public class UniFiClientCache extends UniFiCache<UniFiClient> {
 
     public UniFiClientCache() {
-        super(PREFIX_MAC, PREFIX_IP, PREFIX_HOSTNAME, PREFIX_ALIAS);
+        super(PREFIX_ID, PREFIX_MAC, PREFIX_IP, PREFIX_HOSTNAME, PREFIX_ALIAS);
     }
 
     @Override
     protected String getSuffix(UniFiClient client, String prefix) {
         switch (prefix) {
+            case PREFIX_ID:
+                return client.getId();
             case PREFIX_MAC:
                 return client.getMac();
             case PREFIX_IP:

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiClient.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiClient.java
@@ -120,7 +120,7 @@ public abstract class UniFiClient {
     @Override
     public String toString() {
         return String.format(
-                "UniFiClient{mac: '%s', ip: '%s', hostname: '%s', alias: '%s', wired: %b, blocked: %b, device: %s}",
-                mac, ip, hostname, alias, isWired(), blocked, getDevice());
+                "UniFiClient{id: '%s', mac: '%s', ip: '%s', hostname: '%s', alias: '%s', wired: %b, blocked: %b, device: %s}",
+                id, mac, ip, hostname, alias, isWired(), blocked, getDevice());
     }
 }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.unifi.internal.api.model;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -40,11 +42,14 @@ import com.google.gson.GsonBuilder;
  *
  * @author Matthew Bowman - Initial contribution
  * @author Patrik Wimnell - Blocking / Unblocking client support
+ * @author Jacob Laursen - Fix online/blocked channels (broken by UniFi Controller 5.12.35)
  */
 @NonNullByDefault
 public class UniFiController {
 
     private final Logger logger = LoggerFactory.getLogger(UniFiController.class);
+
+    private Map<String, String> cidToIdCache = new ConcurrentHashMap<String, String>();
 
     private UniFiSiteCache sitesCache = new UniFiSiteCache();
 
@@ -172,18 +177,22 @@ public class UniFiController {
 
     // Client API
 
-    public @Nullable UniFiClient getClient(@Nullable String id) {
+    public @Nullable UniFiClient getClient(@Nullable String cid) {
         UniFiClient client = null;
-        if (id != null && !id.isBlank()) {
+        if (cid != null && !cid.isBlank()) {
+            // Prefer lookups through _id, until initialized use cid.
+            String id = cidToIdCache.get(cid);
             synchronized (this) {
                 // mgb: first check active clients and fallback to insights if not found
-                client = clientsCache.get(id);
+                client = clientsCache.get(id != null ? id : cid);
                 if (client == null) {
-                    client = insightsCache.get(id);
+                    client = insightsCache.get(id != null ? id : cid);
                 }
             }
             if (client == null) {
-                logger.debug("Could not find a matching client for id = {}", id);
+                logger.debug("Could not find a matching client for cid = {}", cid);
+            } else {
+                cidToIdCache.put(cid, client.id);
             }
         }
         return client;


### PR DESCRIPTION
Fixes #7001

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fixes a problem with the **online** channel never being updated to OFF after client disconnects. This was most likely introduced by Uni-Fi Controller 5.12.35. The same problem impacted the **blocked** channel also in the way that unblocking was not possible.

This pull request replaces #11410 with a better approach. Previous PR would keep clients in the cache after they are no longer connected to the access point. This worked for the **online** channel, but broke the **blocked** channel as a blocked client would immediately be disconnected from AP, but kept in client cache. This resulted in blocked status going back to unblocked since this was last known status.

New approach chosen is to keep a map of cid (configured key) -> _id values. When _id is returned by controller for the first time, it's kept in this cache and preferred for subsequent lookups. When client disconnects, it can no longer be found in client cache by either _id nor cid. It can however still be found in insights cache by _id. This fixes the problem as the insights cache doesn't contain IP address since controller version 5.12.35 release in beginning of 2020.

### Example

When online (other clients/insights removed):

```
2021-10-17 22:05:37.731 [DEBUG] [i.internal.api.model.UniFiController] - Found 16 UniFi Client(s): 
 - UniFiClient{id: '5f5a2cb946e0fb0015cb4a68', mac: 'xx:xx:xx:xx:1a:79', ip: '192.168.0.28', hostname: 'oneplus-8', alias: 'oneplus 8 jacob', wired: false, blocked: false, device: UniFiDevice{id: '5cc8962d46e0fb0016dc486c', mac: 'b4:fb:e4:ca:a2:6c', name: 'Skynet', model: 'U7NHD', site: UniFiSite{name: 'oc9023uo', desc: 'Skynet'}}}
2021-10-17 22:05:37.755 [DEBUG] [i.internal.api.model.UniFiController] - Found 19 UniFi Insights(s): 
 - UniFiClient{id: '5f5a2cb946e0fb0015cb4a68', mac: 'xx:xx:xx:xx:1a:79', ip: 'null', hostname: 'oneplus-8', alias: 'oneplus 8 jacob', wired: false, blocked: false, device: null}
```

After going offline:

```
2021-10-17 22:05:47.864 [DEBUG] [i.internal.api.model.UniFiController] - Found 15 UniFi Client(s): 
2021-10-17 22:05:47.885 [DEBUG] [i.internal.api.model.UniFiController] - Found 19 UniFi Insights(s): 
 - UniFiClient{id: '5f5a2cb946e0fb0015cb4a68', mac: 'xx:xx:xx:xx:1a:79', ip: 'null', hostname: 'oneplus-8', alias: 'oneplus 8 jacob', wired: false, blocked: false, device: null}
```