### PR TITLE
Add GitHub Actions CI build

### DIFF
--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+BUILD_LOG=build.log
+DEFAULT_ARGUMENTS="clean verify -B -T 1.5C -U"
+
+function print_reactor_summary() {
+    local start_end=$(grep -anE "\[INFO\] \\-{70,}" "$BUILD_LOG" | tail -n4 | cut -f1 -d: | sed -e 1b -e '$!d' | xargs)
+    local start=$(awk '{print $1}' <<< $start_end)
+    local end=$(awk '{print $2}' <<< $start_end)
+    cat "$BUILD_LOG" | sed -n "${start},${end}p" | sed 's/\[INFO\] //'
+}
+
+function mvnp() {
+    set -o pipefail # exit build with error when pipes fail
+    local reactor_size=$(find -name "pom.xml" | grep -vE '/src/|/target/' | wc -l)
+    local padding=$(bc -l <<< "scale=0;2*(l($reactor_size)/l(10)+1)")
+    local command=(mvn $@)
+    exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
+        tee "$BUILD_LOG" | # write output to log
+        stdbuf -oL grep -aE '^\[INFO\] Building .+ \[.+\]$' | # filter progress
+        stdbuf -o0 sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
+        stdbuf -o0 sed -e :a -e "s/^.\{1,${padding}\}|/ &/;ta" # right align progress with padding
+}
+
+mvn -v
+echo
+
+if [ $# -ge 1 ]; then
+    mvnp $@
+else
+    mvnp $DEFAULT_ARGUMENTS
+fi
+
+status=$?
+echo
+
+if [ $status -eq 0 ]; then
+    print_reactor_summary
+else
+    tail -n 2000 "$BUILD_LOG"
+fi
+
+exit $status

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths-ignore:
+      - '.github/**/*.md'
+  pull_request:
+    branches:
+      - 'main'
+    paths-ignore:
+      - '.github/**/*.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [ '11' ]
+        maven: [ '3.8.3']
+        os: [ 'ubuntu-20.04' ]
+    name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/openhab
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up Java ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+
+      - name: Set up Maven ${{ matrix.maven }}
+        uses: stCarolas/setup-maven@v4.2
+        with:
+          maven-version: ${{ matrix.maven }}
+
+      - name: Build
+        id: build
+        run: './.github/scripts/maven-build'
+        env:
+          MAVEN_OPTS: >-
+            -Xmx2g
+            -Dmaven.wagon.http.retryHandler.count=5
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+      - name: Upload Build Log
+        if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-log-java-${{ matrix.java }}-${{ matrix.os }}
+          path: build.log
+
+      - name: Upload SAT Summary Report
+        if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: sat-summary-report
+          path: target/summary_report.html


### PR DESCRIPTION
This PR adds a CI build using GitHub Actions.
Besides having a backup for Jenkins, it will also make it easy for contributors to use a GitHub Actions build with their fork.

It features the following:

* Uncluttered simple build progress like we used with Travis CI
* Uploads the full build log and SAT summary report so they can be downloaded for further analysis
* Uses a Maven repository cache to speed up builds (first build takes a bit longer)
* Has some maven.wagon configuration options to prevent Maven Central artifact download issues from Azure
* Uses a matrix so we can easily add builds for other OS-es or newer Java LTS versions in the future

---

See also these [workflow runs](https://github.com/wborn/openhab-addons/actions/workflows/ci-build.yml) in my own fork for what this will look like.