### PR TITLE
[zoneminder] Only update state options if they've changed

### DIFF
--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
@@ -100,7 +100,6 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
     private @Nullable Future<?> refreshMonitorsJob;
 
     private List<Monitor> savedMonitors = new ArrayList<>();
-    private List<StateOption> savedStateOptions = new ArrayList<>();
 
     private String host = "";
     private boolean useSSL;
@@ -320,7 +319,11 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
                         options.add(new StateOption(monitorDTO.id, "Monitor " + monitorDTO.id));
                     }
                 }
-                updateStateOptions(options);
+                // Update state options
+                stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_IMAGE_MONITOR_ID),
+                        options);
+                stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_VIDEO_MONITOR_ID),
+                        options);
                 // Only update alarm and event info for monitors whose handlers are initialized
                 Set<String> ids = monitorHandlers.keySet();
                 for (Monitor m : monitorList) {
@@ -334,17 +337,6 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
             logger.debug("Bridge: JsonSyntaxException: {}", e.getMessage(), e);
         }
         return monitorList;
-    }
-
-    private void updateStateOptions(List<StateOption> options) {
-        // Only update state options if they've changed
-        if (!savedStateOptions.equals(options)) {
-            stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_IMAGE_MONITOR_ID),
-                    options);
-            stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_VIDEO_MONITOR_ID),
-                    options);
-        }
-        savedStateOptions = options;
     }
 
     private void extractEventCounts(Monitor monitor, MonitorItemDTO monitorItemDTO) {

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
@@ -100,6 +100,7 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
     private @Nullable Future<?> refreshMonitorsJob;
 
     private List<Monitor> savedMonitors = new ArrayList<>();
+    private List<StateOption> savedStateOptions = new ArrayList<>();
 
     private String host = "";
     private boolean useSSL;
@@ -318,11 +319,8 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
                         monitorList.add(monitor);
                         options.add(new StateOption(monitorDTO.id, "Monitor " + monitorDTO.id));
                     }
-                    stateDescriptionProvider
-                            .setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_IMAGE_MONITOR_ID), options);
-                    stateDescriptionProvider
-                            .setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_VIDEO_MONITOR_ID), options);
                 }
+                updateStateOptions(options);
                 // Only update alarm and event info for monitors whose handlers are initialized
                 Set<String> ids = monitorHandlers.keySet();
                 for (Monitor m : monitorList) {
@@ -336,6 +334,17 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
             logger.debug("Bridge: JsonSyntaxException: {}", e.getMessage(), e);
         }
         return monitorList;
+    }
+
+    private void updateStateOptions(List<StateOption> options) {
+        // Only update state options if they've changed
+        if (!savedStateOptions.equals(options)) {
+            stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_IMAGE_MONITOR_ID),
+                    options);
+            stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_VIDEO_MONITOR_ID),
+                    options);
+        }
+        savedStateOptions = options;
     }
 
     private void extractEventCounts(Monitor monitor, MonitorItemDTO monitorItemDTO) {


### PR DESCRIPTION
There are situations when the binding updates the state options even if the options haven't changed. This results in an unnecessary reload of the page in Basic UI. With this change, the state options are updated only if they change.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
