### PR TITLE
[pjlinkdevice] fix authentication

### DIFF
--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -152,11 +152,11 @@ public class PJLinkDevice {
             socket.connect(socketAddress, timeout);
             socket.setSoTimeout(timeout);
             BufferedReader reader = getReader();
-            String header = reader.readLine();
-            if (header == null) {
+            String rawHeader = reader.readLine();
+            if (rawHeader == null) {
                 throw new ResponseException("No PJLink header received from the device");
             }
-            header = header.toUpperCase();
+            String header = rawHeader.toUpperCase();
             switch (header.substring(0, "PJLINK x".length())) {
                 case "PJLINK 0":
                     logger.debug("Authentication not needed");
@@ -170,7 +170,7 @@ public class PJLinkDevice {
                         throw new AuthenticationException("No password provided, but device requires authentication");
                     } else {
                         try {
-                            authenticate(header.substring("PJLINK 1 ".length()));
+                            authenticate(rawHeader.substring("PJLINK 1 ".length()));
                         } catch (AuthenticationException e) {
                             // propagate AuthenticationException
                             throw e;


### PR DESCRIPTION
<!-- TITLE -->



<!-- DESCRIPTION -->
Fixes authentication problems that have been [reported by itseogo on the OpenHAB Community](https://community.openhab.org/t/new-pjlink-binding-for-controlling-multiple-projector-brands-models/56608/47?u=nils.schnabel).

The problem was caused by an earlier compatibility fix that generally uppercased responses from the projector. This should not be done for the authentication nonce (which contains lowercase characters that have to be preserved).

<!-- TESTING -->
The JAR should be available soon. 
[Here I guess](https://openhab.jfrog.io/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.pjlinkdevice/3.2.0-SNAPSHOT/org.openhab.binding.pjlinkdevice-3.2.0-SNAPSHOT.jar) (needs to be validated after the build).