### PR TITLE
[samsungtv] Fix reconnect after first connection to TV is lost

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
@@ -375,6 +375,7 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
             logger.debug("Device removed: udn={}", upnpUDN);
             shutdown();
             putOffline();
+            checkCreateManualConnection();
         }
     }
 

--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/MainTVServerService.java
@@ -109,7 +109,7 @@ public class MainTVServerService implements UpnpIOParticipant, SamsungTvService 
 
     @Override
     public void handleCommand(String channel, Command command) {
-        logger.debug("Received channel: {}, command: {}", channel, command);
+        logger.trace("Received channel: {}, command: {}", channel, command);
 
         if (!started) {
             return;

--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/service/RemoteControllerService.java
@@ -174,7 +174,7 @@ public class RemoteControllerService implements SamsungTvService, RemoteControll
             supported = new ArrayList<>(supported);
             supported.addAll(extraSupportedCommandsWebSocket);
         }
-        logger.debug("getSupportedChannelNames: {}", supported);
+        logger.trace("getSupportedChannelNames: {}", supported);
         return supported;
     }
 
@@ -254,7 +254,7 @@ public class RemoteControllerService implements SamsungTvService, RemoteControll
 
     @Override
     public void handleCommand(String channel, Command command) {
-        logger.debug("Received channel: {}, command: {}", channel, command);
+        logger.trace("Received channel: {}, command: {}", channel, command);
         if (command == RefreshType.REFRESH) {
             return;
         }


### PR DESCRIPTION
Fixes #7055 
Fixes #7406

Signed-off-by: Jacob Laursen jacob-github@vindvejr.dk

Initially the binding will start RemoteControllerService in non-UPnP mode by calling **createNonUpnpService**.

When device is added, some additional services are started and RemoteControllerService is replaced by new UPnP instance from **createUpnpService**.

When device is removed, the binding would stop all services, including the RemoteControllerService - without restarting the non-UPnP service. This made it unable to detect when device would be added again.

This has been fixed by calling **checkCreateManualConnection** after stopping all services in order to go back to original state listening for devices being added - like after initialize(). See comment in linked issue for additional information.

Tested with Samsung UE55D8005 (legacy protocol).

Additionally reduced log level from DEBUG to TRACE for some specific logging of methods that would be entered once per second:

```
2021-10-30 21:52:32.446 [DEBUG] [rnal.service.RemoteControllerService] - getSupportedChannelNames: [keyCode, power, channel]
2021-10-30 21:52:32.448 [DEBUG] [rnal.service.RemoteControllerService] - Received channel: keyCode, command: REFRESH
2021-10-30 21:52:32.450 [DEBUG] [rnal.service.RemoteControllerService] - Received channel: power, command: REFRESH
2021-10-30 21:52:32.451 [DEBUG] [rnal.service.RemoteControllerService] - Received channel: channel, command: REFRESH
2021-10-30 21:52:32.454 [DEBUG] [internal.service.MainTVServerService] - Received channel: channel, command: REFRESH
2021-10-30 21:52:32.501 [DEBUG] [internal.service.MainTVServerService] - Received channel: sourceName, command: REFRESH
2021-10-30 21:52:32.517 [DEBUG] [internal.service.MainTVServerService] - Received channel: programTitle, command: REFRESH
2021-10-30 21:52:33.519 [DEBUG] [rnal.service.RemoteControllerService] - getSupportedChannelNames: [keyCode, power, channel]
2021-10-30 21:52:33.521 [DEBUG] [rnal.service.RemoteControllerService] - Received channel: keyCode, command: REFRESH
2021-10-30 21:52:33.523 [DEBUG] [rnal.service.RemoteControllerService] - Received channel: power, command: REFRESH
2021-10-30 21:52:33.525 [DEBUG] [rnal.service.RemoteControllerService] - Received channel: channel, command: REFRESH
2021-10-30 21:52:33.526 [DEBUG] [internal.service.MainTVServerService] - Received channel: channel, command: REFRESH
2021-10-30 21:52:33.543 [DEBUG] [internal.service.MainTVServerService] - Received channel: sourceName, command: REFRESH
2021-10-30 21:52:33.554 [DEBUG] [internal.service.MainTVServerService] - Received channel: programTitle, command: REFRESH
```