### PR TITLE
GitHub Actions workflow improvements

### DIFF
--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 BUILD_LOG=build.log
-DEFAULT_ARGUMENTS="clean verify -B -T 1.5C -U"
+
+ARGUMENTS="clean verify -B -T 1.5C -U"
+if [ $# -ge 1 ]; then
+    ARGUMENTS=$@
+fi
 
 function print_reactor_summary() {
     local start_end=$(grep -anE "\[INFO\] \\-{70,}" "$BUILD_LOG" | tail -n4 | cut -f1 -d: | sed -e 1b -e '$!d' | xargs)
@@ -22,22 +26,78 @@ function mvnp() {
         stdbuf -o0 sed -e :a -e "s/^.\{1,${padding}\}|/ &/;ta" # right align progress with padding
 }
 
+function build_all() {
+    echo
+    echo "Building all projects"
+    echo
+    echo "+ mvn $ARGUMENTS"
+    echo
+
+    mvnp $ARGUMENTS
+
+    status=$?
+    echo
+
+    if [ $status -eq 0 ]; then
+        print_reactor_summary
+    else
+        tail -n 2000 "$BUILD_LOG"
+    fi
+
+    exit $status
+}
+
+function changed_files() {
+    sed 's#,#\n#g' <<< $CHANGED_FILES
+}
+
+function addon_unrelated_changed_files() {
+    local addon="$1"
+    changed_files | \
+        grep -Ev "^(bundles/|itests/)$addon([/.].*)?$" | \
+        grep -Ev "^(CODEOWNERS|bom/openhab-addons/pom.xml|bundles/pom.xml|itests/pom.xml)$"
+}
+
+function changed_addons() {
+    changed_files | grep -E '(bundles/|itests/)org\.openhab\.' | sed -E 's#.+/(org\.openhab\.[a-z0-9]+\.[a-z0-9]+).*#\1#g' | sort -u
+}
+
+function addon_projects() {
+    local addon="$1"
+
+    # include add-on projects
+    local projects=":$(find . -mindepth 2 -maxdepth 2 -type d -regextype egrep -regex "./(bundles|itests)/$addon(\..*)?$" | grep -Ev 'org.openhab.binding.mqtt.homeassistant.tests|org.openhab.binding.mqtt.homie.tests' | sort | sed -E 's#./(bundles|itests)/##g' | xargs | sed 's# #,:#g')"
+
+    # include BOMs
+    projects="$projects,:org.openhab.addons.bom.openhab-core-index,:org.openhab.addons.bom.runtime-index,:org.openhab.addons.bom.test-index"
+
+    # exclude features
+    projects="$projects,-:org.openhab.addons.reactor.features.karaf,-:org.openhab.addons.features.karaf.openhab-addons,-:org.openhab.addons.features.karaf.openhab-addons-external"
+
+    echo $projects
+}
+
+function build_addon() {
+    local addon="$1"
+    local mvn_command="mvn $ARGUMENTS -am -amd -pl $(addon_projects $addon)"
+
+    echo
+    echo "Building add-on: $addon"
+    echo
+    echo "+ $mvn_command"
+    echo
+
+    $mvn_command 2>&1 | tee "$BUILD_LOG"
+}
+
+function build_based_on_changes() {
+    local changed_addon=$(changed_addons | xargs)
+    if [ $(echo $changed_addon | wc -w) -eq 1 ] && [ $(addon_unrelated_changed_files $changed_addon | wc -l) -eq 0 ]; then
+        build_addon $changed_addon
+    else
+        build_all
+    fi
+}
+
 mvn -v
-echo
-
-if [ $# -ge 1 ]; then
-    mvnp $@
-else
-    mvnp $DEFAULT_ARGUMENTS
-fi
-
-status=$?
-echo
-
-if [ $status -eq 0 ]; then
-    print_reactor_summary
-else
-    tail -n 2000 "$BUILD_LOG"
-fi
-
-exit $status
+build_based_on_changes

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
+        if: github.head_ref == ''
         uses: actions/checkout@v2
+
+      - name: Checkout merge
+        if: github.head_ref != ''
+        uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{github.event.pull_request.number}}/merge
 
       - name: Set up Cache
         uses: actions/cache@v2
@@ -47,10 +54,17 @@ jobs:
         with:
           maven-version: ${{ matrix.maven }}
 
+      - name: Get Changed Files
+        id: files
+        uses: Ana06/get-changed-files@v2.0.0
+        with:
+          format: 'csv'
+
       - name: Build
         id: build
         run: './.github/scripts/maven-build'
         env:
+          CHANGED_FILES: ${{ steps.files.outputs.all }}
           MAVEN_OPTS: >-
             -Xmx2g
             -Dmaven.wagon.http.retryHandler.count=5


### PR DESCRIPTION
* Checkout merged branches for pull requests
* Add support for incremental add-on builds to speed up PR builds
* Echo the mvn command used for builds

The incremental build should also work for initial add-on contributions and it will also build everything in just one Maven reactor instead of several which we had with Travis CI. It should also figure out add-on dependencies and dependants using the `-am` and `-amd` options.