### PR TITLE
[chromecast] Added support for next command

### DIFF
--- a/bundles/org.openhab.binding.chromecast/README.md
+++ b/bundles/org.openhab.binding.chromecast/README.md
@@ -49,7 +49,7 @@ Thing chromecast:audiogroup:bathroom  [ ipAddress="192.168.0.23", port=42139]
 
 | Channel Type ID | Item Type   | Description                                                                                                                                                                           |
 |-----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| control         | Player      | Player control; currently only supports play/pause and does not correctly update, if the state changes on the device itself                                                           |
+| control         | Player      | Player control; currently only supports play/pause/next and does not correctly update, if the state changes on the device itself                                                           |
 | stop            | Switch      | Send `ON` to this channel: Stops the Chromecast. If this channel is `ON`, the Chromecast is stopped, otherwise it is in another state (see control channel)                           |
 | volume          | Dimmer      | Control the volume, this is also updated if the volume is changed by another app                                                                                                      |
 | mute            | Switch      | Mute the audio                                                                                                                                                                        |

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -135,10 +135,19 @@ public class ChromecastCommander {
     private void handleControl(final Command command) {
         try {
             if (command instanceof NextPreviousType) {
-                // I can't find a way to control next/previous from the API. The Google app doesn't seem to
-                // allow it either, so I suspect there isn't a way.
-                logger.info("{} command not yet implemented", command);
-                return;
+                // Next is implemented by seeking to the end of the current media
+                if (command == NextPreviousType.NEXT) {
+
+                    Double duration = statusUpdater.getLastDuration();
+                    if (duration != null) {
+                        chromeCast.seek(duration.doubleValue() - 5);
+                    } else {
+                        logger.info("{} command failed - unknown media duration", command);
+                    }
+                } else {
+                    logger.info("{} command not yet implemented", command);
+                    return;
+                }
             }
 
             Application app = chromeCast.getRunningApp();

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -134,22 +134,6 @@ public class ChromecastCommander {
 
     private void handleControl(final Command command) {
         try {
-            if (command instanceof NextPreviousType) {
-                // Next is implemented by seeking to the end of the current media
-                if (command == NextPreviousType.NEXT) {
-
-                    Double duration = statusUpdater.getLastDuration();
-                    if (duration != null) {
-                        chromeCast.seek(duration.doubleValue() - 5);
-                    } else {
-                        logger.info("{} command failed - unknown media duration", command);
-                    }
-                } else {
-                    logger.info("{} command not yet implemented", command);
-                    return;
-                }
-            }
-
             Application app = chromeCast.getRunningApp();
             statusUpdater.updateStatus(ThingStatus.ONLINE);
             if (app == null) {
@@ -175,6 +159,23 @@ public class ChromecastCommander {
                     logger.info("{} command not supported by current media", command);
                 }
             }
+
+            if (command instanceof NextPreviousType) {
+                // Next is implemented by seeking to the end of the current media
+                if (command == NextPreviousType.NEXT) {
+
+                    Double duration = statusUpdater.getLastDuration();
+                    if (duration != null) {
+                        chromeCast.seek(duration.doubleValue() - 5);
+                    } else {
+                        logger.info("{} command failed - unknown media duration", command);
+                    }
+                } else {
+                    logger.info("{} command not yet implemented", command);
+                    return;
+                }
+            }
+
         } catch (final IOException e) {
             logger.debug("{} command failed: {}", command, e.getMessage());
             statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, e.getMessage());

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
@@ -73,6 +73,9 @@ public class ChromecastStatusUpdater {
     private @Nullable String appSessionId;
     private PercentType volume = PercentType.ZERO;
 
+    // Null is valid value for last duration
+    private @Nullable Double lastDuration = null;
+
     public ChromecastStatusUpdater(Thing thing, ChromecastHandler callback) {
         this.thing = thing;
         this.callback = callback;
@@ -80,6 +83,10 @@ public class ChromecastStatusUpdater {
 
     public PercentType getVolume() {
         return volume;
+    }
+
+    public @Nullable Double getLastDuration() {
+        return lastDuration;
     }
 
     public @Nullable String getAppSessionId() {
@@ -186,6 +193,7 @@ public class ChromecastStatusUpdater {
         if (media != null) {
             metadataType = media.getMetadataType().name();
 
+            lastDuration = media.duration;
             // duration can be null when a new song is about to play.
             if (media.duration != null) {
                 duration = new QuantityType<>(media.duration, Units.SECOND);


### PR DESCRIPTION
[chromecast] Next Command Support

Add support for next command to chromecast binding, this is implemented by seeking to the end of the current track as there is no native next command.  This is the same implementation for next that the python library uses for chromecast, which is used by home assistant to achieve this functionality. 

