### PR TITLE
Fix wrong build result when single add-on build fails

### DIFF
--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -87,7 +87,9 @@ function build_addon() {
     echo "+ $mvn_command"
     echo
 
+    set -o pipefail # exit build with error when pipes fail
     $mvn_command 2>&1 | tee "$BUILD_LOG"
+    exit $?
 }
 
 function build_based_on_changes() {


### PR DESCRIPTION
Fixes the issue that single add-on builds that fail are not marked as such in GitHub Actions.

See for instance this build which should have been marked as "Failure" instead of "Success": https://github.com/openhab/openhab-addons/actions/runs/1426422792