### PR TITLE
Always run OSGi HTTP service on random port in itests

### DIFF
--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -24,6 +24,10 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 -runfw: org.eclipse.osgi
 -runee: JavaSE-11
 
+# An unused random HTTP port is used during tests to prevent resource conflicts
+# This property is set by the build-helper-maven-plugin in the itests pom.xml
+-runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
+
 # The integration test itself does not export anything.
 Export-Package: 
 -exportcontents: 

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -14,8 +14,6 @@ Fragment-Host: org.openhab.binding.feed
 -runblacklist: \
 	bnd.identity;id='org.openhab.core.storage.json'
 
--runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
-
 #
 # done
 #

--- a/itests/org.openhab.binding.feed.tests/pom.xml
+++ b/itests/org.openhab.binding.feed.tests/pom.xml
@@ -15,8 +15,6 @@
   <name>openHAB Add-ons :: Integration Tests :: Feed Binding Tests</name>
 
   <properties>
-    <org.osgi.service.http.port>9090</org.osgi.service.http.port>
-
     <rome.version>1.15.0</rome.version>
   </properties>
 
@@ -43,28 +41,5 @@
       </exclusions>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>org.osgi.service.http.port</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
@@ -12,8 +12,6 @@ Fragment-Host: org.openhab.binding.mielecloud
     bnd.identity;id='org.openhab.core.storage.json',\
     bnd.identity;id='org.openhab.core.storage.mapdb'
 
--runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
-
 #
 # done
 #

--- a/itests/org.openhab.binding.mielecloud.tests/pom.xml
+++ b/itests/org.openhab.binding.mielecloud.tests/pom.xml
@@ -22,27 +22,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>org.osgi.service.http.port</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -38,6 +38,7 @@
 
   <properties>
     <m2e.jdt.annotationpath>target/dependency</m2e.jdt.annotationpath>
+    <org.osgi.service.http.port>9090</org.osgi.service.http.port>
   </properties>
 
   <dependencies>
@@ -178,6 +179,24 @@
                 <bndrun>itest.bndrun</bndrun>
               </bndruns>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>reserve-network-port</id>
+                <goals>
+                  <goal>reserve-network-port</goal>
+                </goals>
+                <phase>process-resources</phase>
+                <configuration>
+                  <portNames>
+                    <portName>org.osgi.service.http.port</portName>
+                  </portNames>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
It is probably always a good idea to run the OSGi HTTP service on a random available port in itests.
So when this is always done it prevents future issues and removes a bit of duplication.

See also: https://github.com/openhab/openhab-addons/issues/11350