### PR TITLE
[monopriceaudio] Clarify supported models and documentation

### DIFF
--- a/bundles/org.openhab.binding.monopriceaudio/README.md
+++ b/bundles/org.openhab.binding.monopriceaudio/README.md
@@ -13,7 +13,8 @@ The binding supports two different kinds of connections:
 For users without a serial port on the server side, you can use a USB to serial adapter.
 
 You don't need to have your whole house amplifier device directly connected to your openHAB server.
-You can connect it for example to a Raspberry Pi and use [ser2net Linux tool](https://sourceforge.net/projects/ser2net/) to make the serial connection available on the LAN (serial over IP).
+Some newer versions of the amplifier have a built-in ethernet port that supports serial over IP.
+Or you can connect it for example to a Raspberry Pi and use [ser2net Linux tool](https://sourceforge.net/projects/ser2net/) to make the serial connection available on the LAN (serial over IP).
 
 ## Supported Things
 
@@ -37,8 +38,8 @@ The thing has the following configuration parameters:
 | Parameter Label      | Parameter ID     | Description                                                                                                                    | Accepted values  |
 |----------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------|
 | Serial Port          | serialPort       | Serial port to use for connecting to the Monoprice whole house amplifier device                                                | Serial port name |
-| Address              | host             | Host name or IP address of the machine connected to the Monoprice whole house amplifier device (serial over IP)                | Host name or IP  |
-| Port                 | port             | Communication port (serial over IP).                                                                                           | TCP port number  |
+| Address              | host             | Host name or IP address of the amplifier or serial over IP device                                                              | Host name or IP  |
+| Port                 | port             | Communication port (default 8080 for newer amps with built-in serial over IP)                                                  | TCP port number  |
 | Number of Zones      | numZones         | (Optional) Number of amplifier zones to utilize in the binding (up to 18 zones with 3 amplifiers connected together)           | 1-18; default 6  |
 | Polling Interval     | pollingInterval  | (Optional) Configures how often (in seconds) to poll the controller to check for zone updates                                  | 5-60; default 15 |
 | Ignore Zones         | ignoreZones      | (Optional) A comma seperated list of Zone numbers that will ignore the 'All Zone' (except All Off) commands                    | ie: "1,6,10"     |
@@ -56,10 +57,10 @@ Some notes:
 * You can get around this by adding the `openhab` user to the `dialout` group like this: `usermod -a -G dialout openhab`.
 * Also on Linux you may have issues with the USB if using two serial USB devices e.g. MonopriceAudio and RFXcom.
 * See the [general documentation about serial port configuration](/docs/administration/serial.html) for more on symlinking the USB ports.
-* Here is an example of ser2net.conf you can use to share your serial port /dev/ttyUSB0 on IP port 4444 using [ser2net Linux tool](https://sourceforge.net/projects/ser2net/):
+* Here is an example of ser2net.conf you can use to share your serial port /dev/ttyUSB0 on IP port 8080 using [ser2net Linux tool](https://sourceforge.net/projects/ser2net/):
 
 ```
-4444:raw:0:/dev/ttyUSB0:9600 8DATABITS NONE 1STOPBIT LOCAL
+8080:raw:0:/dev/ttyUSB0:9600 8DATABITS NONE 1STOPBIT LOCAL
 ```
 
 ## Channels
@@ -92,7 +93,7 @@ monoprice.things:
 monopriceaudio:amplifier:myamp "Monoprice WHA" [ serialPort="COM5", pollingInterval=15, numZones=6, inputLabel1="Chromecast", inputLabel2="Radio", inputLabel3="CD Player", inputLabel4="Bluetooth Audio", inputLabel5="HTPC", inputLabel6="Phono"]
 
 // serial over IP connection
-monopriceaudio:amplifier:myamp "Monoprice WHA" [ host="192.168.0.10", port=4444, pollingInterval=15, numZones=6, inputLabel1="Chromecast", inputLabel2="Radio", inputLabel3="CD Player", inputLabel4="Bluetooth Audio", inputLabel5="HTPC", inputLabel6="Phono"]
+monopriceaudio:amplifier:myamp "Monoprice WHA" [ host="192.168.0.10", port=8080, pollingInterval=15, numZones=6, inputLabel1="Chromecast", inputLabel2="Radio", inputLabel3="CD Player", inputLabel4="Bluetooth Audio", inputLabel5="HTPC", inputLabel6="Phono"]
 
 ```
 

--- a/bundles/org.openhab.binding.monopriceaudio/README.md
+++ b/bundles/org.openhab.binding.monopriceaudio/README.md
@@ -2,7 +2,7 @@
 
 This binding can be used to control a Monoprice MPR-SG6Z (10761), Monoprice Passive Matrix (39261) & Dayton Audio DAX66 whole house multi-zone amplifier system.
 All controller functions available through the serial port interface can be controlled by the binding.
-Up to 18 zones can be controlled when 3 units are connected together (if not all zones on the amp are used they can be excluded via configuration).
+Up to 18 zones can be controlled when 3 amps are connected together (if not all zones on the amp are used they can be excluded via configuration).
 Activating the 'Page All Zones' feature can only be done through the +12v trigger input on the back of the amplifier.
 
 The binding supports two different kinds of connections:

--- a/bundles/org.openhab.binding.monopriceaudio/README.md
+++ b/bundles/org.openhab.binding.monopriceaudio/README.md
@@ -1,8 +1,8 @@
 # Monoprice Whole House Audio Binding
 
-This binding can be used to control the Monoprice MPR-SG6Z (10761) or Dayton Audio DAX66 whole house multi-zone amplifier.
+This binding can be used to control a Monoprice MPR-SG6Z (10761), Monoprice Passive Matrix (39261) & Dayton Audio DAX66 whole house multi-zone amplifier system.
 All controller functions available through the serial port interface can be controlled by the binding.
-Up to 18 zones can be controlled when 3 amplifiers are connected together (if not all zones on the amp are used they can be excluded via configuration).
+Up to 18 zones can be controlled when 3 units are connected together (if not all zones on the amp are used they can be excluded via configuration).
 Activating the 'Page All Zones' feature can only be done through the +12v trigger input on the back of the amplifier.
 
 The binding supports two different kinds of connections:
@@ -10,10 +10,10 @@ The binding supports two different kinds of connections:
 * serial connection,
 * serial over IP connection
 
-For users without serial connector on the server side, you can add a serial to USB adapter.
+For users without a serial port on the server side, you can use a USB to serial adapter.
 
-You don't need to have your Monoprice whole house amplifier device directly connected to your openHAB server.
-You can connect it for example to a Raspberry Pi and use [ser2net Linux tool](https://sourceforge.net/projects/ser2net/) to make the serial connection available on LAN (serial over IP).
+You don't need to have your whole house amplifier device directly connected to your openHAB server.
+You can connect it for example to a Raspberry Pi and use [ser2net Linux tool](https://sourceforge.net/projects/ser2net/) to make the serial connection available on the LAN (serial over IP).
 
 ## Supported Things
 
@@ -56,7 +56,7 @@ Some notes:
 * You can get around this by adding the `openhab` user to the `dialout` group like this: `usermod -a -G dialout openhab`.
 * Also on Linux you may have issues with the USB if using two serial USB devices e.g. MonopriceAudio and RFXcom.
 * See the [general documentation about serial port configuration](/docs/administration/serial.html) for more on symlinking the USB ports.
-* Here is an example of ser2net.conf you can use to share your serial port /dev/ttyUSB0 on IP port 4444 using [ser2net Linux tool](https://sourceforge.net/projects/ser2net/) (take care, the baud rate is specific to the Monoprice amplifier):
+* Here is an example of ser2net.conf you can use to share your serial port /dev/ttyUSB0 on IP port 4444 using [ser2net Linux tool](https://sourceforge.net/projects/ser2net/):
 
 ```
 4444:raw:0:/dev/ttyUSB0:9600 8DATABITS NONE 1STOPBIT LOCAL
@@ -87,8 +87,8 @@ The following channels are available:
 
 monoprice.things:
 
-```java
-//serial port connection
+```
+// serial port connection
 monopriceaudio:amplifier:myamp "Monoprice WHA" [ serialPort="COM5", pollingInterval=15, numZones=6, inputLabel1="Chromecast", inputLabel2="Radio", inputLabel3="CD Player", inputLabel4="Bluetooth Audio", inputLabel5="HTPC", inputLabel6="Phono"]
 
 // serial over IP connection
@@ -98,7 +98,7 @@ monopriceaudio:amplifier:myamp "Monoprice WHA" [ host="192.168.0.10", port=4444,
 
 monoprice.items:
 
-```java
+```
 Switch all_allpower "All Zones Power" { channel="monopriceaudio:amplifier:myamp:all#allpower" }
 Number all_source "Source Input [%s]" { channel="monopriceaudio:amplifier:myamp:all#allsource" }
 Dimmer all_volume "Volume [%d %%]" { channel="monopriceaudio:amplifier:myamp:all#allvolume" }
@@ -115,12 +115,12 @@ Switch z1_dnd "Do Not Disturb" { channel="monopriceaudio:amplifier:myamp:zone1#d
 Switch z1_page "Page Active: [%s]" { channel="monopriceaudio:amplifier:myamp:zone1#page" }
 Switch z1_keypad "Keypad Connected: [%s]" { channel="monopriceaudio:amplifier:myamp:zone1#keypad" }
 
-//repeat for zones 2-18 (substitute z1 and zone1)
+// repeat for zones 2-18 (substitute z1 and zone1)
 ```
 
 monoprice.sitemap:
 
-```perl
+```
 sitemap monoprice label="Audio Control" {
     Frame label="All Zones" {
         Switch item=all_allpower label="All Zones On" mappings=[ON=" "]
@@ -133,7 +133,7 @@ sitemap monoprice label="Audio Control" {
     Frame label="Zone 1" {
         Switch item=z1_power
         Selection item=z1_source visibility=[z1_power==ON]
-        //Volume can be a Slider also
+        // Volume can be a Slider also
         Setpoint item=z1_volume minValue=0 maxValue=100 step=1 visibility=[z1_power==ON]
         Switch item=z1_mute visibility=[z1_power==ON]
         Setpoint item=z1_treble label="Treble Adjustment [%d]" minValue=-7 maxValue=7 step=1 visibility=[z1_power==ON]
@@ -144,6 +144,6 @@ sitemap monoprice label="Audio Control" {
         Text item=z1_keypad label="Keypad Connected: [%s]" visibility=[z1_power==ON]
     }
     
-    //repeat for zones 2-18 (substitute z1)
+    // repeat for zones 2-18 (substitute z1)
 }
 ```

--- a/bundles/org.openhab.binding.monopriceaudio/README.md
+++ b/bundles/org.openhab.binding.monopriceaudio/README.md
@@ -1,7 +1,7 @@
 # Monoprice Whole House Audio Binding
 
 This binding can be used to control a Monoprice MPR-SG6Z (10761), Monoprice Passive Matrix (39261) & Dayton Audio DAX66 whole house multi-zone amplifier system.
-All controller functions available through the serial port interface can be controlled by the binding.
+All amplifier functions available through the serial port interface can be controlled by the binding.
 Up to 18 zones can be controlled when 3 amps are connected together (if not all zones on the amp are used they can be excluded via configuration).
 Activating the 'Page All Zones' feature can only be done through the +12v trigger input on the back of the amplifier.
 
@@ -41,7 +41,7 @@ The thing has the following configuration parameters:
 | Address              | host             | Host name or IP address of the amplifier or serial over IP device                                                              | Host name or IP  |
 | Port                 | port             | Communication port (default 8080 for newer amps with built-in serial over IP)                                                  | TCP port number  |
 | Number of Zones      | numZones         | (Optional) Number of amplifier zones to utilize in the binding (up to 18 zones with 3 amplifiers connected together)           | 1-18; default 6  |
-| Polling Interval     | pollingInterval  | (Optional) Configures how often (in seconds) to poll the controller to check for zone updates                                  | 5-60; default 15 |
+| Polling Interval     | pollingInterval  | (Optional) Configures how often (in seconds) to poll the amplifier to check for zone updates                                   | 5-60; default 15 |
 | Ignore Zones         | ignoreZones      | (Optional) A comma seperated list of Zone numbers that will ignore the 'All Zone' (except All Off) commands                    | ie: "1,6,10"     |
 | Initial All Volume   | initialAllVolume | (Optional) When 'All' zones are activated, the volume will reset to this value to prevent excessive blaring of sound ;)        | 1-30; default 10 |
 | Source 1 Input Label | inputLabel1      | (Optional) Friendly name for the input source to be displayed in the UI (ie: Chromecast, Radio, CD, etc.) (default "Source 1") | A free text name |
@@ -80,7 +80,7 @@ The following channels are available:
 | zoneN#treble (where N= 1-18)  | Number    | Adjust the treble control for a zone (-7 to 7) -7=none, 0=flat, 7=full                                        |
 | zoneN#bass (where N= 1-18)    | Number    | Adjust the bass control for a zone (-7 to 7) -7=none, 0=flat, 7=full                                          |
 | zoneN#balance (where N= 1-18) | Number    | Adjust the balance control for a zone (-10 to 10) -10=left, 0=center, 10=right                                |
-| zoneN#dnd (where N= 1-18)     | Switch    | Turn on or off the Do Not Disturb for the zone (for when the controller's external page trigger is activated) |
+| zoneN#dnd (where N= 1-18)     | Switch    | Turn on or off the Do Not Disturb for the zone (for when the amplifier's external page trigger is activated)  |
 | zoneN#page (where N= 1-18)    | Contact   | Indicates if the page input is activated for the zone                                                         |
 | zoneN#keypad (where N= 1-18)  | Contact   | Indicates if the physical keypad is attached to a zone                                                        |
 

--- a/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/binding/binding.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Monoprice Whole House Audio Binding</name>
-	<description>Controls the Monoprice MPR-SG6Z or Dayton Audio DAX66 Whole House Amplifier.</description>
+	<description>Controls Monoprice and Dayton Audio Whole House Amplifiers.</description>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
@@ -99,12 +99,12 @@
 			<parameter name="host" type="text" required="false">
 				<context>network-address</context>
 				<label>Address</label>
-				<description>Host Name or IP Address of the Machine Connected to the Monoprice Amplifier (Serial over IP)</description>
+				<description>Host Name or IP Address of the Amplifier or Serial over IP device</description>
 			</parameter>
 			<parameter name="port" type="integer" min="1" max="65535" required="false">
 				<label>Port</label>
-				<description>Communication Port (IP or Serial over IP). For IP connection to the Monoprice Amplifier</description>
-				<default>4444</default>
+				<description>Communication Port for Serial over IP connection to the Monoprice Amplifier (Default 8080 for amps with built-in Serial over IP)</description>
+				<default>8080</default>
 			</parameter>
 			<parameter name="numZones" type="integer" min="1" max="18" required="true">
 				<label>Number of Zones</label>

--- a/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
@@ -103,7 +103,8 @@
 			</parameter>
 			<parameter name="port" type="integer" min="1" max="65535" required="false">
 				<label>Port</label>
-				<description>Communication Port for Serial over IP connection to the Amplifier (Default 8080 for amps with built-in Serial over IP)</description>
+				<description>Communication Port for Serial over IP connection to the Amplifier (Default 8080 for amps with built-in
+					Serial over IP)</description>
 				<default>8080</default>
 			</parameter>
 			<parameter name="numZones" type="integer" min="1" max="18" required="true">

--- a/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
@@ -6,7 +6,7 @@
 
 	<!-- Monoprice Whole House Amplifier Thing -->
 	<thing-type id="amplifier">
-		<label>Whole House Amplifier</label>
+		<label>Monoprice 10761 Amplifier, 39261 Matrix or Dayton DAX66 Amplifier</label>
 		<description>
 			A Multi-zone Whole House Amplifier System
 		</description>

--- a/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
@@ -103,7 +103,7 @@
 			</parameter>
 			<parameter name="port" type="integer" min="1" max="65535" required="false">
 				<label>Port</label>
-				<description>Communication Port for Serial over IP connection to the Monoprice Amplifier (Default 8080 for amps with built-in Serial over IP)</description>
+				<description>Communication Port for Serial over IP connection to the Amplifier (Default 8080 for amps with built-in Serial over IP)</description>
 				<default>8080</default>
 			</parameter>
 			<parameter name="numZones" type="integer" min="1" max="18" required="true">

--- a/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.monopriceaudio/src/main/resources/OH-INF/thing/channels.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- Monoprice Whole House Amplifier Thing -->
+	<!-- Monoprice 10761/39261/DAX66 Amplifier Thing -->
 	<thing-type id="amplifier">
 		<label>Monoprice 10761 Amplifier, 39261 Matrix or Dayton DAX66 Amplifier</label>
 		<description>


### PR DESCRIPTION
In preparation to release a beta version of this binding to the marketplace which will support additional models, the mainline version is updated via this PR to better identify which models are supported. No functional changes are present in this PR, only documentation and name/label changes are made.