### PR TITLE
Update Jackson version to 2.12.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <bnd.version>6.0.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
-    <jackson.version>2.12.3</jackson.version>
+    <jackson.version>2.12.5</jackson.version>
     <karaf.version>4.3.3</karaf.version>
     <netty.version>4.1.68.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>


### PR DESCRIPTION
This is the version used in the feature provided by openhab-core.

Depends on https://github.com/openhab/openhab-core/pull/2572