### PR TITLE
[radiothermostat] Fix JSON thermostat data parsing error

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -74,7 +74,7 @@ The thermostat information that is retrieved is available as these channels:
 
 radiotherm.map:
 
-```text
+```
 UNDEF_stus=-
 NULL_stus=-
 -_stus=-
@@ -117,14 +117,14 @@ NULL_over=-
 
 radiotherm.things:
 
-```java
+```
 radiothermostat:rtherm:mytherm1 "My 1st floor thermostat" [ hostName="192.168.10.1", refresh=2, logRefresh=10, isCT80=false, disableLogs=false, setpointMode="temporary" ]
 radiothermostat:rtherm:mytherm2 "My 2nd floor thermostat" [ hostName="mythermhost2", refresh=1, logRefresh=20, isCT80=true, disableLogs=false, setpointMode="absolute" ]
 ```
 
 radiotherm.items:
 
-```java
+```
 Number:Temperature  Therm_Temp  "Current Temperature [%.1f °F] " <temperature>  { channel="radiothermostat:rtherm:mytherm1:temperature" }
 // Humidity only supported on CT80
 Number Therm_Hum                "Current Humidity [%d %%]" <temperature>        { channel="radiothermostat:rtherm:mytherm1:humidity" }
@@ -158,7 +158,7 @@ Switch Therm_mysetting   "Send my preferred setting"
 
 radiotherm.sitemap:
 
-```perl
+```
 sitemap radiotherm label="My Thermostat" {
     Frame label="My 1st floor thermostat" {
         Text item=Therm_Temp icon="temperature" valuecolor=[>76="orange",>67.5="green",<=67.5="blue"]
@@ -196,7 +196,7 @@ sitemap radiotherm label="My Thermostat" {
 
 radiotherm.rules:
 
-```java
+```
 rule "Send my thermostat command"
 when
   Item Therm_mysetting received command

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/dto/RadioThermostatTstatDTO.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/dto/RadioThermostatTstatDTO.java
@@ -35,10 +35,10 @@ public class RadioThermostatTstatDTO {
     private Integer programMode;
 
     @SerializedName("t_heat")
-    private Integer heatTarget;
+    private Double heatTarget;
 
     @SerializedName("t_cool")
-    private Integer coolTarget;
+    private Double coolTarget;
 
     @SerializedName("override")
     private Integer override;
@@ -86,19 +86,19 @@ public class RadioThermostatTstatDTO {
         this.programMode = programMode;
     }
 
-    public Integer getHeatTarget() {
+    public Double getHeatTarget() {
         return heatTarget;
     }
 
-    public void setHeatTarget(Integer heatTarget) {
+    public void setHeatTarget(Double heatTarget) {
         this.heatTarget = heatTarget;
     }
 
-    public Integer getCoolTarget() {
+    public Double getCoolTarget() {
         return coolTarget;
     }
 
-    public void setCoolTarget(Integer coolTarget) {
+    public void setCoolTarget(Double coolTarget) {
         this.coolTarget = coolTarget;
     }
 
@@ -129,9 +129,9 @@ public class RadioThermostatTstatDTO {
      */
     public Integer getSetpoint() {
         if (mode == 1) {
-            return heatTarget;
+            return heatTarget.intValue();
         } else if (mode == 2) {
-            return coolTarget;
+            return coolTarget.intValue();
         } else {
             return 0;
         }

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -233,7 +233,8 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
             };
 
             logRefreshJob = null;
-            this.logRefreshJob = scheduler.scheduleWithFixedDelay(runnable, 1, logRefreshPeriod, TimeUnit.MINUTES);
+            this.logRefreshJob = scheduler.scheduleWithFixedDelay(runnable, (!this.clockSync ? 1 : 2), logRefreshPeriod,
+                    TimeUnit.MINUTES);
         }
     }
 
@@ -289,8 +290,8 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
                         // set the new operating mode, reset everything else,
                         // because refreshing the tstat data below is really slow.
                         rthermData.getThermostatData().setMode(cmdInt);
-                        rthermData.getThermostatData().setHeatTarget(0);
-                        rthermData.getThermostatData().setCoolTarget(0);
+                        rthermData.getThermostatData().setHeatTarget(Double.valueOf(0));
+                        rthermData.getThermostatData().setCoolTarget(Double.valueOf(0));
                         updateChannel(SET_POINT, rthermData);
                         rthermData.getThermostatData().setHold(0);
                         updateChannel(HOLD, rthermData);
@@ -323,10 +324,10 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
                     String cmdKey = null;
                     if (rthermData.getThermostatData().getMode() == 1) {
                         cmdKey = this.setpointCmdKeyPrefix + "heat";
-                        rthermData.getThermostatData().setHeatTarget(cmdInt);
+                        rthermData.getThermostatData().setHeatTarget(Double.valueOf(cmdInt));
                     } else if (rthermData.getThermostatData().getMode() == 2) {
                         cmdKey = this.setpointCmdKeyPrefix + "cool";
-                        rthermData.getThermostatData().setCoolTarget(cmdInt);
+                        rthermData.getThermostatData().setCoolTarget(Double.valueOf(cmdInt));
                     } else {
                         // don't do anything if we are not in heat or cool mode
                         break;


### PR DESCRIPTION
Fix #11625 
If the thermostat returned a JSON value for the set point that was not a whole number (not ending in .00), the JSON parsing would silently fail and prevent the thermostat channels from updating. The DTO was updated to parse these values as a Double instead of Integer.

Test build available here:
https://github.com/mlobstein/mlobstein-beta-test/raw/master/org.openhab.binding.radiothermostat-3.2.0-SNAPSHOT.jar
