### PR TITLE
[avmfritz] Add representation-property to bridge type definitions

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzUpnpDiscoveryParticipant.java
@@ -16,7 +16,6 @@ import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 import static org.openhab.core.thing.Thing.PROPERTY_VENDOR;
 
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,6 +27,7 @@ import org.jupnp.model.meta.RemoteDevice;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.openhab.core.config.discovery.upnp.internal.UpnpDiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.ComponentContext;
@@ -83,16 +83,11 @@ public class AVMFritzUpnpDiscoveryParticipant implements UpnpDiscoveryParticipan
             if (uid != null) {
                 logger.debug("discovered: {} ({}) at {}", device.getDisplayString(),
                         device.getDetails().getFriendlyName(), device.getIdentity().getDescriptorURL().getHost());
-
-                Map<String, Object> properties = new HashMap<>();
-                properties.put(CONFIG_IP_ADDRESS, device.getIdentity().getDescriptorURL().getHost());
-                properties.put(PROPERTY_VENDOR, device.getDetails().getManufacturerDetails().getManufacturer());
-
-                DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                return DiscoveryResultBuilder.create(uid)
+                        .withProperties(Map.of(CONFIG_IP_ADDRESS, device.getIdentity().getDescriptorURL().getHost(),
+                                PROPERTY_VENDOR, device.getDetails().getManufacturerDetails().getManufacturer()))
                         .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(CONFIG_IP_ADDRESS)
                         .build();
-
-                return result;
             }
         }
         return null;

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/thing/bridge-types.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/thing/bridge-types.xml
@@ -17,6 +17,8 @@
 			<channel id="apply_template" typeId="apply_template"/>
 		</channels>
 
+		<representation-property>ipAddress</representation-property>
+
 		<config-description-ref uri="bridge-type:avmfritz:fritzbox"/>
 	</bridge-type>
 
@@ -33,6 +35,8 @@
 			<channel id="power" typeId="power"/>
 			<channel id="outlet" typeId="outlet"/>
 		</channels>
+
+		<representation-property>ipAddress</representation-property>
 
 		<config-description-ref uri="bridge-type:avmfritz:fritzpowerline"/>
 	</bridge-type>


### PR DESCRIPTION
- Added representation-property to bridge type definitions

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
