### PR TITLE
[openwebnet] Fixes discovery of devices on local bus. Added it translation

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -188,7 +188,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
 
         DiscoveryResult discoveryResult = null;
 
-        String whereConfig = bridgeHandler.normalizeWhere(where);
+        String whereConfig = where.value();
         if (where instanceof WhereZigBee && WhereZigBee.UNIT_02.equals(((WhereZigBee) where).getUnit())) {
             logger.debug("UNIT=02 found (WHERE={}) -> will remove previous result if exists", where);
             thingRemoved(thingUID); // remove previously discovered thing

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -600,7 +600,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     }
 
     /**
-     * Normalize a Where address
+     * Normalize a Where address to generate ownId and Thing id
      *
      * @param where the Where address
      * @return the normalized address as String

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -1,12 +1,18 @@
-# Thing status descriptions
-offline.conf-error-no-ip-address = Cannot connect to gateway. No host/IP has been provided in Bridge configuration.
-offline.conf-error-no-serial-port = Cannot connect to gateway. No serial port has been provided in Bridge configuration.
-offline.conf-error-where = WHERE parameter in Thing configuration is null or invalid
-offline.conf-error-no-bridge = No bridge associated, please assign a bridge in Thing configuration.
-offline.conf-error-auth = Authentication error. Check gateway password in Thing Configuration Parameters
+# binding
 
-offline.comm-error-disconnected = Disconnected from gateway
-offline.comm-error-timeout = Connection to gateway timed out
-offline.comm-error-connection = Could not connect to gateway 
+binding.openwebnet.name = OpenWebNet (BTicino/Legrand) Binding
+binding.openwebnet.description = The OpenWebNet binding integrates BTicino (Legrand) MyHOME&reg; BUS and wireless systems using the OpenWebNet protocol.
+
+# thing status descriptions
+
+offline.conf-error-no-ip-address = Cannot connect to gateway. No host/IP address has been provided in configuration.
+offline.conf-error-no-serial-port = Cannot connect to gateway. No serial port has been provided in configuration.
+offline.conf-error-where = OpenWebNet Address (where) parameter in configuration is null or invalid.
+offline.conf-error-no-bridge = No bridge associated. Assign a bridge in configuration.
+offline.conf-error-auth = Authentication failed. Check gateway password in configuration.
+
+offline.comm-error-disconnected = Disconnected from gateway.
+offline.comm-error-timeout = Connection to gateway timed out.
+offline.comm-error-connection = Could not connect to gateway.
 
 unknown.waiting-state = Waiting state update...

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_hu.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_hu.properties
@@ -1,7 +1,7 @@
 # Thing status descriptions
 offline.conf-error-no-ip-address = Nem lehet az átjáróhoz csatlakozni. Nincs gazdanév/IP megadva a híd konfigurációjában.
 offline.conf-error-no-serial-port = Nem lehet az átjáróhoz csatlakozni. Nincs soros port megadva a híd konfigurációjában.
-offline.conf-error-where = WHERE paraméter a dolog konfigurációjában null vagy érvénytelen
+offline.conf-error-where = OpenWebNet Address (where) paraméter a dolog konfigurációjában null vagy érvénytelen
 offline.conf-error-no-bridge = Nincs híd hozzárendelve, a dolog konfigurációjában adjon meg egyet.
 offline.conf-error-auth = Hitelesítési hiba. Ellenőrizze az átjáró jelszavát a dolog beállítási paramétereiben
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_it.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_it.properties
@@ -1,0 +1,18 @@
+# binding
+
+binding.openwebnet.name = OpenWebNet (BTicino/Legrand) Binding
+binding.openwebnet.description = Il binding OpenWebNet integra i sistemi BTicino (Legrand) MyHOME&reg; BUS e wireless tramite il protocollo OpenWebNet.
+
+# thing status descriptions
+
+offline.conf-error-no-ip-address = Impossibile connettersi al gateway. Nessun host/IP specificato nella configurazione.
+offline.conf-error-no-serial-port = Impossibile connettersi al gateway. Nessuna porta seriale specificata nella configurazione.
+offline.conf-error-where = Il parametro OpenWebNet Address (where) nella configurazione è nullo o non valido.
+offline.conf-error-no-bridge = Nessun bridge associato. Assegnare un bridge nella configurazione.
+offline.conf-error-auth = Autenticazione fallita. Verificare la password nella configurazione.
+
+offline.comm-error-disconnected = Disconnesso dal gateway.
+offline.comm-error-timeout = Connessione al gateway non riuscita in tempo.
+offline.comm-error-connection = Impossibile connettersi al gateway.
+
+unknown.waiting-state = In attesa di aggiornamento di stato...


### PR DESCRIPTION
This PR fixes #11582: while discovering devices on local bus the where parameter is now set correctly, not using normalizeWhere().
In addition this PR adds translations string for `it ` locale.
