### PR TITLE
[transform][map] Fixed wrong i18n properties and added label of Profile

### DIFF
--- a/bundles/org.openhab.transform.map/src/main/resources/OH-INF/i18n/transform.properties
+++ b/bundles/org.openhab.transform.map/src/main/resources/OH-INF/i18n/transform.properties
@@ -1,6 +1,7 @@
 # bundle config
 
-profile.config.transform.function.label = Filename
-profile.config.transform.function.description = Filename containing the mapping information.
-profile.config.transform.sourceFormat.label = State Formatter
-profile.config.transform.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)
+profile-type.transform.MAP.label = MAP
+profile.config.transform.MAP.function.label = Filename
+profile.config.transform.MAP.function.description = Filename containing the mapping information.
+profile.config.transform.MAP.sourceFormat.label = State Formatter
+profile.config.transform.MAP.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).


### PR DESCRIPTION
- Fixed wrong i18n properties and added label of Profile

The i18n properties for Profiles were not created correctly in https://github.com/openhab/openhab-addons/pull/11574. Additional the label of the Profile was not added automatically.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
