### PR TITLE
Add i18n-maven-plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,12 @@ Import-Package: \\
         </plugin>
 
         <plugin>
+          <groupId>org.openhab.core.tools</groupId>
+          <artifactId>i18n-maven-plugin</artifactId>
+          <version>${ohc.version}</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.openhab.tools.sat</groupId>
           <artifactId>sat-plugin</artifactId>
           <version>${sat.version}</version>
@@ -541,6 +547,7 @@ Import-Package: \\
             </execution>
           </executions>
         </plugin>
+
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>


### PR DESCRIPTION
When the plugin dependency is managed you can also use the plugin without adding GAV parameters to commands.

E.g. it allows for using it with:

```
mvn i18n:generate-default-translations
```

Depends on https://github.com/openhab/openhab-core/pull/2544