### PR TITLE
[lifx] Improve InterruptedException handling

### DIFF
--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/util/LifxThrottlingUtil.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/util/LifxThrottlingUtil.java
@@ -81,7 +81,7 @@ public final class LifxThrottlingUtil {
 
     private static Map<MACAddress, LifxLightCommunicationTracker> macTrackerMapping = new ConcurrentHashMap<>();
 
-    public static void lock(@Nullable MACAddress mac) {
+    public static void lock(@Nullable MACAddress mac) throws InterruptedException {
         if (mac != null) {
             LifxLightCommunicationTracker tracker = getOrCreateTracker(mac);
             tracker.lock();
@@ -108,14 +108,10 @@ public final class LifxThrottlingUtil {
         return tracker;
     }
 
-    private static void waitForNextPacketInterval(long timestamp) {
+    private static void waitForNextPacketInterval(long timestamp) throws InterruptedException {
         long timeToWait = Math.max(PACKET_INTERVAL - (System.currentTimeMillis() - timestamp), 0);
         if (timeToWait > 0) {
-            try {
-                Thread.sleep(timeToWait);
-            } catch (InterruptedException e) {
-                LOGGER.error("An exception occurred while putting the thread to sleep : '{}'", e.getMessage());
-            }
+            Thread.sleep(timeToWait);
         }
     }
 
@@ -130,7 +126,7 @@ public final class LifxThrottlingUtil {
         }
     }
 
-    public static void lock() {
+    public static void lock() throws InterruptedException {
         long lastStamp = 0;
         for (LifxLightCommunicationTracker tracker : trackers) {
             tracker.lock();


### PR DESCRIPTION
When the binding is stopped sleeping threads are interrupted by design.
By throwing the InterruptedException, it should be caught in LifxSelectorUtil.sendPacket (which is waiting for the packet interval to elapse), which will then abort sending a packet.

This prevents:

```
[ERROR] [lifx.internal.util.LifxThrottlingUtil] - An exception occurred while putting the thread to sleep : 'sleep interrupted'
```