### PR TITLE
[xmppclient] Update smack to 4.4.4 and fix dependencies

### DIFF
--- a/bundles/org.openhab.binding.xmppclient/pom.xml
+++ b/bundles/org.openhab.binding.xmppclient/pom.xml
@@ -108,37 +108,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.igniterealtime.smack</groupId>
-      <artifactId>smack-resolver-minidns</artifactId>
-      <version>${smack.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.minidns</groupId>
       <artifactId>minidns-core</artifactId>
       <version>1.0.2</version>
     </dependency>
-    <dependency>
-      <groupId>org.minidns</groupId>
-      <artifactId>minidns-dnssec</artifactId>
-      <version>1.0.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.minidns</groupId>
-      <artifactId>minidns-client</artifactId>
-      <version>1.0.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.minidns</groupId>
-      <artifactId>minidns-iterative-resolver</artifactId>
-      <version>1.0.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.minidns</groupId>
-      <artifactId>minidns-hla</artifactId>
-      <version>1.0.2</version>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.aries.spifly</groupId>
       <artifactId>org.apache.aries.spifly.dynamic.framework.extension</artifactId>

--- a/bundles/org.openhab.binding.xmppclient/pom.xml
+++ b/bundles/org.openhab.binding.xmppclient/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>xpp3</groupId>
-      <artifactId>xpp3_min</artifactId>
+      <artifactId>xpp3</artifactId>
       <version>1.1.4c</version>
     </dependency>
     <dependency>
@@ -146,12 +146,6 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
       <version>9.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xmlpull</artifactId>
-      <version>1.1.3.1_2</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.xmppclient/pom.xml
+++ b/bundles/org.openhab.binding.xmppclient/pom.xml
@@ -15,45 +15,170 @@
   <name>openHAB Add-ons :: Bundles :: XMPPClient Binding</name>
 
   <properties>
-    <smack.version>4.3.3</smack.version>
+    <smack.version>4.4.4</smack.version>
+    <bnd.importpackage>
+      !android.*,!sun.security.*
+    </bnd.importpackage>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
-      <artifactId>smack-java7</artifactId>
+      <artifactId>smack-core</artifactId>
       <version>${smack.version}</version>
-      <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-xmlparser</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-xmlparser-xpp3</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>xpp3</groupId>
+      <artifactId>xpp3_min</artifactId>
+      <version>1.1.4c</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jxmpp</groupId>
+      <artifactId>jxmpp-core</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jxmpp</groupId>
+      <artifactId>jxmpp-util-cache</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jxmpp</groupId>
+      <artifactId>jxmpp-jid</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-java8</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-sasl-javax</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-resolver-javax</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-extensions</artifactId>
       <version>${smack.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-im</artifactId>
       <version>${smack.version}</version>
-      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-tcp</artifactId>
       <version>${smack.version}</version>
-      <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-streammanagement</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-experimental</artifactId>
       <version>${smack.version}</version>
-      <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hsluv</groupId>
+      <artifactId>hsluv</artifactId>
+      <version>0.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.igniterealtime.smack</groupId>
+      <artifactId>smack-resolver-minidns</artifactId>
+      <version>${smack.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.minidns</groupId>
       <artifactId>minidns-core</artifactId>
-      <version>0.3.3</version>
-      <scope>provided</scope>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.minidns</groupId>
+      <artifactId>minidns-dnssec</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.minidns</groupId>
+      <artifactId>minidns-client</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.minidns</groupId>
+      <artifactId>minidns-iterative-resolver</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.minidns</groupId>
+      <artifactId>minidns-hla</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.aries.spifly</groupId>
+      <artifactId>org.apache.aries.spifly.dynamic.framework.extension</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.aries.spifly</groupId>
+      <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-tree</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>9.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.xmlpull</artifactId>
+      <version>1.1.3.1_2</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
@@ -5,11 +5,6 @@
 	<feature name="openhab-binding-xmppclient" description="XMPP Client Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.69</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-core/1.0.2</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-dnssec/1.0.2</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-client/1.0.2</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-iterative-resolver/1.0.2</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-hla/1.0.2</bundle>
 		<bundle dependency="true">mvn:org.jxmpp/jxmpp-core/1.0.3</bundle>
 		<bundle dependency="true">mvn:org.jxmpp/jxmpp-jid/1.0.3</bundle>
 		<bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/1.0.3</bundle>

--- a/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
@@ -4,22 +4,22 @@
 
 	<feature name="openhab-binding-xmppclient" description="XMPP Client Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-extensions/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-experimental/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-im/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-tcp/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-core/0.6.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-jid/0.6.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/0.6.3</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-core/0.3.3</bundle>
 		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.69</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-core/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-sasl-javax/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_7</bundle>
-		<!-- FIXME: implicit dependencies required at runtime but not automatically installed, this is a workaround -->
-		<bundle start-level="80">mvn:org.igniterealtime.smack/smack-resolver-javax/4.3.3</bundle>
-		<bundle start-level="80">mvn:org.igniterealtime.smack/smack-java7/4.3.3</bundle>
+		<bundle dependency="true">mvn:org.minidns/minidns-core/1.0.2</bundle>
+		<bundle dependency="true">mvn:org.minidns/minidns-dnssec/1.0.2</bundle>
+		<bundle dependency="true">mvn:org.minidns/minidns-client/1.0.2</bundle>
+		<bundle dependency="true">mvn:org.minidns/minidns-iterative-resolver/1.0.2</bundle>
+		<bundle dependency="true">mvn:org.minidns/minidns-hla/1.0.2</bundle>
+		<bundle dependency="true">mvn:org.jxmpp/jxmpp-core/1.0.3</bundle>
+		<bundle dependency="true">mvn:org.jxmpp/jxmpp-jid/1.0.3</bundle>
+		<bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/1.0.3</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-core/4.4.4</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-extensions/4.4.4</bundle>
+		<!-- SPI Fly provides the ServiceLoader for OSGi, required by smack-xmlparser -->
+		<bundle start-level="50">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.framework.extension/1.3.2</bundle>
+		<bundle start-level="50">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlpull/1.1.3.1_2</bundle>
+		<bundle start-level="60">mvn:org.igniterealtime.smack/smack-xmlparser-xpp3/4.4.4</bundle>
+		<bundle start-level="70">mvn:org.igniterealtime.smack/smack-xmlparser/4.4.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.xmppclient/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
@@ -4,15 +4,25 @@
 
 	<feature name="openhab-binding-xmppclient" description="XMPP Client Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.69</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-core/1.0.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-jid/1.0.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/1.0.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-core/4.4.4</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-extensions/4.4.4</bundle>
+		<feature prerequisite="true">wrap</feature>
+		<bundle>mvn:org.jxmpp/jxmpp-core/1.0.3</bundle>
+		<bundle>mvn:org.jxmpp/jxmpp-jid/1.0.3</bundle>
+		<bundle>mvn:org.jxmpp/jxmpp-util-cache/1.0.3</bundle>
+		<bundle>mvn:org.minidns/minidns-core/1.0.2</bundle>
+		<bundle>wrap:mvn:org.igniterealtime.smack/smack-core/4.4.4$Import-Package=!sun.security.pkcs11,org.jivesoftware.*&amp;overwrite=merge</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-extensions/4.4.4</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-experimental/4.4.4</bundle>
+		<bundle>wrap:mvn:org.hsluv/hsluv/0.2</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-im/4.4.4</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-tcp/4.4.4</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-streammanagement/4.4.4</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-resolver-javax/4.4.4</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-sasl-javax/4.4.4</bundle>
+		<bundle>mvn:org.igniterealtime.smack/smack-java8/4.4.4</bundle>
 		<!-- SPI Fly provides the ServiceLoader for OSGi, required by smack-xmlparser -->
 		<bundle start-level="50">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.framework.extension/1.3.2</bundle>
-		<bundle start-level="50">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlpull/1.1.3.1_2</bundle>
+		<bundle start-level="50">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.3.2</bundle>
+		<bundle start-level="50">wrap:mvn:xpp3/xpp3/1.1.4c</bundle>
 		<bundle start-level="60">mvn:org.igniterealtime.smack/smack-xmlparser-xpp3/4.4.4</bundle>
 		<bundle start-level="70">mvn:org.igniterealtime.smack/smack-xmlparser/4.4.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.xmppclient/${project.version}</bundle>


### PR DESCRIPTION
I updated smack to 4.4.4 and updated also all transitive dependencies. A connection to a XMPP server is working when letting it run with eclipse/bndtools and the karaf feature verification succeeds, too. But when building a kar and deploying it in an openHAB instance, I get the following error:
```
org.apache.felix.resolver.reason.ReasonException: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=org.openhab.binding.xmppclient; type=karaf.feature; version="[3.2.0.SNAPSHOT,3.2.0.SNAPSHOT]"; filter:="(&(osgi.identity=org.openhab.binding.xmppclient)(type=karaf.feature)(version>=3.2.0.SNAPSHOT)(version<=3.2.0.SNAPSHOT))" [caused by: Unable to resolve org.openhab.binding.xmppclient/3.2.0.SNAPSHOT: missing requirement [org.openhab.binding.xmppclient/3.2.0.SNAPSHOT] osgi.identity; osgi.identity=minidns-client; type=osgi.bundle; version="[1.0.2,1.0.2]"; resolution:=mandatory [caused by: Unable to resolve minidns-client/1.0.2: missing requirement [minidns-client/1.0.2] osgi.wiring.package; filter:="(osgi.wiring.package=android.os)"]]
```
The transitive dependency minidns-client imports `android.os`. I tried to wrap the minidns-client bundle and add `!android.*` to `Import-Package`, but that doesn't seem to have any effect to the manifest file in the minidns-client JAR in the KAR file.
```
<bundle dependency="true">wrap:mvn:org.minidns/minidns-client/1.0.2$Import-Package=!android.*&amp;overwrite=merge</bundle>
```

I think I came to an end with my OSGi/karaf knowledge. Any help appreciated. @wborn @flowdalic @ibauersachs

Fixes #11560