### PR TITLE
[homekit] switch to official Java HAP lib release

### DIFF
--- a/bundles/org.openhab.io.homekit/pom.xml
+++ b/bundles/org.openhab.io.homekit/pom.xml
@@ -20,9 +20,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.j-n-k</groupId>
-      <artifactId>hap-java</artifactId>
-      <version>2.1.0.OH</version>
+      <groupId>io.github.hap-java</groupId>
+      <artifactId>hap</artifactId>
+      <version>2.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitGarageDoorOpenerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitGarageDoorOpenerImpl.java
@@ -74,7 +74,7 @@ public class HomekitGarageDoorOpenerImpl extends AbstractHomekitAccessoryImpl im
         } else if (stringValue.equalsIgnoreCase(settings.doorCurrentStateOpening)) {
             mode = CurrentDoorStateEnum.OPENING;
         } else if (stringValue.equalsIgnoreCase(settings.doorCurrentStateStopped)) {
-            mode = CurrentDoorStateEnum.SOPPED;
+            mode = CurrentDoorStateEnum.STOPPED;
         } else if (stringValue.equals("UNDEF") || stringValue.equals("NULL")) {
             logger.warn("Current door state not available. Relaying value of CLOSED to HomeKit");
             mode = CurrentDoorStateEnum.CLOSED;


### PR DESCRIPTION
homekit binding uses Java-HAP library that implements apple homekit protocol. 
as Java-HAP project had very long release cycles, @J-N-K  was creating in the past the openHAB specific releases in order to make latest features available to openHAB.

few months ago, Java HAP project made an official release that incorporates all the changes of @J-N-K  release as well as few minor improvements, e.g. fix of a typo. 

this PR switch OH to the official release of Java-HAP

Signed-off-by: Eugen Freiter <freiter@gmx.de>
