### PR TITLE
[nuvo] Update thing label for better matching in Add-On search

### DIFF
--- a/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/thing/channels.xml
@@ -6,7 +6,7 @@
 
 	<!-- Nuvo Whole House Amplifier Thing -->
 	<thing-type id="amplifier">
-		<label>Nuvo Whole House Amplifier</label>
+		<label>Grand Concerto or Essentia G Whole House Amplifier</label>
 		<description>
 			A Multi-zone Whole House Amplifier System
 		</description>

--- a/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/thing/channels.xml
@@ -6,9 +6,9 @@
 
 	<!-- Nuvo Whole House Amplifier Thing -->
 	<thing-type id="amplifier">
-		<label>Grand Concerto or Essentia G Whole House Amplifier</label>
+		<label>Nuvo Whole House Amplifier</label>
 		<description>
-			A Multi-zone Whole House Amplifier System
+			Grand Concerto or Essentia G Amplifier System
 		</description>
 
 		<channel-groups>


### PR DESCRIPTION
Update the thing label name so searching by the model name returns a thing result in the Add-On search page.