### PR TITLE
[radiothermostat] Update thing label for better matching in Add-On search

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -6,9 +6,9 @@
 
 	<!-- RadioThemostat Thing -->
 	<thing-type id="rtherm">
-		<label>CT30, CT50/3M50 or CT80 Wi-Fi Thermostat</label>
+		<label>Thermostat</label>
 		<description>
-			A Thermostat to Control the House's HVAC System
+			CT30, CT50/3M50 or CT80 Wi-Fi Thermostat
 		</description>
 
 		<channels>

--- a/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -6,7 +6,7 @@
 
 	<!-- RadioThemostat Thing -->
 	<thing-type id="rtherm">
-		<label>Thermostat</label>
+		<label>CT30, CT50/3M50 or CT80 Wi-Fi Thermostat</label>
 		<description>
 			A Thermostat to Control the House's HVAC System
 		</description>


### PR DESCRIPTION
Update the thing label name so searching by the thermostat model name returns a thing result in the Add-On search page.