### PR TITLE
[tplinksmarthome] Fixed invalid channels in KL125/KL135 definition.

### DIFF
--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/KL125.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/KL125.xml
@@ -10,7 +10,7 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="system.brightness"/>
+			<channel id="color" typeId="system.color"/>
 			<channel id="colorTemperature" typeId="system.color-temperature"/>
 			<channel id="colorTemperatureAbs" typeId="colorTemperatureAbs3"/>
 			<channel id="power" typeId="power"/>

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/KL135.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/KL135.xml
@@ -10,7 +10,7 @@
 		<category>Lightbulb</category>
 
 		<channels>
-			<channel id="brightness" typeId="system.brightness"/>
+			<channel id="color" typeId="system.color"/>
 			<channel id="colorTemperature" typeId="system.color-temperature"/>
 			<channel id="colorTemperatureAbs" typeId="colorTemperatureAbs3"/>
 			<channel id="power" typeId="power"/>


### PR DESCRIPTION
These are color bulbs and should have the color channel instead of the brightness channel.
Closes #11660
