### PR TITLE
[logreader] Added pattern for DateTime channel types

### DIFF
--- a/bundles/org.openhab.binding.logreader/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.logreader/src/main/resources/OH-INF/thing/channels.xml
@@ -8,62 +8,60 @@
 		<item-type>String</item-type>
 		<label>Last Error Event</label>
 		<description>Displays contents of last [ERROR] event</description>
-		<state readOnly="true"></state>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="lastWarningEvent">
 		<item-type>String</item-type>
 		<label>Last Warning Event</label>
 		<description>Displays contents of last [WARN] event</description>
-		<state readOnly="true"></state>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="lastCustomEvent" advanced="true">
 		<item-type>String</item-type>
 		<label>Last Custom Event</label>
 		<description>Displays contents of last custom event</description>
-		<state readOnly="true"></state>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="warningEvents">
 		<item-type>Number</item-type>
 		<label>Warning Events Matched</label>
 		<description>Displays number of [WARN] lines matched to search pattern</description>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="errorEvents">
 		<item-type>Number</item-type>
 		<label>Error Events Matched</label>
 		<description>Displays number of [ERROR] lines matched to search pattern</description>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="customEvents" advanced="true">
 		<item-type>Number</item-type>
 		<label>Custom Events Matched</label>
 		<description>Displays number of custom lines matched to search pattern</description>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="logRotated" advanced="true">
 		<item-type>DateTime</item-type>
 		<label>Log Rotated</label>
 		<description>Last time when log rotated recognized</description>
-		<state readOnly="true"></state>
+		<category>Time</category>
+		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
 	</channel-type>
 
 	<channel-type id="newErrorEvent">
 		<kind>trigger</kind>
 		<label>New Error Event</label>
 		<description>Fires when a new [ERROR] appears in the log</description>
-		<event>
-		</event>
 	</channel-type>
 	<channel-type id="newWarningEvent">
 		<kind>trigger</kind>
 		<label>New Warning Event</label>
 		<description>Fires when a new [WARN] appears in the log</description>
-		<event>
-		</event>
 	</channel-type>
 	<channel-type id="newCustomEvent" advanced="true">
 		<kind>trigger</kind>
 		<label>New Custom Event</label>
 		<description>Fires when a new [CUSTOM] appears in the log</description>
-		<event>
-		</event>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
- Added pattern for DateTime channel types

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
