### PR TITLE
[chromecast] Added configuration flag to disable background discovery

### DIFF
--- a/bundles/org.openhab.binding.chromecast/README.md
+++ b/bundles/org.openhab.binding.chromecast/README.md
@@ -30,6 +30,12 @@ Configure a Callback URL when the Chromecast cannot connect using the Primary Ad
 
 Chromecast devices are discovered on the network using UPnP.
 No authentication is required for accessing the devices on the network.
+Auto-discovery is enabled by default.
+To disable it, you can add the following line to `<openHAB-conf>/services/runtime.cfg`:
+
+```
+discovery.chromecast:background=false
+```
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.chromecast/README.md
+++ b/bundles/org.openhab.binding.chromecast/README.md
@@ -28,7 +28,7 @@ Configure a Callback URL when the Chromecast cannot connect using the Primary Ad
 
 ## Discovery
 
-Chromecast devices are discovered on the network using UPnP.
+Chromecast devices are discovered on the network using mDNS.
 No authentication is required for accessing the devices on the network.
 Auto-discovery is enabled by default.
 To disable it, you can add the following line to `<openHAB-conf>/services/runtime.cfg`:
@@ -42,7 +42,7 @@ discovery.chromecast:background=false
 Chromecast devices can also be manually added.
 The only configuration parameter is the `ipAddress`.
 For an audio group also the port is necessary.
-The autodiscovery process finds the port automatically.
+The auto-discovery process finds the port automatically.
 With manual thing configuration the parameter `port` must be determined manually.
 
 Example for audio group:

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
@@ -14,7 +14,7 @@ package org.openhab.binding.chromecast.internal.discovery;
 
 import static org.openhab.binding.chromecast.internal.ChromecastBindingConstants.*;
 
-import java.util.HashMap;
+import java.util.Dictionary;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,7 +27,10 @@ import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,16 +39,38 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Daniel Walters - Change discovery protocol to mDNS
+ * @author Christoph Weitkamp - Use "discovery.chromecast:background=false" to disable discovery service
  */
-@Component
+@Component(configurationPid = "discovery.chromecast")
 @NonNullByDefault
 public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant {
+
     private final Logger logger = LoggerFactory.getLogger(ChromecastDiscoveryParticipant.class);
 
     private static final String PROPERTY_MODEL = "md";
     private static final String PROPERTY_FRIENDLY_NAME = "fn";
     private static final String PROPERTY_DEVICE_ID = "id";
     private static final String SERVICE_TYPE = "_googlecast._tcp.local.";
+
+    private boolean isAutoDiscoveryEnabled = true;
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        activateOrModifyService(componentContext);
+    }
+
+    @Modified
+    protected void modified(ComponentContext componentContext) {
+        activateOrModifyService(componentContext);
+    }
+
+    private void activateOrModifyService(ComponentContext componentContext) {
+        Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
+        String autoDiscoveryPropertyValue = (String) properties.get("background");
+        if (autoDiscoveryPropertyValue != null && autoDiscoveryPropertyValue.length() != 0) {
+            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
+        }
+    }
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
@@ -59,25 +84,20 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
     @Override
     public @Nullable DiscoveryResult createResult(ServiceInfo service) {
-        final ThingUID uid = getThingUID(service);
-        if (uid == null) {
-            return null;
+        if (isAutoDiscoveryEnabled) {
+            ThingUID uid = getThingUID(service);
+            if (uid != null) {
+                String host = service.getHostAddresses()[0];
+                int port = service.getPort();
+                logger.debug("Chromecast Found: {} {}", host, port);
+                String id = service.getPropertyString(PROPERTY_DEVICE_ID);
+                String friendlyName = service.getPropertyString(PROPERTY_FRIENDLY_NAME); // friendly name;
+                return DiscoveryResultBuilder.create(uid).withThingType(getThingType(service))
+                        .withProperties(Map.of(HOST, host, PORT, port, DEVICE_ID, id))
+                        .withRepresentationProperty(DEVICE_ID).withLabel(friendlyName).build();
+            }
         }
-
-        final Map<String, Object> properties = new HashMap<>(5);
-        String host = service.getHostAddresses()[0];
-        properties.put(HOST, host);
-        int port = service.getPort();
-        properties.put(PORT, port);
-        logger.debug("Chromecast Found: {} {}", host, port);
-        String id = service.getPropertyString(PROPERTY_DEVICE_ID);
-        properties.put(DEVICE_ID, id);
-        String friendlyName = service.getPropertyString(PROPERTY_FRIENDLY_NAME); // friendly name;
-
-        final DiscoveryResult result = DiscoveryResultBuilder.create(uid).withThingType(getThingType(service))
-                .withProperties(properties).withRepresentationProperty(DEVICE_ID).withLabel(friendlyName).build();
-
-        return result;
+        return null;
     }
 
     private @Nullable ThingTypeUID getThingType(final ServiceInfo service) {
@@ -102,8 +122,7 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
         if (thingTypeUID != null) {
             String id = service.getPropertyString(PROPERTY_DEVICE_ID); // device id
             return new ThingUID(thingTypeUID, id);
-        } else {
-            return null;
         }
+        return null;
     }
 }

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -35,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link ChromecastDiscoveryParticipant} is responsible for discovering Chromecast devices through UPnP.
+ * The {@link ChromecastDiscoveryParticipant} is responsible for discovering Chromecast devices through mDNS.
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Daniel Walters - Change discovery protocol to mDNS
@@ -66,8 +67,9 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
 
     private void activateOrModifyService(ComponentContext componentContext) {
         Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
-        String autoDiscoveryPropertyValue = (String) properties.get("background");
-        if (autoDiscoveryPropertyValue != null && autoDiscoveryPropertyValue.length() != 0) {
+        String autoDiscoveryPropertyValue = (String) properties
+                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
+        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
             isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
         }
     }


### PR DESCRIPTION
- Added configuration flag to disable background discovery

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
