### PR TITLE
[homeconnect] Add oven control

### DIFF
--- a/bundles/org.openhab.binding.homeconnect/README.md
+++ b/bundles/org.openhab.binding.homeconnect/README.md
@@ -285,11 +285,6 @@ Otherwise, all you need to do is re-authorize your bridge.
 
 ## FAQ
 
-### I can't start my oven via openHAB.
-
-Some operations are not possible at the moment. You need to sign an "Additional Partner Agreement". Please have a look at:
-https://developer.home-connect.com/docs/authorization/scope
-
 ### I can't switch remote start to on.
 
 The channel of type `remote_start_allowance_state` is read only. You can only enable it directly on the physical appliance.

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/HomeConnectBindingConstants.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/HomeConnectBindingConstants.java
@@ -241,7 +241,7 @@ public class HomeConnectBindingConstants {
     public static final String API_SIMULATOR_BASE_URL = "https://simulator.home-connect.com";
     public static final String OAUTH_TOKEN_PATH = "/security/oauth/token";
     public static final String OAUTH_AUTHORIZE_PATH = "/security/oauth/authorize";
-    public static final String OAUTH_SCOPE = "IdentifyAppliance Monitor Settings Dishwasher-Control Washer-Control Dryer-Control WasherDryer-Control CoffeeMaker-Control Hood-Control CleaningRobot-Control";
+    public static final String OAUTH_SCOPE = "IdentifyAppliance Monitor Settings Dishwasher-Control Washer-Control Dryer-Control WasherDryer-Control CoffeeMaker-Control Hood-Control Oven-Control CleaningRobot-Control";
 
     // Operation states
     public static final String OPERATION_STATE_INACTIVE = "BSH.Common.EnumType.OperationState.Inactive";


### PR DESCRIPTION
Allow to control oven via binding. It is now possible to control the oven without an additional agreement (start the program, etc.

Signed-off-by: Jonas Brüstel <jonas@bruestel.net>

