### PR TITLE
[hdpowerview] Fix initialization of shade handler

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -135,7 +135,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
 
         if (host == null || host.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "@text/offline.conf-error-no-host-address");
+                    "@text/offline.conf-error.no-host-address");
             return;
         }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -39,6 +39,7 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -80,14 +81,25 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
             getShadeId();
         } catch (NumberFormatException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Configuration 'id' not a valid integer");
+                    "@text/offline.conf-error.invalid-id");
             return;
         }
-        if (getBridgeHandler() == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Hub not configured");
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             return;
         }
-        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+        if (!(bridge.getHandler() instanceof HDPowerViewHubHandler)) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "@text/offline.conf-error.invalid-bridge-handler");
+            return;
+        }
+        ThingStatus bridgeStatus = bridge.getStatus();
+        if (bridgeStatus == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.ONLINE);
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
@@ -36,7 +36,9 @@ channel-type.hdpowerview.shade-vane.description = The opening of the slats in th
 
 # thing status descriptions
 
-offline.conf-error-no-host-address = Host address must be set
+offline.conf-error.no-host-address = Host address must be set
+offline.conf-error.invalid-id = Configuration 'id' not a valid integer
+offline.conf-error.invalid-bridge-handler = Invalid bridge handler
 
 # dynamic channels
 


### PR DESCRIPTION
Fixes #11702

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Shade things are initially incorrectly marked as offline with communication error, even after receiving the first update from the bridge handler. Only after one minute are they marked as online again.