### PR TITLE
[homekit] restart HomeKit bridge on network changes

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -33,6 +33,8 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mdns.MDNSClient;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.net.CidrAddress;
+import org.openhab.core.net.NetworkAddressChangeListener;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.storage.StorageService;
 import org.openhab.io.homekit.Homekit;
@@ -61,7 +63,7 @@ import io.github.hapjava.server.impl.crypto.HAPSetupCodeUtils;
         Constants.SERVICE_PID + "=org.openhab.homekit", "port:Integer=9123" })
 @ConfigurableService(category = "io", label = "HomeKit Integration", description_uri = "io:homekit")
 @NonNullByDefault
-public class HomekitImpl implements Homekit {
+public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
     private final Logger logger = LoggerFactory.getLogger(HomekitImpl.class);
 
     private final NetworkAddressService networkAddressService;
@@ -88,13 +90,14 @@ public class HomekitImpl implements Homekit {
         this.configAdmin = configAdmin;
         this.settings = processConfig(properties);
         this.mdnsClient = mdnsClient;
+        networkAddressService.addNetworkAddressChangeListener(this);
         this.changeListener = new HomekitChangeListener(itemRegistry, settings, metadataRegistry, storageService);
         try {
             authInfo = new HomekitAuthInfoImpl(storageService.getStorage(HomekitAuthInfoImpl.STORAGE_KEY), settings.pin,
                     settings.setupId);
             startHomekitServer();
         } catch (IOException | InvalidAlgorithmParameterException e) {
-            logger.warn("Cannot activate HomeKit binding. {}", e.getMessage());
+            logger.warn("cannot activate HomeKit binding. {}", e.getMessage());
             throw e;
         }
     }
@@ -107,7 +110,7 @@ public class HomekitImpl implements Homekit {
             config = configAdmin.getConfiguration(HomekitSettings.CONFIG_PID);
             props = config.getProperties();
         } catch (IOException e) {
-            logger.warn("Cannot retrieve config admin {}", e.getMessage());
+            logger.warn("cannot retrieve config admin {}", e.getMessage());
         }
 
         if (props == null) { // if null, the configuration is new
@@ -133,7 +136,7 @@ public class HomekitImpl implements Homekit {
             try {
                 config.updateIfDifferent(props);
             } catch (IOException e) {
-                logger.warn("Cannot update configuration {}", e.getMessage());
+                logger.warn("cannot update configuration {}", e.getMessage());
             }
         }
         return settings;
@@ -158,7 +161,7 @@ public class HomekitImpl implements Homekit {
                 startHomekitServer();
             }
         } catch (IOException e) {
-            logger.warn("Could not initialize HomeKit connector: {}", e.getMessage());
+            logger.warn("could not initialize HomeKit bridge: {}", e.getMessage());
         }
     }
 
@@ -185,7 +188,7 @@ public class HomekitImpl implements Homekit {
             int currentAccessoryCount = changeListener.getAccessories().size();
             if (currentAccessoryCount < lastAccessoryCount) {
                 logger.debug(
-                        "It looks like not all items were initialized yet. Old configuration had {} accessories, the current one has only {} accessories. Delay HomeKit bridge start for {} seconds.",
+                        "it looks like not all items were initialized yet. Old configuration had {} accessories, the current one has only {} accessories. Delay HomeKit bridge start for {} seconds.",
                         lastAccessoryCount, currentAccessoryCount, settings.startDelay);
                 scheduler.schedule(() -> {
                     if (currentAccessoryCount < lastAccessoryCount) {
@@ -205,17 +208,18 @@ public class HomekitImpl implements Homekit {
     }
 
     private void startHomekitServer() throws IOException {
+        logger.trace("start HomeKit bridge");
         if (homekitServer == null) {
             if (settings.useOHmDNS) {
                 if ((settings.networkInterface == null) || (settings.networkInterface.isEmpty())) {
                     logger.trace(
-                            "No IP address configured in HomeKit settings. HomeKit will use the first configured address of openHAB");
+                            "no IP address configured in HomeKit settings. HomeKit will use the first configured address of openHAB");
                     homekitServer = new HomekitServer(mdnsClient.getClientInstances().iterator().next(), settings.port);
                 } else {
                     networkInterface = InetAddress.getByName(settings.networkInterface);
                     for (JmDNS mdns : mdnsClient.getClientInstances()) {
                         if (mdns.getInetAddress().equals(networkInterface)) {
-                            logger.trace("Suitable mDNS client for IP {} found and will be used for HomeKit",
+                            logger.trace("suitable mDNS client for IP {} found and will be used for HomeKit",
                                     networkInterface);
                             homekitServer = new HomekitServer(mdns, settings.port);
                         }
@@ -224,9 +228,9 @@ public class HomekitImpl implements Homekit {
             }
             if (homekitServer == null) {
                 if (settings.useOHmDNS) {
-                    logger.trace("Not suitable mDNS server for IP {} found", networkInterface);
+                    logger.trace("no suitable mDNS server for IP {} found", networkInterface);
                 }
-                logger.trace("Create HomeKit server with dedicated mDNS server");
+                logger.trace("create HomeKit server with dedicated mDNS server");
                 homekitServer = new HomekitServer(networkInterface, settings.port);
             }
             startBridge();
@@ -236,6 +240,7 @@ public class HomekitImpl implements Homekit {
     }
 
     private void stopHomekitServer() {
+        logger.trace("stop HomeKit bridge");
         final @Nullable HomekitServer homekit = this.homekitServer;
         if (homekit != null) {
             if (bridge != null) {
@@ -248,6 +253,7 @@ public class HomekitImpl implements Homekit {
 
     @Deactivate
     protected void deactivate() {
+        networkAddressService.removeNetworkAddressChangeListener(this);
         changeListener.clearAccessories();
         stopHomekitServer();
         changeListener.stop();
@@ -280,7 +286,18 @@ public class HomekitImpl implements Homekit {
             authInfo.clear();
             refreshAuthInfo();
         } catch (Exception e) {
-            logger.warn("Could not clear HomeKit pairings", e);
+            logger.warn("could not clear HomeKit pairings", e);
+        }
+    }
+
+    @Override
+    public void onChanged(final List<CidrAddress> list, final List<CidrAddress> list1) {
+        logger.trace("restarting homekit bridge on network interface changes.");
+        stopHomekitServer();
+        try {
+            startHomekitServer();
+        } catch (IOException e) {
+            logger.warn("could not initialize HomeKit bridge: {}", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
this PR:
- add listener to network changes and restart HomeKit bridge on changes. This will recover HomeKit bridge after network connection losses and IP address changes. this will fix the issue reported here https://community.openhab.org/t/oh3-homekit-bug-fails-after-network-down-up/
- make logger messages consistent with small letter.

Signed-off-by: Eugen Freiter <freiter@gmx.de>
