### PR TITLE
[lutron] Explicitly enable proper monitoring types for HomeWorks connections

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/IPBridgeHandler.java
@@ -33,6 +33,7 @@ import org.openhab.binding.lutron.internal.protocol.LIPCommand;
 import org.openhab.binding.lutron.internal.protocol.LutronCommandNew;
 import org.openhab.binding.lutron.internal.protocol.lip.LutronCommandType;
 import org.openhab.binding.lutron.internal.protocol.lip.LutronOperation;
+import org.openhab.binding.lutron.internal.protocol.lip.Monitoring;
 import org.openhab.binding.lutron.internal.protocol.lip.TargetType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -56,11 +57,6 @@ public class IPBridgeHandler extends LutronBridgeHandler {
             .compile("~(OUTPUT|DEVICE|SYSTEM|TIMECLOCK|MODE|SYSVAR|GROUP),([0-9\\.:/]+),([0-9,\\.:/]*)\\Z");
 
     private static final String DB_UPDATE_DATE_FORMAT = "MM/dd/yyyy HH:mm:ss";
-
-    private static final Integer MONITOR_PROMPT = 12;
-    private static final Integer MONITOR_SYSVAR = 10;
-    private static final Integer MONITOR_ENABLE = 1;
-    private static final Integer MONITOR_DISABLE = 2;
 
     private static final Integer SYSTEM_DBEXPORTDATETIME = 10;
 
@@ -208,8 +204,9 @@ public class IPBridgeHandler extends LutronBridgeHandler {
 
         // Disable prompts
         sendCommand(new LIPCommand(TargetType.BRIDGE, LutronOperation.EXECUTE, LutronCommandType.MONITORING, null,
-                MONITOR_PROMPT, MONITOR_DISABLE));
+                Monitoring.PROMPT, Monitoring.ACTION_DISABLE));
 
+        initMonitoring();
         if (requireSysvarMonitoring.get()) {
             setSysvarMonitoring(true);
         }
@@ -457,10 +454,17 @@ public class IPBridgeHandler extends LutronBridgeHandler {
         }
     }
 
+    private void initMonitoring() {
+        for (Integer monitorType : Monitoring.REQUIRED_SET) {
+            sendCommand(new LIPCommand(TargetType.BRIDGE, LutronOperation.EXECUTE, LutronCommandType.MONITORING, null,
+                    monitorType, Monitoring.ACTION_ENABLE));
+        }
+    }
+
     private void setSysvarMonitoring(boolean enable) {
-        Integer setting = (enable) ? MONITOR_ENABLE : MONITOR_DISABLE;
+        Integer setting = (enable) ? Monitoring.ACTION_ENABLE : Monitoring.ACTION_DISABLE;
         sendCommand(new LIPCommand(TargetType.BRIDGE, LutronOperation.EXECUTE, LutronCommandType.MONITORING, null,
-                MONITOR_SYSVAR, setting));
+                Monitoring.SYSVAR, setting));
     }
 
     @Override

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/lip/Monitoring.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/lip/Monitoring.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.protocol.lip;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link Monitoring} class defines constants for LIP Monitoring types
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public class Monitoring {
+    // Monitoring Actions
+    public static final Integer ACTION_ENABLE = 1;
+    public static final Integer ACTION_DISABLE = 2;
+
+    // Monitoring Types
+    public static final Integer DIAG = 1;
+    public static final Integer EVENT = 2;
+    public static final Integer BUTTON = 3;
+    public static final Integer LED = 4;
+    public static final Integer ZONE = 5;
+    public static final Integer OCCUPANCY = 6;
+    public static final Integer PHOTOSENSOR = 7;
+    public static final Integer SCENE = 8;
+    public static final Integer TIMECLOCK = 9;
+    public static final Integer SYSVAR = 10;
+    public static final Integer REPLY = 11;
+    public static final Integer PROMPT = 12;
+    public static final Integer DEVICE = 14;
+    public static final Integer ADDRESS = 15;
+    public static final Integer SEQUENCE = 16;
+    public static final Integer HVAC = 17;
+    public static final Integer MODE = 18;
+    public static final Integer PRESET = 19;
+    public static final Integer L1RUNTIME = 20;
+    public static final Integer L2RUNTIME = 21;
+    public static final Integer DIAGERROR = 22;
+    public static final Integer SHADEGRP = 23;
+    public static final Integer PARTITION = 24;
+    public static final Integer SYSTEM = 25;
+    public static final Integer SENSORGROUP = 26;
+    public static final Integer TEMPSENSOR = 27;
+    public static final Integer ALL = 255;
+
+    /** Set of monitoring types which must be enabled */
+    public static final Set<Integer> REQUIRED_SET = Collections.unmodifiableSet(
+            Stream.of(BUTTON, LED, ZONE, OCCUPANCY, SCENE, TIMECLOCK, REPLY, HVAC, MODE).collect(Collectors.toSet()));
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/lip/Monitoring.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/lip/Monitoring.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.lutron.internal.protocol.lip;
 
-import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -60,6 +57,6 @@ public class Monitoring {
     public static final Integer ALL = 255;
 
     /** Set of monitoring types which must be enabled */
-    public static final Set<Integer> REQUIRED_SET = Collections.unmodifiableSet(
-            Stream.of(BUTTON, LED, ZONE, OCCUPANCY, SCENE, TIMECLOCK, REPLY, HVAC, MODE).collect(Collectors.toSet()));
+    public static final Set<Integer> REQUIRED_SET = Set.of(BUTTON, LED, ZONE, OCCUPANCY, SCENE, TIMECLOCK, REPLY, HVAC,
+            MODE);
 }


### PR DESCRIPTION
Update to ipbridge to explicitly enable the proper monitoring types for HomeWorks LIP connections at connection init time.

Closes #11604 
