### PR TITLE
[hpprinter] Change status channel from hash map values to state description options.

### DIFF
--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPProductUsageFeatures.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPProductUsageFeatures.java
@@ -65,7 +65,7 @@ public class HPProductUsageFeatures {
             final String inkName = currInk.getElementsByTagName("dd:MarkerColor").item(0).getTextContent();
             final String consumeType = currInk.getElementsByTagName("dd:ConsumableTypeEnum").item(0).getTextContent();
 
-            if (consumeType.equalsIgnoreCase("printhead")) {
+            if ("printhead".equalsIgnoreCase(consumeType)) {
                 continue;
             }
 

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPStatus.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPStatus.java
@@ -12,9 +12,6 @@
  */
 package org.openhab.binding.hpprinter.internal.api;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.w3c.dom.Document;
@@ -30,8 +27,6 @@ import org.w3c.dom.NodeList;
 public class HPStatus {
     public static final String ENDPOINT = "/DevMgmt/ProductStatusDyn.xml";
 
-    private static final Map<String, String> STATUS_MESSAGES = initializeStatus();
-
     private final String printerStatus;
     private final boolean trayEmptyOrOpen;
 
@@ -44,7 +39,7 @@ public class HPStatus {
             Element element = (Element) nodes.item(i);
             String statusCategory = element.getElementsByTagName("pscat:StatusCategory").item(0).getTextContent();
             if (!"genuineHP".equals(statusCategory) && !"trayEmpty".equals(statusCategory)) {
-                localPrinterStatus = STATUS_MESSAGES.getOrDefault(statusCategory, statusCategory);
+                localPrinterStatus = statusCategory;
             }
             if ("trayEmpty".equals(statusCategory)) {
                 localTrayEmptyOrOpen = true;
@@ -52,20 +47,6 @@ public class HPStatus {
         }
         trayEmptyOrOpen = localTrayEmptyOrOpen;
         printerStatus = localPrinterStatus;
-    }
-
-    private static Map<String, String> initializeStatus() {
-        Map<String, String> statusMap = new HashMap<>();
-
-        statusMap.put("processing", "Printing...");
-        statusMap.put("scanProcessing", "Scanning...");
-        statusMap.put("inPowerSave", "Power Save");
-        statusMap.put("ready", "Idle");
-        statusMap.put("initializing", "Initializing...");
-        statusMap.put("closeDoorOrCover", "Door/Cover Open");
-        statusMap.put("inkSystemInitializing", "Loading Ink...");
-        statusMap.put("shuttingDown", "Shutting Down...");
-        return statusMap;
     }
 
     public boolean getTrayEmptyOrOpen() {

--- a/bundles/org.openhab.binding.hpprinter/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.hpprinter/src/main/resources/OH-INF/thing/channel-types.xml
@@ -35,7 +35,19 @@
 		<item-type>String</item-type>
 		<label>Status</label>
 		<description>Printer Status</description>
-		<state readOnly="true"/>
+		<state readOnly="true">
+			<options>
+				<option value="ready">Idle</option>
+				<option value="processing">Printing</option>
+				<option value="scanProcessing">Scanning</option>
+				<option value="inPowerSave">Power Save</option>
+				<option value="initializing">Initializing</option>
+				<option value="closeDoorOrCover">Door/Cover</option>
+				<option value="inkSystemInitializing">Loading Ink</option>
+				<option value="shuttingDown">Shutting Down</option>
+				<option value="replaceCartridgeOut">Cartridge Depleted</option>
+			</options>
+		</state>
 	</channel-type>
 
 	<channel-type id="readonlyswitch" advanced="true">


### PR DESCRIPTION
This changes how both the status channels work. Originally, they referenced a hash table with the name of the status value. It seems more appropriate to have these as state description options as it would allow the statuses to be localised.