### PR TITLE
Upgrade to Karaf 4.3.4

### DIFF
--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -17,8 +17,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -36,8 +34,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.openhab.core.io.console;version='[3.2.0,3.2.1)',\
 	org.openhab.core.storage.json;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -50,4 +46,8 @@ Fragment-Host: org.openhab.binding.astro
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -24,8 +24,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
@@ -50,7 +48,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.openhab.core.io.net;version='[3.2.0,3.2.1)',\
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -62,8 +59,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.eclipse.jetty.websocket.api;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -75,4 +70,9 @@ Fragment-Host: org.openhab.binding.avmfritz
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -28,8 +28,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
@@ -54,7 +52,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -63,11 +60,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.xml;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-jetty;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-runtime;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.19,7.3.20)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -75,4 +67,12 @@ Fragment-Host: org.openhab.binding.feed
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-runtime;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.23,7.3.24)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -28,8 +28,6 @@ Fragment-Host: org.openhab.binding.hue
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
@@ -58,7 +56,6 @@ Fragment-Host: org.openhab.binding.hue
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -70,8 +67,6 @@ Fragment-Host: org.openhab.binding.hue
 	org.eclipse.jetty.websocket.api;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -79,4 +74,9 @@ Fragment-Host: org.openhab.binding.hue
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -27,8 +27,6 @@ Fragment-Host: org.openhab.binding.max
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
 	org.apache.commons.lang3;version='[3.12.0,3.12.1)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -50,7 +48,6 @@ Fragment-Host: org.openhab.binding.max
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -58,7 +55,6 @@ Fragment-Host: org.openhab.binding.max
 	org.eclipse.jetty.servlet;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -66,4 +62,8 @@ Fragment-Host: org.openhab.binding.max
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
@@ -29,8 +29,6 @@ Fragment-Host: org.openhab.binding.mielecloud
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -56,7 +54,6 @@ Fragment-Host: org.openhab.binding.mielecloud
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -69,11 +66,6 @@ Fragment-Host: org.openhab.binding.mielecloud
 	org.eclipse.jetty.websocket.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.xml;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-jetty;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-runtime;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.19,7.3.20)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -85,4 +77,12 @@ Fragment-Host: org.openhab.binding.mielecloud
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-runtime;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.23,7.3.24)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -28,8 +28,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -53,7 +51,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
 	org.openhab.core.transform;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -61,7 +58,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.eclipse.jetty.servlet;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -75,4 +71,8 @@ Fragment-Host: org.openhab.binding.modbus
 	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -20,7 +20,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
@@ -29,7 +28,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
 	org.apache.aries.javax.jax.rs-api;version='[1.0.1,1.0.2)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
@@ -67,7 +65,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -80,10 +77,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.eclipse.jetty.websocket.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.xml;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-jetty;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.19,7.3.20)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.6,6.2.7)',\
 	org.apache.cxf.cxf-core;version='[3.4.5,3.4.6)',\
 	org.apache.cxf.cxf-rt-frontend-jaxrs;version='[3.4.5,3.4.6)',\
@@ -104,4 +97,11 @@ Fragment-Host: org.openhab.binding.nest
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
-	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)'
+	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.23,7.3.24)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -27,8 +27,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -50,7 +48,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -58,7 +55,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.eclipse.jetty.servlet;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -70,4 +66,8 @@ Fragment-Host: org.openhab.binding.ntp
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -28,8 +28,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -51,7 +49,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -59,7 +56,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.eclipse.jetty.servlet;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	com.sun.jna;version='[5.9.0,5.9.1)',\
 	com.sun.jna.platform;version='[5.9.0,5.9.1)',\
 	si-units;version='[2.1.0,2.1.1)',\
@@ -73,4 +69,8 @@ Fragment-Host: org.openhab.binding.systeminfo
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -30,8 +30,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -55,7 +53,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -63,7 +60,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.eclipse.jetty.servlet;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -76,4 +72,8 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -27,8 +27,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
@@ -58,7 +56,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing;version='[3.2.0,3.2.1)',\
 	org.openhab.core.thing.xml;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -70,8 +67,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.eclipse.jetty.websocket.api;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -83,4 +78,9 @@ Fragment-Host: org.openhab.binding.wemo
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -26,8 +26,6 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
@@ -41,7 +39,6 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.openhab.core.test;version='[3.2.0,3.2.1)',\
 	org.openhab.persistence.mapdb;version='[3.2.0,3.2.1)',\
 	org.openhab.persistence.mapdb.tests;version='[3.2.0,3.2.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -49,7 +46,6 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.eclipse.jetty.servlet;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.43,9.4.44)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	si-units;version='[2.1.0,2.1.1)',\
 	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
 	junit-jupiter-api;version='[5.8.1,5.8.2)',\
@@ -57,4 +53,8 @@ Fragment-Host: org.openhab.persistence.mapdb
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)'

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.5</jackson.version>
-    <karaf.version>4.3.3</karaf.version>
+    <karaf.version>4.3.4</karaf.version>
     <netty.version>4.1.68.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
     <sat.version>0.12.0</sat.version>


### PR DESCRIPTION
* Syncs the karaf.version so the new Maven plugin is used
* Resolves itest runbundles for the new runtime dependencies

---

Related to openhab/openhab-distro#1344