### PR TITLE
[nikohomecontrol] Added ability to directly use virtual flags as switches

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlConstants.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlConstants.java
@@ -35,6 +35,9 @@ public class NikoHomeControlConstants {
     public static final String NHCON = "On";
     public static final String NHCOFF = "Off";
 
+    public static final String NHCTRUE = "True";
+    public static final String NHCFALSE = "False";
+
     public static final String NHCTRIGGERED = "Triggered";
 
     // rollershutter constants in the Nhc layer

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcAction2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcAction2.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.protocol.nhc2;
 
+import static org.openhab.binding.nikohomecontrol.internal.protocol.NikoHomeControlConstants.*;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.nikohomecontrol.internal.protocol.NhcAction;
@@ -117,7 +119,14 @@ public class NhcAction2 extends NhcAction {
     public void execute(String command) {
         logger.debug("execute action {} of type {} for {}", command, type, id);
 
-        nhcComm.executeAction(id, command);
+        String cmd;
+        if ("flag".equals(model)) {
+            cmd = NHCON.equals(command) ? NHCTRUE : NHCFALSE;
+        } else {
+            cmd = command;
+        }
+
+        nhcComm.executeAction(id, cmd);
     }
 
     /**

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -362,7 +362,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                     .orElse(null);
         }
 
-        if ("action".equals(device.type)) {
+        if ("action".equals(device.type) || "virtual".equals(device.type)) {
             if (!actions.containsKey(device.uuid)) {
                 logger.debug("adding action device {}, {}", device.uuid, device.name);
 
@@ -382,6 +382,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                     case "socket":
                     case "switched-generic":
                     case "switched-fan":
+                    case "flag":
                         actionType = ActionType.RELAY;
                         break;
                     case "dimmer":
@@ -480,7 +481,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             booleanState = basicStateProperty.get().basicState;
         }
 
-        if (NHCOFF.equals(booleanState)) {
+        if (NHCOFF.equals(booleanState) || NHCFALSE.equals(booleanState)) {
             action.setBooleanState(false);
             logger.debug("setting action {} internally to OFF", action.getId());
         }
@@ -497,7 +498,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             }
         }
 
-        if (NHCON.equals(booleanState)) {
+        if (NHCON.equals(booleanState) || NHCTRUE.equals(booleanState)) {
             action.setBooleanState(true);
             logger.debug("setting action {} internally to ON", action.getId());
         }


### PR DESCRIPTION
Closes #11740

Virtual flags are now directly visible in OH, without needing a workaround of creating free start/stop actions in NHC.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

