### PR TITLE
Add default translations for io add-ons

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/i18n/homekit.properties
+++ b/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/i18n/homekit.properties
@@ -1,0 +1,47 @@
+io.config.homekit.blockUserDeletion.label = Block deletion of the HomeKit user
+io.config.homekit.blockUserDeletion.description = Block deletion of the HomeKit user information from openHAB and the unpairing of devices
+io.config.homekit.group.core.label = Core Configuration
+io.config.homekit.group.network.label = Network Settings
+io.config.homekit.group.network.description = General network settings
+io.config.homekit.group.thermostat.label = Thermostat Settings
+io.config.homekit.group.thermostat.description = General thermostat settings
+io.config.homekit.group.thermostatCurrentHeatingCooling.label = Thermostat Current Heating/Cooling Mapping
+io.config.homekit.group.thermostatCurrentHeatingCooling.description = String values used by your thermostat to set different targetHeatingCooling modes
+io.config.homekit.group.thermostatTargetHeatingCooling.label = Thermostat Target Heating/Cooling Mapping
+io.config.homekit.group.thermostatTargetHeatingCooling.description = String values used by your thermostat to set different targetHeatingCooling modes
+io.config.homekit.name.label = Bridge name
+io.config.homekit.name.description = Name of the HomeKit bridge
+io.config.homekit.networkInterface.label = Network Interface
+io.config.homekit.networkInterface.description = Defines the IP address of the network interface to expose the HomeKit integration on.
+io.config.homekit.pin.label = Pin
+io.config.homekit.pin.description = Defines the pin, used for pairing, in the form ###-##-###.
+io.config.homekit.port.label = Port
+io.config.homekit.port.description = Defines the port the HomeKit integration listens on.
+io.config.homekit.qrCode.label = HomeKit QR Code
+io.config.homekit.qrCode.description = Scan QR code with home app to add openHAB as HomeKit bridge.
+io.config.homekit.setupId.label = Setup ID
+io.config.homekit.setupId.description = Setup ID used for pairing using QR Code. Alphanumeric code of length 4.
+io.config.homekit.startDelay.label = Start Delay
+io.config.homekit.startDelay.description = HomeKit start delay in case of item configuration differences.
+io.config.homekit.thermostatCurrentModeCooling.label = Cooling Value
+io.config.homekit.thermostatCurrentModeCooling.description = Value for setting target heatingCoolingCurrentMode to COOL (IE: indicating that the air condition is currently cooling the home).
+io.config.homekit.thermostatCurrentModeHeating.label = Heating Value
+io.config.homekit.thermostatCurrentModeHeating.description = Value for setting target heatingCoolingCurrentMode to HEAT (IE: indicating that the heater is currently warming the home).
+io.config.homekit.thermostatCurrentModeOff.label = Off Value
+io.config.homekit.thermostatCurrentModeOff.description = Value for setting target heatingCoolingCurrentMode to OFF (IE: the hvac is currently idle, because the target temperature has been reached per the mode).
+io.config.homekit.thermostatTargetModeAuto.label = Auto Value
+io.config.homekit.thermostatTargetModeAuto.description = Word used to set the target heatingCoolingMode to AUTO (if a thermostat is defined).
+io.config.homekit.thermostatTargetModeCool.label = Cool Value
+io.config.homekit.thermostatTargetModeCool.description = Word used to set the target heatingCoolingMode to COOL (if a thermostat is defined).
+io.config.homekit.thermostatTargetModeHeat.label = Heat Value
+io.config.homekit.thermostatTargetModeHeat.description = Word used to set the target heatingCoolingMode to HEAT (if a thermostat is defined).
+io.config.homekit.thermostatTargetModeOff.label = Off Value
+io.config.homekit.thermostatTargetModeOff.description = Word used to set the target heatingCoolingMode to OFF (if a thermostat is defined).
+io.config.homekit.useFahrenheitTemperature.label = Use Fahrenheit Temperature
+io.config.homekit.useFahrenheitTemperature.description = Defines whether or not to direct HomeKit clients to use fahrenheit temperatures instead of celsius.
+io.config.homekit.useOHmDNS.label = Use openHAB mDNS service
+io.config.homekit.useOHmDNS.description = Defines whether mDNS service of openHAB or a separate instance of mDNS should be used.
+
+# service
+
+service.io.homekit.label = HomeKit Integration

--- a/bundles/org.openhab.io.hueemulation/src/main/resources/OH-INF/i18n/hueemulation.properties
+++ b/bundles/org.openhab.io.hueemulation/src/main/resources/OH-INF/i18n/hueemulation.properties
@@ -1,0 +1,28 @@
+io.config.hueemulation.createNewUserOnEveryEndpoint.label = Pairing: Add Unknown User-keys
+io.config.hueemulation.createNewUserOnEveryEndpoint.description = Set this option to create new users on the fly during the next pairing mode period. This helps with Amazon Echo device discovery. This option is automatically switched off after the timeout.
+io.config.hueemulation.discoveryHttpPort.label = Optional Discovery Web Port
+io.config.hueemulation.discoveryHttpPort.description = Some Hue applications require a different port (80) then what openHAB runs on by default (8080). This option will only advertise a different port then what we are listening on. Useful if you have an iptables rule redirect traffic from this port to the openHAB port.
+io.config.hueemulation.discoveryIp.label = Optional Discovery Address
+io.config.hueemulation.discoveryIp.description = If your host has multiple IP addresses you may specify the IP(s) you would like to advertise in the UPNP discovery process. You may safely leave this empty on most systems. Use commas to separate multiple entries.
+io.config.hueemulation.ignoreItemsWithTags.label = Ignore Items by Tag
+io.config.hueemulation.ignoreItemsWithTags.description = All items that are tagged with the given tags are ignore by the Hue Emulation Service. Use commas to separate multiple entries.
+io.config.hueemulation.pairingEnabled.label = Device Pairing
+io.config.hueemulation.pairingEnabled.description = Pairing must be enabled to connect a new device. Pairing is automatically disabled after the configured pairing time (usually 60 seconds).
+io.config.hueemulation.pairingTimeout.label = Pairing Timeout
+io.config.hueemulation.pairingTimeout.description = Pairing is automatically disabled after the given time in seconds.
+io.config.hueemulation.permanentV1bridge.label = Permanently Emulate V1 Hue Bridge
+io.config.hueemulation.permanentV1bridge.description = There is no obvious reason to not emulate the newer bridge all the time, but here is the option if you want the old (round Hue bridge) to be emulated.
+io.config.hueemulation.restrictToTagsColorLights.label = Color Item Tags
+io.config.hueemulation.restrictToTagsColorLights.description = The HUE emulation can either publish all Color items if this is set to an empty string or filter items by tags. Use commas to separate multiple entries.
+io.config.hueemulation.restrictToTagsSwitches.label = Switch Item Tags
+io.config.hueemulation.restrictToTagsSwitches.description = The HUE emulation can either publish Switch items if this is set to an empty string or filter items by tags. Use commas to separate multiple entries.
+io.config.hueemulation.restrictToTagsWhiteLights.label = White Item Tags
+io.config.hueemulation.restrictToTagsWhiteLights.description = The HUE emulation can either publish all Dimmer items if this is set to an empty string or filter items by tags. Use commas to separate multiple entries.
+io.config.hueemulation.temporarilyEmulateV1bridge.label = Pairing: Temporarily Emulate V1 Hue Bridge
+io.config.hueemulation.temporarilyEmulateV1bridge.description = Some Amazon Echos only support V1 bridges (round hardware bridge). This option is only active during discovery and automatically switched off after the timeout.
+io.config.hueemulation.uuid.label = Unique Bridge ID
+io.config.hueemulation.uuid.description = Each Hue bridge has a universal unique id (UUID) assigned. This is random generated if no value has been assigned. Note on Amazon Alexa Echo devices: It might help to change the UUID after you have changed item ids. The Echos will recognize this service as a new bridge.
+
+# service
+
+service.io.hueemulation.label = Hue Emulation

--- a/bundles/org.openhab.io.metrics/src/main/java/org/openhab/io/metrics/MetricsRestController.java
+++ b/bundles/org.openhab.io.metrics/src/main/java/org/openhab/io/metrics/MetricsRestController.java
@@ -64,7 +64,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RolesAllowed({ Role.USER, Role.ADMIN })
 @Tag(name = MetricsRestController.PATH_METRICS)
 @NonNullByDefault
-@ConfigurableService(category = "io", label = "Metrics service", description_uri = "io:metrics")
+@ConfigurableService(category = "io", label = "Metrics Service", description_uri = "io:metrics")
 public class MetricsRestController {
     private final Logger logger = LoggerFactory.getLogger(MetricsRestController.class);
     public static final String PATH_METRICS = "metrics";

--- a/bundles/org.openhab.io.metrics/src/main/resources/OH-INF/i18n/metrics.properties
+++ b/bundles/org.openhab.io.metrics/src/main/resources/OH-INF/i18n/metrics.properties
@@ -1,0 +1,20 @@
+io.config.metrics.group.influx.label = Influx Metrics
+io.config.metrics.group.jmx.label = JMX Metrics
+io.config.metrics.influxDB.label = Database Name
+io.config.metrics.influxDB.description = The Name of the Database to Use. Defaults to "openhab".
+io.config.metrics.influxMetricsEnabled.label = Enabled
+io.config.metrics.influxMetricsEnabled.description = Enable the Influx (www.influxdata.com) Metrics. Further Configuration of the InfluxDB Instance Necessary.
+io.config.metrics.influxPassword.label = Password
+io.config.metrics.influxPassword.description = The InfluxDB Password (No Default).
+io.config.metrics.influxURL.label = URL
+io.config.metrics.influxURL.description = The URL of the InfluxDB Instance. Defaults to http://localhost:8086
+io.config.metrics.influxUpdateIntervalInSeconds.label = Update Interval in Seconds
+io.config.metrics.influxUpdateIntervalInSeconds.description = Controls How Often Metrics Are Exported to InfluxDB (in Seconds). Defaults to 300
+io.config.metrics.influxUsername.label = User Name
+io.config.metrics.influxUsername.description = The InfluxDB User Name (No Default).
+io.config.metrics.jmxMetricsEnabled.label = Enabled
+io.config.metrics.jmxMetricsEnabled.description = Enable the Java Management Extensions (JMX) Metrics.
+
+# service
+
+service.io.metrics.label = Metrics Service

--- a/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/NeeoService.java
+++ b/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/NeeoService.java
@@ -28,6 +28,7 @@ import javax.ws.rs.client.ClientBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.binding.BindingInfoRegistry;
+import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventPublisher;
@@ -70,9 +71,8 @@ import org.slf4j.LoggerFactory;
  * @author Tim Roberts - Initial Contribution
  */
 @NonNullByDefault
-@Component(service = EventSubscriber.class, property = { "service.pid=org.openhab.io.neeo.NeeoService",
-        "service.config.description.uri=io:neeo", "service.config.label=NEEO Integration",
-        "service.config.category=io" })
+@Component(service = EventSubscriber.class, property = { "service.pid=org.openhab.io.neeo.NeeoService" })
+@ConfigurableService(category = "io", label = "NEEO Integration", description_uri = "io:neeo")
 public class NeeoService implements EventSubscriber, NetworkAddressChangeListener {
 
     /** The logger */

--- a/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/i18n/neeo.properties
+++ b/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/i18n/neeo.properties
@@ -6,3 +6,7 @@ io.config.neeo.exposeNeeoBinding.label = Expose NEEO Binding
 io.config.neeo.exposeNeeoBinding.description = Expose things found by the NEEO Binding
 io.config.neeo.searchLimit.label = Search Limit
 io.config.neeo.searchLimit.description = The maximum number of results to return for a search
+
+# service
+
+service.io.neeo.label = NEEO Integration

--- a/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/i18n/neeo.properties
+++ b/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/i18n/neeo.properties
@@ -1,0 +1,8 @@
+io.config.neeo.checkStatusInterval.label = Check Status Interval (seconds)
+io.config.neeo.checkStatusInterval.description = The interval (in seconds) to check the status of the brain
+io.config.neeo.exposeAll.label = Expose All
+io.config.neeo.exposeAll.description = Expose all things
+io.config.neeo.exposeNeeoBinding.label = Expose NEEO Binding
+io.config.neeo.exposeNeeoBinding.description = Expose things found by the NEEO Binding
+io.config.neeo.searchLimit.label = Search Limit
+io.config.neeo.searchLimit.description = The maximum number of results to return for a search


### PR DESCRIPTION
This makes the texts used by these add-ons translatable with Crowdin.