### PR TITLE
Add default translations for persistence add-ons

### DIFF
--- a/bundles/org.openhab.persistence.dynamodb/src/main/resources/OH-INF/i18n/dynamodb.properties
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/resources/OH-INF/i18n/dynamodb.properties
@@ -1,0 +1,24 @@
+persistence.config.dynamodb.accessKey.label = AWS access key
+persistence.config.dynamodb.accessKey.description = AWS access key<br /> Give either 1) access key and secret key, or 2) credentials file and profile name.
+persistence.config.dynamodb.expireDays.label = Data Expiry, in Days
+persistence.config.dynamodb.expireDays.description = Expire time for data.<br /> Data older than this is automatically removed by DynamoDB Time to Live (TTL) feature. Use empty value to disable data expiration.
+persistence.config.dynamodb.profile.label = Profile name
+persistence.config.dynamodb.profile.description = Profile name in AWS credentials file. <br /> Give either 1) access key and secret key, or 2) credentials file and profile name.
+persistence.config.dynamodb.profilesConfigFile.label = AWS credentials file
+persistence.config.dynamodb.profilesConfigFile.description = Path to the AWS credentials file. <br /> For example, /etc/openhab/aws_creds. Please note that the user that runs openHAB must have approriate read rights to the credential file. <br /> Give either 1) access key and secret key, or 2) credentials file and profile name.
+persistence.config.dynamodb.readCapacityUnits.label = Read Capacity
+persistence.config.dynamodb.readCapacityUnits.description = Provisioned read capacity.<br /> Default is 1.
+persistence.config.dynamodb.region.label = AWS region ID
+persistence.config.dynamodb.region.description = AWS region ID<br /> The region needs to match the region of the AWS user that will access Amazon DynamoDB.<br /> For example, eu-west-1.
+persistence.config.dynamodb.secretKey.label = AWS secret key
+persistence.config.dynamodb.secretKey.description = AWS secret key<br /> Give either 1) access key and secret key, or 2) credentials file and profile name.
+persistence.config.dynamodb.table.label = Table
+persistence.config.dynamodb.table.description = Table name. <br /> Specify this parameter over Table Prefix to use the new optimized table format.
+persistence.config.dynamodb.tablePrefix.label = Table Prefix
+persistence.config.dynamodb.tablePrefix.description = Legacy: Table prefix used in the name of created tables. <br /> Default is "openhab-"
+persistence.config.dynamodb.writeCapacityUnits.label = Write Capacity
+persistence.config.dynamodb.writeCapacityUnits.description = Provisioned write capacity.<br /> Default is 1.
+
+# service
+
+service.persistence.dynamodb.label = DynamoDB Persistence Service

--- a/bundles/org.openhab.persistence.influxdb/src/main/resources/OH-INF/i18n/influxdb.properties
+++ b/bundles/org.openhab.persistence.influxdb/src/main/resources/OH-INF/i18n/influxdb.properties
@@ -1,0 +1,34 @@
+persistence.config.influxdb.addCategoryTag.label = Add Category Tag
+persistence.config.influxdb.addCategoryTag.description = Should the category of the item be included as tag "category"? If no category is set, "n/a" is used.
+persistence.config.influxdb.addLabelTag.label = Add Label Tag
+persistence.config.influxdb.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
+persistence.config.influxdb.addTypeTag.label = Add Type Tag
+persistence.config.influxdb.addTypeTag.description = Should the item type be included as tag "type"?
+persistence.config.influxdb.db.label = Database/Organization
+persistence.config.influxdb.db.description = The name of the database (InfluxDB 1.0) or Organization for (InfluxDB 2.0)
+persistence.config.influxdb.group.connection.label = Connection
+persistence.config.influxdb.group.connection.description = This group defines connection parameters.
+persistence.config.influxdb.group.misc.label = Miscellaneous
+persistence.config.influxdb.group.misc.description = This group defines miscellaneous parameters.
+persistence.config.influxdb.group.tags.label = Additional Tags
+persistence.config.influxdb.group.tags.description = This group defines additional tags which can be added to your measurements.
+persistence.config.influxdb.password.label = Database Password
+persistence.config.influxdb.password.description = Database password
+persistence.config.influxdb.replaceUnderscore.label = Replace Underscore
+persistence.config.influxdb.replaceUnderscore.description = Whether underscores "_" in item names should be replaced by a dot "." ("test_item" -> "test.item"). Only for measurement name, not for tags. Also applies to alias names.
+persistence.config.influxdb.retentionPolicy.label = Retention Policy / Bucket
+persistence.config.influxdb.retentionPolicy.description = The name of the retention policy (Influx DB 1.0) or bucket (InfluxDB 2.0) to write data
+persistence.config.influxdb.token.label = Authentication Token
+persistence.config.influxdb.token.description = The token to authenticate to database (alternative to username/password for InfluxDB 2.0)
+persistence.config.influxdb.url.label = Database URL
+persistence.config.influxdb.url.description = The database URL, e.g. http://127.0.0.1:8086
+persistence.config.influxdb.user.label = Username
+persistence.config.influxdb.user.description = Database username
+persistence.config.influxdb.version.label = Database Version
+persistence.config.influxdb.version.description = InfluxDB version
+persistence.config.influxdb.version.option.V1 = InfluxDB 1
+persistence.config.influxdb.version.option.V2 = InfluxDB 2
+
+# service
+
+service.persistence.influxdb.label = InfluxDB Persistence Service

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/i18n/jdbc.properties
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/i18n/jdbc.properties
@@ -1,0 +1,54 @@
+persistence.config.jdbc.enableLogTime.label = Timekeeping Enable
+persistence.config.jdbc.enableLogTime.description = Enables a time, performance measurement. <br>(optional, default: disabled)
+persistence.config.jdbc.enableLogTime.option.true = Enable
+persistence.config.jdbc.enableLogTime.option.false = Disable
+persistence.config.jdbc.maximumPoolSize.label = Connections Max Pool Size
+persistence.config.jdbc.maximumPoolSize.description = Overrides max pool size in database connection. <br>(optional, default: differs each Database)<br> https://github.com/brettwooldridge/HikariCP/issues/256
+persistence.config.jdbc.minimumIdle.label = Connections Min Idle
+persistence.config.jdbc.minimumIdle.description = Overrides min idle database connections. <br>(optional, default: differs each Database)<br> https://github.com/brettwooldridge/HikariCP/issues/256
+persistence.config.jdbc.password.label = Database Password
+persistence.config.jdbc.password.description = Defines the database password.
+persistence.config.jdbc.rebuildTableNames.label = Tablename Rebuild
+persistence.config.jdbc.rebuildTableNames.description = Rename existing tables using 'Tablename Realname Generation' and 'Tablename Suffix ID Count', (optional, default: disabled). <br> USE WITH CARE! Deactivate after renaming is done!
+persistence.config.jdbc.rebuildTableNames.option.true = Enable
+persistence.config.jdbc.rebuildTableNames.option.false = Disable
+persistence.config.jdbc.sqltype.CALL.label = SqlType CALL
+persistence.config.jdbc.sqltype.CALL.description = Overrides used JDBC/SQL datatype for CALL <br>(optional, default: "VARCHAR(200)"). <br> General about JdbcTypes/SqlTypes see: https://mybatis.github.io/mybatis-3/apidocs/reference/org/apache/ibatis/type/JdbcType.html <br> see: http://www.h2database.com/html/datatypes.html <br> see: http://www.postgresql.org/docs/9.5/static/datatype.html
+persistence.config.jdbc.sqltype.COLOR.label = SqlType COLOR
+persistence.config.jdbc.sqltype.COLOR.description = Overrides used JDBC/SQL datatype for COLOR <br>(optional, default: "VARCHAR(70)").
+persistence.config.jdbc.sqltype.CONTACT.label = SqlType CONTACT
+persistence.config.jdbc.sqltype.CONTACT.description = Overrides used JDBC/SQL datatype for CONTACT <br>(optional, default: "VARCHAR(6)").
+persistence.config.jdbc.sqltype.DATETIME.label = SqlType DATETIME
+persistence.config.jdbc.sqltype.DATETIME.description = Overrides used JDBC/SQL datatype for DATETIME <br>(optional, default: "DATETIME").
+persistence.config.jdbc.sqltype.DIMMER.label = SqlType DIMMER
+persistence.config.jdbc.sqltype.DIMMER.description = Overrides used JDBC/SQL datatype for DIMMER <br>(optional, default: "TINYINT").
+persistence.config.jdbc.sqltype.IMAGE.label = SqlType IMAGE
+persistence.config.jdbc.sqltype.IMAGE.description = Overrides used JDBC/SQL datatype for IMAGE <br>(optional, default: "VARCHAR(65500)").
+persistence.config.jdbc.sqltype.LOCATION.label = SqlType LOCATION
+persistence.config.jdbc.sqltype.LOCATION.description = Overrides used JDBC/SQL datatype for LOCATION <br>(optional, default: "VARCHAR(50)").
+persistence.config.jdbc.sqltype.NUMBER.label = SqlType NUMBER
+persistence.config.jdbc.sqltype.NUMBER.description = Overrides used JDBC/SQL datatype for NUMBER <br>(optional, default: "DOUBLE").
+persistence.config.jdbc.sqltype.PLAYER.label = SqlType PLAYER
+persistence.config.jdbc.sqltype.PLAYER.description = Overrides used JDBC/SQL datatype for PLAYER <br>(optional, default: "VARCHAR(20)").
+persistence.config.jdbc.sqltype.ROLLERSHUTTER.label = SqlType ROLLERSHUTTER
+persistence.config.jdbc.sqltype.ROLLERSHUTTER.description = Overrides used JDBC/SQL datatype for ROLLERSHUTTER <br>(optional, default: "TINYINT").
+persistence.config.jdbc.sqltype.STRING.label = SqlType STRING
+persistence.config.jdbc.sqltype.STRING.description = Overrides used JDBC/SQL datatype for STRING <br>(optional, default: "VARCHAR(65500)").
+persistence.config.jdbc.sqltype.SWITCH.label = SqlType SWITCH
+persistence.config.jdbc.sqltype.SWITCH.description = Overrides used JDBC/SQL datatype for SWITCH <br>(optional, default: "VARCHAR(6)").
+persistence.config.jdbc.tableIdDigitCount.label = Tablename Suffix ID Count
+persistence.config.jdbc.tableIdDigitCount.description = Tablename Suffix ID Count <br>(optional, default: 4 -> 0001-9999). <br> For migration from MYSQL-Bundle set to 0.
+persistence.config.jdbc.tableNamePrefix.label = Tablename Prefix String
+persistence.config.jdbc.tableNamePrefix.description = Tablename prefix string <br>(optional, default: "item"). <br> For migration from MYSQL-Bundle set to 'Item'.
+persistence.config.jdbc.tableUseRealItemNames.label = Tablename Realname Generation
+persistence.config.jdbc.tableUseRealItemNames.description = Enables Tablename prefix generation per Items realname <br>(optional, default: disabled -> "Tablename Prefix String" is used). <br> If true, 'Tablename Prefix String' is ignored.
+persistence.config.jdbc.tableUseRealItemNames.option.true = Enable
+persistence.config.jdbc.tableUseRealItemNames.option.false = Disable
+persistence.config.jdbc.url.label = Database URL
+persistence.config.jdbc.url.description = Defines required database URL and optional path and parameters.<br> Required database url like 'jdbc:<service>:<host>[:<port>;<attributes>]'<br> Parameter 'service' is used as identifier for the selected jdbc driver. URL-Examples:<br> jdbc:derby:./testDerby;create=true<br> jdbc:h2:./testH2<br> jdbc:hsqldb:./testHsqlDb<br> jdbc:mariadb://192.168.0.1:3306/testMariadb<br> jdbc:mysql://192.168.0.1:3306/testMysql<br> jdbc:postgresql://192.168.0.1:5432/testPostgresql<br> jdbc:sqlite:./testSqlite.db
+persistence.config.jdbc.user.label = Database User
+persistence.config.jdbc.user.description = Defines the database user.
+
+# service
+
+service.persistence.jdbc.label = JDBC Persistence Service


### PR DESCRIPTION
This makes the texts used by these add-ons translatable with Crowdin.