### PR TITLE
Add default translations for transform add-ons

### DIFF
--- a/bundles/org.openhab.transform.exec/src/main/resources/OH-INF/config/execProfile.xml
+++ b/bundles/org.openhab.transform.exec/src/main/resources/OH-INF/config/execProfile.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text" required="false">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.exec/src/main/resources/OH-INF/i18n/exec.properties
+++ b/bundles/org.openhab.transform.exec/src/main/resources/OH-INF/i18n/exec.properties
@@ -1,0 +1,8 @@
+profile.config.transform.EXEC.function.label = Command
+profile.config.transform.EXEC.function.description = Command to be executed on the command line. It should contain %s which will be substituted with the state.
+profile.config.transform.EXEC.sourceFormat.label = State Formatter
+profile.config.transform.EXEC.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.EXEC.label = EXEC

--- a/bundles/org.openhab.transform.javascript/src/main/resources/OH-INF/config/javascriptProfile.xml
+++ b/bundles/org.openhab.transform.javascript/src/main/resources/OH-INF/config/javascriptProfile.xml
@@ -13,7 +13,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.javascript/src/main/resources/OH-INF/i18n/js.properties
+++ b/bundles/org.openhab.transform.javascript/src/main/resources/OH-INF/i18n/js.properties
@@ -1,0 +1,8 @@
+profile.config.transform.JS.function.label = JavaScript Filename
+profile.config.transform.JS.function.description = Filename of the JavaScript in the transform folder. The state will be available in the variable \"input\".
+profile.config.transform.JS.sourceFormat.label = State Formatter
+profile.config.transform.JS.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.JS.label = JS

--- a/bundles/org.openhab.transform.jinja/src/main/resources/OH-INF/config/jinjaProfile.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/resources/OH-INF/config/jinjaProfile.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text" required="false">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.jinja/src/main/resources/OH-INF/i18n/jinja.properties
+++ b/bundles/org.openhab.transform.jinja/src/main/resources/OH-INF/i18n/jinja.properties
@@ -1,0 +1,8 @@
+profile.config.transform.JINJA.function.label = Jinja Template
+profile.config.transform.JINJA.function.description = Template to be evaluated. For example: {{ value_json.device.status.temperature }}
+profile.config.transform.JINJA.sourceFormat.label = State Formatter
+profile.config.transform.JINJA.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.JINJA.label = JINJA

--- a/bundles/org.openhab.transform.jsonpath/src/main/resources/OH-INF/config/jsonpathProfile.xml
+++ b/bundles/org.openhab.transform.jsonpath/src/main/resources/OH-INF/config/jsonpathProfile.xml
@@ -11,7 +11,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text" required="false">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.jsonpath/src/main/resources/OH-INF/i18n/jsonpath.properties
+++ b/bundles/org.openhab.transform.jsonpath/src/main/resources/OH-INF/i18n/jsonpath.properties
@@ -1,0 +1,8 @@
+profile.config.transform.JSONPATH.function.label = JSONPath Expression
+profile.config.transform.JSONPATH.function.description = Expression to be applied on the state. For example: $.device.status.temperature
+profile.config.transform.JSONPATH.sourceFormat.label = State Formatter
+profile.config.transform.JSONPATH.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.JSONPATH.label = JSONPATH

--- a/bundles/org.openhab.transform.regex/src/main/resources/OH-INF/config/regexProfile.xml
+++ b/bundles/org.openhab.transform.regex/src/main/resources/OH-INF/config/regexProfile.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text" required="false">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.regex/src/main/resources/OH-INF/i18n/regex.properties
+++ b/bundles/org.openhab.transform.regex/src/main/resources/OH-INF/i18n/regex.properties
@@ -1,0 +1,8 @@
+profile.config.transform.REGEX.function.label = Regular Expression
+profile.config.transform.REGEX.function.description = Regular expression to be applied on the state. Should contain a capture group whose outcome will be the result. For example: .*=(\\d*.\\d*).* extracts the 23.5 from temp=23.5°C
+profile.config.transform.REGEX.sourceFormat.label = State Formatter
+profile.config.transform.REGEX.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.REGEX.label = REGEX

--- a/bundles/org.openhab.transform.scale/src/main/resources/OH-INF/config/scaleProfile.xml
+++ b/bundles/org.openhab.transform.scale/src/main/resources/OH-INF/config/scaleProfile.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.scale/src/main/resources/OH-INF/i18n/scale.properties
+++ b/bundles/org.openhab.transform.scale/src/main/resources/OH-INF/i18n/scale.properties
@@ -1,0 +1,8 @@
+profile.config.transform.SCALE.function.label = Filename
+profile.config.transform.SCALE.function.description = Filename containing the scale mappings.
+profile.config.transform.SCALE.sourceFormat.label = State Formatter
+profile.config.transform.SCALE.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.SCALE.label = SCALE

--- a/bundles/org.openhab.transform.xpath/src/main/resources/OH-INF/config/xpathProfile.xml
+++ b/bundles/org.openhab.transform.xpath/src/main/resources/OH-INF/config/xpathProfile.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text" required="false">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.xpath/src/main/resources/OH-INF/i18n/xpath.properties
+++ b/bundles/org.openhab.transform.xpath/src/main/resources/OH-INF/i18n/xpath.properties
@@ -1,0 +1,8 @@
+profile.config.transform.XPATH.function.label = XPath Expression
+profile.config.transform.XPATH.function.description = XPath expression to be applied on the state: For example: /*[name()='PTZStatus']/*[name()='AbsoluteHigh']/*[name()='azimuth']/
+profile.config.transform.XPATH.sourceFormat.label = State Formatter
+profile.config.transform.XPATH.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.XPATH.label = XPATH

--- a/bundles/org.openhab.transform.xslt/src/main/resources/OH-INF/config/xsltProfile.xml
+++ b/bundles/org.openhab.transform.xslt/src/main/resources/OH-INF/config/xsltProfile.xml
@@ -11,7 +11,7 @@
 		</parameter>
 		<parameter name="sourceFormat" type="text" required="false">
 			<label>State Formatter</label>
-			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s)</description>
+			<description>How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.transform.xslt/src/main/resources/OH-INF/i18n/xslt.properties
+++ b/bundles/org.openhab.transform.xslt/src/main/resources/OH-INF/i18n/xslt.properties
@@ -1,0 +1,8 @@
+profile.config.transform.XSLT.function.label = XSL Filename
+profile.config.transform.XSLT.function.description = XSL file name in transform folder, containing the transformation expression.
+profile.config.transform.XSLT.sourceFormat.label = State Formatter
+profile.config.transform.XSLT.sourceFormat.description = How to format the state on the channel before transforming it, i.e. %s or %.1f °C (default is %s).
+
+# profile type
+
+profile-type.transform.XSLT.label = XSLT


### PR DESCRIPTION
This makes the texts used by these add-ons translatable with Crowdin.