### PR TITLE
[hdpowerview] Update positions after triggering scene/scene group

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -237,7 +237,6 @@ public class HDPowerViewWebTargets {
      * @param query the http query parameter
      * @param jsonCommand the request command content (as a json string)
      * @return the response content (as a json string)
-     * @throws HubProcessingException
      * @throws HubMaintenanceException
      * @throws HubProcessingException
      */

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -113,7 +113,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (RefreshType.REFRESH.equals(command)) {
+        if (RefreshType.REFRESH == command) {
             requestRefreshShadePositions();
             return;
         }
@@ -129,14 +129,14 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
                 throw new ProcessingException("Web targets not initialized");
             }
             int id = Integer.parseInt(channelUID.getIdWithoutGroup());
-            if (sceneChannelTypeUID.equals(channel.getChannelTypeUID()) && OnOffType.ON.equals(command)) {
+            if (sceneChannelTypeUID.equals(channel.getChannelTypeUID()) && OnOffType.ON == command) {
                 webTargets.activateScene(id);
                 pollShades();
-            } else if (sceneGroupChannelTypeUID.equals(channel.getChannelTypeUID()) && OnOffType.ON.equals(command)) {
+            } else if (sceneGroupChannelTypeUID.equals(channel.getChannelTypeUID()) && OnOffType.ON == command) {
                 webTargets.activateSceneCollection(id);
                 pollShades();
             } else if (automationChannelTypeUID.equals(channel.getChannelTypeUID())) {
-                webTargets.enableScheduledEvent(id, OnOffType.ON.equals(command));
+                webTargets.enableScheduledEvent(id, OnOffType.ON == command);
             }
         } catch (HubMaintenanceException e) {
             // exceptions are logged in HDPowerViewWebTargets

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -155,7 +155,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
                 logger.warn("Bridge returned a bad JSON response: {}", e.getMessage());
             } catch (HubProcessingException e) {
                 logger.warn("Error connecting to bridge: {}", e.getMessage());
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             } catch (HubMaintenanceException e) {
                 // exceptions are logged in HDPowerViewWebTargets
             }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -131,8 +131,10 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
             int id = Integer.parseInt(channelUID.getIdWithoutGroup());
             if (sceneChannelTypeUID.equals(channel.getChannelTypeUID()) && OnOffType.ON.equals(command)) {
                 webTargets.activateScene(id);
+                pollShades();
             } else if (sceneGroupChannelTypeUID.equals(channel.getChannelTypeUID()) && OnOffType.ON.equals(command)) {
                 webTargets.activateSceneCollection(id);
+                pollShades();
             } else if (automationChannelTypeUID.equals(channel.getChannelTypeUID())) {
                 webTargets.enableScheduledEvent(id, OnOffType.ON.equals(command));
             }


### PR DESCRIPTION
When triggering a scene or scene group, some shades will have new positions. These new positions are available in the hub immediately after triggering the scene or scene group, i.e. before the shades will reach those new positions.

Previously it would take up to one minute to have the positions refreshed. Now it will happen a few seconds after the scene or scene group has been triggered.

Fixes #11697

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

### Test documentation

Before change:
```
2021-12-12 21:26:42.228 [INFO ] [openhab.event.ItemCommandEvent      ] - Item 'PowerViewHub_Scene_Office_Up' received command ON
2021-12-12 21:27:08.782 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Blind9_Position' changed from 100 to 0

```
After change:
```
2021-12-12 21:50:22.834 [INFO ] [openhab.event.ItemCommandEvent      ] - Item 'PowerViewHub_Scene_Office_Up' received command ON
2021-12-12 21:50:26.105 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Blind9_Position' changed from 100 to 0

```
And back:
```
2021-12-12 21:50:29.706 [INFO ] [openhab.event.ItemCommandEvent      ] - Item 'PowerViewHub_Scene_Office_Down' received command ON
2021-12-12 21:50:32.955 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Blind9_Position' changed from 0 to 100

```