### PR TITLE
[lgtvserial] Fixes #8646 - fix binding for recent openHab versions

### DIFF
--- a/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/handler/LgTvSerialHandler.java
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/handler/LgTvSerialHandler.java
@@ -170,6 +170,12 @@ public class LgTvSerialHandler extends BaseThingHandler {
         if (updateJob == null || updateJob.isCancelled()) {
             updateJob = scheduler.scheduleWithFixedDelay(eventRunnable, 0, EVENT_REFRESH_INTERVAL, TimeUnit.SECONDS);
         }
+        // trigger REFRESH commands for all linked Channels to start polling
+        getThing().getChannels().forEach(channel -> {
+            if (isLinked(channel.getUID())) {
+                channelLinked(channel.getUID());
+            }
+        });
 
         updateStatus(ThingStatus.ONLINE);
     }

--- a/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/LGSerialCommunicator.java
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/LGSerialCommunicator.java
@@ -79,7 +79,7 @@ public class LGSerialCommunicator {
         int data;
         int len = 0;
         int offset = 0;
-        while ((data = input.read()) > -1) {
+        while (input.available() > 0 && (data = input.read()) > -1) {
             if (data == 'x') {
                 String result = new String(buffer, offset, len);
                 if (logger.isDebugEnabled()) {


### PR DESCRIPTION
I tried to fix bugs mentioned in #8646 about the problems to be able to send command to LG tv through serial port.



### Bugfix for lg tv serial binding for greather versions of openHAB than 2.5

In previous versions of openHab <=2.4 the binding runs succesfully and can send commands to tv. But after upgrading openHAB, it didn't work anymore.

After debugging original component, I detected two bugs.

1. channellinked function is never called, as mentioned for example in openHAB core repo #https://github.com/openhab/openhab-core/issues/1707 . Resulting in a null command because the commands list is empty. This is fixed in initalization as explained in the issue
2. reading from serial ports hangs the thread. After channel initalization, the binding sends a command to retrieve the status (for example, if the tv is powered on or off) and then, reads the serial port to get the status. The binding tries to read all the characters,  and stops after getting a -1, that means the end of the communication.
The problem here, is that sometime reading from serial port don't send anything or timeout until the device writes something, resulting in a thread blocked waiting for a read.
I tried to fix it adding a `while (input.available() > 0 && (data = input.read()) > -1) {` where input.available() returns remaining characters on the buffer.

