### PR TITLE
[miele] Reduce log level to TRACE for request/response logging

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -586,7 +586,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         }
 
         if (responseData != null) {
-            logger.debug("The request '{}' yields '{}'", requestData, responseData);
+            logger.trace("The request '{}' yields '{}'", requestData, responseData);
             JsonObject resp = (JsonObject) JsonParser.parseReader(new StringReader(responseData));
 
             result = resp.get("result");


### PR DESCRIPTION
Fixes #11781

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Full requests and responses are logged as log level **DEBUG**. This makes log level **DEBUG** almost unusable as it's completely spammed with requests all the time. This pull request reduces log level to **TRACE**.