### PR TITLE
[wled] add configuration to sort state options of channels

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedConfiguration.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedConfiguration.java
@@ -25,4 +25,6 @@ public class WLedConfiguration {
     public int pollTime;
     public int segmentIndex;
     public int saturationThreshold;
+    public boolean sortEffects = false;
+    public boolean sortPalettes = false;
 }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -305,6 +305,7 @@ public class WLedHandler extends BaseThingHandler {
             future.cancel(true);
             pollingFuture = null;
         }
+        api = null; // re-initialize api after configuration change
     }
 
     @Override

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.wled.internal.WLedBindingConstants.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -230,6 +231,9 @@ public class WledApiV084 implements WledApi {
         for (String value : state.jsonResponse.effects) {
             fxOptions.add(new StateOption(Integer.toString(counter++), value));
         }
+        if (handler.config.sortEffects) {
+            fxOptions.sort(Comparator.comparing(o -> o.getValue().equals("0") ? "" : o.getLabel()));
+        }
         handler.stateDescriptionProvider.setStateOptions(new ChannelUID(handler.getThing().getUID(), CHANNEL_FX),
                 fxOptions);
     }
@@ -239,6 +243,9 @@ public class WledApiV084 implements WledApi {
         int counter = 0;
         for (String value : state.jsonResponse.palettes) {
             palleteOptions.add(new StateOption(Integer.toString(counter++), value));
+        }
+        if (handler.config.sortPalettes) {
+            palleteOptions.sort(Comparator.comparing(o -> o.getValue().equals("0") ? "" : o.getLabel()));
         }
         handler.stateDescriptionProvider.setStateOptions(new ChannelUID(handler.getThing().getUID(), CHANNEL_PALETTES),
                 palleteOptions);

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -57,6 +57,18 @@
 				</description>
 				<default>0</default>
 			</parameter>
+			<parameter name="sortEffects" type="boolean">
+				<label>Sort Effects</label>
+				<description>If set, will sort the state options of the effects channel alphabetically while keeping the first
+					option (Solid) at the top.</description>
+				<default>false</default>
+			</parameter>
+			<parameter name="sortPalettes" type="boolean">
+				<label>Sort Palettes</label>
+				<description>If set, will sort the state options of the palettes channel alphabetically while keeping the first
+					option (Default) at the top.</description>
+				<default>false</default>
+			</parameter>
 		</config-description>
 	</thing-type>
 


### PR DESCRIPTION
As discussed in the forum, it would be nice to have the state options for the channels "effects" and "palettes" sorted like they are in the WLED mobile app, i.e. the first option at the top and the rest alphabetically. This PR adds two thing options that allows to enable exactly that on both channels separately.

https://community.openhab.org/t/mainui-sorting-choices-provided-by-thing-channel/129883/5?u=lordjaxom

This allows for displaying the channels' state options in a sorted list in the various UIs without having to maintain that list manually by adding state option metadata to items.
