### PR TITLE
[wled] Fix two events being logged when light is off.

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV084.java
@@ -264,7 +264,6 @@ public class WledApiV084 implements WledApi {
         }
         HSBType tempHSB = WLedHelper
                 .parseToHSBType(state.stateResponse.seg[handler.config.segmentIndex].col[0].toString());
-        handler.update(CHANNEL_MASTER_CONTROLS, tempHSB);
         handler.update(CHANNEL_PRIMARY_COLOR, tempHSB);
         handler.update(CHANNEL_SECONDARY_COLOR,
                 WLedHelper.parseToHSBType(state.stateResponse.seg[handler.config.segmentIndex].col[1].toString()));
@@ -283,6 +282,7 @@ public class WledApiV084 implements WledApi {
             handler.update(CHANNEL_MASTER_CONTROLS, OnOffType.OFF);
             handler.update(CHANNEL_SEGMENT_BRIGHTNESS, OnOffType.OFF);
         } else {
+            handler.update(CHANNEL_MASTER_CONTROLS, tempHSB);
             handler.update(CHANNEL_SEGMENT_BRIGHTNESS,
                     new PercentType(new BigDecimal(state.stateResponse.seg[handler.config.segmentIndex].bri)
                             .divide(BIG_DECIMAL_2_55, RoundingMode.HALF_UP)));


### PR DESCRIPTION
Because colours come from RGB values the controls were jumping to the colour that was set and then jumping to OFF as the binding was parsing the two values separately. This PR fixes it so the event.log only shows the channel getting the off state and not a HSB that is on, followed by an OFF.

Signed-off-by: Matthew Skinner <matt@pcmus.com>