### PR TITLE
[avmfritz] Prevent attempt to set brightness of blinds

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -159,7 +159,7 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
                 }
                 if (deviceModel.isColorLight()) {
                     updateColorLight(deviceModel.getColorControlModel(), deviceModel.getLevelControlModel());
-                } else if (deviceModel.isDimmableLight()) {
+                } else if (deviceModel.isDimmableLight() && !deviceModel.isHANFUNBlinds()) {
                     updateDimmableLight(deviceModel.getLevelControlModel());
                 } else if (device.isHANFUNUnit() && device.isHANFUNOnOff()) {
                     updateSimpleOnOffUnit(device.getSimpleOnOffUnit());


### PR DESCRIPTION
This is a bug fix for issue #11789. It prevents the AVMFritzBaseThingHandler from attempting to set the (non-existing) brightness channel for HAN-FUN blinds.

Signed-off-by: Ulrich Mertin <mail@ulrich-mertin.de>
