### PR TITLE
[wled] Fix global OFF blocks lights turning on via the masterControls

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -139,6 +139,10 @@ public class WLedHandler extends BaseThingHandler {
                     break;
                 case CHANNEL_MASTER_CONTROLS:
                     if (command instanceof OnOffType) {
+                        if (OnOffType.ON.equals(command)) {
+                            // global may be off, but we don't want to switch global off and affect other segments
+                            localApi.setGlobalOn(true);
+                        }
                         localApi.setMasterOn(OnOffType.ON.equals(command), config.segmentIndex);
                     } else if (command instanceof IncreaseDecreaseType) {
                         if (IncreaseDecreaseType.INCREASE.equals(command)) {
@@ -159,6 +163,7 @@ public class WLedHandler extends BaseThingHandler {
                             localApi.setMasterOn(false, config.segmentIndex);
                             return;
                         }
+                        localApi.setGlobalOn(true);
                         primaryColor = (HSBType) command;
                         if (primaryColor.getSaturation().intValue() < config.saturationThreshold && hasWhite) {
                             localApi.setWhiteOnly((PercentType) command, config.segmentIndex);


### PR DESCRIPTION
WLED has a global on/off as well as each lightglobe (aka segment) has an individual on/off control. This fixes an issue when the sleep timer has turned the global control OFF and you wish to turn one of the lights ON or you ask Google/Alexa to turn the light on. Google will reply the light has been turned on, yet the light stays off. This fix makes it behave as expected.

Signed-off-by: Matthew Skinner <matt@pcmus.com>