### PR TITLE
Bump netty to 4.1.72.Final for log4j2 2.15.0 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.5</jackson.version>
     <karaf.version>4.3.4</karaf.version>
-    <netty.version>4.1.68.Final</netty.version>
+    <netty.version>4.1.72.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
     <sat.version>0.12.0</sat.version>
     <spotless.version>2.0.3</spotless.version>


### PR DESCRIPTION
PR made to the core repo that is also needed.
https://github.com/openhab/openhab-core/pull/2634

Nettys news/change log is here:
https://netty.io/news/2021/12/13/4-1-72-Final.html

Contains an update to log4j2 2.15.0 to fix security issue.


Signed-off-by: Matthew Skinner <matt@pcmus.com>