### PR TITLE
[jsscripting] JS script engine no longer watches node_modules for scripts

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/fs/watch/JSDependencyTracker.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/fs/watch/JSDependencyTracker.java
@@ -16,9 +16,6 @@ import java.io.File;
 
 import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.rulesupport.loader.DependencyTracker;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +24,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jonathan Gilbert - Initial contribution
  */
-@Component(immediate = true, service = JSDependencyTracker.class)
 public class JSDependencyTracker extends DependencyTracker {
 
     private final Logger logger = LoggerFactory.getLogger(JSDependencyTracker.class);
@@ -39,7 +35,6 @@ public class JSDependencyTracker extends DependencyTracker {
         super(LIB_PATH);
     }
 
-    @Activate
     public void activate() {
         File directory = new File(LIB_PATH);
         if (!directory.exists()) {
@@ -51,10 +46,5 @@ public class JSDependencyTracker extends DependencyTracker {
         }
 
         super.activate();
-    }
-
-    @Deactivate
-    public void deactivate() {
-        super.deactivate();
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/fs/watch/JSFileWatcher.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/fs/watch/JSFileWatcher.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscripting.internal.fs.watch;
+
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.service.ReadyService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Monitors <openHAB-conf>/automation/js for Javascript files & libraries.
+ *
+ * This class is required to ensure that the *order* of set up is correct. Specifically, the dependency tracker must
+ * be activated after the script file watcher. This is because AbstractWatchService only allows a single service to
+ * watch a single directory, and given that the watchers are nested and the last registration wins, the one we want to
+ * monitor the libraries must be registered last.
+ *
+ * @author Jonathan Gilbert - Initial contribution
+ */
+@Component(immediate = true, service = JSFileWatcher.class)
+public class JSFileWatcher {
+
+    private final JSScriptFileWatcher jsScriptFileWatcher;
+    private final JSDependencyTracker jsDependencyTracker;
+
+    @Activate
+    public JSFileWatcher(final @Reference ScriptEngineManager manager, final @Reference ReadyService readyService) {
+        jsDependencyTracker = new JSDependencyTracker();
+        jsScriptFileWatcher = new JSScriptFileWatcher(manager, readyService, jsDependencyTracker);
+    }
+
+    @Activate
+    public void activate() {
+        jsScriptFileWatcher.activate();
+        jsDependencyTracker.activate();
+        jsDependencyTracker.addChangeTracker(jsScriptFileWatcher);
+    }
+
+    @Deactivate
+    void deactivate() {
+        jsDependencyTracker.removeChangeTracker(jsScriptFileWatcher);
+        jsDependencyTracker.deactivate();
+        jsScriptFileWatcher.deactivate();
+    }
+}

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/fs/watch/JSScriptFileWatcher.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/fs/watch/JSScriptFileWatcher.java
@@ -13,43 +13,41 @@
 package org.openhab.automation.jsscripting.internal.fs.watch;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.automation.jsscripting.internal.GraalJSScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
 import org.openhab.core.automation.module.script.rulesupport.loader.ScriptFileReference;
 import org.openhab.core.automation.module.script.rulesupport.loader.ScriptFileWatcher;
 import org.openhab.core.service.ReadyService;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 /**
- * Monitors <openHAB-conf>/automation/js for Javascript files
+ * Monitors <openHAB-conf>/automation/js for Javascript files, but not libraries
  *
  * @author Jonathan Gilbert - Initial contribution
  */
-@Component(immediate = true)
 public class JSScriptFileWatcher extends ScriptFileWatcher {
     private static final String FILE_DIRECTORY = "automation" + File.separator + "js";
+    private static final String IGNORE_DIR_NAME = "node_modules";
 
-    @Activate
-    public JSScriptFileWatcher(final @Reference ScriptEngineManager manager, final @Reference ReadyService readyService,
-            final @Reference JSDependencyTracker jsDependencyTracker) {
-        super(manager, jsDependencyTracker, readyService, FILE_DIRECTORY);
+    private final String ignorePath;
+
+    public JSScriptFileWatcher(final ScriptEngineManager manager, final ReadyService readyService,
+            JSDependencyTracker dependencyTracker) {
+        super(manager, dependencyTracker, readyService, FILE_DIRECTORY);
+
+        ignorePath = pathToWatch + File.separator + "node_modules";
     }
 
-    @Activate
     @Override
-    public void activate() {
-        super.activate();
-    }
-
-    @Deactivate
-    @Override
-    public void deactivate() {
-        super.deactivate();
+    protected void processWatchEvent(@Nullable WatchEvent<?> event, WatchEvent.@Nullable Kind<?> kind,
+            @Nullable Path path) {
+        if (!path.startsWith(ignorePath)) {
+            super.processWatchEvent(event, kind, path);
+        }
     }
 
     @Override
@@ -61,5 +59,10 @@ public class JSScriptFileWatcher extends ScriptFileWatcher {
                 return Optional.of(GraalJSScriptEngineFactory.MIME_TYPE);
             }
         });
+    }
+
+    @Override
+    protected boolean watchSubDirectories() {
+        return false;
     }
 }


### PR DESCRIPTION
Fixes #11831 where `node_modules` is watched for scripts. This change prevents this subdir being watched (library changes are still watched elsewhere).

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>