### PR TITLE
[cbus] fix exception from threadpool at startup

### DIFF
--- a/bundles/org.openhab.binding.cbus/src/main/java/org/openhab/binding/cbus/internal/CBusThreadPool.java
+++ b/bundles/org.openhab.binding.cbus/src/main/java/org/openhab/binding/cbus/internal/CBusThreadPool.java
@@ -14,7 +14,7 @@ package org.openhab.binding.cbus.internal;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -45,10 +45,10 @@ public class CBusThreadPool extends CGateThreadPool {
     }
 
     public class CBusThreadPoolExecutor extends CGateThreadPoolExecutor {
-        private final ThreadPoolExecutor threadPool;
+        private final ExecutorService threadPool;
 
         public CBusThreadPoolExecutor(@Nullable String poolName) {
-            threadPool = (ThreadPoolExecutor) ThreadPoolManager.getPool("binding.cbus-" + poolName);
+            threadPool = (ExecutorService) ThreadPoolManager.getPool("binding.cbus-" + poolName);
         }
 
         @Override

--- a/bundles/org.openhab.binding.cbus/src/main/java/org/openhab/binding/cbus/internal/CBusThreadPool.java
+++ b/bundles/org.openhab.binding.cbus/src/main/java/org/openhab/binding/cbus/internal/CBusThreadPool.java
@@ -48,7 +48,7 @@ public class CBusThreadPool extends CGateThreadPool {
         private final ExecutorService threadPool;
 
         public CBusThreadPoolExecutor(@Nullable String poolName) {
-            threadPool = (ExecutorService) ThreadPoolManager.getPool("binding.cbus-" + poolName);
+            threadPool = ThreadPoolManager.getPool("binding.cbus-" + poolName);
         }
 
         @Override


### PR DESCRIPTION

Fixes #11845
After changes in 3.2 to the ThreadPool implementation the return from getpool can no longer be cast to ThreadPoolExecutor.
Changing this to ExecutorService fixes this problem and the binding works again.

