### PR TITLE
[myStrom] Request info is not supported by the first generation of plug

### DIFF
--- a/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/AbstractMyStromHandler.java
+++ b/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/AbstractMyStromHandler.java
@@ -47,8 +47,10 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The {@link AbstractMyStromHandler} is responsible for handling commands, which are
@@ -65,6 +67,7 @@ public abstract class AbstractMyStromHandler extends BaseThingHandler {
     protected String hostname = "";
     protected String mac = "";
 
+    private final Logger logger = LoggerFactory.getLogger(AbstractMyStromHandler.class);
     private @Nullable ScheduledFuture<?> pollingJob;
     protected final Gson gson = new Gson();
 
@@ -116,12 +119,10 @@ public abstract class AbstractMyStromHandler extends BaseThingHandler {
                     Locale.getDefault());
             properties.put(PROPERTY_LAST_REFRESH, formatter.format(calendar.getTime()));
             updateProperties(properties);
-        } catch (Exception ex) {
-            getLogger().debug("Updating properties failed: ", ex);
+        } catch (JsonSyntaxException | MyStromException ex) {
+            logger.debug("Updating properties failed: ", ex);
         }
     }
-
-    protected abstract Logger getLogger();
 
     /**
      * Calls the API with the given http method, request path and actual data.

--- a/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromBulbHandler.java
+++ b/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromBulbHandler.java
@@ -154,6 +154,18 @@ public class MyStromBulbHandler extends AbstractMyStromHandler {
         }
     }
 
+    @Override
+    protected final Logger getLogger() {
+        return logger;
+    }
+
+    @Override
+    protected void checkRequiredInfo() throws MyStromException {
+        if (mac.equals("")) {
+            throw new MyStromException("Cannot retrieve MAC info from myStrom device " + getThing().getUID());
+        }
+    }
+
     private @Nullable Map<String, MyStromDeviceSpecificInfo> getReport() {
         try {
             String returnContent = sendHttpRequest(HttpMethod.GET, "/api/v1/device", null);

--- a/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromBulbHandler.java
+++ b/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromBulbHandler.java
@@ -155,13 +155,8 @@ public class MyStromBulbHandler extends AbstractMyStromHandler {
     }
 
     @Override
-    protected final Logger getLogger() {
-        return logger;
-    }
-
-    @Override
     protected void checkRequiredInfo() throws MyStromException {
-        if (mac.equals("")) {
+        if (mac.isBlank()) {
             throw new MyStromException("Cannot retrieve MAC info from myStrom device " + getThing().getUID());
         }
     }

--- a/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromPlugHandler.java
+++ b/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromPlugHandler.java
@@ -78,11 +78,6 @@ public class MyStromPlugHandler extends AbstractMyStromHandler {
         }
     }
 
-    @Override
-    protected final Logger getLogger() {
-        return logger;
-    }
-
     private @Nullable MyStromReport getReport() {
         try {
             String returnContent = sendHttpRequest(HttpMethod.GET, "/report", null);

--- a/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromPlugHandler.java
+++ b/bundles/org.openhab.binding.mystrom/src/main/java/org/openhab/binding/mystrom/internal/MyStromPlugHandler.java
@@ -78,6 +78,11 @@ public class MyStromPlugHandler extends AbstractMyStromHandler {
         }
     }
 
+    @Override
+    protected final Logger getLogger() {
+        return logger;
+    }
+
     private @Nullable MyStromReport getReport() {
         try {
             String returnContent = sendHttpRequest(HttpMethod.GET, "/report", null);


### PR DESCRIPTION
closes #10432

If the request to "http://[Switch IP]/api/v1/info" fails (not supported by first generatino of plug), it will not prevent the plug from working because it does not require any information. For the Bulb, the information "mac" is required. With this Thing, it will fail as before.

https://github.com/openhab/openhab-addons/issues/10432
https://community.openhab.org/t/mystrom-smart-plugs-with-firmware-2-68-not-work-in-oh3/124427/6

Signed-off-by: Frederic Chastagnol <fchastagnol@fredoware.ch>
