### PR TITLE
[hdpowerview] Fix support for PowerView Hub v1

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -109,8 +109,11 @@ public class HDPowerViewWebTargets {
         shades = base + "shades/";
         sceneActivate = base + "scenes";
         scenes = base + "scenes/";
-        sceneCollectionActivate = base + "sceneCollections";
-        sceneCollections = base + "sceneCollections/";
+
+        // Hub v1 only supports "scenecollections". Hub v2 will redirect to "sceneCollections".
+        sceneCollectionActivate = base + "scenecollections";
+        sceneCollections = base + "scenecollections/";
+
         scheduledEvents = base + "scheduledevents";
         this.httpClient = httpClient;
     }


### PR DESCRIPTION
Fixes #11856

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Unfortunately #11534 has caused a regression in 3.2 since scene collection URL's were renamed in Hunter Douglas PowerView Hub v2.

This pull request is a limited version of #11853 fixing only the needed lines for Hub v1 compatibility and preserving scene group support for both Hub versions.

If there will be a branch for 3.2.x hotfixes, this PR would be a candidate.