### PR TITLE
Revert "Bump netty to 4.1.72.Final for log4j2 2.15.0 fix"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.5</jackson.version>
     <karaf.version>4.3.4</karaf.version>
-    <netty.version>4.1.72.Final</netty.version>
+    <netty.version>4.1.68.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
     <sat.version>0.12.0</sat.version>
     <spotless.version>2.0.3</spotless.version>


### PR DESCRIPTION
Reverts openhab/openhab-addons#11826