### PR TITLE
Bump netty to 4.1.72.Final for log4j2 fix TELSTICK FIXED

### DIFF
--- a/bundles/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/org.openhab.binding.tellstick/pom.xml
@@ -113,6 +113,12 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-kqueue</artifactId>
+      <version>${netty.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
       <version>${netty.version}</version>
       <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.5</jackson.version>
     <karaf.version>4.3.4</karaf.version>
-    <netty.version>4.1.68.Final</netty.version>
+    <netty.version>4.1.72.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
     <sat.version>0.12.0</sat.version>
     <spotless.version>2.0.3</spotless.version>


### PR DESCRIPTION
Bumping netty to 4.1.72.Final as it contains a log4j2 fix. This PR contains an extra line that allows telstick binding to compile with the newer Netty.

Core changes are also needed in separate PR here:
https://github.com/openhab/openhab-core/pull/2648

Christmas time here is nuts :) Merry Christmas to all...

Signed-off-by: Matthew Skinner <matt@pcmus.com>