### PR TITLE
[yeelight] Fixed ceiling3 device being recognized as device without night mode

### DIFF
--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactory.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactory.java
@@ -67,10 +67,9 @@ public class YeelightHandlerFactory extends BaseThingHandlerFactory {
             return new YeelightColorHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_STRIPE)) {
             return new YeelightStripeHandler(thing);
-        } else if (thingTypeUID.equals(THING_TYPE_CEILING) || thingTypeUID.equals(THING_TYPE_CEILING3)
-                || thingTypeUID.equals(THING_TYPE_DESKLAMP)) {
+        } else if (thingTypeUID.equals(THING_TYPE_CEILING) || thingTypeUID.equals(THING_TYPE_DESKLAMP)) {
             return new YeelightCeilingHandler(thing);
-        } else if (thingTypeUID.equals(THING_TYPE_CEILING1)) {
+        } else if (thingTypeUID.equals(THING_TYPE_CEILING1) || thingTypeUID.equals(THING_TYPE_CEILING3)) {
             return new YeelightCeilingWithNightHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_CEILING4)) {
             return new YeelightCeilingWithAmbientHandler(thing);

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
@@ -34,9 +34,9 @@ public class DeviceFactory {
         DeviceType type = DeviceType.valueOf(model);
         switch (type) {
             case ceiling:
-            case ceiling3:
                 return new CeilingDevice(id);
             case ceiling1:
+            case ceiling3:
                 return new CeilingDeviceWithNightDevice(id);
             case ceiling4:
                 return new CeilingDeviceWithAmbientDevice(id);

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
@@ -332,9 +332,9 @@ public class DeviceManager {
         }
         switch (device.getDeviceType()) {
             case ceiling:
-            case ceiling3:
                 return "Yeelight LED Ceiling";
             case ceiling1:
+            case ceiling3:
                 return "Yeelight LED Ceiling with night mode";
             case ceiling4:
                 return "Yeelight LED Ceiling with ambient light";

--- a/bundles/org.openhab.binding.yeelight/src/test/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactoryTest.java
+++ b/bundles/org.openhab.binding.yeelight/src/test/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactoryTest.java
@@ -51,7 +51,7 @@ public class YeelightHandlerFactoryTest {
     private static final List<Object[]> TESTS = Arrays.asList(
             new Object[][] { { "dolphin", YeelightWhiteHandler.class }, { "ct_bulb", YeelightWhiteHandler.class },
                     { "wonder", YeelightColorHandler.class }, { "stripe", YeelightStripeHandler.class },
-                    { "ceiling", YeelightCeilingHandler.class }, { "ceiling3", YeelightCeilingHandler.class },
+                    { "ceiling", YeelightCeilingHandler.class }, { "ceiling3", YeelightCeilingWithNightHandler.class },
                     { "ceiling1", YeelightCeilingWithNightHandler.class }, { "desklamp", YeelightCeilingHandler.class },
                     { "ceiling4", YeelightCeilingWithAmbientHandler.class }, { "unknown", null } });
 


### PR DESCRIPTION
Hi,

this PR fixes discovery of ceiling3 devices, which are being recognized as standard ones - without the night mode feature.
Ceiling3 devices have night mode as well as ceiling1 devices...

Thanks.
Ondrej
