### PR TITLE
[googletts] Use returned sound to get play informations

### DIFF
--- a/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleTTSService.java
+++ b/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleTTSService.java
@@ -341,10 +341,13 @@ public class GoogleTTSService implements TTSService {
             throw new TTSException("Could not read from Google Cloud TTS Service");
         }
 
-        // compute the real format returned by google
-        AudioFormat realAudioFormat = parseAudioFormat(audio);
+        // compute the real format returned by google if wave file
+        AudioFormat finalFormat = requestedFormat;
+        if (AudioFormat.CONTAINER_WAVE.equals(requestedFormat.getContainer())) {
+            finalFormat = parseAudioFormat(audio);
+        }
 
-        return new ByteArrayAudioStream(audio, realAudioFormat);
+        return new ByteArrayAudioStream(audio, finalFormat);
     }
 
     private AudioFormat parseAudioFormat(byte[] audio) {


### PR DESCRIPTION
When google tts returns a wav file, it is now parsed to get correct informations about it.
(It is mandatory for playing it with, at least, the System speaker audio sink)

This is the fix for the issue [discuted here](https://community.openhab.org/t/oh3-google-tts-only-white-noise/112714).

[Snapshot release](https://github.com/dalgwen/openhab-addons/releases/tag/3.3.0-snapshot-googleTTS-fix_white_noise)

Close #10015

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>
