### PR TITLE
[shelly] Fix comment in translations file

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -7,7 +7,7 @@ binding.shelly.config.localIP.description = This interface will be used to setup
 binding.shelly.config.autoCoIoT.label = Auto-CoIoT
 binding.shelly.config.autoCoIoT.description = If enabled CoIoT will be automatically used when the devices runs a firmware version 1.6 or newer; false: Use thing configuration to enabled/disable CoIoT events.  
 
-discovery.failed# Config status messages
+# Config status messages
 config-status.error.missing-device-ip = IP address of the Shelly device is missing.
 
 # Thing status descriptions

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly_de.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly_de.properties
@@ -7,7 +7,7 @@ binding.shelly.config.localIP.description = Lokale IP-Adresse der Netzwerk-Schni
 binding.shelly.config.autoCoIoT.label = Auto-CoIoT
 binding.shelly.config.autoCoIoT.description = Bei aktiviertem Auto-CoIoT wird das Protokoll aktiviert, sobald das Gerät eine Firmwareversion 1.6 oder neuer verwendet. Andernfalls wird dies über die Thing-Konfiguration gesteuert.
 
-discovery.failed\# Statusmeldung-Konfiguration
+# Config status messages
 config-status.error.missing-device-ip = Die IP-Adresse des Shelly Gerätes ist nicht konfiguriert.
 
 # Thing status descriptions


### PR DESCRIPTION
This fixes the comment showing up in the translations.
The code seems to use the 'message.discovery.failed' instead of 'discovery.failed'.