### PR TITLE
[chromecast] Prevent errors in log when URI host is null

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
@@ -267,11 +267,17 @@ public class ChromecastStatusUpdater {
 
     private @Nullable RawType downloadImage(String url) {
         logger.debug("Trying to download the content of URL '{}'", url);
-        RawType downloadedImage = HttpUtil.downloadImage(url);
-        if (downloadedImage == null) {
-            logger.debug("Failed to download the content of URL '{}'", url);
+        try {
+            RawType downloadedImage = HttpUtil.downloadImage(url);
+            if (downloadedImage == null) {
+                logger.debug("Failed to download the content of URL '{}'", url);
+            }
+            return downloadedImage;
+        } catch (IllegalArgumentException e) {
+            // we catch this exception to avoid confusion errors in the log file
+            // see https://github.com/openhab/openhab-core/issues/2494#issuecomment-970162025
         }
-        return downloadedImage;
+        return null;
     }
 
     private @Nullable RawType downloadImageFromCache(String url) {


### PR DESCRIPTION
- Prevent errors in log when URI host is null

See https://github.com/openhab/openhab-core/issues/2494#issuecomment-970162025

```
2021-12-30 10:27:03.868 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
java.lang.IllegalArgumentException: Invalid URI host: null (authority: null)
        at org.eclipse.jetty.client.HttpClient.checkHost(HttpClient.java:521) ~[?:?]
        at org.eclipse.jetty.client.HttpClient.newHttpRequest(HttpClient.java:506) ~[?:?]
        at org.eclipse.jetty.client.HttpClient.newRequest(HttpClient.java:464) ~[?:?]
        at org.eclipse.jetty.client.HttpClient.newRequest(HttpClient.java:453) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.executeUrlAndGetReponse(HttpUtil.java:212) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadData(HttpUtil.java:439) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadImage(HttpUtil.java:402) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadImage(HttpUtil.java:373) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadImage(HttpUtil.java:359) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.downloadImage(ChromecastStatusUpdater.java:270) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.downloadImageFromCache(ChromecastStatusUpdater.java:288) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateImage(ChromecastStatusUpdater.java:263) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateMetadataStatus(ChromecastStatusUpdater.java:211) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateMediaInfoStatus(ChromecastStatusUpdater.java:206) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateMediaStatus(ChromecastStatusUpdater.java:187) ~[?:?]
        at org.openhab.binding.chromecast.internal.ChromecastCommander.handleRefresh(ChromecastCommander.java:115) ~[?:?]
        at org.openhab.binding.chromecast.internal.handler.ChromecastHandler$Coordinator.refresh(ChromecastHandler.java:324) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(Unknown Source) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
        at java.lang.Thread.run(Unknown Source) [?:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
