### PR TITLE
[mqtt.homie] Add DateTime channel type to comply with MQTT Homie convention 3.x

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
@@ -30,6 +30,7 @@ import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass;
 import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass.AttributeChanged;
 import org.openhab.binding.mqtt.generic.mapping.ColorMode;
 import org.openhab.binding.mqtt.generic.values.ColorValue;
+import org.openhab.binding.mqtt.generic.values.DateTimeValue;
 import org.openhab.binding.mqtt.generic.values.NumberValue;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.PercentageValue;
@@ -217,6 +218,9 @@ public class Property implements AttributeChanged {
                 } else {
                     value = new NumberValue(min, max, step, attributes.unit);
                 }
+                break;
+            case datetime_:
+                value = new DateTimeValue();
                 break;
             case string_:
             case unknown:

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/PropertyAttributes.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/PropertyAttributes.java
@@ -36,7 +36,8 @@ public class PropertyAttributes extends AbstractMqttAttributeClass {
         boolean_,
         string_,
         enum_,
-        color_
+        color_,
+        datetime_
     }
 
     public String name = "";

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/config/homie-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/config/homie-channel-config.xml
@@ -42,6 +42,7 @@
 				<option value="string_">String</option>
 				<option value="enum_">Enumeration</option>
 				<option value="color_">Colour</option>
+				<option value="datetime_">DateTime</option>
 			</options>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/i18n/mqtt.properties
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/i18n/mqtt.properties
@@ -6,6 +6,7 @@ channel-type.config.mqtt.homie-channel.datatype.option.boolean_ = Boolean
 channel-type.config.mqtt.homie-channel.datatype.option.string_ = String
 channel-type.config.mqtt.homie-channel.datatype.option.enum_ = Enumeration
 channel-type.config.mqtt.homie-channel.datatype.option.color_ = Colour
+channel-type.config.mqtt.homie-channel.datatype.option.datetime_ = DateTime
 channel-type.config.mqtt.homie-channel.format.label = Format
 channel-type.config.mqtt.homie-channel.format.description = The output format.
 channel-type.config.mqtt.homie-channel.name.label = Name


### PR DESCRIPTION
This adds support for DateTime channels to the mqtt homie binding, see https://homieiot.github.io/specification/#datetime

Relates to #10839 