### PR TITLE
[rotel] Fix default properties

### DIFF
--- a/bundles/org.openhab.binding.rotel/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.rotel/src/main/resources/OH-INF/config/config.xml
@@ -234,7 +234,7 @@
 		</parameter>
 		<parameter name="inputLabelTape" type="text" required="false">
 			<label>@text/config.inputLabelTape.label</label>
-			<description>>@text/config.inputLabelTape.description</description>
+			<description>@text/config.inputLabelTape.description</description>
 		</parameter>
 		<parameter name="inputLabelVideo1" type="text" required="false">
 			<label>@text/config.inputLabelVideo1.label</label>
@@ -312,7 +312,7 @@
 		</parameter>
 		<parameter name="inputLabelVideo6" type="text" required="false">
 			<label>@text/config.inputLabelVideo6.label</label>
-			<description>config.inputLabelVideo6.description</description>
+			<description>@text/config.inputLabelVideo6.description</description>
 		</parameter>
 		<parameter name="inputLabelMulti" type="text" required="false">
 			<label>@text/config.inputLabelMulti.label</label>

--- a/bundles/org.openhab.binding.rotel/src/main/resources/OH-INF/i18n/rotel.properties
+++ b/bundles/org.openhab.binding.rotel/src/main/resources/OH-INF/i18n/rotel.properties
@@ -7,206 +7,162 @@ binding.rotel.description = The Rotel binding controls a Rotel audio device like
 
 thing-type.rotel.a11.label = A11 Integrated Amplifier
 thing-type.rotel.a11.description = Connection to the Rotel A11 integrated amplifier
-
 thing-type.rotel.a12.label = A12 Integrated Amplifier
 thing-type.rotel.a12.description = Connection to the Rotel A12 integrated amplifier
-
 thing-type.rotel.a14.label = A14 Integrated Amplifier
 thing-type.rotel.a14.description = Connection to the Rotel A14 integrated amplifier
-
 thing-type.rotel.cd11.label = CD11 CD Player
 thing-type.rotel.cd11.description = Connection to the Rotel CD11 CD player
-
 thing-type.rotel.cd14.label = CD14 CD Player
 thing-type.rotel.cd14.description = Connection to the Rotel CD14 CD player
-
 thing-type.rotel.ra11.label = RA-11 Integrated Amplifier
 thing-type.rotel.ra11.description = Connection to the Rotel RA-11 integrated amplifier
-
 thing-type.rotel.ra12.label = RA-12 Integrated Amplifier
 thing-type.rotel.ra12.description = Connection to the Rotel RA-12 integrated amplifier
-
 thing-type.rotel.ra1570.label = RA-1570 Integrated Amplifier
 thing-type.rotel.ra1570.description = Connection to the Rotel RA-1570 integrated amplifier
-
 thing-type.rotel.ra1572.label = RA-1572 Integrated Amplifier
 thing-type.rotel.ra1572.description = Connection to the Rotel RA-1572 integrated amplifier
-
 thing-type.rotel.ra1592.label = RA-1592 Integrated Amplifier
 thing-type.rotel.ra1592.description = Connection to the Rotel RA-1592 integrated amplifier
-
 thing-type.rotel.rap1580.label = RAP-1580 Surround Amplified Processor
 thing-type.rotel.rap1580.description = Connection to the Rotel RAP-1580 surround amplified processor
-
 thing-type.rotel.rc1570.label = RC-1570 Stereo Preamplifier
 thing-type.rotel.rc1570.description = Connection to the Rotel RC-1570 stereo preamplifier
-
 thing-type.rotel.rc1572.label = RC-1572 Stereo Preamplifier
 thing-type.rotel.rc1572.description = Connection to the Rotel RC-1572 stereo preamplifier
-
 thing-type.rotel.rc1590.label = RC-1590 Stereo Preamplifier
 thing-type.rotel.rc1590.description = Connection to the Rotel RC-1590 stereo preamplifier
-
 thing-type.rotel.rcd1570.label = RCD-1570 CD Player
 thing-type.rotel.rcd1570.description = Connection to the Rotel RCD-1570 CD player
-
 thing-type.rotel.rcd1572.label = RCD-1572 CD Player
 thing-type.rotel.rcd1572.description = Connection to the Rotel RCD-1572 CD player
-
 thing-type.rotel.rcx1500.label = RCX-1500 Stereo Receiver
 thing-type.rotel.rcx1500.description = Connection to the Rotel RCX-1500 stereo receiver
-
 thing-type.rotel.rdd1580.label = RDD-1580 Stereo DAC
 thing-type.rotel.rdd1580.description = Connection to the Rotel RDD-1580 stereo DAC
-
 thing-type.rotel.rdg1520.label = RDG-1520 Tuner
 thing-type.rotel.rdg1520.description = Connection to the Rotel RDG-1520 tuner
-
 thing-type.rotel.rsp1066.label = RSP-1066 Surround Processor
 thing-type.rotel.rsp1066.description = Connection to the Rotel RSP-1066 surround processor
-
 thing-type.rotel.rsp1068.label = RSP-1068 Surround Processor
 thing-type.rotel.rsp1068.description = Connection to the Rotel RSP-1068 surround processor
-
 thing-type.rotel.rsp1069.label = RSP-1069 Surround Processor
 thing-type.rotel.rsp1069.description = Connection to the Rotel RSP-1069 surround processor
-
 thing-type.rotel.rsp1098.label = RSP-1098 Surround Processor
 thing-type.rotel.rsp1098.description = Connection to the Rotel RSP-1098 surround processor
-
 thing-type.rotel.rsp1570.label = RSP-1570 Surround Processor
 thing-type.rotel.rsp1570.description = Connection to the Rotel RSP-1570 surround processor
-
 thing-type.rotel.rsp1572.label = RSP-1572 Surround Processor
 thing-type.rotel.rsp1572.description = Connection to the Rotel RSP-1572 surround processor
-
 thing-type.rotel.rsp1576.label = RSP-1576 Surround Processor
 thing-type.rotel.rsp1576.description = Connection to the Rotel RSP-1576 surround processor
-
 thing-type.rotel.rsp1582.label = RSP-1582 Surround Processor
 thing-type.rotel.rsp1582.description = Connection to the Rotel RSP-1582 surround processor
-
 thing-type.rotel.rsx1055.label = RSX-1055 Surround Receiver
 thing-type.rotel.rsx1055.description = Connection to the Rotel RSX-1055 surround receiver
-
 thing-type.rotel.rsx1056.label = RSX-1056 Surround Receiver
 thing-type.rotel.rsx1056.description = Connection to the Rotel RSX-1056 surround receiver
-
 thing-type.rotel.rsx1057.label = RSX-1057 Surround Receiver
 thing-type.rotel.rsx1057.description = Connection to the Rotel RSX-1057 surround receiver
-
 thing-type.rotel.rsx1058.label = RSX-1058 Surround Receiver
 thing-type.rotel.rsx1058.description = Connection to the Rotel RSX-1058 surround receiver
-
 thing-type.rotel.rsx1065.label = RSX-1065 Surround Receiver
 thing-type.rotel.rsx1065.description = Connection to the Rotel RSX-1065 surround receiver
-
 thing-type.rotel.rsx1067.label = RSX-1067 Surround Receiver
 thing-type.rotel.rsx1067.description = Connection to the Rotel RSX-1067 surround receiver
-
 thing-type.rotel.rsx1550.label = RSX-1550 Surround Receiver
 thing-type.rotel.rsx1550.description = Connection to the Rotel RSX-1550 surround receiver
-
 thing-type.rotel.rsx1560.label = RSX-1560 Surround Receiver
 thing-type.rotel.rsx1560.description = Connection to the Rotel RSX-1560 surround receiver
-
 thing-type.rotel.rsx1562.label = RSX-1562 Surround Receiver
 thing-type.rotel.rsx1562.description = Connection to the Rotel RSX-1562 surround receiver
-
 thing-type.rotel.rt09.label = RT-09 Tuner
 thing-type.rotel.rt09.description = Connection to the Rotel RT-09 tuner
-
 thing-type.rotel.rt11.label = RT-11 Tuner
 thing-type.rotel.rt11.description = Connection to the Rotel RT-11 tuner
-
 thing-type.rotel.rt1570.label = RT-1570 Tuner
 thing-type.rotel.rt1570.description = Connection to the Rotel RT-1570 tuner
-
 thing-type.rotel.t11.label = T11 Tuner
 thing-type.rotel.t11.description = Connection to the Rotel T11 tuner
-
 thing-type.rotel.t14.label = T14 Tuner
 thing-type.rotel.t14.description = Connection to the Rotel T14 tuner
 
+# channel types
+
+channel-type.rotel.bass.label = Bass Adjustment
+channel-type.rotel.bass.description = Adjust the bass
+channel-type.rotel.brightness.label = Front Panel Display Brightness
+channel-type.rotel.brightness.description = The backlight brightness level (in %) of the device front panel
+channel-type.rotel.dsp.label = DSP Mode
+channel-type.rotel.dsp.description = Select the DSP mode
+channel-type.rotel.frequency.label = Current Frequency
+channel-type.rotel.frequency.description = The current frequency (in kHz) for digital source input
+channel-type.rotel.frontPanelLine.label = Front Panel Line
+channel-type.rotel.frontPanelLine.description = The line content displayed on the device front panel
+channel-type.rotel.recordSource.label = Record Source
+channel-type.rotel.recordSource.description = Select the source to be recorded
+channel-type.rotel.source.label = Source Input
+channel-type.rotel.source.description = Select the source input
+channel-type.rotel.track.label = Current Track
+channel-type.rotel.track.description = The current CD track number
+channel-type.rotel.treble.label = Treble Adjustment
+channel-type.rotel.treble.description = Adjust the treble
+channel-type.rotel.volumeUpDown.label = Volume
+channel-type.rotel.volumeUpDown.description = Increase or decrease the volume
+
 # thing type configuration
 
-config.serialPort.label = Serial Port
-config.serialPort.description = Serial port to use for connecting to the Rotel device
-
+config.host.label = Address
+config.host.description = Host name or IP address of the Rotel device (IP connection) or the machine connected to the Rotel device (serial over IP)
+config.hostOverIp.label = Address
+config.hostOverIp.description = Host name or IP address of the machine connected to the Rotel device (serial over IP)
+config.inputLabelCd.label = Input Label CD
+config.inputLabelCd.description = Label setup for the source CD
+config.inputLabelMulti.label = Input Label Multi Input
+config.inputLabelMulti.description = Label setup for the source Multi Input
+config.inputLabelTape.label = Input Label Tape
+config.inputLabelTape.description = Label setup for the source Tape
+config.inputLabelTuner.label = Input Label Tuner
+config.inputLabelTuner.description = Label setup for the source Tuner
+config.inputLabelUsb.label = Input Label USB
+config.inputLabelUsb.description = Label setup for the source USB
+config.inputLabelVideo1.label = Input Label Video 1
+config.inputLabelVideo1.description = Label setup for the source Video 1
+config.inputLabelVideo2.label = Input Label Video 2
+config.inputLabelVideo2.description = Label setup for the source Video 2
+config.inputLabelVideo3.label = Input Label Video 3
+config.inputLabelVideo3.description = Label setup for the source Video 3
+config.inputLabelVideo4.label = Input Label Video 4
+config.inputLabelVideo4.description = Label setup for the source Video 4
+config.inputLabelVideo5.label = Input Label Video 5
+config.inputLabelVideo5.description = Label setup for the source Video 5
+config.inputLabelVideo6.label = Input Label Video 6
+config.inputLabelVideo6.description = Label setup for the source Video 6
+config.port.label = Port
+config.port.description = Communication port (IP or serial over IP). For IP connection to the Rotel device, keep the default port 9590
+config.portOverIp.label = Port
+config.portOverIp.description = Communication port (serial over IP)
 config.protocol.label = Protocol Version
 config.protocol.description = Choose one of the two protocol versions (depends on your device firmware)
 config.protocol.option.ASCII_V1 = ASCII V1
 config.protocol.option.ASCII_V2 = ASCII V2
-
-config.host.label = Address
-config.host.description = Host name or IP address of the Rotel device (IP connection) or the machine connected to the Rotel device (serial over IP)
-
-config.port.label = Port
-config.port.description = Communication port (IP or serial over IP). For IP connection to the Rotel device, keep the default port 9590
-
-config.hostOverIp.label = Address
-config.hostOverIp.description = Host name or IP address of the machine connected to the Rotel device (serial over IP)
-
-config.portOverIp.label = Port
-config.portOverIp.description = Communication port (serial over IP)
-
-config.inputLabelCd.label = Input Label CD
-config.inputLabelCd.description = Label setup for the source CD
-
-config.inputLabelTuner.label = Input Label Tuner
-config.inputLabelTuner.description = Label setup for the source Tuner
-
-config.inputLabelTape.label = Input Label Tape
-config.inputLabelTape.description = Label setup for the source Tape
-
-config.inputLabelUsb.label = Input Label USB
-config.inputLabelUsb.description = Label setup for the source USB
-
-config.inputLabelVideo1.label = Input Label Video 1
-config.inputLabelVideo1.description = Label setup for the source Video 1
-
-config.inputLabelVideo2.label = Input Label Video 2
-config.inputLabelVideo2.description = Label setup for the source Video 2
-
-config.inputLabelVideo3.label = Input Label Video 3
-config.inputLabelVideo3.description = Label setup for the source Video 3
-
-config.inputLabelVideo4.label = Input Label Video 4
-config.inputLabelVideo4.description = Label setup for the source Video 4
-
-config.inputLabelVideo5.label = Input Label Video 5
-config.inputLabelVideo5.description = Label setup for the source Video 5
-
-config.inputLabelVideo6.label = Input Label Video 6
-config.inputLabelVideo6.description = Label setup for the source Video 6
-
-config.inputLabelMulti.label = Input Label Multi Input
-config.inputLabelMulti.description = Label setup for the source Multi Input
+config.serialPort.label = Serial Port
+config.serialPort.description = Serial port to use for connecting to the Rotel device
 
 # channel group types
 
 channel-group.mainZone.label = Main Zone
 channel-group.mainZone.description = The controls of the main zone
-
 channel-group.zone2.label = Zone 2
 channel-group.zone2.description = The controls of the zone 2
-
 channel-group.zone3.label = Zone 3
 channel-group.zone3.description = The controls of the zone 3
-
 channel-group.zone4.label = Zone 4
 channel-group.zone4.description = The controls of the zone 4
 
 # channel types
 
-channel-type.rotel.source.label = Source Input
-channel-type.rotel.source.description = Select the source input
-
-channel-type.rotel.recordSource.label = Record Source
-channel-type.rotel.recordSource.description = Select the source to be recorded
-
-channel-type.rotel.dsp.label = DSP Mode
-channel-type.rotel.dsp.description = Select the DSP mode
 channel-type.rotel.dsp.state.option.NONE = No DSP
 channel-type.rotel.dsp.state.option.STEREO3 = Dolby 3 Stereo
 channel-type.rotel.dsp.state.option.STEREO5 = 5 Channel Stereo
@@ -235,28 +191,7 @@ channel-type.rotel.dsp.state.option.BYPASS = Analog Bypass
 channel-type.rotel.dsp.state.option.ATMOS = Dolby Atmos
 channel-type.rotel.dsp.state.option.NEURALX = dts Neural:X
 
-channel-type.rotel.volumeUpDown.label = Volume
-channel-type.rotel.volumeUpDown.description = Increase or decrease the volume
-
-channel-type.rotel.bass.label = Bass Adjustment
-channel-type.rotel.bass.description = Adjust the bass
-
-channel-type.rotel.treble.label = Treble Adjustment
-channel-type.rotel.treble.description = Adjust the treble
-
-channel-type.rotel.track.label = Current Track
-channel-type.rotel.track.description = The current CD track number
-
-channel-type.rotel.frequency.label = Current Frequency
-channel-type.rotel.frequency.description = The current frequency (in kHz) for digital source input
-
-channel-type.rotel.frontPanelLine.label = Front Panel Line
-channel-type.rotel.frontPanelLine.description = The line content displayed on the device front panel
-
-channel-type.rotel.brightness.label = Front Panel Display Brightness
-channel-type.rotel.brightness.description = The backlight brightness level (in %) of the device front panel
-
-# Thing status descriptions
+# thing status descriptions
 
 offline.config-error-unknown-serialport-and-host = Undefined serialPort and host configuration settings; please set one of them
 offline.config-error-unknown-port = Undefined port configuration setting
@@ -269,7 +204,7 @@ offline.comm-error-sending-command = Sending command failed
 offline.comm-error-reconnection = Reconnection failed
 offline.comm-error-first-command-after-reconnection = First command after connection failed
 
-# Source labels
+# source labels
 
 source.CD = CD
 source.TUNER = Tuner

--- a/bundles/org.openhab.binding.rotel/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.rotel/src/main/resources/OH-INF/thing/channels.xml
@@ -108,7 +108,7 @@
 
 	<channel-group-type id="zone3">
 		<label>@text/channel-group.zone3.label</label>
-		<description>T@text/channel-group.zone3.description</description>
+		<description>@text/channel-group.zone3.description</description>
 		<channels>
 			<channel id="power" typeId="system.power"/>
 			<channel id="source" typeId="source"/>


### PR DESCRIPTION
Also reorder properties by running mvn i18n:generate-default-translations

Signed-off-by: Laurent Garnier <lg.hc@free.fr>