### PR TITLE
[voicerss] Add support for WAV audio format

### DIFF
--- a/bundles/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/cloudapi/VoiceRSSCloudAPI.java
+++ b/bundles/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/cloudapi/VoiceRSSCloudAPI.java
@@ -41,7 +41,7 @@ public interface VoiceRSSCloudAPI {
      *
      * @return A set of all audio formats supported
      */
-    Set<String> getAvailableAudioFormats();
+    Set<AudioFormat> getAvailableAudioFormats();
 
     /**
      * Get all supported voices.
@@ -70,6 +70,8 @@ public interface VoiceRSSCloudAPI {
      *            the locale to use
      * @param voice
      *            the voice to use, "default" for the default voice
+     * @param audioCodec
+     *            the audio codec to use
      * @param audioFormat
      *            the audio format to use
      * @return an InputStream to the audio data in specified format
@@ -77,6 +79,6 @@ public interface VoiceRSSCloudAPI {
      *             will be raised if the audio data can not be retrieved from
      *             cloud service
      */
-    InputStream getTextToSpeech(String apiKey, String text, String locale, String voice, String audioFormat)
-            throws IOException;
+    InputStream getTextToSpeech(String apiKey, String text, String locale, String voice, String audioCodec,
+            String audioFormat) throws IOException;
 }

--- a/bundles/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/cloudapi/VoiceRSSCloudImpl.java
+++ b/bundles/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/internal/cloudapi/VoiceRSSCloudImpl.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.voice.voicerss.internal.cloudapi;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -28,8 +26,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Stream;
 
+import org.openhab.core.audio.AudioFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +39,14 @@ import org.slf4j.LoggerFactory;
  * <ul>
  * <li>All API languages supported</li>
  * <li>Only default voice supported with good audio quality</li>
- * <li>Only MP3, OGG and AAC audio formats supported</li>
+ * <li>MP3, OGG, AAC and WAV audio formats supported</li>
  * <li>It uses HTTP and not HTTPS (for performance reasons)</li>
  * </ul>
  *
  * @author Jochen Hiller - Initial contribution
  * @author Laurent Garnier - add support for all API languages
  * @author Laurent Garnier - add support for OGG and AAC audio formats
+ * @author Andreas Brenk - add support for WAV audio format
  */
 public class VoiceRSSCloudImpl implements VoiceRSSCloudAPI {
 
@@ -55,7 +54,36 @@ public class VoiceRSSCloudImpl implements VoiceRSSCloudAPI {
 
     private final Logger logger = LoggerFactory.getLogger(VoiceRSSCloudImpl.class);
 
-    private static final Set<String> SUPPORTED_AUDIO_FORMATS = Stream.of("MP3", "OGG", "AAC").collect(toSet());
+    private static final Set<AudioFormat> SUPPORTED_AUDIO_FORMATS = Set.of(
+            new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_MP3, null, 16, null, 44_100L),
+            new AudioFormat(AudioFormat.CONTAINER_OGG, AudioFormat.CODEC_VORBIS, null, 16, null, 44_100L),
+            new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_AAC, null, 16, null, 44_100L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, null, 8, 64_000, 8_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, null, 16, 128_000, 8_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 88_200, 11_025L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 176_400, 11_025L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 96_000, 12_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 192_000, 12_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 128_000, 16_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 256_000, 16_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 176_400, 22_050L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 352_800, 22_050L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 192_000, 24_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 384_000, 24_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 256_000, 32_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 512_000, 32_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 352_800, 44_100L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 705_600, 44_100L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 8, 384_000, 48_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 768_000, 48_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ALAW, null, 8, 64_000, 8_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ALAW, null, 8, 88_200, 11_025L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ALAW, null, 8, 176_400, 22_050L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ALAW, null, 8, 352_800, 44_100L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ULAW, null, 8, 64_000, 8_000L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ULAW, null, 8, 88_200, 11_025L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ULAW, null, 8, 176_400, 22_050L),
+            new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_ULAW, null, 8, 352_800, 44_100L));
 
     private static final Set<Locale> SUPPORTED_LOCALES = new HashSet<>();
     static {
@@ -164,7 +192,7 @@ public class VoiceRSSCloudImpl implements VoiceRSSCloudAPI {
     }
 
     @Override
-    public Set<String> getAvailableAudioFormats() {
+    public Set<AudioFormat> getAvailableAudioFormats() {
         return SUPPORTED_AUDIO_FORMATS;
     }
 
@@ -208,9 +236,9 @@ public class VoiceRSSCloudImpl implements VoiceRSSCloudAPI {
      * dependencies.
      */
     @Override
-    public InputStream getTextToSpeech(String apiKey, String text, String locale, String voice, String audioFormat)
-            throws IOException {
-        String url = createURL(apiKey, text, locale, voice, audioFormat);
+    public InputStream getTextToSpeech(String apiKey, String text, String locale, String voice, String audioCodec,
+            String audioFormat) throws IOException {
+        String url = createURL(apiKey, text, locale, voice, audioCodec, audioFormat);
         logger.debug("Call {}", url);
         URLConnection connection = new URL(url).openConnection();
 
@@ -254,13 +282,15 @@ public class VoiceRSSCloudImpl implements VoiceRSSCloudAPI {
      *
      * It is in package scope to be accessed by tests.
      */
-    private String createURL(String apiKey, String text, String locale, String voice, String audioFormat) {
+    private String createURL(String apiKey, String text, String locale, String voice, String audioCodec,
+            String audioFormat) {
         String encodedMsg = URLEncoder.encode(text, StandardCharsets.UTF_8);
-        String url = "http://api.voicerss.org/?key=" + apiKey + "&hl=" + locale + "&c=" + audioFormat;
+        String url = "http://api.voicerss.org/?key=" + apiKey + "&hl=" + locale + "&c=" + audioCodec + "&f="
+                + audioFormat;
         if (!DEFAULT_VOICE.equals(voice)) {
             url += "&v=" + voice;
         }
-        url += "&f=44khz_16bit_mono&src=" + encodedMsg;
+        url += "&src=" + encodedMsg;
         return url;
     }
 }

--- a/bundles/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/tool/CreateTTSCache.java
+++ b/bundles/org.openhab.voice.voicerss/src/main/java/org/openhab/voice/voicerss/tool/CreateTTSCache.java
@@ -106,7 +106,7 @@ public class CreateTTSCache {
             return;
         }
         CachedVoiceRSSCloudImpl impl = new CachedVoiceRSSCloudImpl(cacheDir);
-        File cachedFile = impl.getTextToSpeechAsFile(apiKey, trimmedMsg, locale, voice, "MP3");
+        File cachedFile = impl.getTextToSpeechAsFile(apiKey, trimmedMsg, locale, voice, "MP3", null);
         System.out.println(
                 "Created cached audio for locale='" + locale + "', msg='" + trimmedMsg + "' to file=" + cachedFile);
     }

--- a/bundles/org.openhab.voice.voicerss/src/test/java/org/openhab/voice/voicerss/internal/CompatibleAudioFormatMatcher.java
+++ b/bundles/org.openhab.voice.voicerss/src/test/java/org/openhab/voice/voicerss/internal/CompatibleAudioFormatMatcher.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.voice.voicerss.internal;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.openhab.core.audio.AudioFormat;
+
+/**
+ * Hamcrest {@link Matcher} to assert a compatible {@link AudioFormat}.
+ *
+ * @author Andreas Brenk - Initial contribution
+ */
+public class CompatibleAudioFormatMatcher extends TypeSafeMatcher<AudioFormat> {
+
+    private final AudioFormat audioFormat;
+
+    public CompatibleAudioFormatMatcher(AudioFormat audioFormat) {
+        this.audioFormat = audioFormat;
+    }
+
+    @Override
+    protected boolean matchesSafely(AudioFormat actual) {
+        return audioFormat.isCompatible(actual);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("an audio format compatible to ").appendValue(audioFormat);
+    }
+
+    /**
+     * Creates a matcher that matches when the examined object is
+     * compatible to the specified <code>audioFormat</code>.
+     *
+     * @param audioFormat the audio format which must be compatible
+     */
+    public static Matcher<AudioFormat> compatibleAudioFormat(AudioFormat audioFormat) {
+        return new CompatibleAudioFormatMatcher(audioFormat);
+    }
+}

--- a/bundles/org.openhab.voice.voicerss/src/test/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSServiceTest.java
+++ b/bundles/org.openhab.voice.voicerss/src/test/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSServiceTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.voice.voicerss.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
+import static org.hamcrest.core.IsNot.not;
+import static org.openhab.core.audio.AudioFormat.*;
+import static org.openhab.voice.voicerss.internal.CompatibleAudioFormatMatcher.compatibleAudioFormat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.audio.AudioFormat;
+import org.openhab.core.voice.TTSService;
+
+/**
+ * Tests for {@link VoiceRSSTTSService}.
+ *
+ * @author Andreas Brenk - Initial contribution
+ */
+public class VoiceRSSTTSServiceTest {
+
+    private static final AudioFormat MP3_44KHZ_16BIT = new AudioFormat(AudioFormat.CONTAINER_NONE,
+            AudioFormat.CODEC_MP3, null, 16, null, 44_100L);
+    private static final AudioFormat OGG_44KHZ_16BIT = new AudioFormat(AudioFormat.CONTAINER_OGG,
+            AudioFormat.CODEC_VORBIS, null, 16, null, 44_100L);
+    private static final AudioFormat AAC_44KHZ_16BIT = new AudioFormat(AudioFormat.CONTAINER_NONE,
+            AudioFormat.CODEC_MP3, null, 16, null, 44_100L);
+
+    /**
+     * The {@link VoiceRSSTTSService} under test.
+     */
+    private TTSService ttsService;
+
+    @BeforeEach
+    public void setUp() {
+        final VoiceRSSTTSService ttsService = new VoiceRSSTTSService();
+        ttsService.activate(null);
+
+        this.ttsService = ttsService;
+    }
+
+    @Test
+    public void testSupportedFormats() {
+        final Set<AudioFormat> supportedFormats = ttsService.getSupportedFormats();
+
+        // check generic formats without any further constraints
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(MP3)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(OGG)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(AAC)));
+
+        // check specific formats with common constraints
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(MP3_44KHZ_16BIT)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(OGG_44KHZ_16BIT)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(AAC_44KHZ_16BIT)));
+
+        // check unsupported formats
+        assertThat(supportedFormats, not(hasItem(compatibleAudioFormat(bitDepth(WAV, 24)))));
+    }
+
+    private AudioFormat bitDepth(AudioFormat format, Integer bitDepth) {
+        return new AudioFormat(format.getContainer(), format.getCodec(), format.isBigEndian(), bitDepth,
+                format.getBitRate(), format.getFrequency());
+    }
+
+    private AudioFormat bitRate(AudioFormat format, Integer bitRate) {
+        return new AudioFormat(format.getContainer(), format.getCodec(), format.isBigEndian(), format.getBitDepth(),
+                bitRate, format.getFrequency());
+    }
+}

--- a/bundles/org.openhab.voice.voicerss/src/test/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSServiceTest.java
+++ b/bundles/org.openhab.voice.voicerss/src/test/java/org/openhab/voice/voicerss/internal/VoiceRSSTTSServiceTest.java
@@ -38,6 +38,10 @@ public class VoiceRSSTTSServiceTest {
             AudioFormat.CODEC_VORBIS, null, 16, null, 44_100L);
     private static final AudioFormat AAC_44KHZ_16BIT = new AudioFormat(AudioFormat.CONTAINER_NONE,
             AudioFormat.CODEC_MP3, null, 16, null, 44_100L);
+    private static final AudioFormat WAV_22KHZ_8BIT = new AudioFormat(AudioFormat.CONTAINER_WAVE,
+            AudioFormat.CODEC_PCM_UNSIGNED, null, 8, null, 22_050L);
+    private static final AudioFormat WAV_48KHZ_16BIT = new AudioFormat(AudioFormat.CONTAINER_WAVE,
+            AudioFormat.CODEC_PCM_SIGNED, false, 16, null, 48_000L);
 
     /**
      * The {@link VoiceRSSTTSService} under test.
@@ -58,6 +62,7 @@ public class VoiceRSSTTSServiceTest {
 
         // check generic formats without any further constraints
         assertThat(supportedFormats, hasItem(compatibleAudioFormat(MP3)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(WAV)));
         assertThat(supportedFormats, hasItem(compatibleAudioFormat(OGG)));
         assertThat(supportedFormats, hasItem(compatibleAudioFormat(AAC)));
 
@@ -65,6 +70,11 @@ public class VoiceRSSTTSServiceTest {
         assertThat(supportedFormats, hasItem(compatibleAudioFormat(MP3_44KHZ_16BIT)));
         assertThat(supportedFormats, hasItem(compatibleAudioFormat(OGG_44KHZ_16BIT)));
         assertThat(supportedFormats, hasItem(compatibleAudioFormat(AAC_44KHZ_16BIT)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(WAV_22KHZ_8BIT)));
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(WAV_48KHZ_16BIT)));
+
+        // check specific formats with additional constraints
+        assertThat(supportedFormats, hasItem(compatibleAudioFormat(bitRate(WAV, 705_600)))); // 44.1 kHz 16-bit
 
         // check unsupported formats
         assertThat(supportedFormats, not(hasItem(compatibleAudioFormat(bitDepth(WAV, 24)))));


### PR DESCRIPTION
This pull request adds support for WAV / PCM audio in all frequencies and bit depths supported by VoiceRSS.

Support for MP3, Ogg Vorbis and AAC was kept as it was (44.1 kHz, 16 bit) but could be extended based on this work.

The file-based cache was kept backwards compatible and only adds a format specifier to the file name if it is different from the default.