### PR TITLE
[shelly] set min value to 1s for updateInterval in config.xml

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/config/config.xml
@@ -43,7 +43,7 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="10" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>General Update Interval</label>
 			<description>Interval to query an update from the device.</description>
 			<default>60</default>
@@ -89,7 +89,7 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="10" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>General Update Interval</label>
 			<description>Interval to query an update from the device.</description>
 			<default>60</default>
@@ -142,7 +142,7 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="10" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>General Update Interval</label>
 			<description>Interval to query an update from the device.</description>
 			<default>60</default>
@@ -183,7 +183,7 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="10" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>General Update Interval</label>
 			<description>Interval to query an update from the device.</description>
 			<default>60</default>
@@ -218,7 +218,7 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="10" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>General Update Interval</label>
 			<description>Interval to query an update from the device.</description>
 			<default>60</default>
@@ -261,10 +261,10 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="60" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>General Update Interval</label>
 			<description>Interval to query an update from the device.</description>
-			<default>900</default>
+			<default>60</default>
 			<unitLabel>seconds</unitLabel>
 			<advanced>true</advanced>
 		</parameter>
@@ -297,7 +297,7 @@
 			<advanced>true</advanced>
 			<default>true</default>
 		</parameter>
-		<parameter name="updateInterval" type="integer" min="10" required="true" unit="s">
+		<parameter name="updateInterval" type="integer" min="1" required="true" unit="s">
 			<label>Update Interval</label>
 			<description>Interval to query an update from the device.</description>
 			<default>60</default>


### PR DESCRIPTION
https://github.com/openhab/openhab-addons/issues/11892

<!-- [shelly] set min value to 1s for updateInterval in config.xml -->

<!-- The shelly binding allows now a minimum updateInterval value of 1s for all shelly thigns -->

<!--
#11892
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/
-->
