### PR TITLE
[mihome] Update README.md

### DIFF
--- a/bundles/org.openhab.binding.mihome/README.md
+++ b/bundles/org.openhab.binding.mihome/README.md
@@ -246,8 +246,8 @@ rule "Mijia & Aqara Wireless Switch"
 when
     Channel "mihome:sensor_switch:<GwID>:<ID>:button" triggered
 then
-    var actionName = receivedEvent.getEvent()
-    switch(actionName) {
+    
+    switch(receivedEvent) {
         case "SHORT_PRESSED": {
             <ACTION>
         }
@@ -267,8 +267,7 @@ rule "Mijia & Aqara Cube Controller"
 when
     Channel 'mihome:sensor_cube:<GwID>:<ID>:action' triggered
 then
-    var actionName = receivedEvent.getEvent()
-    switch(actionName) {
+    switch(receivedEvent) {
         case "MOVE": {
             <ACTION>
         }
@@ -303,8 +302,7 @@ rule "Aqara Smart Motion Sensor"
 when
     Channel 'mihome:sensor_vibration:<GwID>:<ID>:action' triggered
 then
-    var actionName = receivedEvent.getEvent()
-    switch(actionName) {
+    switch(receivedEvent) {
         case "VIBRATE": {
             <ACTION>
         }


### PR DESCRIPTION
<!-- TITLE -->
[mihome] Updated documentation for rules examples in area of receivedEvent implicit variable usage.

<!-- DESCRIPTION -->

<!--
Following https://www.openhab.org/docs/configuration/rules-dsl.html#rule-examples
one can find receivedEvent is now implicitly available in every rule that has a channel-based trigger.

Currently given examples are obsolete (was working properly on OH 2.x). 
On OH 3.1 given examples results in 'getEvent' is not a member of 'java.lang.String' error during rules execution.

Signed-off-by: Radoslaw Olejnik <uni.raolejnik@gmail.com>

<!-- TESTING -->

