### PR TITLE
[LuxtronikHeatpump] fix channel type of newly defined unknown channels

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
@@ -277,8 +277,12 @@ public class LuxtronikHeatpumpHandler extends BaseThingHandler {
             Integer channelId = channel.getChannelId();
             int length = channel.isWritable() ? heatpumpParams.length : heatpumpValues.length;
             ChannelUID channelUID = new ChannelUID(thing.getUID(), channel.getCommand());
-            ChannelTypeUID channelTypeUID = new ChannelTypeUID(LuxtronikHeatpumpBindingConstants.BINDING_ID,
-                    channel.getCommand());
+            ChannelTypeUID channelTypeUID;
+            if (channel.getCommand().matches("^channel[0-9]+$")) {
+                channelTypeUID = new ChannelTypeUID(LuxtronikHeatpumpBindingConstants.BINDING_ID, "unknown");
+            } else {
+                channelTypeUID = new ChannelTypeUID(LuxtronikHeatpumpBindingConstants.BINDING_ID, channel.getCommand());
+            }
             if ((channelId != null && length <= channelId)
                     || (config.showAllChannels == Boolean.FALSE && !channel.isVisible(visibilityValues))) {
                 logger.debug("Hiding channel {}", channel.getCommand());


### PR DESCRIPTION
Fixes an issue introduced with https://github.com/openhab/openhab-addons/pull/11860

The new "unknown" channels are all using the same channel type. When a new thing is created the channels are rebuilt based on the available channels. Before the channel id and the channel type were always the same. This fails for the new channels. 
This PR should fix this.

See https://github.com/openhab/openhab-addons/pull/11860#issuecomment-1003620849