### PR TITLE
[amazonechocontrol] fix refresh time for skill connected devices

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceStateGroupUpdateCalculator.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceStateGroupUpdateCalculator.java
@@ -34,8 +34,8 @@ import org.slf4j.LoggerFactory;
 public class SmartHomeDeviceStateGroupUpdateCalculator {
     private final Logger logger = LoggerFactory.getLogger(SmartHomeDeviceStateGroupUpdateCalculator.class);
 
-    private static final Integer UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS = 10;
-    private static final Integer UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS_TRACE = 600;
+    private static final Integer UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS = 600;
+    private static final Integer UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS_TRACE = 10;
     private static final Integer UPDATE_INTERVAL_ACOUSTIC_EVENTS_IN_SECONDS = 10;
     private Integer updateIntervalAmazonInSeconds;
     private Integer updateIntervalSkillsInSeconds;


### PR DESCRIPTION
It was recently discovered that during the refactoring from #6140 to #7969 I made a mistake that could lead to very frequent requests and high load on smarthome skills (ioBroker and openHAB). Since at least AWS hosted skills are paid per request this has the potential to cause high bills for the skill authors. I'm very sorry for that.