### PR TITLE
[hdpowerview] Support refresh command for signal strength channel

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -166,6 +166,7 @@ For single shades the refresh takes the item's channel into consideration:
 | lowBattery     | Battery           |
 | batteryLevel   | Battery           |
 | batteryVoltage | Battery           |
+| signalStrength | Survey            |
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -33,6 +33,7 @@ import org.openhab.binding.hdpowerview.internal.api.responses.Scenes;
 import org.openhab.binding.hdpowerview.internal.api.responses.ScheduledEvents;
 import org.openhab.binding.hdpowerview.internal.api.responses.Shade;
 import org.openhab.binding.hdpowerview.internal.api.responses.Shades;
+import org.openhab.binding.hdpowerview.internal.api.responses.Survey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ import com.google.gson.JsonParser;
  *
  * @author Andy Lintner - Initial contribution
  * @author Andrew Fiddian-Green - Added support for secondary rail positions
- * @author Jacob Laursen - Add support for scene groups and automations
+ * @author Jacob Laursen - Added support for scene groups and automations
  */
 @NonNullByDefault
 public class HDPowerViewWebTargets {
@@ -323,6 +324,25 @@ public class HDPowerViewWebTargets {
         String json = invoke(HttpMethod.GET, shades + Integer.toString(shadeId),
                 Query.of("refresh", Boolean.toString(true)), null);
         return gson.fromJson(json, Shade.class);
+    }
+
+    /**
+     * Instructs the hub to do a hard refresh (discovery on the hubs RF network) on
+     * a specific shade's survey data, which will also refresh signal strength;
+     * fetches a JSON package that describes that survey, and wraps it in a Survey
+     * class instance
+     *
+     * @param shadeId id of the shade to be surveyed
+     * @return Survey class instance
+     * @throws JsonParseException if there is a JSON parsing error
+     * @throws HubProcessingException if there is any processing error
+     * @throws HubMaintenanceException if the hub is down for maintenance
+     */
+    public @Nullable Survey getShadeSurvey(int shadeId)
+            throws JsonParseException, HubProcessingException, HubMaintenanceException {
+        String json = invoke(HttpMethod.GET, shades + Integer.toString(shadeId),
+                Query.of("survey", Boolean.toString(true)), null);
+        return gson.fromJson(json, Survey.class);
     }
 
     /**

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Survey.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Survey.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api.responses;
+
+import java.util.List;
+import java.util.StringJoiner;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Survey data of a single Shade, as returned by an HD PowerView hub
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+public class Survey {
+    @SerializedName("shade_id")
+    public int shadeId;
+    @SerializedName("survey")
+    public List<SurveyData> surveyData;
+
+    public static class SurveyData {
+        @SerializedName("neighbor_id")
+        public int neighborId;
+        public int rssi;
+
+        @Override
+        public String toString() {
+            return String.format("{neighbor id:%d, rssi:%d}", neighborId, rssi);
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (surveyData == null) {
+            return "{}";
+        }
+        StringJoiner joiner = new StringJoiner(", ");
+        surveyData.forEach(data -> joiner.add(data.toString()));
+        return joiner.toString();
+    }
+}


### PR DESCRIPTION
Fixes #11942

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Channel **signalStrength** was added by #11198 while #11933 refactored the _REFRESH_ command for shades to be relative to channel for requested item. The missing piece now is the **signalStrength** channel which currently cannot be refreshed on request.

This pull request makes the _REFRESH_ command for shades feature complete as each channel now has a dedicated method assigned for requesting a hard refresh for the item context.

Tested with both negative result:
```
2022-01-03 00:52:58.796 [TRACE] [rview.internal.HDPowerViewWebTargets] - JSON response = null
2022-01-03 00:52:58.800 [WARN ] [rnal.handler.HDPowerViewShadeHandler] - No response from shade 36321 survey
```

and positive result:
```
2022-01-03 00:54:21.764 [INFO ] [openhab.event.ItemCommandEvent      ] - Item 'Blind11_SignalStrength' received command REFRESH
2022-01-03 00:54:40.781 [TRACE] [rview.internal.HDPowerViewWebTargets] - JSON response = {"shade_id":36321,"survey":[{"neighbor_id":17805,"rssi":-86}]}
2022-01-03 00:54:40.783 [DEBUG] [rnal.handler.HDPowerViewShadeHandler] - Survey response for shade 36321: {neighbor:17805, rssi:-86}
2022-01-03 00:54:40.947 [DEBUG] [ternal.handler.HDPowerViewHubHandler] - Updating shade '36321'
2022-01-03 00:54:40.964 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Blind11_SignalStrength' changed from 0 to 4
```

