### PR TITLE
[nikohomecontrol] Bug fixes and improvements to thermostats

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/README.md
+++ b/bundles/org.openhab.binding.nikohomecontrol/README.md
@@ -237,19 +237,25 @@ OnOff, IncreaseDecrease and Percent command types are supported.
 Note that sending an ON command will switch the dimmer to the value stored when last turning the dimmer off, or 100% depending on the configuration in the Niko Home Control Controller.
 This can be changed with the Niko Home Control programming software.
 
-For thing type `blind` the supported channel is `rollershutter`. UpDown, StopMove and Percent command types are supported.
+For thing type `blind` the supported channel is `rollershutter`.
+UpDown, StopMove and Percent command types are supported.
 
-For thing type `thermostat` the supported channels are `measured`, `mode`, `setpoint`, `overruletime` and `demand`.
+For thing type `thermostat` the supported channels are `measured`, `heatingmode`, `mode`, `setpoint`, `overruletime`, `heatingdemand` and `demand`.
 `measured` gives the current temperature in QuantityType<Temperature>, allowing for different temperature units.
 This channel is read only.
-`mode` can be set and shows the current thermostat mode.
-Allowed values are 0 (day), 1 (night), 2 (eco), 3 (off), 4 (cool), 5 (prog 1), 6 (prog 2), 7 (prog 3).
-If mode is set, the `setpoint` temperature will return to its standard value from the mode.
-`setpoint` can be set and shows the current thermostat setpoint value in QuantityType<Temperature>.
+`heatingmode` can be set and shows the current thermostat mode.
+Allowed values are Day, Night, Eco, Off, Cool, Prog1, Prog2, Prog3.
+As an alternative to `heatingmode` and for backward compatibility, the advanced channel `mode` is provided.
+This channel has the same meaning, but with numeric values (0=Day, 1=Night, 2=Eco, 3=Off, 4=Cool, 5=Prog1, 6=Prog2, 7=Prog3) instead of string values.
+If `heatingmode` or `mode` is set, the `setpoint` temperature will return to the standard value for the mode as defined in Niko Home Control.
+`setpoint` shows the current thermostat setpoint value in QuantityType<Temperature>.
 When updating `setpoint`, it will overrule the temperature setpoint defined by the thermostat mode for `overruletime` duration.
-`overruletime` is used to set the total duration to apply the setpoint temperature set in the setpoint channel before the thermostat returns to the setting in its mode.
-`demand` is a number indicating of the system is actively heating/cooling.
+`overruletime` is used to set the total duration to apply the setpoint temperature set in the setpoint channel before the thermostat returns to the setting from its mode.
+`heatingdemand` is a string indicating if the system is actively heating/cooling.
+This channel will have value Heating, Cooling or None.
+As an alternative to `heatingdemand` and for backward compatibility, the advanced channel `demand` is provided.
 The value will be 1 for heating, -1 for cooling and 0 if not heating or cooling.
+`heatingdemand` and `demand` are read only channels.
 Note that cooling in NHC I is set by the binding, and will incorrectly show cooling demand when the system does not have cooling capabilities.
 In NHC II, `measured` and `setpoint` temperatures will always report in 0.5°C increments due to a Niko Home Control II API restriction.
 
@@ -310,12 +316,12 @@ Switch AllOff           {channel="nikohomecontrol:onOff:nhc1:1:button"}         
 Switch LivingRoom       {channel="nikohomecontrol:onOff:nhc1:2:switch"}           # Switch for onOff type action
 Dimmer TVRoom           {channel="nikohomecontrol:dimmer:nhc1:3:brightness"}      # Changing brightness dimmer type action
 Rollershutter Kitchen   {channel="nikohomecontrol:blind:nhc1:4:rollershutter"}    # Controlling rollershutter or blind type action
-Number:Temperature CurTemperature   "[%.1f °F]"  {channel="nikohomecontrol:thermostat:nhc1:5:measured"}   # Getting measured temperature from thermostat in °F, read only
-Number ThermostatMode   {channel="nikohomecontrol:thermostat:nhc1:5:mode"}        # Get and set thermostat mode
-Number:Temperature SetTemperature   "[%.1f °C]"  {channel="nikohomecontrol:thermostat:nhc1:5:setpoint"}   # Get and set target temperature in °C
-Number OverruleDuration {channel="nikohomecontrol:thermostat:nhc1:5:overruletime"} # Get and set the overrule time
-Number ThermostatDemand {channel="nikohomecontrol:thermostat:nhc1:5:demand"}       # Get the current heating/cooling demand
-Number:Power CurPower   "[%.0f W]"  {channel="nikohomecontrol:energyMeter:nhc2:6:power"}   # Get current power consumption
+Number:Temperature CurTemperature   "[%.1f °F]"  {channel="nikohomecontrol:thermostat:nhc1:5:measured"} # Getting measured temperature from thermostat in °F, read only
+Switch ThermostatMode   {channel="nikohomecontrol:thermostat:nhc1:5:heatingmode"}        # Get and set thermostat mode
+Number:Temperature SetTemperature   "[%.1f °C]"  {channel="nikohomecontrol:thermostat:nhc1:5:setpoint"} # Get and set target temperature in °C
+Number OverruleDuration {channel="nikohomecontrol:thermostat:nhc1:5:overruletime"}       # Get and set the overrule time
+Text ThermostatDemand   {channel="nikohomecontrol:thermostat:nhc1:5:heatingdemand"}      # Get the current heating/cooling demand
+Number:Power CurPower   "[%.0f W]"  {channel="nikohomecontrol:energyMeter:nhc2:6:power"} # Get current power consumption
 ```
 
 .sitemap:
@@ -327,7 +333,7 @@ Slider item=TVRoom
 Switch item=TVRoom          # allows switching dimmer item off or on (with controller defined behavior)
 Rollershutter item=Kitchen
 Text item=CurTemperature
-Selection item=ThermostatMode mappings=[0="day", 1="night", 2="eco", 3="off", 4="cool", 5="prog 1", 6="prog 2", 7="prog 3"]
+Selection item=ThermostatMode mappings=[Day="day", Night="night", Eco="eco", Off="off", Prog1="Away"]
 Setpoint item=SetTemperature minValue=0 maxValue=30
 Slider item=OverruleDuration minValue=0 maxValue=120
 Text item=Power

--- a/bundles/org.openhab.binding.nikohomecontrol/README.md
+++ b/bundles/org.openhab.binding.nikohomecontrol/README.md
@@ -253,7 +253,7 @@ When updating `setpoint`, it will overrule the temperature setpoint defined by t
 `overruletime` is used to set the total duration to apply the setpoint temperature set in the setpoint channel before the thermostat returns to the setting from its mode.
 `heatingdemand` is a string indicating if the system is actively heating/cooling.
 This channel will have value Heating, Cooling or None.
-As an alternative to `heatingdemand` and for backward compatibility, the advanced channel `demand` is provided.
+As an alternative to `heatingdemand`, the advanced channel `demand` is provided.
 The value will be 1 for heating, -1 for cooling and 0 if not heating or cooling.
 `heatingdemand` and `demand` are read only channels.
 Note that cooling in NHC I is set by the binding, and will incorrectly show cooling demand when the system does not have cooling capabilities.
@@ -317,10 +317,10 @@ Switch LivingRoom       {channel="nikohomecontrol:onOff:nhc1:2:switch"}         
 Dimmer TVRoom           {channel="nikohomecontrol:dimmer:nhc1:3:brightness"}      # Changing brightness dimmer type action
 Rollershutter Kitchen   {channel="nikohomecontrol:blind:nhc1:4:rollershutter"}    # Controlling rollershutter or blind type action
 Number:Temperature CurTemperature   "[%.1f °F]"  {channel="nikohomecontrol:thermostat:nhc1:5:measured"} # Getting measured temperature from thermostat in °F, read only
-Switch ThermostatMode   {channel="nikohomecontrol:thermostat:nhc1:5:heatingmode"}        # Get and set thermostat mode
+String ThermostatMode   {channel="nikohomecontrol:thermostat:nhc1:5:heatingmode"}        # Get and set thermostat mode
 Number:Temperature SetTemperature   "[%.1f °C]"  {channel="nikohomecontrol:thermostat:nhc1:5:setpoint"} # Get and set target temperature in °C
 Number OverruleDuration {channel="nikohomecontrol:thermostat:nhc1:5:overruletime"}       # Get and set the overrule time
-Text ThermostatDemand   {channel="nikohomecontrol:thermostat:nhc1:5:heatingdemand"}      # Get the current heating/cooling demand
+String ThermostatDemand   {channel="nikohomecontrol:thermostat:nhc1:5:heatingdemand"}      # Get the current heating/cooling demand
 Number:Power CurPower   "[%.0f W]"  {channel="nikohomecontrol:energyMeter:nhc2:6:power"} # Get current power consumption
 ```
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlBindingConstants.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlBindingConstants.java
@@ -69,6 +69,8 @@ public class NikoHomeControlBindingConstants {
     public static final String CHANNEL_OVERRULETIME = "overruletime";
     public static final String CHANNEL_MODE = "mode";
     public static final String CHANNEL_DEMAND = "demand";
+    public static final String CHANNEL_HEATING_MODE = "heatingmode";
+    public static final String CHANNEL_HEATING_DEMAND = "heatingdemand";
 
     public static final String CHANNEL_POWER = "power";
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
@@ -21,6 +21,7 @@ import org.openhab.binding.nikohomecontrol.internal.handler.NikoHomeControlBridg
 import org.openhab.binding.nikohomecontrol.internal.handler.NikoHomeControlBridgeHandler2;
 import org.openhab.binding.nikohomecontrol.internal.handler.NikoHomeControlEnergyMeterHandler;
 import org.openhab.binding.nikohomecontrol.internal.handler.NikoHomeControlThermostatHandler;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
@@ -43,6 +44,7 @@ import org.osgi.service.component.annotations.Reference;
 public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
 
     private @NonNullByDefault({}) NetworkAddressService networkAddressService;
+    private @NonNullByDefault({}) TimeZoneProvider timeZoneProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -53,9 +55,9 @@ public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         if (BRIDGE_THING_TYPES_UIDS.contains(thing.getThingTypeUID())) {
             if (BRIDGEII_THING_TYPE.equals(thing.getThingTypeUID())) {
-                return new NikoHomeControlBridgeHandler2((Bridge) thing, networkAddressService);
+                return new NikoHomeControlBridgeHandler2((Bridge) thing, networkAddressService, timeZoneProvider);
             } else {
-                return new NikoHomeControlBridgeHandler1((Bridge) thing);
+                return new NikoHomeControlBridgeHandler1((Bridge) thing, timeZoneProvider);
             }
         } else if (THING_TYPE_THERMOSTAT.equals(thing.getThingTypeUID())) {
             return new NikoHomeControlThermostatHandler(thing);
@@ -75,5 +77,14 @@ public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
 
     protected void unsetNetworkAddressService(NetworkAddressService networkAddressService) {
         this.networkAddressService = null;
+    }
+
+    @Reference
+    protected void setTimeZoneProvider(TimeZoneProvider timeZoneProvider) {
+        this.timeZoneProvider = timeZoneProvider;
+    }
+
+    protected void unsetTimeZoneProvider(TimeZoneProvider timeZoneProvider) {
+        this.timeZoneProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
@@ -43,8 +43,15 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.nikohomecontrol")
 public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
 
-    private @NonNullByDefault({}) NetworkAddressService networkAddressService;
-    private @NonNullByDefault({}) TimeZoneProvider timeZoneProvider;
+    private final NetworkAddressService networkAddressService;
+    private final TimeZoneProvider timeZoneProvider;
+
+    public NikoHomeControlHandlerFactory(final @Reference NetworkAddressService networkAddressService,
+            final @Reference TimeZoneProvider timeZoneProvider) {
+        super();
+        this.networkAddressService = networkAddressService;
+        this.timeZoneProvider = timeZoneProvider;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -68,23 +75,5 @@ public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
         }
 
         return null;
-    }
-
-    @Reference
-    protected void setNetworkAddressService(NetworkAddressService networkAddressService) {
-        this.networkAddressService = networkAddressService;
-    }
-
-    protected void unsetNetworkAddressService(NetworkAddressService networkAddressService) {
-        this.networkAddressService = null;
-    }
-
-    @Reference
-    protected void setTimeZoneProvider(TimeZoneProvider timeZoneProvider) {
-        this.timeZoneProvider = timeZoneProvider;
-    }
-
-    protected void unsetTimeZoneProvider(TimeZoneProvider timeZoneProvider) {
-        this.timeZoneProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlHandlerFactory.java
@@ -29,6 +29,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -46,6 +47,7 @@ public class NikoHomeControlHandlerFactory extends BaseThingHandlerFactory {
     private final NetworkAddressService networkAddressService;
     private final TimeZoneProvider timeZoneProvider;
 
+    @Activate
     public NikoHomeControlHandlerFactory(final @Reference NetworkAddressService networkAddressService,
             final @Reference TimeZoneProvider timeZoneProvider) {
         super();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.nikohomecontrol.internal.NikoHomeControlBindin
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -29,6 +30,7 @@ import org.openhab.binding.nikohomecontrol.internal.discovery.NikoHomeControlDis
 import org.openhab.binding.nikohomecontrol.internal.protocol.NhcControllerEvent;
 import org.openhab.binding.nikohomecontrol.internal.protocol.NikoHomeControlCommunication;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingStatus;
@@ -55,8 +57,11 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
 
     private volatile @Nullable ScheduledFuture<?> refreshTimer;
 
-    public NikoHomeControlBridgeHandler(Bridge nikoHomeControlBridge) {
+    protected final TimeZoneProvider timeZoneProvider;
+
+    public NikoHomeControlBridgeHandler(Bridge nikoHomeControlBridge, TimeZoneProvider timeZoneProvider) {
         super(nikoHomeControlBridge);
+        this.timeZoneProvider = timeZoneProvider;
     }
 
     @Override
@@ -251,6 +256,11 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
     @Override
     public int getPort() {
         return getConfig().as(NikoHomeControlBridgeConfig.class).port;
+    }
+
+    @Override
+    public ZoneId getTimeZone() {
+        return timeZoneProvider.getTimeZone();
     }
 
     @Override

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
@@ -15,7 +15,6 @@ package org.openhab.binding.nikohomecontrol.internal.handler;
 import static org.openhab.binding.nikohomecontrol.internal.NikoHomeControlBindingConstants.THREAD_NAME_PREFIX;
 
 import java.net.InetAddress;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,7 +48,6 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
 
         InetAddress addr = getAddr();
         int port = getPort();
-        ZoneId timeZoneId = timeZoneProvider.getTimeZone();
 
         logger.debug("bridge handler host {}, port {}", addr, port);
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
@@ -15,11 +15,13 @@ package org.openhab.binding.nikohomecontrol.internal.handler;
 import static org.openhab.binding.nikohomecontrol.internal.NikoHomeControlBindingConstants.THREAD_NAME_PREFIX;
 
 import java.net.InetAddress;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.nikohomecontrol.internal.protocol.nhc1.NikoHomeControlCommunication1;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
@@ -37,8 +39,8 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
 
     private final Logger logger = LoggerFactory.getLogger(NikoHomeControlBridgeHandler1.class);
 
-    public NikoHomeControlBridgeHandler1(Bridge nikoHomeControlBridge) {
-        super(nikoHomeControlBridge);
+    public NikoHomeControlBridgeHandler1(Bridge nikoHomeControlBridge, TimeZoneProvider timeZoneProvider) {
+        super(nikoHomeControlBridge, timeZoneProvider);
     }
 
     @Override
@@ -47,6 +49,7 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
 
         InetAddress addr = getAddr();
         int port = getPort();
+        ZoneId timeZoneId = timeZoneProvider.getTimeZone();
 
         logger.debug("bridge handler host {}, port {}", addr, port);
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
@@ -24,6 +24,7 @@ import java.util.NoSuchElementException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.nikohomecontrol.internal.protocol.nhc2.NikoHomeControlCommunication2;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingStatus;
@@ -50,8 +51,9 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
 
     NetworkAddressService networkAddressService;
 
-    public NikoHomeControlBridgeHandler2(Bridge nikoHomeControlBridge, NetworkAddressService networkAddressService) {
-        super(nikoHomeControlBridge);
+    public NikoHomeControlBridgeHandler2(Bridge nikoHomeControlBridge, NetworkAddressService networkAddressService,
+            TimeZoneProvider timeZoneProvider) {
+        super(nikoHomeControlBridge, timeZoneProvider);
         this.networkAddressService = networkAddressService;
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcControllerEvent.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcControllerEvent.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.nikohomecontrol.internal.protocol;
 
 import java.net.InetAddress;
+import java.time.ZoneId;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -63,6 +64,13 @@ public interface NhcControllerEvent {
     public default String getToken() {
         return "";
     }
+
+    /**
+     * Get the time zone ID of the Niko Home Control system.
+     *
+     * @return the zone ID
+     */
+    public ZoneId getTimeZone();
 
     /**
      * Called to indicate the connection with the Niko Home Control Controller is offline.

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeter.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeter.java
@@ -20,10 +20,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link NhcEnergyMeter} class represents the energyMeters metering Niko Home Control communication object. It
- * contains all
- * fields representing a Niko Home Control energyMeters meter and has methods to receive energyMeters usage information.
- * A specific
- * implementation is {@link NhcEnergyMeter2}.
+ * contains all fields representing a Niko Home Control energyMeters meter and has methods to receive energyMeters usage
+ * information. A specific implementation is {@link NhcEnergyMeter2}.
  *
  * @author Mark Herwege - Initial Contribution
  */

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.protocol;
 
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,7 +55,7 @@ public abstract class NikoHomeControlCommunication {
     // restart attempts
     private volatile int delay = 0;
     private volatile int attempt = 0;
-    protected @Nullable ScheduledFuture<?> scheduledRestart = null;
+    protected volatile @Nullable ScheduledFuture<?> scheduledRestart = null;
 
     protected NikoHomeControlCommunication(NhcControllerEvent handler, ScheduledExecutorService scheduler) {
         this.handler = handler;
@@ -136,6 +137,15 @@ public abstract class NikoHomeControlCommunication {
      * @return True if active
      */
     public abstract boolean communicationActive();
+
+    /**
+     * Return the timezone for the system.
+     *
+     * @return zoneId
+     */
+    public ZoneId getTimeZone() {
+        return handler.getTimeZone();
+    }
 
     /**
      * Return all actions in the Niko Home Control Controller.

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlConstants.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlConstants.java
@@ -47,4 +47,5 @@ public class NikoHomeControlConstants {
 
     // NhcII thermostat modes
     public static final String[] THERMOSTATMODES = { "Day", "Night", "Eco", "Off", "Cool", "Prog1", "Prog2", "Prog3" };
+    public static final String[] THERMOSTATDEMAND = { "Cooling", "None", "Heating" };
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -569,11 +569,11 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         int measured = ambientTemperatureProperty.orElse(thermostat.getMeasured());
         int setpoint = setpointTemperatureProperty.orElse(thermostat.getSetpoint());
 
-        int overrule = thermostat.getOverrule();
-        int overruletime = thermostat.getRemainingOverruletime();
-        if (overruleActiveProperty.orElse(false)) {
-            overrule = overruleSetpointProperty.orElse(0);
-            overruletime = overruleTimeProperty.orElse(0);
+        int overrule = 0;
+        int overruletime = 0;
+        if (overruleActiveProperty.orElse(true)) {
+            overrule = overruleSetpointProperty.orElse(thermostat.getOverrule());
+            overruletime = overruleTimeProperty.orElse(thermostat.getRemainingOverruletime());
         }
 
         int ecosave = thermostat.getEcosave();
@@ -618,7 +618,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             energyMeter.setPower(power);
         } catch (NumberFormatException e) {
             energyMeter.setPower(null);
-            logger.trace("received empty energy meter {} power reading", energyMeter.getId());
+            logger.trace("wrong format in energy meter {} power reading", energyMeter.getId());
         }
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/i18n/nikohomecontrol.properties
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/i18n/nikohomecontrol.properties
@@ -83,14 +83,20 @@ channelOverruletimeDescription = Time duration for overruling thermostat target 
 
 channelModeLabel = Mode
 channelModeDescription = Thermostat mode
-channelModeOption0 = day
-channelModeOption1 = night
-channelModeOption2 = eco
-channelModeOption3 = off
-channelModeOption4 = cool
-channelModeOption5 = prog 1
-channelModeOption6 = prog 2
-channelModeOption7 = prog 3
+channelModeOption0 = Day
+channelModeOption1 = Night
+channelModeOption2 = Eco
+channelModeOption3 = Off
+channelModeOption4 = Cool
+channelModeOption5 = Program 1
+channelModeOption6 = Program 2
+channelModeOption7 = Program 3
+
+channelDemandLabel = Demand
+channelDemandDescription = Heating/cooling demand
+channelDemand-1 = Cooling
+channelDemand0 = None
+channelDemand1 = Heating
 
 channelPowerLabel = Power
 channelPowerDescription = Momentary power consumption/production (positive is consumption)

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -161,13 +161,16 @@
 			<bridge-type-ref id="bridge"/>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>@text/ThermostatLabel</label>
-		<description>@text/ThermostatDescription</description>
+		<label>@text/thermostatLabel</label>
+		<description>@text/thermostatDescription</description>
 		<channels>
 			<channel id="measured" typeId="measured"/>
+			<channel id="heatingmode" typeId="heatingmode"/>
 			<channel id="mode" typeId="mode"/>
 			<channel id="setpoint" typeId="setpoint"/>
 			<channel id="overruletime" typeId="overruletime"/>
+			<channel id="heatingdemand" typeId="heatingdemand"/>
+			<channel id="demand" typeId="demand"/>
 		</channels>
 		<config-description>
 			<parameter name="thermostatId" type="text" required="true">
@@ -244,7 +247,25 @@
 		<category>Number</category>
 		<state min="0" max="1440" step="5"/>
 	</channel-type>
-	<channel-type id="mode">
+	<channel-type id="heatingmode">
+		<item-type>String</item-type>
+		<label>@text/channelModeLabel</label>
+		<description>@text/channelModeDescription</description>
+		<category>Temperature</category>
+		<state>
+			<options>
+				<option value="Day">@text/channelModeOption0</option>
+				<option value="Night">@text/channelModeOption1</option>
+				<option value="Eco">@text/channelModeOption2</option>
+				<option value="Off">@text/channelModeOption3</option>
+				<option value="Cool">@text/channelModeOption4</option>
+				<option value="Prog1">@text/channelModeOption5</option>
+				<option value="Prog2">@text/channelModeOption6</option>
+				<option value="Prog3">@text/channelModeOption7</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="mode" advanced="true">
 		<item-type>Number</item-type>
 		<label>@text/channelModeLabel</label>
 		<description>@text/channelModeDescription</description>
@@ -262,6 +283,33 @@
 			</options>
 		</state>
 	</channel-type>
+	<channel-type id="heatingdemand">
+		<item-type>String</item-type>
+		<label>@text/channelDemandLabel</label>
+		<description>@text/channelDemandDescription</description>
+		<category>Temperature</category>
+		<state readOnly="true">
+			<options>
+				<option value="Cooling">@text/channelDemand-1</option>
+				<option value="None">@text/channelDemand0</option>
+				<option value="Heating">@text/channelDemand1</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="demand" advanced="true">
+		<item-type>Number</item-type>
+		<label>@text/channelDemandLabel</label>
+		<description>@text/channelDemandDescription</description>
+		<category>Number</category>
+		<state readOnly="true">
+			<options>
+				<option value="-1">@text/channelDemand-1</option>
+				<option value="0">@text/channelDemand0</option>
+				<option value="1">@text/channelDemand1</option>
+			</options>
+		</state>
+	</channel-type>
+
 	<channel-type id="power">
 		<item-type>Number:Power</item-type>
 		<label>@text/channelPowerLabel</label>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -251,7 +251,6 @@
 		<item-type>String</item-type>
 		<label>@text/channelModeLabel</label>
 		<description>@text/channelModeDescription</description>
-		<category>Temperature</category>
 		<state>
 			<options>
 				<option value="Day">@text/channelModeOption0</option>
@@ -269,7 +268,6 @@
 		<item-type>Number</item-type>
 		<label>@text/channelModeLabel</label>
 		<description>@text/channelModeDescription</description>
-		<category>Number</category>
 		<state>
 			<options>
 				<option value="0">@text/channelModeOption0</option>
@@ -287,7 +285,6 @@
 		<item-type>String</item-type>
 		<label>@text/channelDemandLabel</label>
 		<description>@text/channelDemandDescription</description>
-		<category>Temperature</category>
 		<state readOnly="true">
 			<options>
 				<option value="Cooling">@text/channelDemand-1</option>
@@ -300,7 +297,6 @@
 		<item-type>Number</item-type>
 		<label>@text/channelDemandLabel</label>
 		<description>@text/channelDemandDescription</description>
-		<category>Number</category>
 		<state readOnly="true">
 			<options>
 				<option value="-1">@text/channelDemand-1</option>


### PR DESCRIPTION
Depends on [PR #12885](https://github.com/openhab/openhab-addons/pull/12885)

The focus of this PR is now solely on improving thermostats:
- Thermostats now also have string channels. These make it easier to map the inputs and outputs without rules (as all assistants use string channels). The old (numeric) channels have been declared advanced.
- A few bugs with thermostats have been fixed.
