### PR TITLE
[atlona] Correct spelling of atlona

### DIFF
--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
@@ -200,7 +200,7 @@ class AtlonaPro3PortocolHandler {
         try {
             response = callback.getResponse();
             if (!response.equals("")) {
-                logger.debug("Altona protocol violation - didn't start with an inital empty response: '{}'", response);
+                logger.debug("Atlona protocol violation - didn't start with an inital empty response: '{}'", response);
             }
         } catch (Exception e) {
             // ignore - may not having given us an initial ""
@@ -213,10 +213,10 @@ class AtlonaPro3PortocolHandler {
         // we can tell which by the response to the invalid command
         session.sendCommand(NOTVALID_USER_OR_CMD);
 
-        // Command failed - Altona not configured with IPLogin - return success
+        // Command failed - Atlona not configured with IPLogin - return success
         response = callback.getResponse();
         if (response.startsWith(RSP_FAILED)) {
-            logger.debug("Altona didn't require a login");
+            logger.debug("Atlona didn't require a login");
             postLogin();
             return null;
         }
@@ -224,7 +224,7 @@ class AtlonaPro3PortocolHandler {
         // We should have been presented with a new "\r\nLogin: "
         response = callback.getResponse();
         if (!response.equals("")) {
-            logger.debug("Altona protocol violation - didn't start with an inital empty response: '{}'", response);
+            logger.debug("Atlona protocol violation - didn't start with an inital empty response: '{}'", response);
         }
 
         // Get the new "Login: " prompt response
@@ -237,7 +237,7 @@ class AtlonaPro3PortocolHandler {
             // Send the username and wait for a ": " response
             session.sendCommand(config.getUserName());
         } else {
-            return "Altona protocol violation - wasn't initially a command failure or login prompt: " + response;
+            return "Atlona protocol violation - wasn't initially a command failure or login prompt: " + response;
         }
 
         // We should have gotten the password response
@@ -252,7 +252,7 @@ class AtlonaPro3PortocolHandler {
             if (response.equals(RSP_LOGIN)) {
                 return "Username " + config.getUserName() + " is not a valid user on the atlona";
             }
-            return "Altona protocol violation - invalid response to a login: " + response;
+            return "Atlona protocol violation - invalid response to a login: " + response;
         }
 
         // Make sure we have a password
@@ -271,7 +271,7 @@ class AtlonaPro3PortocolHandler {
 
         // First make sure we had an empty response (the "\r\n" part)
         if (!response.equals("")) {
-            logger.debug("Altona protocol violation - not an empty response after password: '{}'", response);
+            logger.debug("Atlona protocol violation - not an empty response after password: '{}'", response);
         }
 
         // Now send an invalid command
@@ -308,7 +308,7 @@ class AtlonaPro3PortocolHandler {
         try {
             response = callback.getResponse();
             if (!response.equals("")) {
-                logger.debug("Altona protocol violation - didn't start with an inital empty response: '{}'", response);
+                logger.debug("Atlona protocol violation - didn't start with an inital empty response: '{}'", response);
             }
         } catch (Exception e) {
             // ignore - may not having given us an initial ""
@@ -316,12 +316,12 @@ class AtlonaPro3PortocolHandler {
 
         response = callback.getResponse();
         if (response.startsWith(RSP_WELCOME)) {
-            logger.debug("Altona AT-PRO3HD66M didn't require a login");
+            logger.debug("Atlona AT-PRO3HD66M didn't require a login");
             postLogin();
             return null;
         } else {
             if (!response.startsWith(RSP_LOGIN_PLEASE)) {
-                logger.debug("Altona protocol violation - didn't start with login prompt '{}'", response);
+                logger.debug("Atlona protocol violation - didn't start with login prompt '{}'", response);
             }
             // Since we were not logged in automatically, a user name is required from the configuration
             if (config.getUserName() == null || config.getUserName().trim().length() == 0) {
@@ -336,7 +336,7 @@ class AtlonaPro3PortocolHandler {
             // Check for an empty response after the login prompt (the "\r\n" part)
             response = callback.getResponse();
             if (!response.equals("")) {
-                logger.debug("Altona protocol violation - not an empty response after password: '{}'", response);
+                logger.debug("Atlona protocol violation - not an empty response after password: '{}'", response);
             }
 
             // Send the username and wait for a ": " response
@@ -345,7 +345,7 @@ class AtlonaPro3PortocolHandler {
             // We should have gotten the username response
             response = callback.getResponse();
             if (!response.startsWith(RSP_USERNAME)) {
-                logger.debug("Altona protocol violation - invalid response to username: '{}'", response);
+                logger.debug("Atlona protocol violation - invalid response to username: '{}'", response);
             }
 
             // Send the password

--- a/bundles/org.openhab.binding.atlona/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.atlona/src/main/resources/OH-INF/config/config.xml
@@ -4,7 +4,7 @@
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="thing-type:altona:hdmimatrix">
+	<config-description uri="thing-type:atlona:hdmimatrix">
 		<parameter name="ipAddress" type="text" required="true">
 			<context>network-address</context>
 			<label>IP or Host Name</label>

--- a/bundles/org.openhab.binding.atlona/src/main/resources/OH-INF/i18n/atlona.properties
+++ b/bundles/org.openhab.binding.atlona/src/main/resources/OH-INF/i18n/atlona.properties
@@ -184,18 +184,18 @@ thing-type.atlona.pro3-hd66m.group.port6.description = Output Port 6 Channels
 
 # thing types config
 
-thing-type.config.altona.hdmimatrix.ipAddress.label = IP or Host Name
-thing-type.config.altona.hdmimatrix.ipAddress.description = IP or Host name of Atlona Matrix Switch
-thing-type.config.altona.hdmimatrix.password.label = Password
-thing-type.config.altona.hdmimatrix.password.description = Password to login with if Telnet Login is on
-thing-type.config.altona.hdmimatrix.ping.label = Ping Interval
-thing-type.config.altona.hdmimatrix.ping.description = Ping Interval (in seconds) to keep the connection alive
-thing-type.config.altona.hdmimatrix.polling.label = Polling Interval
-thing-type.config.altona.hdmimatrix.polling.description = Interval (in seconds) to poll the actual state of the Matrix
-thing-type.config.altona.hdmimatrix.retryPolling.label = Polling Interval to Try to Reconnect
-thing-type.config.altona.hdmimatrix.retryPolling.description = Interval (in seconds) to try to (re)connect to the Matrix
-thing-type.config.altona.hdmimatrix.userName.label = User Name
-thing-type.config.altona.hdmimatrix.userName.description = User Name to login with if Telnet Login is on
+thing-type.config.atlona.hdmimatrix.ipAddress.label = IP or Host Name
+thing-type.config.atlona.hdmimatrix.ipAddress.description = IP or Host name of Atlona Matrix Switch
+thing-type.config.atlona.hdmimatrix.password.label = Password
+thing-type.config.atlona.hdmimatrix.password.description = Password to login with if Telnet Login is on
+thing-type.config.atlona.hdmimatrix.ping.label = Ping Interval
+thing-type.config.atlona.hdmimatrix.ping.description = Ping Interval (in seconds) to keep the connection alive
+thing-type.config.atlona.hdmimatrix.polling.label = Polling Interval
+thing-type.config.atlona.hdmimatrix.polling.description = Interval (in seconds) to poll the actual state of the Matrix
+thing-type.config.atlona.hdmimatrix.retryPolling.label = Polling Interval to Try to Reconnect
+thing-type.config.atlona.hdmimatrix.retryPolling.description = Interval (in seconds) to try to (re)connect to the Matrix
+thing-type.config.atlona.hdmimatrix.userName.label = User Name
+thing-type.config.atlona.hdmimatrix.userName.description = User Name to login with if Telnet Login is on
 
 # channel group types
 

--- a/bundles/org.openhab.binding.atlona/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.atlona/src/main/resources/OH-INF/thing/thing-types.xml
@@ -49,7 +49,7 @@
 			</channel-group>
 		</channel-groups>
 
-		<config-description-ref uri="thing-type:altona:hdmimatrix"/>
+		<config-description-ref uri="thing-type:atlona:hdmimatrix"/>
 	</thing-type>
 
 	<!-- AT-UHD-PRO3-66M -->
@@ -117,7 +117,7 @@
 			</channel-group>
 		</channel-groups>
 
-		<config-description-ref uri="thing-type:altona:hdmimatrix"/>
+		<config-description-ref uri="thing-type:atlona:hdmimatrix"/>
 	</thing-type>
 
 	<!-- AT-UHD-PRO3-88M -->
@@ -201,7 +201,7 @@
 			</channel-group>
 		</channel-groups>
 
-		<config-description-ref uri="thing-type:altona:hdmimatrix"/>
+		<config-description-ref uri="thing-type:atlona:hdmimatrix"/>
 	</thing-type>
 
 	<!-- AT-UHD-PRO3-1616M -->
@@ -357,7 +357,7 @@
 			</channel-group>
 		</channel-groups>
 
-		<config-description-ref uri="thing-type:altona:hdmimatrix"/>
+		<config-description-ref uri="thing-type:atlona:hdmimatrix"/>
 	</thing-type>
 
 	<!-- AT-PRO3HD66M -->
@@ -393,7 +393,7 @@
 			</channel-group>
 		</channel-groups>
 
-		<config-description-ref uri="thing-type:altona:hdmimatrix"/>
+		<config-description-ref uri="thing-type:atlona:hdmimatrix"/>
 	</thing-type>
 
 	<channel-group-type id="primarygroup">


### PR DESCRIPTION
Fix misspelled word _atlona_ throughout the binding. No functional changes.