### PR TITLE
[tapocontrol] fix "device not found" with L510/L530 hw rev2 / add L920 and P110 things

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -6,13 +6,13 @@ This binding adds support to control Tapo (Copyright © TP-Link Corporation Limi
 
 The following Tapo-Devices are supported
 
-### P100/P105 SmartPlug (WiFi)
+### P100/P105/P110 SmartPlug (WiFi)
 
 * Power On/Off
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### L510_Series dimmable SmartBulb (WiFi)
+### L510(Series) dimmable SmartBulb (WiFi)
 
 * Light On/Off
 * Brightnes (Dimmer)  0-100 %
@@ -20,7 +20,7 @@ The following Tapo-Devices are supported
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### L530_Series MultiColor SmartBulb (WiFi)
+### L530(Series) MultiColor SmartBulb (WiFi)
 
 * Light On/Off
 * Brightnes (Dimmer)  0-100 %
@@ -29,7 +29,7 @@ The following Tapo-Devices are supported
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### L900 MultiColor LightStrip (WiFi)
+### L900/L920 LED-LightStrip (WiFi)
 
 * Light On/Off
 * Brightnes (Dimmer)  0-100 %
@@ -79,14 +79,14 @@ The thing has the following configuration parameters:
 
 All devices support some of the following channels:
 
-| group     | channel          |type                    | description                  | things supporting this channel  |
-|-----------|----------------- |------------------------|------------------------------|---------------------------------|
-| actuator  | output           | Switch                 | Power device on or off       | P100, P105,L510, L530, L900     |
-|           | brightness       | Dimmer                 | Brightness 0-100%            | L510, L530, L900                |
-|           | colorTemperature | Number                 | White-Color-Temp 2500-6500K  | L510, L530, L900                |
-|           | color            | Color                  | Color                        | L530, L900                      |
-| device    | wifiSignal       | system.signal-strength | WiFi-quality-level           | P100, P105, L510, L530, L900    |
-|           | onTime           | Number:Time            | seconds output is on         | P100, P105, L510, L530, L900    |
+| group     | channel          |type                    | description                  | things supporting this channel              |
+|-----------|----------------- |------------------------|------------------------------|---------------------------------------------|
+| actuator  | output           | Switch                 | Power device on or off       | P100, P105, P110, L510, L530, L900, L920    |
+|           | brightness       | Dimmer                 | Brightness 0-100%            | L510, L530, L900                            |
+|           | colorTemperature | Number                 | White-Color-Temp 2500-6500K  | L510, L530, L900                            |
+|           | color            | Color                  | Color                        | L530, L900                                  |
+| device    | wifiSignal       | system.signal-strength | WiFi-quality-level           | P100, P105, P110, L510, L530, L900, L920    |
+|           | onTime           | Number:Time            | seconds output is on         | P100, P105, P110, L510, L530, L900, L920    |
 
 
 ## Channel Refresh
@@ -102,8 +102,8 @@ To minimize network traffic the default refresh-rate is set to 30 seconds. This 
 ```
 tapocontrol:bridge:myTapoBridge                     "Cloud-Login"               [ username="you@yourpovider.com", password="verysecret" ]
 tapocontrol:P100:myTapoBridge:mySocket              "My-Socket"                 [ ipAddress="192.168.178.150", pollingInterval=30 ]
-tapocontrol:L510_Series:myTapoBridge:whiteBulb      "white-light"               [ ipAddress="192.168.178.151", pollingInterval=30 ]
-tapocontrol:L530_Series:myTapoBridge:colorBulb      "color-light"               [ ipAddress="192.168.178.152", pollingInterval=30 ]
+tapocontrol:L510:myTapoBridge:whiteBulb      		"white-light"               [ ipAddress="192.168.178.151", pollingInterval=30 ]
+tapocontrol:L530:myTapoBridge:colorBulb      		"color-light"               [ ipAddress="192.168.178.152", pollingInterval=30 ]
 tapocontrol:L900:myTapoBridge:myLightStrip          "light-strip"               [ ipAddress="192.168.178.153", pollingInterval=30 ]
 ``` 
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/TapoDiscoveryService.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/TapoDiscoveryService.java
@@ -193,6 +193,7 @@ public class TapoDiscoveryService extends AbstractDiscoveryService implements Th
             String deviceModel = device.get(CLOUD_PROPERTY_MODEL).getAsString();
             deviceModel = deviceModel.replaceAll("\\(.*\\)", ""); // replace (DE)
             deviceModel = deviceModel.replace("Tapo", "");
+            deviceModel = deviceModel.replace("Series", "");
             deviceModel = deviceModel.trim();
             deviceModel = deviceModel.replace(" ", "_");
             return deviceModel;

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
@@ -36,9 +36,11 @@ public class TapoThingConstants {
     public static final String DEVICE_BRIDGE = "bridge";
     public static final String DEVICE_P100 = "P100";
     public static final String DEVICE_P105 = "P105";
+    public static final String DEVICE_P110 = "P110";
     public static final String DEVICE_L510E = "L510_Series";
     public static final String DEVICE_L530E = "L530_Series";
     public static final String DEVICE_L900 = "L900";
+    public static final String DEVICE_L920 = "L920";
     public static final String DEVICE_UNIVERSAL = "Test_Device";
 
     /*** LIST OF SUPPORTED DEVICE DESCRIPTIONS ***/
@@ -52,17 +54,20 @@ public class TapoThingConstants {
     public static final ThingTypeUID BRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_BRIDGE);
     public static final ThingTypeUID P100_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P100);
     public static final ThingTypeUID P105_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P105);
+    public static final ThingTypeUID P110_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P110);
     public static final ThingTypeUID L510E_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L510E);
     public static final ThingTypeUID L530E_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L530E);
     public static final ThingTypeUID L900_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L900);
+    public static final ThingTypeUID L920_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L920);
     public static final ThingTypeUID UNIVERSAL_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_UNIVERSAL);
 
     /*** SET OF SUPPORTED UIDS ***/
     public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_UIDS = Set.of(BRIDGE_THING_TYPE);
-    public static final Set<ThingTypeUID> SUPPORTED_SMART_PLUG_UIDS = Set.of(P100_THING_TYPE, P105_THING_TYPE);
+    public static final Set<ThingTypeUID> SUPPORTED_SMART_PLUG_UIDS = Set.of(P100_THING_TYPE, P105_THING_TYPE,
+            P110_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_WHITE_BULB_UIDS = Set.of(L510E_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_COLOR_BULB_UIDS = Set.of(L530E_THING_TYPE);
-    public static final Set<ThingTypeUID> SUPPORTED_LIGHT_STRIP_UIDS = Set.of(L900_THING_TYPE);
+    public static final Set<ThingTypeUID> SUPPORTED_LIGHT_STRIP_UIDS = Set.of(L900_THING_TYPE, L920_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .unmodifiableSet(Stream
                     .of(SUPPORTED_BRIDGE_UIDS, SUPPORTED_SMART_PLUG_UIDS, SUPPORTED_WHITE_BULB_UIDS,

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
@@ -37,8 +37,8 @@ public class TapoThingConstants {
     public static final String DEVICE_P100 = "P100";
     public static final String DEVICE_P105 = "P105";
     public static final String DEVICE_P110 = "P110";
-    public static final String DEVICE_L510E = "L510_Series";
-    public static final String DEVICE_L530E = "L530_Series";
+    public static final String DEVICE_L510 = "L510";
+    public static final String DEVICE_L530 = "L530";
     public static final String DEVICE_L900 = "L900";
     public static final String DEVICE_L920 = "L920";
     public static final String DEVICE_UNIVERSAL = "Test_Device";
@@ -55,8 +55,8 @@ public class TapoThingConstants {
     public static final ThingTypeUID P100_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P100);
     public static final ThingTypeUID P105_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P105);
     public static final ThingTypeUID P110_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P110);
-    public static final ThingTypeUID L510E_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L510E);
-    public static final ThingTypeUID L530E_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L530E);
+    public static final ThingTypeUID L510_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L510);
+    public static final ThingTypeUID L530_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L530);
     public static final ThingTypeUID L900_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L900);
     public static final ThingTypeUID L920_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L920);
     public static final ThingTypeUID UNIVERSAL_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_UNIVERSAL);
@@ -65,8 +65,8 @@ public class TapoThingConstants {
     public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_UIDS = Set.of(BRIDGE_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_SMART_PLUG_UIDS = Set.of(P100_THING_TYPE, P105_THING_TYPE,
             P110_THING_TYPE);
-    public static final Set<ThingTypeUID> SUPPORTED_WHITE_BULB_UIDS = Set.of(L510E_THING_TYPE);
-    public static final Set<ThingTypeUID> SUPPORTED_COLOR_BULB_UIDS = Set.of(L530E_THING_TYPE);
+    public static final Set<ThingTypeUID> SUPPORTED_WHITE_BULB_UIDS = Set.of(L510_THING_TYPE);
+    public static final Set<ThingTypeUID> SUPPORTED_COLOR_BULB_UIDS = Set.of(L530_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_LIGHT_STRIP_UIDS = Set.of(L900_THING_TYPE, L920_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .unmodifiableSet(Stream

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/structures/TapoDeviceInfo.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/structures/TapoDeviceInfo.java
@@ -166,7 +166,7 @@ public class TapoDeviceInfo {
     }
 
     public String getModel() {
-        return model.replace(" ", "_");
+        return model.replace(" Series", "");
     }
 
     public String getNickname() {

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/i18n/tapocontrol.properties
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/i18n/tapocontrol.properties
@@ -5,16 +5,20 @@ binding.tapocontrol.description = Control your TAPO-SmartHome Devices
 
 # thing types
 
-thing-type.tapocontrol.L510_Series.label = L510 Series White-Bulb
-thing-type.tapocontrol.L510_Series.description = Tapo Smart dimmable White-Light-Bulb
-thing-type.tapocontrol.L530_Series.label = L530 Series Color-Bulb
-thing-type.tapocontrol.L530_Series.description = Tapo Smart Multicolor Light-Bulb
+thing-type.tapocontrol.L510.label = L510 Series White-Bulb
+thing-type.tapocontrol.L510.description = Tapo Smart dimmable White-Light-Bulb
+thing-type.tapocontrol.L530.label = L530 Series Color-Bulb
+thing-type.tapocontrol.L530.description = Tapo Smart Multicolor Light-Bulb
 thing-type.tapocontrol.L900.label = L900 LightStrip
-thing-type.tapocontrol.L900.description = Tapo Smart Multicolor Light-Lightstrip
+thing-type.tapocontrol.L900.description = Tapo Smart LED-Lightstrip
+thing-type.tapocontrol.L920.label = L920 LightStrip
+thing-type.tapocontrol.L920.description = Tapo Smart Multicolor LED-Lightstrip
 thing-type.tapocontrol.P100.label = P100 SmartPlug
 thing-type.tapocontrol.P100.description = Tapo Smart Wifi Plug
 thing-type.tapocontrol.P105.label = P105 SmartPlug
 thing-type.tapocontrol.P105.description = Tapo Mini Smart Wifi Plug
+thing-type.tapocontrol.P110.label = P110 SmartPlug
+thing-type.tapocontrol.P110.description = Tapo Smart Monitoring Wifi Plug
 thing-type.tapocontrol.bridge.label = Cloud-Login
 thing-type.tapocontrol.bridge.description = Cloud Connector. Acts as device-bridge
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L510.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L510.xml
@@ -4,8 +4,8 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- L510E THING-TYPE (WHITE-LIGHT-BULB) -->
-	<thing-type id="L510_Series">
+	<!-- L510 THING-TYPE (WHITE-LIGHT-BULB) -->
+	<thing-type id="L510">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
 		</supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L530.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L530.xml
@@ -4,8 +4,8 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- L530 Series THING-TYPE (COLOR-LIGHT-BULB) -->
-	<thing-type id="L530_Series">
+	<!-- L530 THING-TYPE (COLOR-LIGHT-BULB) -->
+	<thing-type id="L530">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
 		</supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L920.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L920.xml
@@ -4,14 +4,14 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- L900 Series THING-TYPE (COLOR-LED-Lightstrip) -->
-	<thing-type id="L900">
+	<!-- L530 Series THING-TYPE (Multicolor LED-Lightstrip) -->
+	<thing-type id="L920">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
 		</supported-bridge-type-refs>
 
-		<label>L900 LightStrip</label>
-		<description>Tapo Smart LED-Lightstrip</description>
+		<label>L920 LightStrip</label>
+		<description>Tapo Smart Multicolor LED-Lightstrip</description>
 		<channel-groups>
 			<channel-group id="actuator" typeId="lightStrip"/>
 			<channel-group id="device" typeId="deviceState"/>

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L920.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/L920.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- L530 Series THING-TYPE (Multicolor LED-Lightstrip) -->
+	<!-- L920 THING-TYPE (Multicolor LED-Lightstrip) -->
 	<thing-type id="L920">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/P105.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/P105.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- P100 THING-TYPE (SOCKET) -->
+	<!-- P105 THING-TYPE (SOCKET) -->
 	<thing-type id="P105">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/P110.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/P110.xml
@@ -4,16 +4,16 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- L900 Series THING-TYPE (COLOR-LED-Lightstrip) -->
-	<thing-type id="L900">
+	<!-- P110 THING-TYPE (SOCKET) -->
+	<thing-type id="P110">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
 		</supported-bridge-type-refs>
 
-		<label>L900 LightStrip</label>
-		<description>Tapo Smart LED-Lightstrip</description>
+		<label>P110 SmartPlug</label>
+		<description>Tapo Smart Monitoring Wifi Plug</description>
 		<channel-groups>
-			<channel-group id="actuator" typeId="lightStrip"/>
+			<channel-group id="actuator" typeId="smartPlug"/>
 			<channel-group id="device" typeId="deviceState"/>
 		</channel-groups>
 		<representation-property>macAddress</representation-property>


### PR DESCRIPTION
This PR fixes the "wrong device found" error for Tapo L510 and L530 Bulbs with Hardware Rev.2
Cause: Tapo renamed types from "L530_Series" to "L530"

Also implemented L920 LED-Lightstrip and P110 SmartPlug with basic functions.
