### PR TITLE
[homematic] fixing incorrect scan duration after openHAB restart

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -52,7 +52,6 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService
     private Future<?> loadDevicesFuture;
     private volatile boolean isInInstallMode = false;
     private volatile Object installModeSync = new Object();
-    private volatile int installModeDuration = HomematicConfig.DEFAULT_INSTALL_MODE_DURATION;
 
     public HomematicDeviceDiscoveryService() {
         super(Collections.singleton(new ThingTypeUID(BINDING_ID, "-")), DISCOVER_TIMEOUT_SECONDS, false);
@@ -103,10 +102,9 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService
             if (bridgeHandler != null) {
                 Thing bridge = bridgeHandler.getThing();
                 bridgeStatus = bridge.getStatus();
-                updateInstallModeDuration(bridge);
             }
             if (ThingStatus.ONLINE == bridgeStatus) {
-                gateway.setInstallMode(true, installModeDuration);
+                gateway.setInstallMode(true, getInstallModeDuration());
 
                 int remaining = gateway.getInstallMode();
                 if (remaining > 0) {
@@ -123,14 +121,16 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService
         }
     }
 
-    private void updateInstallModeDuration(Thing bridge) {
-        HomematicConfig config = bridge.getConfiguration().as(HomematicConfig.class);
-        installModeDuration = config.getInstallModeDuration();
+    private int getInstallModeDuration() {
+        if (bridgeHandler != null) {
+            return bridgeHandler.getThing().getConfiguration().as(HomematicConfig.class).getInstallModeDuration();
+        }
+        return HomematicConfig.DEFAULT_INSTALL_MODE_DURATION;
     }
 
     @Override
     public int getScanTimeout() {
-        return installModeDuration;
+        return getInstallModeDuration();
     }
 
     @Override


### PR DESCRIPTION
Bug fix for #11969

### Issue:
After restart of openHAB the scan duration for homematic devices is read from a variable which is initialized with a default value instead of using the configuration of the binding.

### Fix:
The scan duration is read directly from the configuration of the binding.
