### PR TITLE
[openwebnet] Fix Things synchronization at boot / reconnect

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -123,13 +123,13 @@ Devices can be discovered automatically using an Inbox Scan after a gateway has 
 
 For any manually added device, you must configure:
 
-- the associated gateway (`Parent Bridge` menu)
-- the `where` configuration parameter (`OpenWebNet Address`):
-    - example for BUS/SCS:
-        - light device with WHERE address Point to Point `A=2 PL=4` --> `where="24"`
-        - light device with WHERE address Point to Point `A=03 PL=11` on local bus --> `where="0311#4#01"`
-        - CEN scenario with WHERE address Point to Point `A=05 PL=12` --> `where="0512"`
-        - CEN+ configured scenario `5`: add a `2` before --> `where="25"`
+- the associated gateway Thing (`Parent Bridge` menu)
+- the `where` configuration parameter (`OpenWebNet Address`): this is the OpenWebNet address configured for the device in the BTicino/Legrand system. This address can be found either on the device itself (Physical configuration, using jumpers in case of BUS) or through the MyHOME_Suite software (Virtual configuration). The address can have several formats depending on the device/system:
+    - example for BUS/SCS system, address Point-to-point with Area (A) and Light-point (PL):
+        - light device A=`2` (Area 2), PL=`4` (Light-point 4) --> `where="24"`
+        - light device A=`03`, PL=`11` on local bus --> `where="0311#4#01"`
+        - CEN scenario A=`05`, PL=`12` --> `where="0512"`
+        - CEN+ scenario `5`: add a `2` before --> `where="25"`
         - Dry Contact or IR Interface `99`: add a `3` before --> `where="399"`
     - example for ZigBee devices: `where=765432101#9`. The ID of the device (ADDR part) is usually written in hexadecimal on the device itself, for example `ID 0074CBB1`: convert to decimal (`7654321`) and add `01#9` at the end to obtain `where=765432101#9`. For 2-unit switch devices (`zb_on_off_switch2u`), last part should be `00#9`.
  
@@ -141,7 +141,7 @@ In BTicino MyHOME Thermoregulation (WHO=4) each **zone** has associated a thermo
 Thermo zones can be configured defining a `bus_thermo_zone` Thing for each zone with the following parameters:
 
 - the `where` configuration parameter (`OpenWebNet Address`):
-    - example BUS/SCS Thermo zone `1` --> `where="1"` 
+    - example BUS/SCS zone `1` --> `where="1"` 
 - the `standAlone` configuration parameter (`boolean`, default: `true`): identifies if the zone is managed or not by a Central Unit (4 or 99 zones). `standAlone=true` means no Central Unit is present in the system.
 
 Temperature sensors can be configured defining a `bus_thermo_sensor` Thing with the following parameters:

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.6.0</version>
+      <version>0.7.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.7.1-SNAPSHOT</version>
+      <version>0.7.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -138,7 +138,7 @@ public class OpenWebNetBindingConstants {
     public static final String CONFIG_PROPERTY_WHERE = "where";
     public static final String CONFIG_PROPERTY_SHUTTER_RUN = "shutterRun";
     public static final String CONFIG_PROPERTY_SCENARIO_BUTTONS = "buttons";
-    // BUS gw config properties
+    // gw config properties
     public static final String CONFIG_PROPERTY_HOST = "host";
     public static final String CONFIG_PROPERTY_SERIAL_PORT = "serialPort";
     // properties

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
@@ -54,25 +54,25 @@ public class OpenWebNetHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
         if (OpenWebNetBridgeHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW BRIDGE Handler");
+            logger.debug("creating NEW BRIDGE Handler --- {}", thing.getUID());
             return new OpenWebNetBridgeHandler((Bridge) thing);
         } else if (OpenWebNetGenericHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW GENERIC Handler");
+            logger.debug("creating NEW GENERIC Handler --- {}", thing.getUID());
             return new OpenWebNetGenericHandler(thing);
         } else if (OpenWebNetLightingHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW LIGHTING Handler");
+            logger.debug("creating NEW LIGHTING Handler --- {}", thing.getUID());
             return new OpenWebNetLightingHandler(thing);
         } else if (OpenWebNetAutomationHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW AUTOMATION Handler");
+            logger.debug("creating NEW AUTOMATION Handler --- {}", thing.getUID());
             return new OpenWebNetAutomationHandler(thing);
         } else if (OpenWebNetEnergyHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW ENERGY Handler");
+            logger.debug("creating NEW ENERGY Handler --- {}", thing.getUID());
             return new OpenWebNetEnergyHandler(thing);
         } else if (OpenWebNetThermoregulationHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW THERMO Handler");
+            logger.debug("creating NEW THERMO Handler --- {}", thing.getUID());
             return new OpenWebNetThermoregulationHandler(thing);
         } else if (OpenWebNetScenarioHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
-            logger.debug("creating NEW SCENARIO Handler");
+            logger.debug("creating NEW SCENARIO Handler --- {}", thing.getUID());
             return new OpenWebNetScenarioHandler(thing);
         }
         logger.warn("ThingType {} is not supported by this binding", thing.getThingTypeUID());

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAutomationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAutomationHandler.java
@@ -171,7 +171,7 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
                     logger.debug("Refresh all devices just sent...");
                 }
             } else {
-                requestChannelState(new ChannelUID("any")); // channel here does not make any difference
+                requestChannelState(new ChannelUID("any:any:any:any"));
             }
         }
     }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAutomationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAutomationHandler.java
@@ -61,6 +61,8 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.AUTOMATION_SUPPORTED_THING_TYPES;
 
+    private static long lastAllDevicesRefreshTS = 0; // ts when last all device refresh was sent for this handler
+
     // moving states
     public static final int MOVING_STATE_STOPPED = 0;
     public static final int MOVING_STATE_MOVING_UP = 1;
@@ -150,8 +152,8 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
     }
 
     @Override
-    protected boolean supportsRefreshAllDevices() {
-        return true;
+    protected long getRefreshAllLastTS() {
+        return lastAllDevicesRefreshTS;
     };
 
     @Override
@@ -160,6 +162,7 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
             logger.debug("--- refreshDevice() : refreshing GENERAL... ({})", thing.getUID());
             try {
                 send(Automation.requestStatus(WhereLightAutom.GENERAL.value()));
+                lastAllDevicesRefreshTS = System.currentTimeMillis();
             } catch (OWNException e) {
                 logger.warn("Excpetion while requesting all devices refresh: {}", e.getMessage());
             }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAutomationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAutomationHandler.java
@@ -59,10 +59,6 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
 
     private static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("ss.SSS");
 
-    private static long lastAllDevicesRefreshTS = -1; // timestamp when the last request for all device refresh was sent
-    protected static final int ALL_DEVICES_REFRESH_INTERVAL_MSEC = 60000; // interval in msec before sending another all
-                                                                          // devices refresh request
-
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.AUTOMATION_SUPPORTED_THING_TYPES;
 
     // moving states
@@ -141,38 +137,35 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void requestChannelState(ChannelUID channel) {
-        logger.debug("requestChannelState() thingUID={} channel={}", thing.getUID(), channel.getId());
+        super.requestChannelState(channel);
         Where w = deviceWhere;
         if (w != null) {
             try {
                 send(Automation.requestStatus(w.value()));
             } catch (OWNException e) {
-                logger.debug("Exception while requesting channel {} state: {}", channel, e.getMessage(), e);
+                logger.debug("Exception while requesting state for channel {}: {} ", channel, e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
-        } else {
-            logger.warn("Could not requestChannelState(): deviceWhere is null");
         }
     }
 
     @Override
+    protected boolean supportsRefreshAllDevices() {
+        return true;
+    };
+
+    @Override
     protected void refreshDevice(boolean refreshAll) {
-        OpenWebNetBridgeHandler brH = bridgeHandler;
-        if (brH != null) {
-            if (brH.isBusGateway() && refreshAll) {
-                long now = System.currentTimeMillis();
-                if (now - lastAllDevicesRefreshTS > ALL_DEVICES_REFRESH_INTERVAL_MSEC) {
-                    try {
-                        send(Automation.requestStatus(WhereLightAutom.GENERAL.value()));
-                        lastAllDevicesRefreshTS = now;
-                    } catch (OWNException e) {
-                        logger.warn("Excpetion while requesting all devices refresh: {}", e.getMessage());
-                    }
-                } else {
-                    logger.debug("Refresh all devices just sent...");
-                }
-            } else {
-                requestChannelState(new ChannelUID("any:any:any:any"));
+        if (refreshAll) {
+            logger.debug("--- refreshDevice() : refreshing GENERAL... ({})", thing.getUID());
+            try {
+                send(Automation.requestStatus(WhereLightAutom.GENERAL.value()));
+            } catch (OWNException e) {
+                logger.warn("Excpetion while requesting all devices refresh: {}", e.getMessage());
             }
+        } else {
+            logger.debug("--- refreshDevice() : refreshing SINGLE... ({})", thing.getUID());
+            requestChannelState(new ChannelUID(thing.getUID(), CHANNEL_SHUTTER));
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -418,10 +418,11 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
                     OpenWebNetThingHandler hndlr = (OpenWebNetThingHandler) ownThing.getHandler();
                     if (hndlr != null) {
                         howMany++;
-                        logger.debug("--- REFRESHING thing #{}/{}: {}", howMany, total, ownThing.getUID());
+                        logger.debug("--- REFRESHING ALL DEVICES FOR thing #{}/{}: {}", howMany, total,
+                                ownThing.getUID());
                         hndlr.refreshAllDevices();
                     } else {
-                        logger.warn("--- no handler for thing {}", ownThing.getUID());
+                        logger.warn("--- No handler for thing {}", ownThing.getUID());
                     }
                 }
                 logger.debug("--- --- COMPLETED REFRESH all devices for bridge {}", thing.getUID());
@@ -430,7 +431,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
                 refreshAllSchedule = scheduler.schedule(() -> checkAllRefreshed(things), 20, TimeUnit.SECONDS);
             }
         } else {
-            logger.debug("--- --- NO DEVICE to REFRESH for bridge {}", thing.getUID());
+            logger.debug("--- --- NO CHILD DEVICE to REFRESH for bridge {}", thing.getUID());
         }
     }
 
@@ -451,7 +452,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         if (allOnline) {
             logger.info("--- --- CHECK COMPLETED: ALL THINGS ONLINE for bridge {}", thing.getUID());
         } else {
-            logger.warn("--- --- CHECKED COMPLETED: ^^^NOT ALL THINGS ONLINE^^^ for bridge {}", thing.getUID());
+            logger.warn("--- --- CHECK COMPLETED: ^^^NOT ALL THINGS ONLINE^^^ for bridge {}", thing.getUID());
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
@@ -407,7 +406,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     private void refreshAllBridgeDevices() {
         logger.debug("--- --- ABOUT TO REFRESH ALL devices for bridge {}", thing.getUID());
         int howMany = 0;
-        final List<@NonNull Thing> things = getThing().getThings();
+        final List<Thing> things = getThing().getThings();
         int total = things.size();
         logger.debug("--- FOUND {} things by getThings()", total);
         if (total > 0) {
@@ -442,7 +441,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         }
     }
 
-    private void checkAllRefreshed(List<@NonNull Thing> things) {
+    private void checkAllRefreshed(List<Thing> things) {
         int howMany = 0;
         int total = things.size();
         boolean allOnline = true;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetEnergyHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetEnergyHandler.java
@@ -28,6 +28,7 @@ import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
@@ -146,22 +147,22 @@ public class OpenWebNetEnergyHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void requestChannelState(ChannelUID channel) {
-        logger.debug("requestChannelState() thingUID={} channel={}", thing.getUID(), channel.getId());
+        super.requestChannelState(channel);
         Where w = deviceWhere;
         if (w != null) {
             try {
                 send(EnergyManagement.requestActivePower(w.value()));
             } catch (OWNException e) {
-                logger.debug("Exception while requesting channel {} state: {}", channel, e.getMessage(), e);
+                logger.debug("Exception while requesting state for channel {}: {} ", channel, e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
-        } else {
-            logger.warn("Could not requestChannelState(): deviceWhere is null");
         }
     }
 
     @Override
     protected void refreshDevice(boolean refreshAll) {
-        requestChannelState(new ChannelUID("any:any:any:any"));
+        logger.debug("--- refreshDevice() : refreshing SINGLE... ({})", thing.getUID());
+        requestChannelState(new ChannelUID(thing.getUID(), CHANNEL_POWER));
     }
 
     @Override

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -97,7 +97,29 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void requestChannelState(ChannelUID channel) {
+        super.requestChannelState(channel);
         refreshDevice(false);
+    }
+
+    @Override
+    protected void refreshDevice(boolean refreshAll) {
+        logger.debug("--- refreshDevice() : refreshing SINGLE... ({})", thing.getUID());
+        if (deviceWhere != null) {
+            String w = deviceWhere.value();
+            try {
+                send(Thermoregulation.requestTemperature(w));
+                if (!this.isTempSensor) {
+                    // for bus_thermo_zone request also other single channels updates
+                    send(Thermoregulation.requestSetPointTemperature(w));
+                    send(Thermoregulation.requestFanCoilSpeed(w));
+                    send(Thermoregulation.requestMode(w));
+                    send(Thermoregulation.requestValvesStatus(w));
+                    send(Thermoregulation.requestActuatorsStatus(w));
+                }
+            } catch (OWNException e) {
+                logger.warn("refreshDevice() where='{}' returned OWNException {}", w, e.getMessage());
+            }
+        }
     }
 
     @Override
@@ -312,26 +334,6 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
         } catch (FrameException e) {
             logger.warn("updateActuatorStatus() FrameException on frame {}: {}", tmsg, e.getMessage());
             updateState(CHANNEL_ACTUATORS, UnDefType.UNDEF);
-        }
-    }
-
-    @Override
-    protected void refreshDevice(boolean refreshAll) {
-        if (deviceWhere != null) {
-            String w = deviceWhere.value();
-            try {
-                send(Thermoregulation.requestTemperature(w));
-                if (!this.isTempSensor) {
-                    // for bus_thermo_zone request also other single channels updates
-                    send(Thermoregulation.requestSetPointTemperature(w));
-                    send(Thermoregulation.requestFanCoilSpeed(w));
-                    send(Thermoregulation.requestMode(w));
-                    send(Thermoregulation.requestValvesStatus(w));
-                    send(Thermoregulation.requestActuatorsStatus(w));
-                }
-            } catch (OWNException e) {
-                logger.warn("refreshDevice() where='{}' returned OWNException {}", w, e.getMessage());
-            }
         }
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -233,17 +233,17 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
 
         Thermoregulation.WhatThermo w = Thermoregulation.WhatThermo.fromValue(tmsg.getWhat().value());
 
-        if (w.mode() == null) {
+        if (w.getMode() == null) {
             logger.debug("updateModeAndFunction() Could not parse Mode from: {}", tmsg.getFrameValue());
             return;
         }
-        if (w.function() == null) {
+        if (w.getFunction() == null) {
             logger.debug("updateModeAndFunction() Could not parse Function from: {}", tmsg.getFrameValue());
             return;
         }
 
-        Thermoregulation.OperationMode mode = w.mode();
-        Thermoregulation.Function function = w.function();
+        Thermoregulation.OperationMode mode = w.getMode();
+        Thermoregulation.Function function = w.getFunction();
 
         if (w == Thermoregulation.WhatThermo.HEATING) {
             function = Thermoregulation.Function.HEATING;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
@@ -29,6 +29,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
@@ -105,6 +106,15 @@ public abstract class OpenWebNetThingHandler extends BaseThingHandler {
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-no-bridge");
+        }
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, "@text/unknown.waiting-state");
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
@@ -270,7 +270,7 @@ public abstract class OpenWebNetThingHandler extends BaseThingHandler {
                 refreshTimeout = scheduler.schedule(() -> {
                     if (thing.getStatus().equals(ThingStatus.UNKNOWN)) {
                         logger.debug(
-                                "--- refreshAllDevices() : schedule expired: --UNKNOWN-- status for {}. Rerfreshing it...",
+                                "--- refreshAllDevices() : schedule expired: --UNKNOWN-- status for {}. Refreshing it...",
                                 thing.getUID());
                         refreshDevice(false);
                     } else {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
@@ -115,12 +115,12 @@ public abstract class OpenWebNetThingHandler extends BaseThingHandler {
         if (handler != null) {
             OpenGateway gw = handler.gateway;
             if (gw != null && !gw.isConnected()) {
-                logger.info("Cannot handle {} command for {}: gateway is not connected", command, getThing().getUID());
+                logger.info("Cannot handle {} command for {}: gateway is not connected", command, thing.getUID());
                 return;
             }
             if (deviceWhere == null) {
                 logger.info("Cannot handle {} command for {}: 'where' parameter is not configured or is invalid",
-                        command, getThing().getUID());
+                        command, thing.getUID());
                 return;
             }
             if (command instanceof RefreshType) {
@@ -130,6 +130,7 @@ public abstract class OpenWebNetThingHandler extends BaseThingHandler {
                     if (thing.getStatus().equals(ThingStatus.UNKNOWN)) {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                 "Could not get channel state (timer expired)");
+                        logger.debug("requestChannelState() timeout for thing {}", thing.getUID());
                     }
                 }, THING_STATE_REQ_TIMEOUT_SEC, TimeUnit.SECONDS);
             } else {

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -14,5 +14,6 @@ offline.conf-error-auth = Authentication failed. Check gateway password in confi
 offline.comm-error-disconnected = Disconnected from gateway.
 offline.comm-error-timeout = Connection to gateway timed out.
 offline.comm-error-connection = Could not connect to gateway.
+offline.comm-error-state = Could not get channel state. 
 
 unknown.waiting-state = Waiting state update...

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_it.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_it.properties
@@ -14,6 +14,5 @@ offline.conf-error-auth = Autenticazione fallita. Verificare la password nella c
 offline.comm-error-disconnected = Disconnesso dal gateway.
 offline.comm-error-timeout = Connessione al gateway non riuscita in tempo.
 offline.comm-error-connection = Impossibile connettersi al gateway.
-offline.comm-error-state = Impossibile aggiornare lo stato. 
 
 unknown.waiting-state = In attesa di aggiornamento di stato...

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_it.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet_it.properties
@@ -14,5 +14,6 @@ offline.conf-error-auth = Autenticazione fallita. Verificare la password nella c
 offline.comm-error-disconnected = Disconnesso dal gateway.
 offline.comm-error-timeout = Connessione al gateway non riuscita in tempo.
 offline.comm-error-connection = Impossibile connettersi al gateway.
+offline.comm-error-state = Impossibile aggiornare lo stato. 
 
 unknown.waiting-state = In attesa di aggiornamento di stato...


### PR DESCRIPTION
This PR solves some issues related to Things synchronization when the associated bridge is initialized, for example at boot,  when it is re-enabled or when it reconnects to a BTicino gateway. In systems with many Things configured (+100), not all were synchronized properly and put ONLINE/OFFLINE.
Fixes: #11627. Fixes #11972. Fixes #11974.
It also fixes #11965: USB rollershutters blocked when a REFRESH command was sent to them.

openwebnet4j lib updated to latest: 0.7.1

Several tests performed successfully by power users on real systems with many Things configured (+100 things).
