### PR TITLE
[hdpowerview] Add firmware information properties for hub and shade

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
@@ -54,10 +54,19 @@ public class HDPowerViewBindingConstants {
     public static final String CHANNELTYPE_SCENE_GROUP_ACTIVATE = "scene-group-activate";
     public static final String CHANNELTYPE_AUTOMATION_ENABLED = "automation-enabled";
 
+    // Hub properties
+    public static final String PROPERTY_FIRMWARE_NAME = "firmwareName";
+    public static final String PROPERTY_RADIO_FIRMWARE_VERSION = "radioFirmwareVersion";
+
+    // Hub/shade properties
+    public static final String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
+
+    // Shade properties
     public static final String PROPERTY_SHADE_TYPE = "type";
     public static final String PROPERTY_SHADE_CAPABILITIES = "capabilities";
     public static final String PROPERTY_SECONDARY_RAIL_DETECTED = "secondaryRailDetected";
     public static final String PROPERTY_TILT_ANYWHERE_DETECTED = "tiltAnywhereDetected";
+    public static final String PROPERTY_MOTOR_FIRMWARE_VERSION = "motorFirmwareVersion";
 
     public static final List<String> NETBIOS_NAMES = Arrays.asList("PDBU-Hub3.0", "PowerView-Hub");
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeMove;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeStop;
+import org.openhab.binding.hdpowerview.internal.api.responses.FirmwareVersion;
 import org.openhab.binding.hdpowerview.internal.api.responses.SceneCollections;
 import org.openhab.binding.hdpowerview.internal.api.responses.Scenes;
 import org.openhab.binding.hdpowerview.internal.api.responses.ScheduledEvents;
@@ -64,6 +65,7 @@ public class HDPowerViewWebTargets {
     private Instant maintenanceScheduledEnd = Instant.now().minusSeconds(2 * maintenancePeriod);
 
     private final String base;
+    private final String firmwareVersion;
     private final String shades;
     private final String sceneActivate;
     private final String scenes;
@@ -113,6 +115,7 @@ public class HDPowerViewWebTargets {
     public HDPowerViewWebTargets(HttpClient httpClient, String ipAddress) {
         base = "http://" + ipAddress + "/api/";
         shades = base + "shades/";
+        firmwareVersion = base + "fwversion/";
         sceneActivate = base + "scenes";
         scenes = base + "scenes/";
 
@@ -122,6 +125,20 @@ public class HDPowerViewWebTargets {
 
         scheduledEvents = base + "scheduledevents";
         this.httpClient = httpClient;
+    }
+
+    /**
+     * Fetches a JSON package with firmware information for the hub.
+     *
+     * @return FirmwareVersion class instance
+     * @throws JsonParseException if there is a JSON parsing error
+     * @throws HubProcessingException if there is any processing error
+     * @throws HubMaintenanceException if the hub is down for maintenance
+     */
+    public @Nullable FirmwareVersion getFirmwareVersion()
+            throws JsonParseException, HubProcessingException, HubMaintenanceException {
+        String json = invoke(HttpMethod.GET, firmwareVersion, null, null);
+        return gson.fromJson(json, FirmwareVersion.class);
     }
 
     /**

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Firmware.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Firmware.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api;
+
+/**
+ * Firmware version information for HD PowerView components
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+public class Firmware {
+    public String name;
+    public int revision;
+    public int subRevision;
+    public int build;
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d.%d", revision, subRevision, build);
+    }
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersion.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersion.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api.responses;
+
+/**
+ * Firmware information for an HD PowerView hub
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+public class FirmwareVersion {
+    public FirmwareVersions firmware;
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersions.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersions.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api.responses;
+
+import org.openhab.binding.hdpowerview.internal.api.Firmware;
+
+/**
+ * Firmware information for an HD PowerView hub
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+public class FirmwareVersions {
+    public Firmware mainProcessor;
+    public Firmware radio;
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Shades.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Shades.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hdpowerview.internal.api.Firmware;
 import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 
 /**
@@ -52,6 +53,8 @@ public class Shades {
         public @Nullable Boolean timedOut;
         public int signalStrength;
         public @Nullable Integer capabilities;
+        public @Nullable Firmware firmware;
+        public @Nullable Firmware motor;
 
         public String getName() {
             return new String(Base64.getDecoder().decode(name));

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -28,6 +28,7 @@ import org.openhab.binding.hdpowerview.internal.HDPowerViewWebTargets;
 import org.openhab.binding.hdpowerview.internal.HubMaintenanceException;
 import org.openhab.binding.hdpowerview.internal.HubProcessingException;
 import org.openhab.binding.hdpowerview.internal.api.CoordinateSystem;
+import org.openhab.binding.hdpowerview.internal.api.Firmware;
 import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 import org.openhab.binding.hdpowerview.internal.api.responses.Shade;
 import org.openhab.binding.hdpowerview.internal.api.responses.Shades.ShadeData;
@@ -180,6 +181,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         if (shadeData != null) {
             updateStatus(ThingStatus.ONLINE);
             updateSoftProperties(shadeData);
+            updateFirmwareProperties(shadeData);
             updateBindingStates(shadeData.positions);
             updateBatteryLevel(shadeData.batteryStatus);
             updateState(CHANNEL_SHADE_BATTERY_VOLTAGE,
@@ -240,6 +242,19 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
                 && (capabilitiesVal != db.getType(type).getCapabilities())) {
             db.logCapabilitiesMismatch(type, capabilitiesVal);
         }
+    }
+
+    private void updateFirmwareProperties(ShadeData shadeData) {
+        Map<String, String> properties = editProperties();
+        Firmware shadeFirmware = shadeData.firmware;
+        Firmware motorFirmware = shadeData.motor;
+        if (shadeFirmware != null) {
+            properties.put(PROPERTY_FIRMWARE_VERSION, shadeFirmware.toString());
+        }
+        if (motorFirmware != null) {
+            properties.put(PROPERTY_MOTOR_FIRMWARE_VERSION, motorFirmware.toString());
+        }
+        updateProperties(properties);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fixes #11979

Add firmware information for hub and shade.

Hub:
- Firmware name.
- Main processor firmware version (revision, sub revision and build).
- Radio firmware version (revision, sub revision and build); **V2 Hub only**

Shade:
- Firmware version (revision, sub revision and build)
- Motor firmware version (revision, sub revision and build)

These properties can be useful information for users, but also prepares the binding for handling differences between firmware versions, for example supporting functionality which is only available in V2 Hub. This was almost necessary for #11857.