### PR TITLE
[homematic] Fix long button press handling for HM-IP devices

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonVirtualDatapointHandler.java
@@ -14,6 +14,8 @@ package org.openhab.binding.homematic.internal.communicator.virtual;
 
 import static org.openhab.binding.homematic.internal.misc.HomematicConstants.VIRTUAL_DATAPOINT_NAME_BUTTON;
 
+import java.util.HashSet;
+
 import org.openhab.binding.homematic.internal.misc.MiscUtils;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
@@ -36,7 +38,7 @@ public class ButtonVirtualDatapointHandler extends AbstractVirtualDatapointHandl
     private static final String LONG_REPEATED_EVENT = "LONG_REPEATED";
     private static final String LONG_RELEASED_EVENT = "LONG_RELEASED";
 
-    private boolean usesLongStartEvent;
+    private HashSet<String> devicesUsingLongStartEvent = new HashSet<>();
 
     @Override
     public String getName() {
@@ -63,6 +65,7 @@ public class ButtonVirtualDatapointHandler extends AbstractVirtualDatapointHandl
     @Override
     public void handleEvent(VirtualGateway gateway, HmDatapoint dp) {
         HmChannel channel = dp.getChannel();
+        String deviceSerial = channel.getDevice().getAddress();
         HmDatapoint vdp = getVirtualDatapoint(channel);
         int usPos = dp.getName().indexOf("_");
         String pressType = usPos == -1 ? dp.getName() : dp.getName().substring(usPos + 1);
@@ -88,7 +91,7 @@ public class ButtonVirtualDatapointHandler extends AbstractVirtualDatapointHandl
                     break;
                 case "LONG_START":
                     vdp.setValue(CommonTriggerEvents.LONG_PRESSED);
-                    usesLongStartEvent = true;
+                    devicesUsingLongStartEvent.add(deviceSerial);
                     break;
                 case "LONG_RELEASE":
                     // Only send release events if we sent a pressed event before
@@ -108,8 +111,8 @@ public class ButtonVirtualDatapointHandler extends AbstractVirtualDatapointHandl
                     logger.warn("Unexpected vaule '{}' for PRESS virtual datapoint", pressType);
             }
         } else {
-            String usedStartEveent = usesLongStartEvent ? "LONG_START" : "LONG";
-            if (usedStartEveent.equals(pressType) && LONG_REPEATED_EVENT.equals(vdp.getValue())) {
+            String usedStartEvent = devicesUsingLongStartEvent.contains(deviceSerial) ? "LONG_START" : "LONG";
+            if (usedStartEvent.equals(pressType) && LONG_REPEATED_EVENT.equals(vdp.getValue())) {
                 // If we're currently processing a repeated long-press event, don't let the initial LONG
                 // event time out the repetitions, the CONT delay handler will take care of it
                 vdp.setValue(LONG_REPEATED_EVENT);

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
@@ -60,7 +60,7 @@ public class ButtonDatapointTest extends JavaTest {
     }
 
     @Test
-    public void testLongPress() throws IOException, HomematicClientException {
+    public void testLongPressHm() throws IOException, HomematicClientException {
         HmDatapoint longPressDp = createPressDatapoint("PRESS_LONG", Boolean.TRUE);
         HmDatapoint buttonVirtualDatapoint = getButtonVirtualDatapoint(longPressDp);
 
@@ -68,6 +68,23 @@ public class ButtonDatapointTest extends JavaTest {
         assertThat(buttonVirtualDatapoint.getValue(), is(CommonTriggerEvents.LONG_PRESSED));
 
         HmDatapoint contPressDp = createPressDatapointFrom(longPressDp, "PRESS_CONT", Boolean.TRUE);
+        mockEventReceiver.eventReceived(contPressDp);
+        assertThat(buttonVirtualDatapoint.getValue(), is("LONG_REPEATED"));
+
+        HmDatapoint releaseDp = createPressDatapointFrom(longPressDp, "PRESS_LONG_RELEASE", Boolean.TRUE);
+        mockEventReceiver.eventReceived(releaseDp);
+        assertThat(buttonVirtualDatapoint.getValue(), is("LONG_RELEASED"));
+    }
+
+    @Test
+    public void testLongPressHmIp() throws IOException, HomematicClientException {
+        HmDatapoint longPressDp = createPressDatapoint("PRESS_LONG_START", Boolean.TRUE);
+        HmDatapoint buttonVirtualDatapoint = getButtonVirtualDatapoint(longPressDp);
+
+        mockEventReceiver.eventReceived(longPressDp);
+        assertThat(buttonVirtualDatapoint.getValue(), is(CommonTriggerEvents.LONG_PRESSED));
+
+        HmDatapoint contPressDp = createPressDatapointFrom(longPressDp, "PRESS_LONG", Boolean.TRUE);
         mockEventReceiver.eventReceived(contPressDp);
         assertThat(buttonVirtualDatapoint.getValue(), is("LONG_REPEATED"));
 


### PR DESCRIPTION
HM-IP(W) devices seem to use a different format for long press handling.

(My) HM devices does this:
    PRESS_CONT
    PRESS_LONG
    PRESS_CONT (N times for repetion)
    PRESS_LONG_RELEASE

while (at least) HmIPW-DRI32 does this (as determined [here](https://community.openhab.org/t/homematic-binding-cant-set-value-for-datapoint-warning-for-master-parameter/42145/20)):
    PRESS_LONG
    PRESS_LONG_START
    PRESS_LONG (N times for repetition)
    PRESS_LONG_RELEASE

Add support for the HMIP format while keeping support for the HM format.