### PR TITLE
[hdpowerview] Use standard firmware property constant

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
@@ -58,9 +58,6 @@ public class HDPowerViewBindingConstants {
     public static final String PROPERTY_FIRMWARE_NAME = "firmwareName";
     public static final String PROPERTY_RADIO_FIRMWARE_VERSION = "radioFirmwareVersion";
 
-    // Hub/shade properties
-    public static final String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
-
     // Shade properties
     public static final String PROPERTY_SHADE_TYPE = "type";
     public static final String PROPERTY_SHADE_CAPABILITIES = "capabilities";

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -302,7 +302,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
         if (mainProcessor.name != null) {
             properties.put(HDPowerViewBindingConstants.PROPERTY_FIRMWARE_NAME, mainProcessor.name);
         }
-        properties.put(HDPowerViewBindingConstants.PROPERTY_FIRMWARE_VERSION, mainProcessor.toString());
+        properties.put(Thing.PROPERTY_FIRMWARE_VERSION, mainProcessor.toString());
         Firmware radio = firmwareVersion.firmware.radio;
         if (radio != null) {
             logger.debug("Radio firmware version received: {}", radio.toString());

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -249,7 +249,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         Firmware shadeFirmware = shadeData.firmware;
         Firmware motorFirmware = shadeData.motor;
         if (shadeFirmware != null) {
-            properties.put(PROPERTY_FIRMWARE_VERSION, shadeFirmware.toString());
+            properties.put(Thing.PROPERTY_FIRMWARE_VERSION, shadeFirmware.toString());
         }
         if (motorFirmware != null) {
             properties.put(PROPERTY_MOTOR_FIRMWARE_VERSION, motorFirmware.toString());


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix comment from #11980 after pull request was merged: Use standard firmware property constant from core.