### PR TITLE
[danfossairunit] Consolidate properties for compliance

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitBindingConstants.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitBindingConstants.java
@@ -35,8 +35,4 @@ public class DanfossAirUnitBindingConstants {
 
     // The thing type as a set
     public static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_AIRUNIT);
-
-    // Properties
-    public static String PROPERTY_UNIT_NAME = "Unit Name";
-    public static String PROPERTY_SERIAL = "Serial Number";
 }

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/handler/DanfossAirUnitHandler.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/handler/DanfossAirUnitHandler.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.danfossairunit.internal.handler;
 
-import static org.openhab.binding.danfossairunit.internal.DanfossAirUnitBindingConstants.*;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -184,8 +182,8 @@ public class DanfossAirUnitHandler extends BaseThingHandler {
 
         try {
             Map<String, String> properties = new HashMap<>(2);
-            properties.put(PROPERTY_UNIT_NAME, localAirUnit.getUnitName());
-            properties.put(PROPERTY_SERIAL, localAirUnit.getUnitSerialNumber());
+            properties.put(Thing.PROPERTY_MODEL_ID, localAirUnit.getUnitName());
+            properties.put(Thing.PROPERTY_SERIAL_NUMBER, localAirUnit.getUnitSerialNumber());
             updateProperties(properties);
             propertiesInitializedSuccessfully = true;
             updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -17,8 +17,7 @@
 			<channel-group id="service" typeId="service"/>
 		</channel-groups>
 		<properties>
-			<property name="Unit Name">unknown</property>
-			<property name="Serial Number">unknown</property>
+			<property name="vendor">Danfoss</property>
 		</properties>
 		<config-description>
 			<parameter name="host" type="text" required="true">


### PR DESCRIPTION
Fixes #11991

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

This pull request was made for compliance with naming convention for properties in general and for specific property types in particular. Changes:
- **serialNumber** renamed from **Serial Number**.
- **modelId** renamed from **Unit Name**.
- **vendor** introduced.

Also fixed small issue with properties showing as **unknown** during startup.

There is a slight problem when upgrading to this version, but I wouldn't consider it a breaking change as it's only cosmetic. For things created from UI, there will be duplicate properties until thing is recreated.

![image](https://user-images.githubusercontent.com/19519842/148620881-686d6256-b3eb-412f-8595-4936cbb602a0.png)

For file-based configuration this problem is resolved by openHAB restart:

![image](https://user-images.githubusercontent.com/19519842/148620937-16b892a3-8d1a-4083-a9cf-d4dd9059eb09.png)
