### PR TITLE
[influxdb] Fix previous item state performance issues

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/Influx2FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/Influx2FilterCriteriaQueryCreatorImpl.java
@@ -87,17 +87,29 @@ public class Influx2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQuer
             flux = flux.filter(restrictions);
         }
 
-        if (criteria.getOrdering() != null) {
-            boolean desc = criteria.getOrdering() == FilterCriteria.Ordering.DESCENDING;
-            flux = flux.sort().withDesc(desc).withColumns(new String[] { COLUMN_TIME_NAME_V2 });
-        }
-
-        if (criteria.getPageSize() != Integer.MAX_VALUE) {
-            flux = flux.limit(criteria.getPageSize()).withPropertyValue("offset",
-                    criteria.getPageNumber() * criteria.getPageSize());
-        }
+        flux = applyOrderingAndPageSize(criteria, flux);
 
         return flux.toString();
+    }
+
+    private Flux applyOrderingAndPageSize(FilterCriteria criteria, Flux flux) {
+        var lastOptimization = criteria.getOrdering() == FilterCriteria.Ordering.DESCENDING
+                && criteria.getPageSize() == 1;
+
+        if (lastOptimization) {
+            flux = flux.last();
+        } else {
+            if (criteria.getOrdering() != null) {
+                boolean desc = criteria.getOrdering() == FilterCriteria.Ordering.DESCENDING;
+                flux = flux.sort().withDesc(desc).withColumns(new String[] { COLUMN_TIME_NAME_V2 });
+            }
+
+            if (criteria.getPageSize() != Integer.MAX_VALUE) {
+                flux = flux.limit(criteria.getPageSize()).withPropertyValue("offset",
+                        criteria.getPageNumber() * criteria.getPageSize());
+            }
+        }
+        return flux;
     }
 
     private String calculateMeasurementName(String itemName) {

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -168,6 +168,18 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                         + "|> sort(desc:false, columns:[\"_time\"])"));
     }
 
+    @Test
+    public void testPreviousState() {
+        FilterCriteria criteria = createBaseCriteria();
+        criteria.setOrdering(FilterCriteria.Ordering.DESCENDING);
+        criteria.setPageSize(1);
+        String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
+        assertThat(queryV2,
+                equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t" + "|> last()"));
+    }
+
     private FilterCriteria createBaseCriteria() {
         return createBaseCriteria(ITEM_NAME);
     }


### PR DESCRIPTION
Fix issue #11878 
Optimizing a filter with limit 1 and time descending order for `| last()`
More discussion in the issue thread