### PR TITLE
[http] Provide meaningful error messages

### DIFF
--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/HttpResponseListener.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/HttpResponseListener.java
@@ -61,7 +61,7 @@ public class HttpResponseListener extends BufferingResponseListener {
         Request request = result.getRequest();
         if (result.isFailed()) {
             logger.warn("Requesting '{}' (method='{}', content='{}') failed: {}", request.getURI(), request.getMethod(),
-                    request.getContent(), result.getFailure().getMessage());
+                    request.getContent(), result.getFailure().toString());
             future.complete(null);
         } else {
             switch (response.getStatus()) {


### PR DESCRIPTION
RIght now error messages of the HTTP-Binding look like this:

```
Requesting 'https://api.corona-zahlen.org/districts/03251' (method='GET', content='null') failed: HttpConnectionOverHTTP@d01aa55::DecryptedEndPoint@3eee00d9{l=/XXXXXXX:XXXX,r=api.corona-zahlen.org/104.21.60.139:443,OPEN,fill=-,flush=-,to=599158/0}
```

with this change they look like this:

```
Requesting 'https://api.corona-zahlen.org/districts/03251' (method='GET', content='null') failed: java.io.EOFException: HttpConnectionOverHTTP@d01aa55::DecryptedEndPoint@3eee00d9{l=/XXXXXXX:XXXX,r=api.corona-zahlen.org/104.21.60.139:443,OPEN,fill=-,flush=-,to=599158/0}
```

Not the added `java.io.EOFException: `, which explains what kind of exception actually happened.