### PR TITLE
[publictransportswitzerland] Add missing default translation properties

### DIFF
--- a/bundles/org.openhab.binding.publictransportswitzerland/src/main/resources/OH-INF/i18n/publictransportswitzerland.properties
+++ b/bundles/org.openhab.binding.publictransportswitzerland/src/main/resources/OH-INF/i18n/publictransportswitzerland.properties
@@ -1,0 +1,20 @@
+# binding
+
+binding.publictransportswitzerland.name = Public Transport Switzerland Binding
+binding.publictransportswitzerland.description = Connects to the "Swiss public transport API" to provide real-time public transport information.
+
+# thing types
+
+thing-type.publictransportswitzerland.stationboard.label = Stationboard
+thing-type.publictransportswitzerland.stationboard.description = Upcoming departures for a single station.
+
+# thing types config
+
+thing-type.config.publictransportswitzerland.stationboard.station.label = Station
+thing-type.config.publictransportswitzerland.stationboard.station.description = The name of the station
+
+# channel types
+
+channel-type.publictransportswitzerland.departure.label = Departure
+channel-type.publictransportswitzerland.departure.description = A single departure
+channel-type.publictransportswitzerland.tsv.label = Tab Separated Time Table


### PR DESCRIPTION
I just ran `mvn i18n:generate-default-translations`

As requested here: https://github.com/openhab/openhab-addons/pull/8540#issuecomment-1008285454