### PR TITLE
[mycroft] Init i18n

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -197,8 +197,8 @@
 /bundles/org.openhab.binding.mqtt.generic/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.homeassistant/ @davidgraeff @antroids
 /bundles/org.openhab.binding.mqtt.homie/ @davidgraeff
-/bundles/org.openhab.binding.myq/ @digitaldan
 /bundles/org.openhab.binding.mycroft/ @dalgwen
+/bundles/org.openhab.binding.myq/ @digitaldan
 /bundles/org.openhab.binding.mystrom/ @pail23
 /bundles/org.openhab.binding.nanoleaf/ @raepple @stefan-hoehn
 /bundles/org.openhab.binding.neato/ @jjlauterbach

--- a/bundles/org.openhab.binding.mycroft/src/main/resources/OH-INF/i18n/mycroft.properties
+++ b/bundles/org.openhab.binding.mycroft/src/main/resources/OH-INF/i18n/mycroft.properties
@@ -1,0 +1,34 @@
+# binding
+
+binding.mycroft.name = Mycroft Binding
+binding.mycroft.description = Connects to a Mycroft instance in order to receive information from, and send commands to it. Typical usage includes triggering Mycroft to listen (as if a wake word was detected), sending text for Mycroft to speak, reacting on some specific intent, command skills by faking a spoken utterance, etc.
+
+# thing types
+
+thing-type.mycroft.mycroft.label = Mycroft
+thing-type.mycroft.mycroft.description = A Mycroft instance
+
+# thing types config
+
+thing-type.config.mycroft.mycroft.host.label = Hostname
+thing-type.config.mycroft.mycroft.host.description = This is the host to connect to (ip or hostname)
+thing-type.config.mycroft.mycroft.port.label = Port
+thing-type.config.mycroft.mycroft.port.description = This is the port to connect to.
+thing-type.config.mycroft.mycroft.volume_restoration_level.label = Volume Restoration Level
+thing-type.config.mycroft.mycroft.volume_restoration_level.description = When unmuted, force Mycroft to restore volume to this value
+
+# channel types
+
+channel-type.mycroft.full-message-channel.label = Full Bus Message
+channel-type.mycroft.full-message-channel.description = The last full message seen on the Mycroft Bus.
+channel-type.mycroft.listen-channel.label = Listen State
+channel-type.mycroft.listen-channel.description = Switch to ON when Mycroft is listening. Can simulate a wake work detection to trigger the STT.
+channel-type.mycroft.speak-channel.label = TTS
+channel-type.mycroft.speak-channel.description = The last sentence Mycroft spoke.
+channel-type.mycroft.utterance-channel.label = Utterance
+channel-type.mycroft.utterance-channel.description = The last utterance Mycroft received.
+
+# channel types config
+
+channel-type.config.mycroft.full-message-channel.messageTypes.label = Full Message Channel Filter
+channel-type.config.mycroft.full-message-channel.messageTypes.description = The full message channel will be updated on these message types only (comma separated value)


### PR DESCRIPTION
As asked by @lolodomo in the [mycroft binding initial contrib merge request](https://github.com/openhab/openhab-addons/pull/11040#issuecomment-1009677928), this PR initialize the i18n default file.

(and by the way, reorder alphabetically the CODEOWNERS file)

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>