### PR TITLE
[jsscripting] Wrapped GraalJS ScriptEngines now also Autocloseable

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
@@ -18,7 +18,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.graalvm.polyglot.PolyglotException;
-import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocable;
+import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jonathan Gilbert - Initial contribution
  */
-class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable>
-        extends InvocationInterceptingScriptEngineWithInvocable<T> {
+class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoCloseable>
+        extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<T> {
 
     private static final Logger STACK_LOGGER = LoggerFactory
             .getLogger("org.openhab.automation.script.javascript.stack");

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -46,7 +46,7 @@ import org.openhab.automation.jsscripting.internal.fs.DelegatingFileSystem;
 import org.openhab.automation.jsscripting.internal.fs.PrefixedSeekableByteChannel;
 import org.openhab.automation.jsscripting.internal.fs.ReadOnlySeekableByteArrayChannel;
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
-import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocable;
+import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable;
 import org.openhab.core.automation.module.script.ScriptExtensionAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +59,8 @@ import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
  * @author Jonathan Gilbert - Initial contribution
  * @author Dan Cunningham - Script injections
  */
-public class OpenhabGraalJSScriptEngine extends InvocationInterceptingScriptEngineWithInvocable<GraalJSScriptEngine> {
+public class OpenhabGraalJSScriptEngine
+        extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<GraalJSScriptEngine> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenhabGraalJSScriptEngine.class);
     private static final String GLOBAL_REQUIRE = "require(\"@jsscripting-globals\");";

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/DelegatingScriptEngineWithInvocableAndAutocloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/DelegatingScriptEngineWithInvocableAndAutocloseable.java
@@ -28,11 +28,11 @@ import javax.script.ScriptException;
  *
  * @author Jonathan Gilbert - Initial contribution
  */
-public abstract class DelegatingScriptEngineWithInvocable<T extends ScriptEngine & Invocable>
-        implements ScriptEngine, Invocable {
+public abstract class DelegatingScriptEngineWithInvocableAndAutocloseable<T extends ScriptEngine & Invocable & AutoCloseable>
+        implements ScriptEngine, Invocable, AutoCloseable {
     protected T delegate;
 
-    public DelegatingScriptEngineWithInvocable(T delegate) {
+    public DelegatingScriptEngineWithInvocableAndAutocloseable(T delegate) {
         this.delegate = delegate;
     }
 
@@ -124,5 +124,10 @@ public abstract class DelegatingScriptEngineWithInvocable<T extends ScriptEngine
     @Override
     public <T> T getInterface(Object o, Class<T> aClass) {
         return delegate.getInterface(o, aClass);
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
@@ -28,10 +28,10 @@ import javax.script.ScriptException;
  * @param <T> The delegate class
  * @author Jonathan Gilbert - Initial contribution
  */
-public abstract class InvocationInterceptingScriptEngineWithInvocable<T extends ScriptEngine & Invocable>
-        extends DelegatingScriptEngineWithInvocable<T> {
+public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<T extends ScriptEngine & Invocable & AutoCloseable>
+        extends DelegatingScriptEngineWithInvocableAndAutocloseable<T> {
 
-    public InvocationInterceptingScriptEngineWithInvocable(T delegate) {
+    public InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable(T delegate) {
         super(delegate);
     }
 


### PR DESCRIPTION
Allows wrapped GraalJS scripts to also implement `AutoCloseable` so that they can be cleaned up when no longer used.

With https://github.com/openhab/openhab-core/pull/2681, fixes https://github.com/openhab/openhab-addons/issues/11952.

Note that these changes can be applied independently without issue, however both are required to fix the above issue.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>