### PR TITLE
[homekit] fix Fahrenheit conversion

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.io.homekit.internal.accessories;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -22,9 +20,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import javax.measure.Quantity;
-import javax.measure.Unit;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
@@ -32,8 +27,6 @@ import org.openhab.core.items.Item;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.StringType;
-import org.openhab.core.library.unit.ImperialUnits;
-import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.types.State;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
@@ -282,32 +275,13 @@ abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
         characteristics.add(characteristic);
     }
 
-    @NonNullByDefault
-    private <T extends Quantity<T>> double convertAndRound(double value, Unit<T> from, Unit<T> to) {
-        double rawValue = from.equals(to) ? value : from.getConverterTo(to).convert(value);
-        return new BigDecimal(rawValue).setScale(1, RoundingMode.HALF_UP).doubleValue();
-    }
-
-    @NonNullByDefault
-    protected double convertToCelsius(double degrees) {
-        return convertAndRound(degrees,
-                getSettings().useFahrenheitTemperature ? ImperialUnits.FAHRENHEIT : SIUnits.CELSIUS, SIUnits.CELSIUS);
-    }
-
-    @NonNullByDefault
-    protected double convertFromCelsius(double degrees) {
-        return convertAndRound(degrees,
-                getSettings().useFahrenheitTemperature ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT,
-                ImperialUnits.FAHRENHEIT);
-    }
-
     /**
      * create boolean reader with ON state mapped to trueOnOffValue or trueOpenClosedValue depending of item type
      *
      * @param characteristicType characteristic id
      * @param trueOnOffValue ON value for switch
      * @param trueOpenClosedValue ON value for contact
-     * @return boolean readed
+     * @return boolean read
      * @throws IncompleteAccessoryException
      */
     @NonNullByDefault

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitHeaterCoolerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitHeaterCoolerImpl.java
@@ -108,9 +108,12 @@ public class HomekitHeaterCoolerImpl extends AbstractHomekitAccessoryImpl implem
     public CompletableFuture<Double> getCurrentTemperature() {
         final @Nullable DecimalType state = getStateAs(HomekitCharacteristicType.CURRENT_TEMPERATURE,
                 DecimalType.class);
-        return CompletableFuture.completedFuture(state != null ? convertToCelsius(state.doubleValue())
+        return CompletableFuture.completedFuture(state != null
+                ? HomekitCharacteristicFactory.convertToCelsius(state.doubleValue())
                 : getAccessoryConfiguration(HomekitCharacteristicType.CURRENT_TEMPERATURE, HomekitTaggedItem.MIN_VALUE,
-                        BigDecimal.valueOf(CurrentTemperatureCharacteristic.DEFAULT_MIN_VALUE)).doubleValue());
+                        BigDecimal.valueOf(HomekitCharacteristicFactory
+                                .convertFromCelsius(CurrentTemperatureCharacteristic.DEFAULT_MIN_VALUE)))
+                                        .doubleValue());
     }
 
     @Override
@@ -151,7 +154,7 @@ public class HomekitHeaterCoolerImpl extends AbstractHomekitAccessoryImpl implem
 
     public CompletableFuture<TemperatureDisplayUnitEnum> getTemperatureDisplayUnit() {
         return CompletableFuture
-                .completedFuture(getSettings().useFahrenheitTemperature ? TemperatureDisplayUnitEnum.FAHRENHEIT
+                .completedFuture(HomekitCharacteristicFactory.useFahrenheit() ? TemperatureDisplayUnitEnum.FAHRENHEIT
                         : TemperatureDisplayUnitEnum.CELSIUS);
     }
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
@@ -25,6 +25,7 @@ import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
 import io.github.hapjava.accessories.TemperatureSensorAccessory;
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.thermostat.CurrentTemperatureCharacteristic;
 import io.github.hapjava.characteristics.impl.thermostat.TargetTemperatureCharacteristic;
 import io.github.hapjava.services.impl.TemperatureSensorService;
 
@@ -46,7 +47,8 @@ class HomekitTemperatureSensorImpl extends AbstractHomekitAccessoryImpl implemen
         final @Nullable DecimalType state = getStateAs(HomekitCharacteristicType.CURRENT_TEMPERATURE,
                 DecimalType.class);
         return CompletableFuture
-                .completedFuture(state != null ? convertToCelsius(state.doubleValue()) : getMinCurrentTemperature());
+                .completedFuture(state != null ? HomekitCharacteristicFactory.convertToCelsius(state.doubleValue())
+                        : getMinCurrentTemperature());
     }
 
     @Override
@@ -56,16 +58,23 @@ class HomekitTemperatureSensorImpl extends AbstractHomekitAccessoryImpl implemen
 
     @Override
     public double getMinCurrentTemperature() {
-        return convertToCelsius(
+        // Apple defines default values in Celsius. We need to convert them to Fahrenheit if openHAB is using Fahrenheit
+        // convertToCelsius and convertFromCelsius are only converting if useFahrenheit is set to true, so no additional
+        // check here needed
+        return HomekitCharacteristicFactory.convertToCelsius(
                 getAccessoryConfiguration(HomekitCharacteristicType.CURRENT_TEMPERATURE, HomekitTaggedItem.MIN_VALUE,
-                        BigDecimal.valueOf(TargetTemperatureCharacteristic.DEFAULT_MIN_VALUE)).doubleValue());
+                        BigDecimal.valueOf(HomekitCharacteristicFactory
+                                .convertFromCelsius(CurrentTemperatureCharacteristic.DEFAULT_MIN_VALUE)))
+                                        .doubleValue());
     }
 
     @Override
     public double getMaxCurrentTemperature() {
-        return convertToCelsius(
+        return HomekitCharacteristicFactory.convertToCelsius(
                 getAccessoryConfiguration(HomekitCharacteristicType.CURRENT_TEMPERATURE, HomekitTaggedItem.MAX_VALUE,
-                        BigDecimal.valueOf(TargetTemperatureCharacteristic.DEFAULT_MAX_VALUE)).doubleValue());
+                        BigDecimal.valueOf(HomekitCharacteristicFactory
+                                .convertFromCelsius(CurrentTemperatureCharacteristic.DEFAULT_MAX_VALUE)))
+                                        .doubleValue());
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import io.github.hapjava.accessories.ThermostatAccessory;
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.characteristics.impl.thermostat.CurrentHeatingCoolingStateEnum;
+import io.github.hapjava.characteristics.impl.thermostat.CurrentTemperatureCharacteristic;
 import io.github.hapjava.characteristics.impl.thermostat.TargetHeatingCoolingStateEnum;
 import io.github.hapjava.characteristics.impl.thermostat.TargetTemperatureCharacteristic;
 import io.github.hapjava.characteristics.impl.thermostat.TemperatureDisplayUnitEnum;
@@ -106,21 +107,31 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
     @Override
     public CompletableFuture<Double> getCurrentTemperature() {
         DecimalType state = getStateAs(HomekitCharacteristicType.CURRENT_TEMPERATURE, DecimalType.class);
-        return CompletableFuture.completedFuture(state != null ? convertToCelsius(state.doubleValue()) : 0.0);
+        return CompletableFuture
+                .completedFuture(state != null ? HomekitCharacteristicFactory.convertToCelsius(state.doubleValue())
+                        : getMinCurrentTemperature());
     }
 
     @Override
     public double getMinCurrentTemperature() {
-        return convertToCelsius(
+        // Apple defines default values in Celsius. We need to convert them to Fahrenheit if openHAB is using Fahrenheit
+        // convertToCelsius and convertFromCelsius are only converting if useFahrenheit is set to true, so no additional
+        // check here needed
+
+        return HomekitCharacteristicFactory.convertToCelsius(
                 getAccessoryConfiguration(HomekitCharacteristicType.CURRENT_TEMPERATURE, HomekitTaggedItem.MIN_VALUE,
-                        BigDecimal.valueOf(TargetTemperatureCharacteristic.DEFAULT_MIN_VALUE)).doubleValue());
+                        BigDecimal.valueOf(HomekitCharacteristicFactory
+                                .convertFromCelsius(CurrentTemperatureCharacteristic.DEFAULT_MIN_VALUE)))
+                                        .doubleValue());
     }
 
     @Override
     public double getMaxCurrentTemperature() {
-        return convertToCelsius(
+        return HomekitCharacteristicFactory.convertToCelsius(
                 getAccessoryConfiguration(HomekitCharacteristicType.CURRENT_TEMPERATURE, HomekitTaggedItem.MAX_VALUE,
-                        BigDecimal.valueOf(TargetTemperatureCharacteristic.DEFAULT_MAX_VALUE)).doubleValue());
+                        BigDecimal.valueOf(HomekitCharacteristicFactory
+                                .convertFromCelsius(CurrentTemperatureCharacteristic.DEFAULT_MAX_VALUE)))
+                                        .doubleValue());
     }
 
     @Override
@@ -138,7 +149,7 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
     @Override
     public CompletableFuture<TemperatureDisplayUnitEnum> getTemperatureDisplayUnit() {
         return CompletableFuture
-                .completedFuture(getSettings().useFahrenheitTemperature ? TemperatureDisplayUnitEnum.FAHRENHEIT
+                .completedFuture(HomekitCharacteristicFactory.useFahrenheit() ? TemperatureDisplayUnitEnum.FAHRENHEIT
                         : TemperatureDisplayUnitEnum.CELSIUS);
     }
 
@@ -150,7 +161,8 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
     @Override
     public CompletableFuture<Double> getTargetTemperature() {
         DecimalType state = getStateAs(HomekitCharacteristicType.TARGET_TEMPERATURE, DecimalType.class);
-        return CompletableFuture.completedFuture(state != null ? convertToCelsius(state.doubleValue()) : 0.0);
+        return CompletableFuture.completedFuture(
+                state != null ? HomekitCharacteristicFactory.convertToCelsius(state.doubleValue()) : 0.0);
     }
 
     @Override
@@ -165,7 +177,7 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
                 HomekitCharacteristicType.TARGET_TEMPERATURE);
         if (characteristic.isPresent()) {
             ((NumberItem) characteristic.get().getItem())
-                    .send(new DecimalType(BigDecimal.valueOf(convertFromCelsius(value))));
+                    .send(new DecimalType(BigDecimal.valueOf(HomekitCharacteristicFactory.convertFromCelsius(value))));
         } else {
             logger.warn("Missing mandatory characteristic {}", HomekitCharacteristicType.TARGET_TEMPERATURE);
         }
@@ -173,16 +185,24 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
 
     @Override
     public double getMinTargetTemperature() {
-        return convertToCelsius(
-                getAccessoryConfiguration(HomekitCharacteristicType.TARGET_TEMPERATURE, HomekitTaggedItem.MIN_VALUE,
-                        BigDecimal.valueOf(TargetTemperatureCharacteristic.DEFAULT_MIN_VALUE)).doubleValue());
+        return HomekitCharacteristicFactory
+                .convertToCelsius(
+                        getAccessoryConfiguration(HomekitCharacteristicType.TARGET_TEMPERATURE,
+                                HomekitTaggedItem.MIN_VALUE,
+                                BigDecimal.valueOf(HomekitCharacteristicFactory
+                                        .convertFromCelsius(TargetTemperatureCharacteristic.DEFAULT_MIN_VALUE)))
+                                                .doubleValue());
     }
 
     @Override
     public double getMaxTargetTemperature() {
-        return convertToCelsius(
-                getAccessoryConfiguration(HomekitCharacteristicType.TARGET_TEMPERATURE, HomekitTaggedItem.MAX_VALUE,
-                        BigDecimal.valueOf(TargetTemperatureCharacteristic.DEFAULT_MAX_VALUE)).doubleValue());
+        return HomekitCharacteristicFactory
+                .convertToCelsius(
+                        getAccessoryConfiguration(HomekitCharacteristicType.TARGET_TEMPERATURE,
+                                HomekitTaggedItem.MAX_VALUE,
+                                BigDecimal.valueOf(HomekitCharacteristicFactory
+                                        .convertFromCelsius(TargetTemperatureCharacteristic.DEFAULT_MAX_VALUE)))
+                                                .doubleValue());
     }
 
     @Override


### PR DESCRIPTION
Apple HomeKit protocol  works internally with Celsius for temperature, so that we need to convert temperature in case openHAB is using Fahrenheit. this was already implemented for actual temperature values but not for temperature threshold and min/max values 

This PR add temperature conversion to thresholds and min/max values and fixes 
#11957
#10275

the existing methods convertFromCelsius and convertToCelsius are moved from abstract class to a factory so that they can be used from different places. 

these methods read binding setting "useFahrenheit" via OSGI service as settings could not be injected into factory or propagated to it easily. 

Signed-off-by: Eugen Freiter <freiter@gmx.de>

