### PR TITLE
[hdpowerview] Fix SAT warnings

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -29,6 +29,7 @@ import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeMove;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeStop;
 import org.openhab.binding.hdpowerview.internal.api.responses.FirmwareVersion;
+import org.openhab.binding.hdpowerview.internal.api.responses.FirmwareVersions;
 import org.openhab.binding.hdpowerview.internal.api.responses.SceneCollections;
 import org.openhab.binding.hdpowerview.internal.api.responses.Scenes;
 import org.openhab.binding.hdpowerview.internal.api.responses.ScheduledEvents;
@@ -130,15 +131,23 @@ public class HDPowerViewWebTargets {
     /**
      * Fetches a JSON package with firmware information for the hub.
      *
-     * @return FirmwareVersion class instance
+     * @return FirmwareVersions class instance
      * @throws JsonParseException if there is a JSON parsing error
      * @throws HubProcessingException if there is any processing error
      * @throws HubMaintenanceException if the hub is down for maintenance
      */
-    public @Nullable FirmwareVersion getFirmwareVersion()
+    public FirmwareVersions getFirmwareVersions()
             throws JsonParseException, HubProcessingException, HubMaintenanceException {
         String json = invoke(HttpMethod.GET, firmwareVersion, null, null);
-        return gson.fromJson(json, FirmwareVersion.class);
+        FirmwareVersion firmwareVersion = gson.fromJson(json, FirmwareVersion.class);
+        if (firmwareVersion == null) {
+            throw new JsonParseException("Missing firmware response");
+        }
+        FirmwareVersions firmwareVersions = firmwareVersion.firmware;
+        if (firmwareVersions == null) {
+            throw new JsonParseException("Missing 'firmware' element");
+        }
+        return firmwareVersions;
     }
 
     /**

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Firmware.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Firmware.java
@@ -12,12 +12,17 @@
  */
 package org.openhab.binding.hdpowerview.internal.api;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Firmware version information for HD PowerView components
  *
  * @author Jacob Laursen - Initial contribution
  */
+@NonNullByDefault
 public class Firmware {
+    @Nullable
     public String name;
     public int revision;
     public int subRevision;

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersion.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersion.java
@@ -12,11 +12,16 @@
  */
 package org.openhab.binding.hdpowerview.internal.api.responses;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Firmware information for an HD PowerView hub
  *
  * @author Jacob Laursen - Initial contribution
  */
+@NonNullByDefault
 public class FirmwareVersion {
+    @Nullable
     public FirmwareVersions firmware;
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersions.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/FirmwareVersions.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.hdpowerview.internal.api.responses;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.hdpowerview.internal.api.Firmware;
 
 /**
@@ -19,7 +21,10 @@ import org.openhab.binding.hdpowerview.internal.api.Firmware;
  *
  * @author Jacob Laursen - Initial contribution
  */
+@NonNullByDefault
 public class FirmwareVersions {
+    @Nullable
     public Firmware mainProcessor;
+    @Nullable
     public Firmware radio;
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Survey.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Survey.java
@@ -15,6 +15,9 @@ package org.openhab.binding.hdpowerview.internal.api.responses;
 import java.util.List;
 import java.util.StringJoiner;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -22,9 +25,11 @@ import com.google.gson.annotations.SerializedName;
  *
  * @author Jacob Laursen - Initial contribution
  */
+@NonNullByDefault
 public class Survey {
     @SerializedName("shade_id")
     public int shadeId;
+    @Nullable
     @SerializedName("survey")
     public List<SurveyData> surveyData;
 
@@ -41,6 +46,7 @@ public class Survey {
 
     @Override
     public String toString() {
+        List<SurveyData> surveyData = this.surveyData;
         if (surveyData == null) {
             return "{}";
         }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -37,7 +37,6 @@ import org.openhab.binding.hdpowerview.internal.HDPowerViewWebTargets;
 import org.openhab.binding.hdpowerview.internal.HubMaintenanceException;
 import org.openhab.binding.hdpowerview.internal.HubProcessingException;
 import org.openhab.binding.hdpowerview.internal.api.Firmware;
-import org.openhab.binding.hdpowerview.internal.api.responses.FirmwareVersion;
 import org.openhab.binding.hdpowerview.internal.api.responses.FirmwareVersions;
 import org.openhab.binding.hdpowerview.internal.api.responses.SceneCollections;
 import org.openhab.binding.hdpowerview.internal.api.responses.SceneCollections.SceneCollection;
@@ -286,13 +285,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
         if (webTargets == null) {
             throw new ProcessingException("Web targets not initialized");
         }
-        FirmwareVersion firmwareVersion = webTargets.getFirmwareVersion();
-        FirmwareVersions firmwareVersions = firmwareVersion != null ? firmwareVersion.firmware : null;
-        if (firmwareVersions == null) {
-            logger.warn("Unable to get firmware version.");
-            return;
-        }
-        this.firmwareVersions = firmwareVersions;
+        FirmwareVersions firmwareVersions = webTargets.getFirmwareVersions();
         Firmware mainProcessor = firmwareVersions.mainProcessor;
         if (mainProcessor == null) {
             logger.warn("Main processor firmware version missing in response.");

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -287,23 +287,25 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
             throw new ProcessingException("Web targets not initialized");
         }
         FirmwareVersion firmwareVersion = webTargets.getFirmwareVersion();
-        if (firmwareVersion == null || firmwareVersion.firmware == null) {
+        FirmwareVersions firmwareVersions = firmwareVersion != null ? firmwareVersion.firmware : null;
+        if (firmwareVersions == null) {
             logger.warn("Unable to get firmware version.");
             return;
         }
-        this.firmwareVersions = firmwareVersion.firmware;
-        Firmware mainProcessor = firmwareVersion.firmware.mainProcessor;
+        this.firmwareVersions = firmwareVersions;
+        Firmware mainProcessor = firmwareVersions.mainProcessor;
         if (mainProcessor == null) {
             logger.warn("Main processor firmware version missing in response.");
             return;
         }
         logger.debug("Main processor firmware version received: {}, {}", mainProcessor.name, mainProcessor.toString());
         Map<String, String> properties = editProperties();
-        if (mainProcessor.name != null) {
-            properties.put(HDPowerViewBindingConstants.PROPERTY_FIRMWARE_NAME, mainProcessor.name);
+        String mainProcessorName = mainProcessor.name;
+        if (mainProcessorName != null) {
+            properties.put(HDPowerViewBindingConstants.PROPERTY_FIRMWARE_NAME, mainProcessorName);
         }
         properties.put(Thing.PROPERTY_FIRMWARE_VERSION, mainProcessor.toString());
-        Firmware radio = firmwareVersion.firmware.radio;
+        Firmware radio = firmwareVersions.radio;
         if (radio != null) {
             logger.debug("Radio firmware version received: {}", radio.toString());
             properties.put(HDPowerViewBindingConstants.PROPERTY_RADIO_FIRMWARE_VERSION, radio.toString());


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fixes #12027 

Changes done:
1. Fix SAT warnings about missing `@NonNullByDefault` annotations on classes.

Next steps (in context of new PR):
1. Refactor error handling: Throw exception if contract is breached.
2. Consider separating deserialization classes so they are not exposed directly to handlers (with `@Nullable` when contract doesn't allow this). Or find other way to make sure handlers are not bloated with null handling which shouldn't be needed for valid responses.