### PR TITLE
[knx] Update README.md

### DIFF
--- a/bundles/org.openhab.binding.knx/README.md
+++ b/bundles/org.openhab.binding.knx/README.md
@@ -264,7 +264,7 @@ Bridge knx:ip:bridge [
         Type rollershutter : demoRollershutter "Shade"       [ upDown="4/3/50+4/3/51", stopMove="4/3/52+4/3/53", position="4/3/54+<4/3/55" ]
         Type contact       : demoContact       "Door"        [ ga="1.019:<5/1/2" ]
         Type number        : demoTemperature   "Temperature" [ ga="9.001:<5/0/0" ]
-        Type dimmer        : demoDimmer        "Dimmer"      [ switch="5/0/0+<5/0/1", position="5/0/2+<5/0/3", increaseDecrease="5/0/4" ]
+        Type dimmer        : demoDimmer        "Dimmer"      [ switch="5/0/0", position="5/0/2+<5/0/3", increaseDecrease="5/0/4" ]
         Type string        : demoString        "Message"     [ ga="5/3/1" ]
         Type datetime      : demoDatetime      "Alarm"       [ ga="5/5/42" ]
     }


### PR DESCRIPTION
Changed Example of Dimmer channel. Makes no sense to provide both Switch and Position Status in configuration, as an update of Switch Status will delete Position and vice versa. Position Status makes sense.