### PR TITLE
[groovyscripting] add conf/automation/groovy to the classpath

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -37,8 +37,8 @@ import groovy.lang.GroovyClassLoader;
 @NonNullByDefault
 public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
 
-    private final org.codehaus.groovy.jsr223.GroovyScriptEngineFactory factory = new org.codehaus.groovy.jsr223.GroovyScriptEngineFactory();
     private static final String FILE_DIRECTORY = "automation" + File.separator + "groovy";
+    private final org.codehaus.groovy.jsr223.GroovyScriptEngineFactory factory = new org.codehaus.groovy.jsr223.GroovyScriptEngineFactory();
 
     private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(), factory.getMimeTypes())
             .flatMap(List::stream) //
@@ -48,7 +48,7 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     public GroovyScriptEngineFactory() {
         String scriptDir = OpenHAB.getConfigFolder() + File.separator + FILE_DIRECTORY;
-        logger.info("Adding script directory {} to the GroovyScriptEngine class path.", scriptDir);
+        logger.debug("Adding script directory {} to the GroovyScriptEngine class path.", scriptDir);
         gcl.addClasspath(scriptDir);
     }
 

--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -45,10 +45,11 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
             .collect(Collectors.toUnmodifiableList());
 
     private final GroovyClassLoader gcl = new GroovyClassLoader();
+
     public GroovyScriptEngineFactory() {
         String scriptDir = OpenHAB.getConfigFolder() + File.separator + FILE_DIRECTORY;
         logger.info("Adding script directory {} to the GroovyScriptEngine class path.", scriptDir);
-        gcl.addClasspath (scriptDir);
+        gcl.addClasspath(scriptDir);
     }
 
     @Override
@@ -58,7 +59,7 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     @Override
     public @Nullable ScriptEngine createScriptEngine(String scriptType) {
-        if(scriptTypes.contains(scriptType)) {
+        if (scriptTypes.contains(scriptType)) {
             return new org.codehaus.groovy.jsr223.GroovyScriptEngineImpl(gcl);
         }
         return null;

--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.automation.groovyscripting.internal;
 
+import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -20,9 +21,12 @@ import javax.script.ScriptEngine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.osgi.service.component.annotations.Component;
+
+import groovy.lang.GroovyClassLoader;
 
 /**
  * This is an implementation of a {@link ScriptEngineFactory} for Groovy.
@@ -34,10 +38,18 @@ import org.osgi.service.component.annotations.Component;
 public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     private final org.codehaus.groovy.jsr223.GroovyScriptEngineFactory factory = new org.codehaus.groovy.jsr223.GroovyScriptEngineFactory();
+    private static final String FILE_DIRECTORY = "automation" + File.separator + "groovy";
 
     private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(), factory.getMimeTypes())
             .flatMap(List::stream) //
             .collect(Collectors.toUnmodifiableList());
+
+    private final GroovyClassLoader gcl = new GroovyClassLoader();
+    public GroovyScriptEngineFactory() {
+        String scriptDir = OpenHAB.getConfigFolder() + File.separator + FILE_DIRECTORY;
+        logger.info("Adding script directory {} to the GroovyScriptEngine class path.", scriptDir);
+        gcl.addClasspath (scriptDir);
+    }
 
     @Override
     public List<String> getScriptTypes() {
@@ -46,6 +58,9 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     @Override
     public @Nullable ScriptEngine createScriptEngine(String scriptType) {
-        return scriptTypes.contains(scriptType) ? factory.getScriptEngine() : null;
+        if(scriptTypes.contains(scriptType)) {
+            return new org.codehaus.groovy.jsr223.GroovyScriptEngineImpl(gcl);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This change adds `conf/automation/groovy` to the `GroovyScriptEngineFactory`-classpath
It enables you to create own classes under that path, which can be imported in jsr223-groovy-scripts
The jsr223-path is **not used**, because the `GroovyClassLoader` takes care of the evaluation of the files.

Example from https://community.openhab.org/t/groovy-scripts-how-to-import-another-groovy-file/105447/17

The following works, when you place your packages under **conf/automation/groovy/**

`$ cat conf/automation/groovy/mytest/Util.groovy `
```groovy
package mytest

class Util {
    public static String getHello() {
        return "Hello world!"
    }
}
```
`$ cat conf/automation/jsr223/test.groovy`
```groovy
import mytest.Util   // <-------- HERE IT IS
import org.slf4j.Logger
import org.slf4j.LoggerFactory

def logger = LoggerFactory.getLogger("org.openhab.core.automation.examples")
def cl = getClass().classLoader

logger.info "classloader1 {} {}", cl, cl.classPath
logger.info "classloader2 {} {}", cl.parent, cl.parent.classPath
logger.info "classloader3 {}", cl.parent.parent

logger.info "mytest.Util.hello -> {}", Util.hello
```
**OUTPUT**
```
[INFO ] [rulesupport.loader.ScriptFileWatcher] - Loading script '/srv/openhab2/conf/automation/jsr223/test.groovy'
[INFO ] [org.openhab.core.automation.examples] - classloader1 groovy.lang.GroovyClassLoader$InnerLoader@136e750b [/srv/openhab/conf/automation/groovy/]
[INFO ] [org.openhab.core.automation.examples] - classloader2 groovy.lang.GroovyClassLoader@11869d70 [/srv/openhab/conf/automation/groovy/]
[INFO ] [org.openhab.core.automation.examples] - classloader3 org.eclipse.osgi.internal.framework.ContextFinder@534a5a98
[INFO ] [org.openhab.core.automation.examples] - mytest.Util.hello -> Hello world!
```