### PR TITLE
Remove non-existing users from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -116,7 +116,7 @@
 /bundles/org.openhab.binding.haywardomnilogic/ @matchews
 /bundles/org.openhab.binding.hccrubbishcollection/ @cossey
 /bundles/org.openhab.binding.hdanywhere/ @kgoderis
-/bundles/org.openhab.binding.hdpowerview/ @beowulfe @jlaur @andrewfg
+/bundles/org.openhab.binding.hdpowerview/ @andylintner @jlaur @andrewfg
 /bundles/org.openhab.binding.helios/ @kgoderis
 /bundles/org.openhab.binding.heliosventilation/ @ramack
 /bundles/org.openhab.binding.heos/ @Wire82
@@ -351,7 +351,7 @@
 /bundles/org.openhab.binding.yioremote/ @miloit
 /bundles/org.openhab.binding.zoneminder/ @mhilbush
 /bundles/org.openhab.binding.zway/ @pathec
-/bundles/org.openhab.io.homekit/ @beowulfe @yfre
+/bundles/org.openhab.io.homekit/ @andylintner @yfre
 /bundles/org.openhab.io.hueemulation/ @davidgraeff @digitaldan
 /bundles/org.openhab.io.imperihome/ @pdegeus
 /bundles/org.openhab.io.metrics/ @pravussum


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

I did a check for registered code owners who no longer exists as GitHub users. Only a single user hit came up. I have no background information about why he disappeared but can confirm that for the **hdpowerview** binding there has been no activity for a long time.

```
#!/usr/bin/python3

import requests

github_user = ''
github_token = ''
github_root = 'https://api.github.com'

file = open('CODEOWNERS', 'r')
lines = file.readlines()
file.close()

headers = {
        'User-Agent': github_user,
        'Authorization': 'token ' + github_token
}

for line in lines:
        if line[0:9] == "/bundles/":
                parsed_line = line.split()
                for idx, val in enumerate(parsed_line):
                        if idx == 0:
                                binding = val
                        else:
                                user = val.lstrip('@')
                                if user == "openhab/add-ons-maintainers":
                                        continue
                                url = github_root + '/users/' + user
                                response = requests.get(url, headers=headers)
                                if response.status_code == 404:
                                        print(binding + ": User " + user + " does not exist.")
```

Result:
```
$ ./check_codeowners.py
/bundles/org.openhab.binding.hdpowerview/: User beowulfe does not exist.
/bundles/org.openhab.io.homekit/: User beowulfe does not exist.
```