### PR TITLE
Upgrade to Karaf 4.3.6

### DIFF
--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -40,7 +40,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.binding.astro;version='[3.3.0,3.3.1)',\
@@ -50,4 +49,5 @@ Fragment-Host: org.openhab.binding.astro
 	org.openhab.core.config.discovery;version='[3.3.0,3.3.1)',\
 	org.openhab.core.io.console;version='[3.3.0,3.3.1)',\
 	org.openhab.core.storage.json;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -36,8 +36,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	org.apache.xbean.bundleutils;version='[4.19.0,4.19.1)',\
-	org.apache.xbean.finder;version='[4.19.0,4.19.1)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -62,7 +60,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
@@ -75,4 +72,7 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.openhab.core.io.console;version='[3.3.0,3.3.1)',\
 	org.openhab.core.io.net;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
+	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
+	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -39,8 +39,6 @@ Fragment-Host: org.openhab.binding.feed
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	org.apache.xbean.bundleutils;version='[4.19.0,4.19.1)',\
-	org.apache.xbean.finder;version='[4.19.0,4.19.1)',\
 	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -59,7 +57,6 @@ Fragment-Host: org.openhab.binding.feed
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.23,7.3.24)',\
@@ -75,4 +72,7 @@ Fragment-Host: org.openhab.binding.feed
 	org.openhab.core.io.console;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
+	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -40,8 +40,6 @@ Fragment-Host: org.openhab.binding.hue
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	org.apache.xbean.bundleutils;version='[4.19.0,4.19.1)',\
-	org.apache.xbean.finder;version='[4.19.0,4.19.1)',\
 	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
@@ -63,7 +61,6 @@ Fragment-Host: org.openhab.binding.hue
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
@@ -79,4 +76,7 @@ Fragment-Host: org.openhab.binding.hue
 	org.openhab.core.io.net;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
+	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.binding.max
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.binding.max;version='[3.3.0,3.3.1)',\
@@ -66,4 +65,5 @@ Fragment-Host: org.openhab.binding.max
 	org.openhab.core.io.console;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
@@ -33,8 +33,6 @@ Fragment-Host: org.openhab.binding.mielecloud
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	org.apache.xbean.bundleutils;version='[4.19.0,4.19.1)',\
-	org.apache.xbean.finder;version='[4.19.0,4.19.1)',\
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.jsr-305;version='[3.0.2,3.0.3)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
@@ -66,7 +64,6 @@ Fragment-Host: org.openhab.binding.mielecloud
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.23,7.3.24)',\
@@ -85,4 +82,7 @@ Fragment-Host: org.openhab.binding.mielecloud
 	org.openhab.core.io.net;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
+	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -60,7 +60,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.binding.modbus;version='[3.3.0,3.3.1)',\
@@ -75,4 +74,5 @@ Fragment-Host: org.openhab.binding.modbus
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
-	org.openhab.core.transform;version='[3.3.0,3.3.1)'
+	org.openhab.core.transform;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -49,8 +49,6 @@ Fragment-Host: org.openhab.binding.nest
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	org.apache.xbean.bundleutils;version='[4.19.0,4.19.1)',\
-	org.apache.xbean.finder;version='[4.19.0,4.19.1)',\
 	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
@@ -86,7 +84,6 @@ Fragment-Host: org.openhab.binding.nest
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.3.23,7.3.24)',\
@@ -104,4 +101,7 @@ Fragment-Host: org.openhab.binding.nest
 	org.openhab.core.io.net;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
+	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -57,7 +57,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.binding.ntp;version='[3.3.0,3.3.1)',\
@@ -70,4 +69,5 @@ Fragment-Host: org.openhab.binding.ntp
 	org.openhab.core.io.console;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -60,7 +60,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.binding.systeminfo;version='[3.3.0,3.3.1)',\
@@ -73,4 +72,5 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.openhab.core.io.console;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -61,7 +61,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.binding.tradfri;version='[3.3.0,3.3.1)',\
@@ -76,4 +75,5 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.openhab.core.io.transport.mdns;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -39,8 +39,6 @@ Fragment-Host: org.openhab.binding.wemo
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	org.apache.xbean.bundleutils;version='[4.19.0,4.19.1)',\
-	org.apache.xbean.finder;version='[4.19.0,4.19.1)',\
 	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
@@ -66,7 +64,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
@@ -83,4 +80,7 @@ Fragment-Host: org.openhab.binding.wemo
 	org.openhab.core.io.transport.upnp;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
-	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)'
+	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
+	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
+	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -49,7 +49,6 @@ Fragment-Host: org.openhab.persistence.mapdb
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.openhab.core;version='[3.3.0,3.3.1)',\
@@ -57,4 +56,5 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.openhab.core.persistence;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.persistence.mapdb;version='[3.3.0,3.3.1)',\
-	org.openhab.persistence.mapdb.tests;version='[3.3.0,3.3.1)'
+	org.openhab.persistence.mapdb.tests;version='[3.3.0,3.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.5</jackson.version>
-    <karaf.version>4.3.4</karaf.version>
+    <karaf.version>4.3.6</karaf.version>
     <netty.version>4.1.72.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
     <sat.version>0.12.0</sat.version>


### PR DESCRIPTION
* Syncs the karaf.version so the new Maven plugin is used
* Resolves itest runbundles for the new runtime dependencies

---

Related to openhab/openhab-distro#1363