### PR TITLE
[androiddebugbridge] fix getting current package on android 11

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -191,7 +191,7 @@ public class AndroidDebugBridgeDevice {
 
     public String getCurrentPackage() throws AndroidDebugBridgeDeviceException, InterruptedException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
-        var out = runAdbShell("dumpsys", "window", "windows", "|", "grep", "mFocusedApp");
+        var out = runAdbShell("dumpsys", "window", "displays", "|", "grep", "mFocusedApp");
         var targetLine = Arrays.stream(out.split("\n")).findFirst().orElse("");
         var lineParts = targetLine.split(" ");
         if (lineParts.length >= 2) {


### PR DESCRIPTION
* NVIDIA SHIELD was updated to Android 11 which introduced changes to the dumpsys command.
  "windows" is now "displays", which when trying to use this binding without adjusting accordingly
  openhab reports back "that it cannot find the current package name". Adjusting the getCurrentPackage() function to use "displays" instead of "windows" resolves this.

* TODO: This change breaks the GetCurrentPackage feature on devices running anything lower then
  android 11. Figure out the best way to approach this. running "getprop ro.build.version"
  before every command should work but there should be a better way.

* TODO: Volume control via adb has been completely reworked. mainly the
  media_session command. Might not be abler to do this the way we have been
  Will revisit at a later date. (Volume via ADB never worked well for me anyways)

# Title

[androiddebugbridge] fix getting current package on android 11

# Description

I've been aware of this bug since mid December when NVIDIA aciidently released the recovery images for the new Android 11 build a bit early but now that the OTA is official I'm sure we will see more complaints now. In A11 google changed some things with the dumpsys commands and "dumpsys window | windows" no longer works because they changed "windows" to "displays" a simple change of this resolves this. But we need to address the new issue of how to handle devices on different android versions. I know from working on android custom roms that we could always run "getprop ro.build.version | grep 'android-11' before each command but I was woner if anyone has a better idea. This is my first PR in a real long time so go easy on me. 
