### PR TITLE
[oppo] Fix Play Mode and Disc Type updates

### DIFF
--- a/bundles/org.openhab.binding.oppo/README.md
+++ b/bundles/org.openhab.binding.oppo/README.md
@@ -279,7 +279,8 @@ M3D 3D Show/hide the 2D-to-3D Conversion or 3D adjustment menu
 SEH Display the Picture Adjustment menu  
 DRB Display the Darbee Adjustment menu  
 
-#### Extra buttons on UDP models:  
+#### Extra buttons on UDP models:
+
 HDR Display the HDR selection menu  
 INH Show on-screen detailed information  
 RLH Set resolution to Auto  

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoBindingConstants.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoBindingConstants.java
@@ -119,6 +119,7 @@ public class OppoBindingConstants {
     public static final String QHD = "QHD";
     public static final String QHR = "QHR";
 
+    public static final String UNKNOW_DISC = "UNKNOW-DISC";
     public static final String NO_DISC = "NO DISC";
     public static final String LOADING = "LOADING";
     public static final String OPEN = "OPEN";

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/communication/OppoStatusCodes.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/communication/OppoStatusCodes.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.oppo.internal.communication;
 
+import static org.openhab.binding.oppo.internal.OppoBindingConstants.*;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,5 +55,37 @@ public class OppoStatusCodes {
         ZOOM_MODE.put("10", "1/2");
         ZOOM_MODE.put("11", "1/3");
         ZOOM_MODE.put("12", "1/4");
+    }
+
+    // map to lookup disc type
+    public static final Map<String, String> DISC_TYPE = new HashMap<>();
+    static {
+        DISC_TYPE.put("BDMV", "BD-MV");
+        DISC_TYPE.put("DVDV", "DVD-VIDEO");
+        DISC_TYPE.put("DVDA", "DVD-AUDIO");
+        DISC_TYPE.put("SACD", "SACD");
+        DISC_TYPE.put("CDDA", "CDDA");
+        DISC_TYPE.put("HDCD", "HDCD");
+        DISC_TYPE.put("DATA", "DATA-DISC");
+        DISC_TYPE.put("VCD2", "VCD2");
+        DISC_TYPE.put("SVCD", "SVCD");
+        DISC_TYPE.put("UHBD", "UHBD");
+        DISC_TYPE.put("UNKN", UNKNOW_DISC);
+    }
+
+    // map to lookup playback status
+    public static final Map<String, String> PLAYBACK_STATUS = new HashMap<>();
+    static {
+        PLAYBACK_STATUS.put("DISC", "NO DISC");
+        PLAYBACK_STATUS.put("LOAD", "LOADING");
+        PLAYBACK_STATUS.put("OPEN", "OPEN");
+        PLAYBACK_STATUS.put("CLOS", "CLOSE");
+        PLAYBACK_STATUS.put("PLAY", "PLAY");
+        PLAYBACK_STATUS.put("PAUS", "PAUSE");
+        PLAYBACK_STATUS.put("STOP", "STOP");
+        PLAYBACK_STATUS.put("HOME", "HOME MENU");
+        PLAYBACK_STATUS.put("MCTR", "MEDIA CENTER");
+        PLAYBACK_STATUS.put("SCSV", "SCREEN SAVER");
+        PLAYBACK_STATUS.put("MENU", "DISC MENU");
     }
 }

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/communication/OppoStatusCodes.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/communication/OppoStatusCodes.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.oppo.internal.communication;
 
+import static java.util.Map.entry;
 import static org.openhab.binding.oppo.internal.OppoBindingConstants.*;
 
 import java.util.HashMap;
@@ -58,34 +59,14 @@ public class OppoStatusCodes {
     }
 
     // map to lookup disc type
-    public static final Map<String, String> DISC_TYPE = new HashMap<>();
-    static {
-        DISC_TYPE.put("BDMV", "BD-MV");
-        DISC_TYPE.put("DVDV", "DVD-VIDEO");
-        DISC_TYPE.put("DVDA", "DVD-AUDIO");
-        DISC_TYPE.put("SACD", "SACD");
-        DISC_TYPE.put("CDDA", "CDDA");
-        DISC_TYPE.put("HDCD", "HDCD");
-        DISC_TYPE.put("DATA", "DATA-DISC");
-        DISC_TYPE.put("VCD2", "VCD2");
-        DISC_TYPE.put("SVCD", "SVCD");
-        DISC_TYPE.put("UHBD", "UHBD");
-        DISC_TYPE.put("UNKN", UNKNOW_DISC);
-    }
+    public static final Map<String, String> DISC_TYPE = Map.ofEntries(entry("BDMV", "BD-MV"),
+            entry("DVDV", "DVD-VIDEO"), entry("DVDA", "DVD-AUDIO"), entry("SACD", "SACD"), entry("CDDA", "CDDA"),
+            entry("HDCD", "HDCD"), entry("DATA", "DATA-DISC"), entry("VCD2", "VCD2"), entry("SVCD", "SVCD"),
+            entry("UHBD", "UHBD"), entry("UNKN", UNKNOW_DISC));
 
     // map to lookup playback status
-    public static final Map<String, String> PLAYBACK_STATUS = new HashMap<>();
-    static {
-        PLAYBACK_STATUS.put("DISC", "NO DISC");
-        PLAYBACK_STATUS.put("LOAD", "LOADING");
-        PLAYBACK_STATUS.put("OPEN", "OPEN");
-        PLAYBACK_STATUS.put("CLOS", "CLOSE");
-        PLAYBACK_STATUS.put("PLAY", "PLAY");
-        PLAYBACK_STATUS.put("PAUS", "PAUSE");
-        PLAYBACK_STATUS.put("STOP", "STOP");
-        PLAYBACK_STATUS.put("HOME", "HOME MENU");
-        PLAYBACK_STATUS.put("MCTR", "MEDIA CENTER");
-        PLAYBACK_STATUS.put("SCSV", "SCREEN SAVER");
-        PLAYBACK_STATUS.put("MENU", "DISC MENU");
-    }
+    public static final Map<String, String> PLAYBACK_STATUS = Map.ofEntries(entry("DISC", "NO DISC"),
+            entry("LOAD", "LOADING"), entry("OPEN", "OPEN"), entry("CLOS", "CLOSE"), entry("PLAY", "PLAY"),
+            entry("PAUS", "PAUSE"), entry("STOP", "STOP"), entry("HOME", "HOME MENU"), entry("MCTR", "MEDIA CENTER"),
+            entry("SCSV", "SCREEN SAVER"), entry("MENU", "DISC MENU"));
 }

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -518,7 +518,7 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         // try to normalize the slightly different responses between UDT and QDT
                         final String discType = OppoStatusCodes.DISC_TYPE.get(updateData);
                         currentDiscType = (discType != null ? discType : updateData);
-                        updateChannelState(CHANNEL_DISC_TYPE, (discType != null ? discType : updateData));
+                        updateChannelState(CHANNEL_DISC_TYPE, currentDiscType);
                         break;
                     case UAT:
                         // we got the audio type status update, throw it away

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -456,11 +456,6 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         // example: 0 BD-PLAYER, split off just the number
                         updateChannelState(CHANNEL_SOURCE, updateData.split(SPACE)[0]);
                         break;
-                    case UPL:
-                        // we got the playback status update, throw it away and call the query because the text output
-                        // is better
-                        connector.sendCommand(OppoCommand.QUERY_PLAYBACK_STATUS);
-                        break;
                     case QTK:
                         // example: 02/10, split off both numbers
                         String[] track = updateData.split(SLASH);
@@ -477,10 +472,17 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                             updateChannelState(CHANNEL_TOTAL_CHAPTER, chapter[1]);
                         }
                         break;
+                    case UPL:
                     case QPL:
+                        // try to normalize the slightly different responses between UPL and QPL
+                        String playStatus = OppoStatusCodes.PLAYBACK_STATUS.get(updateData);
+                        if (playStatus == null) {
+                            playStatus = updateData;
+                        }
+
                         // if playback has stopped, we have to zero out Time, Title and Track info and so on manually
-                        if (NO_DISC.equals(updateData) || LOADING.equals(updateData) || OPEN.equals(updateData)
-                                || CLOSE.equals(updateData) || STOP.equals(updateData)) {
+                        if (NO_DISC.equals(playStatus) || LOADING.equals(playStatus) || OPEN.equals(playStatus)
+                                || CLOSE.equals(playStatus) || STOP.equals(playStatus)) {
                             updateChannelState(CHANNEL_CURRENT_TITLE, ZERO);
                             updateChannelState(CHANNEL_TOTAL_TITLE, ZERO);
                             updateChannelState(CHANNEL_CURRENT_CHAPTER, ZERO);
@@ -489,15 +491,21 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                             updateChannelState(CHANNEL_AUDIO_TYPE, UNDEF);
                             updateChannelState(CHANNEL_SUBTITLE_TYPE, UNDEF);
                         }
-                        updateChannelState(CHANNEL_PLAY_MODE, updateData);
+                        updateChannelState(CHANNEL_PLAY_MODE, playStatus);
+
+                        // ejecting the disc does not produce a UDT message, so clear disc type manually
+                        if (OPEN.equals(playStatus) || NO_DISC.equals(playStatus)) {
+                            updateChannelState(CHANNEL_DISC_TYPE, UNKNOW_DISC);
+                            currentDiscType = BLANK;
+                        }
 
                         // if switching to play mode and not a CD then query the subtitle type...
                         // because if subtitles were on when playback stopped, they got nulled out above
                         // and the subtitle update message ("UST") is not sent when play starts like it is for audio
-                        if (PLAY.equals(updateData) && !CDDA.equals(currentDiscType)) {
+                        if (PLAY.equals(playStatus) && !CDDA.equals(currentDiscType)) {
                             connector.sendCommand(OppoCommand.QUERY_SUBTITLE_TYPE);
                         }
-                        currentPlayMode = updateData;
+                        currentPlayMode = playStatus;
                         break;
                     case QRP:
                         updateChannelState(CHANNEL_REPEAT_MODE, updateData);
@@ -506,16 +514,17 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         updateChannelState(CHANNEL_ZOOM_MODE, updateData);
                         break;
                     case UDT:
-                        // we got the disc type status update, throw it away
-                        // and call the query because the text output is better
-                        connector.sendCommand(OppoCommand.QUERY_DISC_TYPE);
                     case QDT:
-                        currentDiscType = updateData;
-                        updateChannelState(CHANNEL_DISC_TYPE, updateData);
+                        // try to normalize the slightly different responses between UDT and QDT
+                        final String discType = OppoStatusCodes.DISC_TYPE.get(updateData);
+                        currentDiscType = (discType != null ? discType : updateData);
+                        updateChannelState(CHANNEL_DISC_TYPE, (discType != null ? discType : updateData));
                         break;
                     case UAT:
                         // we got the audio type status update, throw it away
                         // and call the query because the text output is better
+                        // wait before sending the command to give the player time to catch up
+                        Thread.sleep(SLEEP_BETWEEN_CMD_MS);
                         connector.sendCommand(OppoCommand.QUERY_AUDIO_TYPE);
                         break;
                     case QAT:
@@ -524,6 +533,8 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                     case UST:
                         // we got the subtitle type status update, throw it away
                         // and call the query because the text output is better
+                        // wait before sending the command to give the player time to catch up
+                        Thread.sleep(SLEEP_BETWEEN_CMD_MS);
                         connector.sendCommand(OppoCommand.QUERY_SUBTITLE_TYPE);
                         break;
                     case QST:
@@ -563,7 +574,7 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         logger.debug("onNewMessageEvent: unhandled key {}, value: {}", key, updateData);
                         break;
                 }
-            } catch (OppoException e) {
+            } catch (OppoException | InterruptedException e) {
                 logger.debug("Exception processing event from player: {}", e.getMessage());
             }
         }


### PR DESCRIPTION
fixes issue #12064 
In some configurations, the player sends unsolicited updates but the update message is an abbreviated code when compared to the longer response provided by the query command that must used in other configurations. The previous strategy to immediately call the query command upon receiving an unsolicited update was flawed in that the query command sometimes provided an outdated value. This PR fixes the issue for Play Mode and Disc Type by mapping the abbreviated unsolicited update code to the values provided by the query command. For Audio Type and Subtitle Type, a slight delay was added before calling the query command.