### PR TITLE
[knx] GroupRead / SendToKNX fails with NullPointerException #12040

### DIFF
--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/client/AbstractKNXClient.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/client/AbstractKNXClient.java
@@ -54,6 +54,8 @@ import tuwien.auto.calimero.process.ProcessCommunicator;
 import tuwien.auto.calimero.process.ProcessCommunicatorImpl;
 import tuwien.auto.calimero.process.ProcessEvent;
 import tuwien.auto.calimero.process.ProcessListener;
+import tuwien.auto.calimero.secure.SecureApplicationLayer;
+import tuwien.auto.calimero.secure.Security;
 
 /**
  * KNX Client which encapsulates the communication with the KNX bus via the calimero libary.
@@ -192,7 +194,8 @@ public abstract class AbstractKNXClient implements NetworkLinkListener, KNXClien
             processCommunicator.addProcessListener(processListener);
             this.processCommunicator = processCommunicator;
 
-            ProcessCommunicationResponder responseCommunicator = new ProcessCommunicationResponder(link, null);
+            ProcessCommunicationResponder responseCommunicator = new ProcessCommunicationResponder(link,
+                    new SecureApplicationLayer(link, Security.defaultInstallation()));
             this.responseCommunicator = responseCommunicator;
 
             link.addLinkListener(this);


### PR DESCRIPTION
# [knx] Fix for the NullPointerException as described in issue #12040 

# Description

This PR fixes the `NullPointerException` that arises from *-control items when a `GroupValueRead` request is issued by the KNX side and openHAB tries to answer with the state known to the bound item.

The cause is the introduction of the secure layer in the calimero library version 2.5. The constructor of the `ProcessCommunicationResponder` now takes two arguments. A `KNXNetworkLink` instance and a `SecureApplicationLayer` instance. The security application layer must not be null, although this precondition is not enforced by the constructor of the `ProcessCommunicationResponder`.

# Testing

This is the URL to the impacted build artefact:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.knx/3.3.0-SNAPSHOT/org.openhab.binding.knx-3.3.0-SNAPSHOT.jar