### PR TITLE
[jrubyscripting] Apply RUBYLIB configuration to $LOAD_PATH

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -234,7 +234,7 @@ public class JRubyScriptEngineConfiguration {
             try {
                 engine.eval(code);
             } catch (ScriptException exception) {
-                logger.error("Error setting $LOAD_PATH from RUBYLIB='{}': {}", rubyLib.get(), exception.getMessage());
+                logger.warn("Error setting $LOAD_PATH from RUBYLIB='{}': {}", rubyLib.get(), exception.getMessage());
             }
         }
     }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -47,6 +47,7 @@ public class JRubyScriptEngineConfiguration {
     private static final Path DEFAULT_RUBYLIB = Paths.get(OpenHAB.getConfigFolder(), "automation", "lib", "ruby");
 
     private static final String GEM_HOME = "gem_home";
+    private static final String RUBYLIB = "rubylib";
 
     // Map of configuration parameters
     private static final Map<String, OptionalConfigurationElement> CONFIGURATION_PARAMETERS = Map.ofEntries(
@@ -62,7 +63,7 @@ public class JRubyScriptEngineConfiguration {
                     new OptionalConfigurationElement.Builder(OptionalConfigurationElement.Type.RUBY_ENVIRONMENT)
                             .mappedTo("GEM_HOME").defaultValue(DEFAULT_GEM_HOME.toString()).build()),
 
-            Map.entry("rubylib",
+            Map.entry(RUBYLIB,
                     new OptionalConfigurationElement.Builder(OptionalConfigurationElement.Type.RUBY_ENVIRONMENT)
                             .mappedTo("RUBYLIB").defaultValue(DEFAULT_RUBYLIB.toString()).build()),
 
@@ -207,6 +208,33 @@ public class JRubyScriptEngineConfiguration {
                 }
             } else {
                 logger.debug("Ruby environment property ({}) has no value", environmentProperty);
+            }
+        }
+
+        configureRubyLib(engine);
+    }
+
+    /**
+     * Split up and insert ENV['RUBYLIB'] into Ruby's $LOAD_PATH
+     * This needs to be called after ENV['RUBYLIB'] has been set by configureRubyEnvironment
+     * 
+     * @param engine Engine in which to configure environment
+     */
+    private void configureRubyLib(ScriptEngine engine) {
+        OptionalConfigurationElement rubyLibConfigElement = CONFIGURATION_PARAMETERS.get(RUBYLIB);
+        if (rubyLibConfigElement == null) {
+            return;
+        }
+
+        Optional<String> rubyLib = rubyLibConfigElement.getValue();
+        if (rubyLib.isPresent() && !rubyLib.get().trim().isEmpty()) {
+            final String code = "$LOAD_PATH.unshift *ENV['RUBYLIB']&.split(File::PATH_SEPARATOR)" + //
+                    "&.reject(&:empty?)" + //
+                    "&.reject { |path| $LOAD_PATH.include?(path) }"; //
+            try {
+                engine.eval(code);
+            } catch (ScriptException exception) {
+                logger.error("Error setting $LOAD_PATH from RUBYLIB='{}': {}", rubyLib.get(), exception.getMessage());
             }
         }
     }


### PR DESCRIPTION
The `rubylib` addon configuration is supposed to alter the $LOAD_PATH but currently it doesn't. As a result, personal libraries located in RUBYLIB path won't be found. Currently a workaround is applied in the helper library to parse RUBYLIB and add the paths into $LOAD_PATH. 

However, GUI users who opt not to use the helper library will not be able to load personal libraries based on the `rubylib` search path.

This PR remedies this situation by updating `$LOAD_PATH` within the addon.