### PR TITLE
[enocean] Nodon rollershutter - enable adjusting repeater mode

### DIFF
--- a/bundles/org.openhab.binding.enocean/README.md
+++ b/bundles/org.openhab.binding.enocean/README.md
@@ -59,6 +59,7 @@ This binding is developed on and tested with the following devices
  * NodOn: 
     * Smart Plug (ASP-2-1-10)
     * In Wall Switch (SIN-2-2-00, SIN-2-1-0x)
+    * In Wall Rollershutter (SIN-2-RS-01)
     * Temperature & humidity sensor (STPH-2-1-05)
  * Permundo 
     * PSC234 (smart plug with metering) = Afriso APR234
@@ -224,9 +225,9 @@ If you change the SenderId of your thing, you have to pair again the thing with 
 |                                 | suppressRepeating | Suppress repeating of msg   | true, false |
 | rollershutter                   | senderIdOffset    |                             | 1-127 |
 |                                 | enoceanId         | | |
-|                                 | sendingEEPId      |                             | A5_3F_7F_EltakoFSB, A5_3F_7F_EltakoFRM, A5_38_08_07, D2_05_00 |
+|                                 | sendingEEPId      |                             | A5_3F_7F_EltakoFSB, A5_3F_7F_EltakoFRM, A5_38_08_07, D2_05_00_NODON |
 |                                 | broadcastMessages |                             | true, false |
-|                                 | receivingEEPId¹   |                             | A5_3F_7F_EltakoFSB, A5_3F_7F_EltakoFRM, A5_11_03, D2_05_00 |
+|                                 | receivingEEPId¹   |                             | A5_3F_7F_EltakoFSB, A5_3F_7F_EltakoFRM, A5_11_03, D2_05_00_NODON |
 |                                 | suppressRepeating |                             | true, false |
 |                                 | pollingInterval   | Refresh interval in seconds | Integer |
 | measurementSwitch               | senderIdOffset    |                             | 1-127 |

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_05/D2_05_00_NodON.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_05/D2_05_00_NodON.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.enocean.internal.eep.D2_05;
+
+import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.CHANNEL_REPEATERMODE;
+
+import java.util.function.Function;
+
+import org.openhab.binding.enocean.internal.EnOceanBindingConstants;
+import org.openhab.binding.enocean.internal.messages.ERP1Message;
+import org.openhab.binding.enocean.internal.messages.ERP1Message.RORG;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+
+/**
+ *
+ * @author Marcel Eckert - based on D2_01_0F_NodON.java and D2_01_12_NodOn.java
+ * 
+ */
+public class D2_05_00_NodON extends D2_05_00 {
+
+    public D2_05_00_NodON() {
+        super();
+    }
+
+    public D2_05_00_NodON(ERP1Message packet) {
+        super(packet);
+    }
+
+    @Override
+    protected void convertFromCommandImpl(String channelId, String channelTypeId, Command command,
+            Function<String, State> getCurrentStateFunc, Configuration config) {
+        if (channelId.equalsIgnoreCase(CHANNEL_REPEATERMODE)) {
+            if (command instanceof RefreshType) {
+                senderId = null; // make this message invalid as we do not support refresh of repeter status
+            } else if (command instanceof StringType) {
+                switch (((StringType) command).toString()) {
+                    case EnOceanBindingConstants.REPEATERMODE_LEVEL_1:
+                        setRORG(RORG.MSC).setData((byte) 0x00, (byte) 0x46, (byte) 0x08, (byte) 0x01, (byte) 0x01);
+                        break;
+                    case EnOceanBindingConstants.REPEATERMODE_LEVEL_2:
+                        setRORG(RORG.MSC).setData((byte) 0x00, (byte) 0x46, (byte) 0x08, (byte) 0x01, (byte) 0x02);
+                        break;
+                    default:
+                        setRORG(RORG.MSC).setData((byte) 0x00, (byte) 0x46, (byte) 0x08, (byte) 0x00, (byte) 0x00);
+                }
+            }
+        } else {
+            super.convertFromCommandImpl(channelId, channelTypeId, command, getCurrentStateFunc, config);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPType.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/EEPType.java
@@ -137,6 +137,7 @@ import org.openhab.binding.enocean.internal.eep.D2_01.D2_01_12;
 import org.openhab.binding.enocean.internal.eep.D2_01.D2_01_12_NodON;
 import org.openhab.binding.enocean.internal.eep.D2_03.D2_03_0A;
 import org.openhab.binding.enocean.internal.eep.D2_05.D2_05_00;
+import org.openhab.binding.enocean.internal.eep.D2_05.D2_05_00_NodON;
 import org.openhab.binding.enocean.internal.eep.D2_06.D2_06_01;
 import org.openhab.binding.enocean.internal.eep.D2_06.D2_06_50;
 import org.openhab.binding.enocean.internal.eep.D2_14.D2_14_30;
@@ -469,6 +470,8 @@ public enum EEPType {
     SwitchWithEnergyMeasurment_12(RORG.VLD, 0x01, 0x12, true, D2_01_12.class, THING_TYPE_MEASUREMENTSWITCH,
             CHANNEL_GENERAL_SWITCHINGA, CHANNEL_GENERAL_SWITCHINGB),
 
+    Rollershutter_D2_NODON(RORG.VLD, 0x05, 0x00, true, "NODON", NODONID, D2_05_00_NodON.class, THING_TYPE_ROLLERSHUTTER,
+            CHANNEL_ROLLERSHUTTER, CHANNEL_REPEATERMODE),
     Rollershutter_D2(RORG.VLD, 0x05, 0x00, true, D2_05_00.class, THING_TYPE_ROLLERSHUTTER, CHANNEL_ROLLERSHUTTER),
 
     WindowSashHandleSensor_50(RORG.VLD, 0x06, 0x50, false, "Siegenia", 0x005D, D2_06_50.class,

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/Rollershutter.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/Rollershutter.xml
@@ -32,7 +32,8 @@
 				<options>
 					<option value="A5_3F_7F_EltakoFSB">Eltako FSB14/61/71</option>
 					<option value="A5_3F_7F_EltakoFRM">Eltako FRM60</option>
-					<option value="D2_05_00">D2-05-00 Rollershutter (like SIN-2-RS-01)</option>
+					<option value="D2_05_00">D2-05-00 Rollershutter</option>
+					<option value="D2_05_00_NODON">NODON SIN-2-RS-01 (EEP: D2-05-00)</option>
 					<option value="A5_38_08_07">Gateway command - blinds (A5_38_08 sub command 0x07)</option>
 				</options>
 				<default>A5_3F_7F_EltakoFSB</default>
@@ -47,7 +48,8 @@
 				<options>
 					<option value="A5_3F_7F_EltakoFSB">Eltako FSB14/61/71</option>
 					<option value="A5_3F_7F_EltakoFRM">Eltako FRM60</option>
-					<option value="D2_05_00">D2-05-00 Rollershutter (like SIN-2-RS-01)</option>
+					<option value="D2_05_00">D2-05-00 Rollershutter</option>
+					<option value="D2_05_00_NODON">NODON SIN-2-RS-01 (EEP: D2-05-00)</option>
 					<option value="A5_11_03">A5-11-03 Rollershutter status</option>
 					<option value="F6_00_00">PTM200 Rollershutter status</option>
 				</options>


### PR DESCRIPTION
For NODONs in Wall Modules SIN-2-2-00 and SIN-2-1-0x it is already possible to adjust the repeater mode. For NODONs rollershutter (SIN-2-RS-01) this wasn't possibly with openhab so far - this series of commits enables the repeater mode setting in openhab also for NODONs rollershutter modules, the same way it is done for the other two in Wall Modules.

Correctness also tested physically with some of the rollershutter modules in my own house.