### PR TITLE
[hdpowerview] Fix autoupdate quirk for scene/scene group items

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -76,8 +76,8 @@ have different `id` values:
 
 | Channel Group | Channel | Item Type | Description |
 |---------------|---------|-----------|-------------|
-| scenes        | id      | Switch    | Setting this to ON will activate the scene. Scenes are stateless in the PowerView hub; they have no on/off state. Note: include `{autoupdate="false"}` in the item configuration to avoid having to reset it to off after use. |
-| sceneGroups   | id      | Switch    | Setting this to ON will activate the scene group. Scene groups are stateless in the PowerView hub; they have no on/off state. Note: include `{autoupdate="false"}` in the item configuration to avoid having to reset it to off after use. |
+| scenes        | id      | Switch    | Setting this to ON will activate the scene. Scenes are stateless in the PowerView hub; they have no on/off state. |
+| sceneGroups   | id      | Switch    | Setting this to ON will activate the scene group. Scene groups are stateless in the PowerView hub; they have no on/off state. |
 | automations   | id      | Switch    | Setting this to ON will enable the automation, while OFF will disable it. |
 
 ### Channels for Shades (Thing type `shade`)
@@ -239,7 +239,7 @@ Switch Bedroom_Repeater_BlinkingEnabled "Bedroom Repeater Blinking Enabled [%s]"
 Scene items:
 
 ```
-Switch Living_Room_Shades_Scene_Heart "Living Room Shades Scene Heart" <blinds> (g_Shades_Scene_Trigger) {channel="hdpowerview:hub:g24:scenes#22663", autoupdate="false"}
+Switch Living_Room_Shades_Scene_Heart "Living Room Shades Scene Heart" <blinds> (g_Shades_Scene_Trigger) {channel="hdpowerview:hub:g24:scenes#22663"}
 ```
 
 ### `demo.sitemap` File

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/builders/SceneChannelBuilder.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/builders/SceneChannelBuilder.java
@@ -24,6 +24,7 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
 
 /**
  * The {@link SceneChannelBuilder} class creates scene channels
@@ -95,6 +96,7 @@ public class SceneChannelBuilder extends BaseChannelBuilder {
         ChannelUID channelUid = new ChannelUID(channelGroupUid, Integer.toString(scene.id));
         String description = translationProvider.getText("dynamic-channel.scene-activate.description", scene.getName());
         return ChannelBuilder.create(channelUid, CoreItemFactory.SWITCH).withType(channelTypeUid)
-                .withLabel(scene.getName()).withDescription(description).build();
+                .withLabel(scene.getName()).withDescription(description).withAutoUpdatePolicy(AutoUpdatePolicy.VETO)
+                .build();
     }
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/builders/SceneGroupChannelBuilder.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/builders/SceneGroupChannelBuilder.java
@@ -24,6 +24,7 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
 
 /**
  * The {@link SceneGroupChannelBuilder} class creates scene group channels
@@ -97,6 +98,7 @@ public class SceneGroupChannelBuilder extends BaseChannelBuilder {
         String description = translationProvider.getText("dynamic-channel.scene-group-activate.description",
                 sceneCollection.getName());
         return ChannelBuilder.create(channelUid, CoreItemFactory.SWITCH).withType(channelTypeUid)
-                .withLabel(sceneCollection.getName()).withDescription(description).build();
+                .withLabel(sceneCollection.getName()).withDescription(description)
+                .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
     }
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/SceneChannelBuilderTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/SceneChannelBuilderTest.java
@@ -29,6 +29,7 @@ import org.openhab.binding.hdpowerview.internal.builders.SceneChannelBuilder;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
 import org.osgi.framework.Bundle;
 
 /**
@@ -78,6 +79,15 @@ public class SceneChannelBuilderTest {
         assertEquals(1, channels.size());
         assertEquals(CHANNEL_GROUP_UID.getId(), channels.get(0).getUID().getGroupId());
         assertEquals(Integer.toString(scenes.get(0).id), channels.get(0).getUID().getIdWithoutGroup());
+    }
+
+    @Test
+    public void autoUpdatePolicyIsCorrect() {
+        List<Scene> scenes = createScenes();
+        List<Channel> channels = builder.withScenes(scenes).build();
+
+        assertEquals(1, channels.size());
+        assertEquals(AutoUpdatePolicy.VETO, channels.get(0).getAutoUpdatePolicy());
     }
 
     @Test

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/SceneGroupChannelBuilderTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/SceneGroupChannelBuilderTest.java
@@ -29,6 +29,7 @@ import org.openhab.binding.hdpowerview.internal.builders.SceneGroupChannelBuilde
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
 import org.osgi.framework.Bundle;
 
 /**
@@ -78,6 +79,15 @@ public class SceneGroupChannelBuilderTest {
         assertEquals(1, channels.size());
         assertEquals(CHANNEL_GROUP_UID.getId(), channels.get(0).getUID().getGroupId());
         assertEquals(Integer.toString(sceneCollections.get(0).id), channels.get(0).getUID().getIdWithoutGroup());
+    }
+
+    @Test
+    public void autoUpdatePolicyIsCorrect() {
+        List<SceneCollection> sceneCollections = createSceneCollections();
+        List<Channel> channels = builder.withSceneCollections(sceneCollections).build();
+
+        assertEquals(1, channels.size());
+        assertEquals(AutoUpdatePolicy.VETO, channels.get(0).getAutoUpdatePolicy());
     }
 
     @Test


### PR DESCRIPTION
Fixes #12140

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix old quirk where stateless items needed to be defined with `autoupdate="false"`. This is instead accomplished by [Auto Update Policy](https://www.openhab.org/docs/developer/bindings/thing-xml.html#auto-update-policies) **veto**.