### PR TITLE
[jrubyscripting] Upgrade jruby version to 9.3.3.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.3.2.0</jruby.version>
+    <jruby.version>9.3.3.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Upgrades jruby version to 9.3.3.0, which was released on the 19th of January 2022

https://www.jruby.org/2022/01/19/jruby-9-3-3-0.html

