### PR TITLE
[radiothermostat] Workaround for incorrectly reported fan state

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -478,7 +478,12 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
             case STATUS:
                 return data.getThermostatData().getStatus();
             case FAN_STATUS:
-                return data.getThermostatData().getFanStatus();
+                // workaround for some thermostats that don't report that the fan is on during heating or cooling
+                if (data.getThermostatData().getStatus() > 0) {
+                    return 1;
+                } else {
+                    return data.getThermostatData().getFanStatus();
+                }
             case DAY:
                 return data.getThermostatData().getTime().getDayOfWeek();
             case HOUR:


### PR DESCRIPTION
Apply logic to the fan_status channel for some thermostats that don't properly report that the fan is on during heating or cooling. Any time the thermostat status is heating (1) or cooling (2), the fan status will be reported as 1. When the thermostat status is off (0), the fan_status will be reported from the json data.

fixes #12144 

