### PR TITLE
[wemo] Improve GENA subscription reliability and error handling

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
@@ -133,100 +133,97 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
 
                 String endDeviceRequest = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
 
-                if (endDeviceRequest != null) {
-                    logger.trace("endDeviceRequest answered '{}'", endDeviceRequest);
+                logger.trace("endDeviceRequest answered '{}'", endDeviceRequest);
 
-                    try {
-                        String stringParser = substringBetween(endDeviceRequest, "<DeviceLists>", "</DeviceLists>");
+                try {
+                    String stringParser = substringBetween(endDeviceRequest, "<DeviceLists>", "</DeviceLists>");
 
-                        stringParser = unescapeXml(stringParser);
+                    stringParser = unescapeXml(stringParser);
 
-                        // check if there are already paired devices with WeMo Link
-                        if ("0".equals(stringParser)) {
-                            logger.debug("There are no devices connected with WeMo Link. Exit discovery");
-                            return;
-                        }
-
-                        // Build parser for received <DeviceList>
-                        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-                        // see
-                        // https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-                        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-                        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-                        dbf.setXIncludeAware(false);
-                        dbf.setExpandEntityReferences(false);
-                        DocumentBuilder db = dbf.newDocumentBuilder();
-                        InputSource is = new InputSource();
-                        is.setCharacterStream(new StringReader(stringParser));
-
-                        Document doc = db.parse(is);
-                        NodeList nodes = doc.getElementsByTagName("DeviceInfo");
-
-                        // iterate the devices
-                        for (int i = 0; i < nodes.getLength(); i++) {
-                            Element element = (Element) nodes.item(i);
-
-                            NodeList deviceIndex = element.getElementsByTagName("DeviceIndex");
-                            Element line = (Element) deviceIndex.item(0);
-                            logger.trace("DeviceIndex: {}", getCharacterDataFromElement(line));
-
-                            NodeList deviceID = element.getElementsByTagName("DeviceID");
-                            line = (Element) deviceID.item(0);
-                            String endDeviceID = getCharacterDataFromElement(line);
-                            logger.trace("DeviceID: {}", endDeviceID);
-
-                            NodeList friendlyName = element.getElementsByTagName("FriendlyName");
-                            line = (Element) friendlyName.item(0);
-                            String endDeviceName = getCharacterDataFromElement(line);
-                            logger.trace("FriendlyName: {}", endDeviceName);
-
-                            NodeList vendor = element.getElementsByTagName("Manufacturer");
-                            line = (Element) vendor.item(0);
-                            String endDeviceVendor = getCharacterDataFromElement(line);
-                            logger.trace("Manufacturer: {}", endDeviceVendor);
-
-                            NodeList model = element.getElementsByTagName("ModelCode");
-                            line = (Element) model.item(0);
-                            String endDeviceModelID = getCharacterDataFromElement(line);
-                            endDeviceModelID = endDeviceModelID.replaceAll(NORMALIZE_ID_REGEX, "_");
-
-                            logger.trace("ModelCode: {}", endDeviceModelID);
-
-                            if (SUPPORTED_THING_TYPES.contains(new ThingTypeUID(BINDING_ID, endDeviceModelID))) {
-                                logger.debug("Discovered a WeMo LED Light thing with ID '{}'", endDeviceID);
-
-                                ThingUID bridgeUID = wemoBridgeHandler.getThing().getUID();
-                                ThingTypeUID thingTypeUID = new ThingTypeUID(BINDING_ID, endDeviceModelID);
-
-                                if (thingTypeUID.equals(THING_TYPE_MZ100)) {
-                                    String thingLightId = endDeviceID;
-                                    ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, thingLightId);
-
-                                    Map<String, Object> properties = new HashMap<>(1);
-                                    properties.put(DEVICE_ID, endDeviceID);
-
-                                    DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID)
-                                            .withProperties(properties)
-                                            .withBridge(wemoBridgeHandler.getThing().getUID()).withLabel(endDeviceName)
-                                            .build();
-
-                                    thingDiscovered(discoveryResult);
-                                }
-                            } else {
-                                logger.debug("Discovered an unsupported device :");
-                                logger.debug("DeviceIndex : {}", getCharacterDataFromElement(line));
-                                logger.debug("DeviceID    : {}", endDeviceID);
-                                logger.debug("FriendlyName: {}", endDeviceName);
-                                logger.debug("Manufacturer: {}", endDeviceVendor);
-                                logger.debug("ModelCode   : {}", endDeviceModelID);
-                            }
-
-                        }
-                    } catch (Exception e) {
-                        logger.error("Failed to parse endDevices for bridge '{}'",
-                                wemoBridgeHandler.getThing().getUID(), e);
+                    // check if there are already paired devices with WeMo Link
+                    if ("0".equals(stringParser)) {
+                        logger.debug("There are no devices connected with WeMo Link. Exit discovery");
+                        return;
                     }
+
+                    // Build parser for received <DeviceList>
+                    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                    // see
+                    // https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+                    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                    dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                    dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                    dbf.setXIncludeAware(false);
+                    dbf.setExpandEntityReferences(false);
+                    DocumentBuilder db = dbf.newDocumentBuilder();
+                    InputSource is = new InputSource();
+                    is.setCharacterStream(new StringReader(stringParser));
+
+                    Document doc = db.parse(is);
+                    NodeList nodes = doc.getElementsByTagName("DeviceInfo");
+
+                    // iterate the devices
+                    for (int i = 0; i < nodes.getLength(); i++) {
+                        Element element = (Element) nodes.item(i);
+
+                        NodeList deviceIndex = element.getElementsByTagName("DeviceIndex");
+                        Element line = (Element) deviceIndex.item(0);
+                        logger.trace("DeviceIndex: {}", getCharacterDataFromElement(line));
+
+                        NodeList deviceID = element.getElementsByTagName("DeviceID");
+                        line = (Element) deviceID.item(0);
+                        String endDeviceID = getCharacterDataFromElement(line);
+                        logger.trace("DeviceID: {}", endDeviceID);
+
+                        NodeList friendlyName = element.getElementsByTagName("FriendlyName");
+                        line = (Element) friendlyName.item(0);
+                        String endDeviceName = getCharacterDataFromElement(line);
+                        logger.trace("FriendlyName: {}", endDeviceName);
+
+                        NodeList vendor = element.getElementsByTagName("Manufacturer");
+                        line = (Element) vendor.item(0);
+                        String endDeviceVendor = getCharacterDataFromElement(line);
+                        logger.trace("Manufacturer: {}", endDeviceVendor);
+
+                        NodeList model = element.getElementsByTagName("ModelCode");
+                        line = (Element) model.item(0);
+                        String endDeviceModelID = getCharacterDataFromElement(line);
+                        endDeviceModelID = endDeviceModelID.replaceAll(NORMALIZE_ID_REGEX, "_");
+
+                        logger.trace("ModelCode: {}", endDeviceModelID);
+
+                        if (SUPPORTED_THING_TYPES.contains(new ThingTypeUID(BINDING_ID, endDeviceModelID))) {
+                            logger.debug("Discovered a WeMo LED Light thing with ID '{}'", endDeviceID);
+
+                            ThingUID bridgeUID = wemoBridgeHandler.getThing().getUID();
+                            ThingTypeUID thingTypeUID = new ThingTypeUID(BINDING_ID, endDeviceModelID);
+
+                            if (thingTypeUID.equals(THING_TYPE_MZ100)) {
+                                String thingLightId = endDeviceID;
+                                ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, thingLightId);
+
+                                Map<String, Object> properties = new HashMap<>(1);
+                                properties.put(DEVICE_ID, endDeviceID);
+
+                                DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID)
+                                        .withProperties(properties).withBridge(wemoBridgeHandler.getThing().getUID())
+                                        .withLabel(endDeviceName).build();
+
+                                thingDiscovered(discoveryResult);
+                            }
+                        } else {
+                            logger.debug("Discovered an unsupported device :");
+                            logger.debug("DeviceIndex : {}", getCharacterDataFromElement(line));
+                            logger.debug("DeviceID    : {}", endDeviceID);
+                            logger.debug("FriendlyName: {}", endDeviceName);
+                            logger.debug("Manufacturer: {}", endDeviceVendor);
+                            logger.debug("ModelCode   : {}", endDeviceModelID);
+                        }
+
+                    }
+                } catch (Exception e) {
+                    logger.error("Failed to parse endDevices for bridge '{}'", wemoBridgeHandler.getThing().getUID(),
+                            e);
                 }
             }
         } catch (Exception e) {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
@@ -222,12 +222,11 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
 
                     }
                 } catch (Exception e) {
-                    logger.error("Failed to parse endDevices for bridge '{}'", wemoBridgeHandler.getThing().getUID(),
-                            e);
+                    logger.warn("Failed to parse endDevices for bridge '{}'", wemoBridgeHandler.getThing().getUID(), e);
                 }
             }
         } catch (Exception e) {
-            logger.error("Failed to get endDevices for bridge '{}'", wemoBridgeHandler.getThing().getUID(), e);
+            logger.warn("Failed to get endDevices for bridge '{}'", wemoBridgeHandler.getThing().getUID(), e);
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoBaseThingHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoBaseThingHandler.java
@@ -13,6 +13,11 @@
 package org.openhab.binding.wemo.internal.handler;
 
 import java.net.URL;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -29,19 +34,24 @@ import org.slf4j.LoggerFactory;
 
 /**
  * {@link WemoBaseThingHandler} provides a base implementation for the
- * concrete WeMo handlers for each thing type.
+ * concrete WeMo handlers.
  *
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
 public abstract class WemoBaseThingHandler extends BaseThingHandler implements UpnpIOParticipant {
 
+    private static final int SUBSCRIPTION_RENEWAL_INITIAL_DELAY_SECONDS = 15;
+    private static final int SUBSCRIPTION_RENEWAL_INTERVAL_SECONDS = 60;
+
     private final Logger logger = LoggerFactory.getLogger(WemoBaseThingHandler.class);
-    private final Object upnpLock = new Object();
 
     protected @Nullable UpnpIOService service;
     protected WemoHttpCall wemoHttpCaller;
     protected String host = "";
+
+    private Map<String, Instant> subscriptions = new ConcurrentHashMap<String, Instant>();
+    private @Nullable ScheduledFuture<?> subscriptionRenewalJob;
 
     public WemoBaseThingHandler(Thing thing, UpnpIOService upnpIOService, WemoHttpCall wemoHttpCaller) {
         super(thing);
@@ -51,7 +61,22 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
 
     @Override
     public void initialize() {
-        // can be overridden by subclasses
+        UpnpIOService service = this.service;
+        if (service != null) {
+            logger.debug("Registering UPnP participant for {}", getThing().getUID());
+            service.registerParticipant(this);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        removeSubscriptions();
+        UpnpIOService service = this.service;
+        if (service != null) {
+            logger.debug("Unregistering UPnP participant for {}", getThing().getUID());
+            service.unregisterParticipant(this);
+        }
+        cancelSubscriptionRenewalJob();
     }
 
     @Override
@@ -71,9 +96,12 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
 
     @Override
     public void onServiceSubscribed(@Nullable String service, boolean succeeded) {
-        if (service != null) {
-            logger.debug("WeMo {}: Subscription to service {} {}", getUDN(), service,
-                    succeeded ? "succeeded" : "failed");
+        if (service == null) {
+            return;
+        }
+        logger.debug("Subscription to service {} for {} {}", service, getUDN(), succeeded ? "succeeded" : "failed");
+        if (succeeded) {
+            subscriptions.put(service, Instant.now());
         }
     }
 
@@ -84,39 +112,115 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
 
     protected boolean isUpnpDeviceRegistered() {
         UpnpIOService service = this.service;
-        if (service != null) {
-            return service.isRegistered(this);
-        }
-        return false;
+        return service != null && service.isRegistered(this);
     }
 
-    protected synchronized void addSubscription(String subscription) {
-        synchronized (upnpLock) {
-            UpnpIOService service = this.service;
-            if (service != null) {
-                if (service.isRegistered(this)) {
-                    logger.debug("Setting up GENA subscription {}: Subscribing to service {}...", getUDN(),
-                            subscription);
-                    service.addSubscription(this, subscription, WemoBindingConstants.SUBSCRIPTION_DURATION_SECONDS);
-                } else {
-                    logger.debug(
-                            "Setting up WeMo GENA subscription for '{}' FAILED - service.isRegistered(this) is FALSE",
-                            getThing().getUID());
-                }
-            }
+    protected void addSubscription(String serviceId) {
+        if (subscriptions.containsKey(serviceId)) {
+            logger.debug("{} already subscribed to {}", getUDN(), serviceId);
+            return;
         }
+        if (subscriptions.isEmpty()) {
+            logger.debug("Adding first GENA subscription for {}, scheduling renewal job", getUDN());
+            scheduleSubscriptionRenewalJob();
+        }
+        subscriptions.put(serviceId, Instant.ofEpochSecond(0));
+        UpnpIOService service = this.service;
+        if (service == null) {
+            return;
+        }
+        if (!service.isRegistered(this)) {
+            logger.debug("Registering UPnP participant for {}", getUDN());
+            service.registerParticipant(this);
+        }
+        if (!service.isRegistered(this)) {
+            logger.debug("Trying to add GENA subscription {} for {}, but service is not registered", serviceId,
+                    getUDN());
+            return;
+        }
+        logger.debug("Adding GENA subscription {} for {}", serviceId, getUDN());
+        service.addSubscription(this, serviceId, WemoBindingConstants.SUBSCRIPTION_DURATION_SECONDS);
     }
 
-    protected synchronized void removeSubscription(String subscription) {
-        synchronized (upnpLock) {
-            UpnpIOService service = this.service;
-            if (service != null) {
-                if (service.isRegistered(this)) {
-                    logger.debug("WeMo {}: Unsubscribing from service {}...", getUDN(), subscription);
-                    service.removeSubscription(this, subscription);
-                }
-            }
+    protected void removeSubscription(String serviceId) {
+        UpnpIOService service = this.service;
+        if (service == null) {
+            return;
         }
+        subscriptions.remove(serviceId);
+        if (subscriptions.isEmpty()) {
+            logger.debug("Removing last GENA subscription for {}, cancelling renewal job", getUDN());
+            cancelSubscriptionRenewalJob();
+        }
+        if (!service.isRegistered(this)) {
+            logger.debug("Trying to remove GENA subscription {} for {}, but service is not registered", serviceId,
+                    getUDN());
+            return;
+        }
+        logger.debug("Unsubscribing {} from service {}", getUDN(), serviceId);
+        service.removeSubscription(this, serviceId);
+    }
+
+    private void scheduleSubscriptionRenewalJob() {
+        cancelSubscriptionRenewalJob();
+        this.subscriptionRenewalJob = scheduler.scheduleWithFixedDelay(this::renewSubscriptions,
+                SUBSCRIPTION_RENEWAL_INITIAL_DELAY_SECONDS, SUBSCRIPTION_RENEWAL_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private void cancelSubscriptionRenewalJob() {
+        ScheduledFuture<?> subscriptionRenewalJob = this.subscriptionRenewalJob;
+        if (subscriptionRenewalJob != null) {
+            subscriptionRenewalJob.cancel(true);
+        }
+        this.subscriptionRenewalJob = null;
+    }
+
+    private void renewSubscriptions() {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+        UpnpIOService service = this.service;
+        if (service == null) {
+            return;
+        }
+        if (!service.isRegistered(this)) {
+            service.registerParticipant(this);
+        }
+        if (!service.isRegistered(this)) {
+            logger.debug("Trying to renew GENA subscriptions for {}, but service is not registered", getUDN());
+            return;
+        }
+        logger.debug("Renewing GENA subscriptions for {}", getUDN());
+        subscriptions.forEach((serviceId, lastRenewed) -> {
+            if (lastRenewed.isBefore(Instant.now().minusSeconds(
+                    WemoBindingConstants.SUBSCRIPTION_DURATION_SECONDS - SUBSCRIPTION_RENEWAL_INTERVAL_SECONDS))) {
+                logger.debug("Subscription for service {} with timestamp {} has expired, renewing", serviceId,
+                        lastRenewed);
+                service.removeSubscription(this, serviceId);
+                service.addSubscription(this, serviceId, WemoBindingConstants.SUBSCRIPTION_DURATION_SECONDS);
+            }
+        });
+    }
+
+    private void removeSubscriptions() {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+        UpnpIOService service = this.service;
+        if (service == null) {
+            return;
+        }
+        if (!service.isRegistered(this)) {
+            logger.debug("Trying to remove GENA subscriptions for {}, but service is not registered",
+                    getThing().getUID());
+            return;
+        }
+        logger.debug("Removing GENA subscriptions for {}", getUDN());
+        subscriptions.forEach((serviceId, lastRenewed) -> {
+            logger.debug("Removing subscription for service {}", serviceId);
+            service.removeSubscription(this, serviceId);
+        });
+        subscriptions.clear();
     }
 
     protected String getHost() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoBaseThingHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoBaseThingHandler.java
@@ -13,8 +13,6 @@
 package org.openhab.binding.wemo.internal.handler;
 
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -44,7 +42,6 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
     protected @Nullable UpnpIOService service;
     protected WemoHttpCall wemoHttpCaller;
     protected String host = "";
-    private Map<String, Boolean> subscriptionState = new HashMap<>();
 
     public WemoBaseThingHandler(Thing thing, UpnpIOService upnpIOService, WemoHttpCall wemoHttpCaller) {
         super(thing);
@@ -77,7 +74,6 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
         if (service != null) {
             logger.debug("WeMo {}: Subscription to service {} {}", getUDN(), service,
                     succeeded ? "succeeded" : "failed");
-            subscriptionState.put(service, succeeded);
         }
     }
 
@@ -99,14 +95,9 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
             UpnpIOService service = this.service;
             if (service != null) {
                 if (service.isRegistered(this)) {
-                    logger.debug("Checking WeMo GENA subscription for '{}'", getThing().getUID());
-
-                    if (subscriptionState.get(subscription) == null) {
-                        logger.debug("Setting up GENA subscription {}: Subscribing to service {}...", getUDN(),
-                                subscription);
-                        service.addSubscription(this, subscription, WemoBindingConstants.SUBSCRIPTION_DURATION_SECONDS);
-                        subscriptionState.put(subscription, true);
-                    }
+                    logger.debug("Setting up GENA subscription {}: Subscribing to service {}...", getUDN(),
+                            subscription);
+                    service.addSubscription(this, subscription, WemoBindingConstants.SUBSCRIPTION_DURATION_SECONDS);
                 } else {
                     logger.debug(
                             "Setting up WeMo GENA subscription for '{}' FAILED - service.isRegistered(this) is FALSE",
@@ -121,23 +112,11 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
             UpnpIOService service = this.service;
             if (service != null) {
                 if (service.isRegistered(this)) {
-                    logger.debug("Removing WeMo GENA subscription for '{}'", getThing().getUID());
-
-                    if (subscriptionState.get(subscription) != null) {
-                        logger.debug("WeMo {}: Unsubscribing from service {}...", getUDN(), subscription);
-                        service.removeSubscription(this, subscription);
-                    }
-
-                    subscriptionState.remove(subscription);
+                    logger.debug("WeMo {}: Unsubscribing from service {}...", getUDN(), subscription);
+                    service.removeSubscription(this, subscription);
                     service.unregisterParticipant(this);
                 }
             }
-        }
-    }
-
-    protected synchronized void clearSubscriptionState() {
-        synchronized (upnpLock) {
-            subscriptionState = new HashMap<>();
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoBaseThingHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoBaseThingHandler.java
@@ -114,7 +114,6 @@ public abstract class WemoBaseThingHandler extends BaseThingHandler implements U
                 if (service.isRegistered(this)) {
                     logger.debug("WeMo {}: Unsubscribing from service {}...", getUDN(), subscription);
                     service.removeSubscription(this, subscription);
-                    service.unregisterParticipant(this);
                 }
             }
         }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -141,7 +141,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.debug("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -208,7 +208,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
         String actionService = DEVICEACTION;
         String wemoURL = getWemoURL(host, actionService);
         if (wemoURL == null) {
-            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -77,14 +77,12 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         Configuration configuration = getConfig();
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoCoffeeHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
-            }
+            addSubscription(DEVICEEVENT);
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
@@ -104,11 +102,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription(DEVICEEVENT);
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private void poll() {
@@ -130,7 +124,6 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription(DEVICEEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -141,7 +141,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to send command '{}' for device '{}': IP address missing", command,
+            logger.warn("Failed to send command '{}' for device '{}': IP address missing", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
@@ -149,7 +149,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -186,7 +186,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                         updateState(CHANNEL_COFFEEMODE, newMode);
                         updateStatus(ThingStatus.ONLINE);
                     } catch (Exception e) {
-                        logger.error("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
+                        logger.warn("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
                                 e.getMessage());
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                     }
@@ -208,7 +208,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
     protected void updateWemoState() {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
@@ -216,7 +216,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
         String actionService = DEVICEACTION;
         String wemoURL = getWemoURL(host, actionService);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;
@@ -354,10 +354,10 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                     }
                 }
             } catch (Exception e) {
-                logger.error("Failed to parse attributeList for WeMo CoffeMaker '{}'", this.getThing().getUID(), e);
+                logger.warn("Failed to parse attributeList for WeMo CoffeMaker '{}'", this.getThing().getUID(), e);
             }
         } catch (Exception e) {
-            logger.error("Failed to get attributes for device '{}'", getThing().getUID(), e);
+            logger.warn("Failed to get attributes for device '{}'", getThing().getUID(), e);
         }
     }
 
@@ -366,7 +366,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
         try {
             value = Long.parseLong(attributeValue);
         } catch (NumberFormatException e) {
-            logger.error("Unable to parse attributeValue '{}' for device '{}'; expected long", attributeValue,
+            logger.warn("Unable to parse attributeValue '{}' for device '{}'; expected long", attributeValue,
                     getThing().getUID());
             return null;
         }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -81,9 +81,9 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoCoffeeHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -98,13 +98,17 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
 
     @Override
     public void dispose() {
-        logger.debug("WeMoCoffeeHandler disposed.");
+        logger.debug("WemoCoffeeHandler disposed.");
         ScheduledFuture<?> job = this.pollingJob;
         if (job != null && !job.isCancelled()) {
             job.cancel(true);
         }
         this.pollingJob = null;
         removeSubscription(DEVICEEVENT);
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
+        }
     }
 
     private void poll() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -122,7 +122,6 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
@@ -346,11 +345,13 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                             break;
                     }
                 }
+                updateStatus(ThingStatus.ONLINE);
             } catch (Exception e) {
                 logger.warn("Failed to parse attributeList for WeMo CoffeMaker '{}'", this.getThing().getUID(), e);
             }
         } catch (Exception e) {
             logger.warn("Failed to get attributes for device '{}'", getThing().getUID(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -195,6 +195,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                                         getThing().getUID());
                             }
                         }
+                        updateStatus(ThingStatus.ONLINE);
                     } catch (Exception e) {
                         logger.error("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
                                 e.getMessage());
@@ -202,9 +203,7 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                     }
                 }
                 // if command.equals(OnOffType.OFF) we do nothing because WeMo Coffee Maker cannot be switched
-                // off
-                // remotely
-                updateStatus(ThingStatus.ONLINE);
+                // off remotely
             }
         }
     }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -122,7 +122,6 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -180,11 +180,11 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
                     logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
                     logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
                 }
+                updateStatus(ThingStatus.ONLINE);
             } catch (RuntimeException e) {
                 logger.debug("Failed to send command '{}' for device '{}':", command, getThing().getUID(), e);
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
-            updateStatus(ThingStatus.ONLINE);
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -111,7 +111,6 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -131,7 +131,7 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to send command '{}' for device '{}': IP address missing", command,
+            logger.warn("Failed to send command '{}' for device '{}': IP address missing", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
@@ -139,7 +139,7 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -202,7 +202,7 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
     protected void updateWemoState() {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
@@ -210,7 +210,7 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
         String actionService = BASICEVENT;
         String wemoURL = getWemoURL(localHost, actionService);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -68,14 +68,12 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         Configuration configuration = getConfig();
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoCrockpotHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
-            }
+            addSubscription(BASICEVENT);
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
@@ -95,11 +93,7 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription(BASICEVENT);
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private void poll() {
@@ -120,7 +114,6 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription(BASICEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -131,7 +131,7 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.debug("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -112,7 +112,6 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -71,9 +71,9 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoCrockpotHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -95,6 +95,10 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
         }
         this.pollingJob = null;
         removeSubscription(BASICEVENT);
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
+        }
     }
 
     private void poll() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -427,7 +427,7 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;
@@ -506,7 +506,7 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to set binary state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to set binary state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -492,7 +492,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         }
         ZonedDateTime zoned = ZonedDateTime.ofInstant(Instant.ofEpochSecond(value), TimeZone.getDefault().toZoneId());
         State dateTimeState = new DateTimeType(zoned);
-        logger.trace("New attribute brewed '{}' received", dateTimeState);
         return dateTimeState;
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -497,7 +497,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                 variable = "nightModeBrightness";
                 this.onValueReceived(variable, value, actionService + "1");
                 updateStatus(ThingStatus.ONLINE);
-
             }
         } catch (Exception e) {
             logger.debug("Failed to get actual NightMode state for device '{}': {}", getThing().getUID(),

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -126,7 +126,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -428,14 +428,14 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
     protected void updateWemoState() {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;
@@ -494,7 +494,7 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         try {
             value = Long.parseLong(attributeValue);
         } catch (NumberFormatException e) {
-            logger.error("Unable to parse attributeValue '{}' for device '{}'; expected long", attributeValue,
+            logger.warn("Unable to parse attributeValue '{}' for device '{}'; expected long", attributeValue,
                     getThing().getUID());
             return null;
         }
@@ -507,14 +507,14 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
     public void setBinaryState(String action, String argument, String value) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to set binary state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to set binary state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to set binary state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to set binary state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;
@@ -538,14 +538,14 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
     public void setTimerStart(String action, String argument, String value) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to set timerStart for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to set timerStart for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to set timerStart for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to set timerStart for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -126,7 +126,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -81,14 +81,12 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         Configuration configuration = getConfig();
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoDimmerHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
-            }
+            addSubscription(BASICEVENT);
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
@@ -109,11 +107,7 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription(BASICEVENT);
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private void poll() {
@@ -134,7 +128,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription(BASICEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -85,9 +85,9 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoDimmerHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -110,6 +110,10 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         }
         this.pollingJob = null;
         removeSubscription(BASICEVENT);
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
+        }
     }
 
     private void poll() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -448,24 +448,16 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         String content = createStateRequestContent(action, actionService);
         try {
             String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                    logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                    logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                    logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-                }
-                value = substringBetween(wemoCallResponse, "<BinaryState>", "</BinaryState>");
-                variable = "BinaryState";
-                this.onValueReceived(variable, value, actionService + "1");
-                value = substringBetween(wemoCallResponse, "<brightness>", "</brightness>");
-                variable = "brightness";
-                this.onValueReceived(variable, value, actionService + "1");
-                value = substringBetween(wemoCallResponse, "<fader>", "</fader>");
-                variable = "fader";
-                this.onValueReceived(variable, value, actionService + "1");
-                updateStatus(ThingStatus.ONLINE);
-            }
+            value = substringBetween(wemoCallResponse, "<BinaryState>", "</BinaryState>");
+            variable = "BinaryState";
+            this.onValueReceived(variable, value, actionService + "1");
+            value = substringBetween(wemoCallResponse, "<brightness>", "</brightness>");
+            variable = "brightness";
+            this.onValueReceived(variable, value, actionService + "1");
+            value = substringBetween(wemoCallResponse, "<fader>", "</fader>");
+            variable = "fader";
+            this.onValueReceived(variable, value, actionService + "1");
+            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
             logger.debug("Failed to get actual state for device '{}': {}", getThing().getUID(), e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
@@ -477,27 +469,19 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
         content = createStateRequestContent(action, actionService);
         try {
             String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                    logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                    logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                    logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-                }
-                value = substringBetween(wemoCallResponse, "<startTime>", "</startTime>");
-                variable = "startTime";
-                this.onValueReceived(variable, value, actionService + "1");
-                value = substringBetween(wemoCallResponse, "<endTime>", "</endTime>");
-                variable = "endTime";
-                this.onValueReceived(variable, value, actionService + "1");
-                value = substringBetween(wemoCallResponse, "<nightMode>", "</nightMode>");
-                variable = "nightMode";
-                this.onValueReceived(variable, value, actionService + "1");
-                value = substringBetween(wemoCallResponse, "<nightModeBrightness>", "</nightModeBrightness>");
-                variable = "nightModeBrightness";
-                this.onValueReceived(variable, value, actionService + "1");
-                updateStatus(ThingStatus.ONLINE);
-            }
+            value = substringBetween(wemoCallResponse, "<startTime>", "</startTime>");
+            variable = "startTime";
+            this.onValueReceived(variable, value, actionService + "1");
+            value = substringBetween(wemoCallResponse, "<endTime>", "</endTime>");
+            variable = "endTime";
+            this.onValueReceived(variable, value, actionService + "1");
+            value = substringBetween(wemoCallResponse, "<nightMode>", "</nightMode>");
+            variable = "nightMode";
+            this.onValueReceived(variable, value, actionService + "1");
+            value = substringBetween(wemoCallResponse, "<nightModeBrightness>", "</nightModeBrightness>");
+            variable = "nightModeBrightness";
+            this.onValueReceived(variable, value, actionService + "1");
+            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
             logger.debug("Failed to get actual NightMode state for device '{}': {}", getThing().getUID(),
                     e.getMessage());
@@ -542,13 +526,8 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                     + "<s:Body>" + "<u:" + action + " xmlns:u=\"urn:Belkin:service:basicevent:1\">" + "<" + argument
                     + ">" + value + "</" + argument + ">" + "</u:" + action + ">" + "</s:Body>" + "</s:Envelope>";
 
-            String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null && logger.isTraceEnabled()) {
-                logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-            }
+            wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
+            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
             logger.debug("Failed to set binaryState '{}' for device '{}': {}", value, getThing().getUID(),
                     e.getMessage());
@@ -577,13 +556,8 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                     + "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
                     + "<s:Body>" + "<u:SetBinaryState xmlns:u=\"urn:Belkin:service:basicevent:1\">" + value
                     + "</u:SetBinaryState>" + "</s:Body>" + "</s:Envelope>";
-            String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null && logger.isTraceEnabled()) {
-                logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-            }
+            wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
+            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
             logger.debug("Failed to set timerStart '{}' for device '{}': {}", value, getThing().getUID(),
                     e.getMessage());

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -59,12 +59,9 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_DIMMER);
 
-    private final Object upnpLock = new Object();
     private final Object jobLock = new Object();
 
     private final Map<String, String> stateMap = Collections.synchronizedMap(new HashMap<>());
-
-    private Map<String, Boolean> subscriptionState = new HashMap<>();
 
     private @Nullable ScheduledFuture<?> pollingJob;
 
@@ -112,7 +109,7 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription();
+        removeSubscription(BASICEVENT);
     }
 
     private void poll() {
@@ -129,14 +126,12 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    synchronized (upnpLock) {
-                        subscriptionState = new HashMap<>();
-                    }
+                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription();
+                addSubscription(BASICEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }
@@ -334,15 +329,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
     }
 
     @Override
-    public void onServiceSubscribed(@Nullable String service, boolean succeeded) {
-        if (service != null) {
-            logger.debug("WeMo {}: Subscription to service {} {}", getUDN(), service,
-                    succeeded ? "succeeded" : "failed");
-            subscriptionState.put(service, succeeded);
-        }
-    }
-
-    @Override
     public void onValueReceived(@Nullable String variable, @Nullable String value, @Nullable String service) {
         logger.debug("Received pair '{}':'{}' (service '{}') for thing '{}'",
                 new Object[] { variable, value, service, this.getThing().getUID() });
@@ -427,41 +413,6 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
                             getThing().getUID());
                     updateState(CHANNEL_NIGHTMODEBRIGHTNESS, nightModeBrightnessState);
                     break;
-            }
-        }
-    }
-
-    private synchronized void addSubscription() {
-        UpnpIOService localService = service;
-        if (localService != null) {
-            if (localService.isRegistered(this)) {
-                logger.debug("Checking WeMo GENA subscription for '{}'", getThing().getUID());
-                String subscription = BASICEVENT;
-                if (subscriptionState.get(subscription) == null) {
-                    logger.debug("Setting up GENA subscription {}: Subscribing to service {}...", getUDN(),
-                            subscription);
-                    localService.addSubscription(this, subscription, SUBSCRIPTION_DURATION_SECONDS);
-                    subscriptionState.put(subscription, true);
-                }
-            } else {
-                logger.debug("Setting up WeMo GENA subscription for '{}' FAILED - service.isRegistered(this) is FALSE",
-                        getThing().getUID());
-            }
-        }
-    }
-
-    private synchronized void removeSubscription() {
-        logger.debug("Removing WeMo GENA subscription for '{}'", getThing().getUID());
-        UpnpIOService localService = service;
-        if (localService != null) {
-            if (localService.isRegistered(this)) {
-                String subscription = BASICEVENT;
-                if (subscriptionState.get(subscription) != null) {
-                    logger.debug("WeMo {}: Unsubscribing from service {}...", getUDN(), subscription);
-                    localService.removeSubscription(this, subscription);
-                }
-                subscriptionState = new HashMap<>();
-                localService.unregisterParticipant(this);
             }
         }
     }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -130,7 +130,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to send command '{}' for device '{}': IP address missing", command,
+            logger.warn("Failed to send command '{}' for device '{}': IP address missing", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
@@ -138,7 +138,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -159,7 +159,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                     wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
                     updateStatus(ThingStatus.ONLINE);
                 } catch (Exception e) {
-                    logger.error("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
+                    logger.warn("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
                             e.getMessage());
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 }
@@ -176,7 +176,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         String actionService = BASICACTION;
         String localhost = getHost();
         if (localhost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
@@ -191,7 +191,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localhost, actionService);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;
@@ -210,7 +210,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                 this.onValueReceived(variable, value, actionService + "1");
             }
         } catch (Exception e) {
-            logger.error("Failed to get actual state for device '{}': {}", getThing().getUID(), e.getMessage());
+            logger.warn("Failed to get actual state for device '{}': {}", getThing().getUID(), e.getMessage());
         }
     }
 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -156,14 +156,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                     boolean binaryState = OnOffType.ON.equals(command) ? true : false;
                     String soapHeader = "\"urn:Belkin:service:basicevent:1#SetBinaryState\"";
                     String content = createBinaryStateContent(binaryState);
-                    String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-                    if (wemoCallResponse != null && logger.isTraceEnabled()) {
-                        logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                        logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                        logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                        logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse,
-                                getThing().getUID());
-                    }
+                    wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
                     updateStatus(ThingStatus.ONLINE);
                 } catch (Exception e) {
                     logger.error("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
@@ -207,22 +200,14 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         String content = createStateRequestContent(action, actionService);
         try {
             String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                    logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                    logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                    logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-                }
-                if ("InsightParams".equals(variable)) {
-                    value = substringBetween(wemoCallResponse, "<InsightParams>", "</InsightParams>");
-                } else {
-                    value = substringBetween(wemoCallResponse, "<BinaryState>", "</BinaryState>");
-                }
-                if (value.length() != 0) {
-                    logger.trace("New state '{}' for device '{}' received", value, getThing().getUID());
-                    this.onValueReceived(variable, value, actionService + "1");
-                }
+            if ("InsightParams".equals(variable)) {
+                value = substringBetween(wemoCallResponse, "<InsightParams>", "</InsightParams>");
+            } else {
+                value = substringBetween(wemoCallResponse, "<BinaryState>", "</BinaryState>");
+            }
+            if (value.length() != 0) {
+                logger.trace("New state '{}' for device '{}' received", value, getThing().getUID());
+                this.onValueReceived(variable, value, actionService + "1");
             }
         } catch (Exception e) {
             logger.error("Failed to get actual state for device '{}': {}", getThing().getUID(), e.getMessage());

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -60,13 +60,14 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         Configuration configuration = getConfig();
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
+            addSubscription(BASICEVENT);
+            if (THING_TYPE_INSIGHT.equals(thing.getThingTypeUID())) {
+                addSubscription(INSIGHTEVENT);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -88,14 +89,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription(BASICEVENT);
-        if (THING_TYPE_INSIGHT.equals(thing.getThingTypeUID())) {
-            removeSubscription(INSIGHTEVENT);
-        }
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private void poll() {
@@ -116,10 +110,6 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription(BASICEVENT);
-                if (THING_TYPE_INSIGHT.equals(thing.getThingTypeUID())) {
-                    addSubscription(INSIGHTEVENT);
-                }
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -64,9 +64,9 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -91,6 +91,10 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         removeSubscription(BASICEVENT);
         if (THING_TYPE_INSIGHT.equals(thing.getThingTypeUID())) {
             removeSubscription(INSIGHTEVENT);
+        }
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -108,7 +108,6 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -127,7 +127,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.debug("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -180,7 +180,7 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localhost, actionService);
         if (wemoURL == null) {
-            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -108,7 +108,6 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -164,12 +164,12 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                         logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse,
                                 getThing().getUID());
                     }
+                    updateStatus(ThingStatus.ONLINE);
                 } catch (Exception e) {
                     logger.error("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
                             e.getMessage());
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 }
-                updateStatus(ThingStatus.ONLINE);
             }
         }
     }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -127,7 +127,6 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -68,12 +68,9 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
     private static final int FILTER_LIFE_DAYS = 330;
     private static final int FILTER_LIFE_MINS = FILTER_LIFE_DAYS * 24 * 60;
 
-    private final Object upnpLock = new Object();
     private final Object jobLock = new Object();
 
     private final Map<String, String> stateMap = Collections.synchronizedMap(new HashMap<>());
-
-    private Map<String, Boolean> subscriptionState = new HashMap<>();
 
     private @Nullable ScheduledFuture<?> pollingJob;
 
@@ -113,7 +110,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription();
+        removeSubscription(BASICEVENT);
     }
 
     private void poll() {
@@ -130,14 +127,12 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    synchronized (upnpLock) {
-                        subscriptionState = new HashMap<>();
-                    }
+                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription();
+                addSubscription(BASICEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }
@@ -284,15 +279,6 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
     }
 
     @Override
-    public void onServiceSubscribed(@Nullable String service, boolean succeeded) {
-        if (service != null) {
-            logger.debug("WeMo {}: Subscription to service {} {}", getUDN(), service,
-                    succeeded ? "succeeded" : "failed");
-            subscriptionState.put(service, succeeded);
-        }
-    }
-
-    @Override
     public void onValueReceived(@Nullable String variable, @Nullable String value, @Nullable String service) {
         logger.debug("Received pair '{}':'{}' (service '{}') for thing '{}'", variable, value, service,
                 this.getThing().getUID());
@@ -300,49 +286,6 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
         updateStatus(ThingStatus.ONLINE);
         if (variable != null && value != null) {
             this.stateMap.put(variable, value);
-        }
-    }
-
-    private synchronized void addSubscription() {
-        synchronized (upnpLock) {
-            UpnpIOService localService = service;
-            if (localService != null) {
-                if (localService.isRegistered(this)) {
-                    logger.debug("Checking WeMo GENA subscription for '{}'", getThing().getUID());
-
-                    String subscription = BASICEVENT;
-
-                    if (subscriptionState.get(subscription) == null) {
-                        logger.debug("Setting up GENA subscription {}: Subscribing to service {}...", getUDN(),
-                                subscription);
-                        localService.addSubscription(this, subscription, SUBSCRIPTION_DURATION_SECONDS);
-                        subscriptionState.put(subscription, true);
-                    }
-                } else {
-                    logger.debug(
-                            "Setting up WeMo GENA subscription for '{}' FAILED - service.isRegistered(this) is FALSE",
-                            getThing().getUID());
-                }
-            }
-        }
-    }
-
-    private synchronized void removeSubscription() {
-        synchronized (upnpLock) {
-            UpnpIOService localService = service;
-            if (localService != null) {
-                if (localService.isRegistered(this)) {
-                    logger.debug("Removing WeMo GENA subscription for '{}'", getThing().getUID());
-                    String subscription = BASICEVENT;
-
-                    if (subscriptionState.get(subscription) != null) {
-                        logger.debug("WeMo {}: Unsubscribing from service {}...", getUDN(), subscription);
-                        localService.removeSubscription(this, subscription);
-                    }
-                    subscriptionState.remove(subscription);
-                    localService.unregisterParticipant(this);
-                }
-            }
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -267,18 +267,12 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                     + "<attributeList>&lt;attribute&gt;&lt;name&gt;" + attribute + "&lt;/name&gt;&lt;value&gt;" + value
                     + "&lt;/value&gt;&lt;/attribute&gt;</attributeList>" + "</u:SetAttributes>" + "</s:Body>"
                     + "</s:Envelope>";
-            String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null && logger.isTraceEnabled()) {
-                logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-            }
-        } catch (RuntimeException e) {
+            wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
+            updateStatus(ThingStatus.ONLINE);
+        } catch (IOException e) {
             logger.debug("Failed to send command '{}' for device '{}':", command, getThing().getUID(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
-        updateStatus(ThingStatus.ONLINE);
     }
 
     @Override
@@ -318,153 +312,49 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
             String soapHeader = "\"urn:Belkin:service:" + actionService + ":1#" + action + "\"";
             String content = createStateRequestContent(action, actionService);
             String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            if (wemoCallResponse != null) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("wemoCall to URL '{}' for device '{}'", wemoURL, getThing().getUID());
-                    logger.trace("wemoCall with soapHeader '{}' for device '{}'", soapHeader, getThing().getUID());
-                    logger.trace("wemoCall with content '{}' for device '{}'", content, getThing().getUID());
-                    logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse, getThing().getUID());
-                }
+            String stringParser = substringBetween(wemoCallResponse, "<attributeList>", "</attributeList>");
 
-                String stringParser = substringBetween(wemoCallResponse, "<attributeList>", "</attributeList>");
+            // Due to Belkins bad response formatting, we need to run this twice.
+            stringParser = unescapeXml(stringParser);
+            stringParser = unescapeXml(stringParser);
 
-                // Due to Belkins bad response formatting, we need to run this twice.
-                stringParser = unescapeXml(stringParser);
-                stringParser = unescapeXml(stringParser);
+            logger.trace("AirPurifier response '{}' for device '{}' received", stringParser, getThing().getUID());
 
-                logger.trace("AirPurifier response '{}' for device '{}' received", stringParser, getThing().getUID());
+            stringParser = "<data>" + stringParser + "</data>";
 
-                stringParser = "<data>" + stringParser + "</data>";
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // see
+            // https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            InputSource is = new InputSource();
+            is.setCharacterStream(new StringReader(stringParser));
 
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-                // see
-                // https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-                dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-                dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-                dbf.setXIncludeAware(false);
-                dbf.setExpandEntityReferences(false);
-                DocumentBuilder db = dbf.newDocumentBuilder();
-                InputSource is = new InputSource();
-                is.setCharacterStream(new StringReader(stringParser));
+            Document doc = db.parse(is);
+            NodeList nodes = doc.getElementsByTagName("attribute");
 
-                Document doc = db.parse(is);
-                NodeList nodes = doc.getElementsByTagName("attribute");
+            // iterate the attributes
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Element element = (Element) nodes.item(i);
 
-                // iterate the attributes
-                for (int i = 0; i < nodes.getLength(); i++) {
-                    Element element = (Element) nodes.item(i);
+                NodeList deviceIndex = element.getElementsByTagName("name");
+                Element line = (Element) deviceIndex.item(0);
+                String attributeName = getCharacterDataFromElement(line);
+                logger.trace("attributeName: {}", attributeName);
 
-                    NodeList deviceIndex = element.getElementsByTagName("name");
-                    Element line = (Element) deviceIndex.item(0);
-                    String attributeName = getCharacterDataFromElement(line);
-                    logger.trace("attributeName: {}", attributeName);
+                NodeList deviceID = element.getElementsByTagName("value");
+                line = (Element) deviceID.item(0);
+                String attributeValue = getCharacterDataFromElement(line);
+                logger.trace("attributeValue: {}", attributeValue);
 
-                    NodeList deviceID = element.getElementsByTagName("value");
-                    line = (Element) deviceID.item(0);
-                    String attributeValue = getCharacterDataFromElement(line);
-                    logger.trace("attributeValue: {}", attributeValue);
-
-                    State newMode = new StringType();
-                    switch (attributeName) {
-                        case "Mode":
-                            if ("purifier".equals(getThing().getThingTypeUID().getId())) {
-                                switch (attributeValue) {
-                                    case "0":
-                                        newMode = new StringType("OFF");
-                                        break;
-                                    case "1":
-                                        newMode = new StringType("LOW");
-                                        break;
-                                    case "2":
-                                        newMode = new StringType("MED");
-                                        break;
-                                    case "3":
-                                        newMode = new StringType("HIGH");
-                                        break;
-                                    case "4":
-                                        newMode = new StringType("AUTO");
-                                        break;
-                                }
-                                updateState(CHANNEL_PURIFIERMODE, newMode);
-                            } else {
-                                switch (attributeValue) {
-                                    case "0":
-                                        newMode = new StringType("OFF");
-                                        break;
-                                    case "1":
-                                        newMode = new StringType("FROSTPROTECT");
-                                        break;
-                                    case "2":
-                                        newMode = new StringType("HIGH");
-                                        break;
-                                    case "3":
-                                        newMode = new StringType("LOW");
-                                        break;
-                                    case "4":
-                                        newMode = new StringType("ECO");
-                                        break;
-                                }
-                                updateState(CHANNEL_HEATERMODE, newMode);
-                            }
-                            break;
-                        case "Ionizer":
-                            switch (attributeValue) {
-                                case "0":
-                                    newMode = OnOffType.OFF;
-                                    break;
-                                case "1":
-                                    newMode = OnOffType.ON;
-                                    break;
-                            }
-                            updateState(CHANNEL_IONIZER, newMode);
-                            break;
-                        case "AirQuality":
-                            switch (attributeValue) {
-                                case "0":
-                                    newMode = new StringType("POOR");
-                                    break;
-                                case "1":
-                                    newMode = new StringType("MODERATE");
-                                    break;
-                                case "2":
-                                    newMode = new StringType("GOOD");
-                                    break;
-                            }
-                            updateState(CHANNEL_AIRQUALITY, newMode);
-                            break;
-                        case "FilterLife":
-                            int filterLife = Integer.valueOf(attributeValue);
-                            if ("purifier".equals(getThing().getThingTypeUID().getId())) {
-                                filterLife = Math.round((filterLife / FILTER_LIFE_MINS) * 100);
-                            } else {
-                                filterLife = Math.round((filterLife / 60480) * 100);
-                            }
-                            updateState(CHANNEL_FILTERLIFE, new PercentType(String.valueOf(filterLife)));
-                            break;
-                        case "ExpiredFilterTime":
-                            switch (attributeValue) {
-                                case "0":
-                                    newMode = OnOffType.OFF;
-                                    break;
-                                case "1":
-                                    newMode = OnOffType.ON;
-                                    break;
-                            }
-                            updateState(CHANNEL_EXPIREDFILTERTIME, newMode);
-                            break;
-                        case "FilterPresent":
-                            switch (attributeValue) {
-                                case "0":
-                                    newMode = OnOffType.OFF;
-                                    break;
-                                case "1":
-                                    newMode = OnOffType.ON;
-                                    break;
-                            }
-                            updateState(CHANNEL_FILTERPRESENT, newMode);
-                            break;
-                        case "FANMode":
+                State newMode = new StringType();
+                switch (attributeName) {
+                    case "Mode":
+                        if ("purifier".equals(getThing().getThingTypeUID().getId())) {
                             switch (attributeValue) {
                                 case "0":
                                     newMode = new StringType("OFF");
@@ -483,48 +373,143 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                                     break;
                             }
                             updateState(CHANNEL_PURIFIERMODE, newMode);
-                            break;
-                        case "DesiredHumidity":
+                        } else {
                             switch (attributeValue) {
                                 case "0":
-                                    newMode = new PercentType("45");
+                                    newMode = new StringType("OFF");
                                     break;
                                 case "1":
-                                    newMode = new PercentType("50");
+                                    newMode = new StringType("FROSTPROTECT");
                                     break;
                                 case "2":
-                                    newMode = new PercentType("55");
+                                    newMode = new StringType("HIGH");
                                     break;
                                 case "3":
-                                    newMode = new PercentType("60");
+                                    newMode = new StringType("LOW");
                                     break;
                                 case "4":
-                                    newMode = new PercentType("100");
+                                    newMode = new StringType("ECO");
                                     break;
                             }
-                            updateState(CHANNEL_DESIREDHUMIDITY, newMode);
-                            break;
-                        case "CurrentHumidity":
-                            newMode = new StringType(attributeValue);
-                            updateState(CHANNEL_CURRENTHUMIDITY, newMode);
-                            break;
-                        case "Temperature":
-                            newMode = new StringType(attributeValue);
-                            updateState(CHANNEL_CURRENTTEMP, newMode);
-                            break;
-                        case "SetTemperature":
-                            newMode = new StringType(attributeValue);
-                            updateState(CHANNEL_TARGETTEMP, newMode);
-                            break;
-                        case "AutoOffTime":
-                            newMode = new StringType(attributeValue);
-                            updateState(CHANNEL_AUTOOFFTIME, newMode);
-                            break;
-                        case "TimeRemaining":
-                            newMode = new StringType(attributeValue);
-                            updateState(CHANNEL_HEATINGREMAINING, newMode);
-                            break;
-                    }
+                            updateState(CHANNEL_HEATERMODE, newMode);
+                        }
+                        break;
+                    case "Ionizer":
+                        switch (attributeValue) {
+                            case "0":
+                                newMode = OnOffType.OFF;
+                                break;
+                            case "1":
+                                newMode = OnOffType.ON;
+                                break;
+                        }
+                        updateState(CHANNEL_IONIZER, newMode);
+                        break;
+                    case "AirQuality":
+                        switch (attributeValue) {
+                            case "0":
+                                newMode = new StringType("POOR");
+                                break;
+                            case "1":
+                                newMode = new StringType("MODERATE");
+                                break;
+                            case "2":
+                                newMode = new StringType("GOOD");
+                                break;
+                        }
+                        updateState(CHANNEL_AIRQUALITY, newMode);
+                        break;
+                    case "FilterLife":
+                        int filterLife = Integer.valueOf(attributeValue);
+                        if ("purifier".equals(getThing().getThingTypeUID().getId())) {
+                            filterLife = Math.round((filterLife / FILTER_LIFE_MINS) * 100);
+                        } else {
+                            filterLife = Math.round((filterLife / 60480) * 100);
+                        }
+                        updateState(CHANNEL_FILTERLIFE, new PercentType(String.valueOf(filterLife)));
+                        break;
+                    case "ExpiredFilterTime":
+                        switch (attributeValue) {
+                            case "0":
+                                newMode = OnOffType.OFF;
+                                break;
+                            case "1":
+                                newMode = OnOffType.ON;
+                                break;
+                        }
+                        updateState(CHANNEL_EXPIREDFILTERTIME, newMode);
+                        break;
+                    case "FilterPresent":
+                        switch (attributeValue) {
+                            case "0":
+                                newMode = OnOffType.OFF;
+                                break;
+                            case "1":
+                                newMode = OnOffType.ON;
+                                break;
+                        }
+                        updateState(CHANNEL_FILTERPRESENT, newMode);
+                        break;
+                    case "FANMode":
+                        switch (attributeValue) {
+                            case "0":
+                                newMode = new StringType("OFF");
+                                break;
+                            case "1":
+                                newMode = new StringType("LOW");
+                                break;
+                            case "2":
+                                newMode = new StringType("MED");
+                                break;
+                            case "3":
+                                newMode = new StringType("HIGH");
+                                break;
+                            case "4":
+                                newMode = new StringType("AUTO");
+                                break;
+                        }
+                        updateState(CHANNEL_PURIFIERMODE, newMode);
+                        break;
+                    case "DesiredHumidity":
+                        switch (attributeValue) {
+                            case "0":
+                                newMode = new PercentType("45");
+                                break;
+                            case "1":
+                                newMode = new PercentType("50");
+                                break;
+                            case "2":
+                                newMode = new PercentType("55");
+                                break;
+                            case "3":
+                                newMode = new PercentType("60");
+                                break;
+                            case "4":
+                                newMode = new PercentType("100");
+                                break;
+                        }
+                        updateState(CHANNEL_DESIREDHUMIDITY, newMode);
+                        break;
+                    case "CurrentHumidity":
+                        newMode = new StringType(attributeValue);
+                        updateState(CHANNEL_CURRENTHUMIDITY, newMode);
+                        break;
+                    case "Temperature":
+                        newMode = new StringType(attributeValue);
+                        updateState(CHANNEL_CURRENTTEMP, newMode);
+                        break;
+                    case "SetTemperature":
+                        newMode = new StringType(attributeValue);
+                        updateState(CHANNEL_TARGETTEMP, newMode);
+                        break;
+                    case "AutoOffTime":
+                        newMode = new StringType(attributeValue);
+                        updateState(CHANNEL_AUTOOFFTIME, newMode);
+                        break;
+                    case "TimeRemaining":
+                        newMode = new StringType(attributeValue);
+                        updateState(CHANNEL_HEATINGREMAINING, newMode);
+                        break;
                 }
             }
             updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -146,7 +146,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, DEVICEACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.debug("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -294,7 +294,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
         String actionService = DEVICEACTION;
         String wemoURL = getWemoURL(localHost, actionService);
         if (wemoURL == null) {
-            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -86,9 +86,9 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoHolmesHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -111,6 +111,10 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
         }
         this.pollingJob = null;
         removeSubscription(BASICEVENT);
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
+        }
     }
 
     private void poll() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -127,7 +127,6 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -82,14 +82,12 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         Configuration configuration = getConfig();
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoHolmesHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
-            }
+            addSubscription(BASICEVENT);
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
@@ -110,11 +108,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription(BASICEVENT);
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private void poll() {
@@ -135,7 +129,6 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                 }
                 updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
-                addSubscription(BASICEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -146,7 +146,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to send command '{}' for device '{}': IP address missing", command,
+            logger.warn("Failed to send command '{}' for device '{}': IP address missing", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
@@ -154,7 +154,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, DEVICEACTION);
         if (wemoURL == null) {
-            logger.error("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -294,7 +294,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
     protected void updateWemoState() {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
@@ -302,7 +302,7 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
         String actionService = DEVICEACTION;
         String wemoURL = getWemoURL(localHost, actionService);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -527,10 +527,10 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
                     }
                 }
             }
+            updateStatus(ThingStatus.ONLINE);
         } catch (RuntimeException | ParserConfigurationException | SAXException | IOException e) {
             logger.debug("Failed to get actual state for device '{}':", getThing().getUID(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
-        updateStatus(ThingStatus.ONLINE);
     }
 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoInsightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoInsightHandler.java
@@ -84,7 +84,7 @@ public class WemoInsightHandler extends WemoHandler {
                 try {
                     lastChangedAt = Long.parseLong(splitInsightParams[1]) * 1000; // convert s to ms
                 } catch (NumberFormatException e) {
-                    logger.error("Unable to parse lastChangedAt value '{}' for device '{}'; expected long",
+                    logger.warn("Unable to parse lastChangedAt value '{}' for device '{}'; expected long",
                             splitInsightParams[1], getThing().getUID());
                 }
                 ZonedDateTime zoned = ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastChangedAt),

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -83,9 +83,9 @@ public class WemoLightHandler extends WemoBaseThingHandler {
 
         final Bridge bridge = getBridge();
         if (bridge != null && bridge.getStatus() == ThingStatus.ONLINE) {
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, DEFAULT_REFRESH_INITIAL_DELAY,
@@ -120,6 +120,10 @@ public class WemoLightHandler extends WemoBaseThingHandler {
         }
         this.pollingJob = null;
         removeSubscription(BRIDGEEVENT);
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
+        }
     }
 
     private synchronized @Nullable WemoBridgeHandler getWemoBridgeHandler() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -78,15 +78,13 @@ public class WemoLightHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         // initialize() is only called if the required parameter 'deviceID' is available
         wemoLightID = (String) getConfig().get(DEVICE_ID);
 
         final Bridge bridge = getBridge();
         if (bridge != null && bridge.getStatus() == ThingStatus.ONLINE) {
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
-            }
+            addSubscription(BRIDGEEVENT);
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, DEFAULT_REFRESH_INITIAL_DELAY,
                     DEFAULT_REFRESH_INTERVAL_SECONDS, TimeUnit.SECONDS);
@@ -112,18 +110,14 @@ public class WemoLightHandler extends WemoBaseThingHandler {
 
     @Override
     public void dispose() {
-        logger.debug("WeMoLightHandler disposed.");
+        logger.debug("WemoLightHandler disposed.");
 
         ScheduledFuture<?> job = this.pollingJob;
         if (job != null && !job.isCancelled()) {
             job.cancel(true);
         }
         this.pollingJob = null;
-        removeSubscription(BRIDGEEVENT);
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private synchronized @Nullable WemoBridgeHandler getWemoBridgeHandler() {
@@ -160,7 +154,6 @@ public class WemoLightHandler extends WemoBaseThingHandler {
                 }
                 updateStatus(ThingStatus.ONLINE);
                 getDeviceState();
-                addSubscription(BRIDGEEVENT);
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
             }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -171,7 +171,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.debug("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -304,7 +304,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
         logger.debug("Request actual state for LightID '{}'", wemoLightID);
         String wemoURL = getWemoURL(localHost, BRIDGEACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -152,7 +152,6 @@ public class WemoLightHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 getDeviceState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
@@ -338,8 +337,10 @@ public class WemoLightHandler extends WemoBaseThingHandler {
                     currentBrightness = newBrightness;
                 }
             }
+            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
-            throw new IllegalStateException("Could not retrieve new Wemo light state", e);
+            logger.debug("Could not retrieve new Wemo light state for '{}':", getThing().getUID(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -129,7 +129,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
     private synchronized @Nullable WemoBridgeHandler getWemoBridgeHandler() {
         Bridge bridge = getBridge();
         if (bridge == null) {
-            logger.error("Required bridge not defined for device {}.", wemoLightID);
+            logger.warn("Required bridge not defined for device {}.", wemoLightID);
             return null;
         }
         ThingHandler handler = bridge.getHandler();
@@ -171,7 +171,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to send command '{}' for device '{}': IP address missing", command,
+            logger.warn("Failed to send command '{}' for device '{}': IP address missing", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
@@ -179,7 +179,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -280,7 +280,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
                     updateStatus(ThingStatus.ONLINE);
                 }
             } catch (Exception e) {
-                logger.error("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
+                logger.warn("Failed to send command '{}' for device '{}': {}", command, getThing().getUID(),
                         e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
             }
@@ -304,7 +304,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
     public void getDeviceState() {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
@@ -312,7 +312,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
         logger.debug("Request actual state for LightID '{}'", wemoLightID);
         String wemoURL = getWemoURL(localHost, BRIDGEACTION);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -152,7 +152,6 @@ public class WemoLightHandler extends WemoBaseThingHandler {
                     logger.debug("UPnP device {} not yet registered", getUDN());
                     updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
-                    clearSubscriptionState();
                     return;
                 }
                 updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -70,14 +70,11 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
 
     @Override
     public void initialize() {
+        super.initialize();
         Configuration configuration = getConfig();
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoMakerHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService service = this.service;
-            if (service != null) {
-                service.registerParticipant(this);
-            }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
@@ -91,17 +88,14 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
 
     @Override
     public void dispose() {
-        logger.debug("WeMoMakerHandler disposed.");
+        logger.debug("WemoMakerHandler disposed.");
 
         ScheduledFuture<?> job = this.pollingJob;
         if (job != null && !job.isCancelled()) {
             job.cancel(true);
         }
         this.pollingJob = null;
-        UpnpIOService service = this.service;
-        if (service != null) {
-            service.unregisterParticipant(this);
-        }
+        super.dispose();
     }
 
     private void poll() {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -74,9 +74,9 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
 
         if (configuration.get(UDN) != null) {
             logger.debug("Initializing WemoMakerHandler for UDN '{}'", configuration.get(UDN));
-            UpnpIOService localService = service;
-            if (localService != null) {
-                localService.registerParticipant(this);
+            UpnpIOService service = this.service;
+            if (service != null) {
+                service.registerParticipant(this);
             }
             host = getHost();
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
@@ -98,9 +98,9 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
             job.cancel(true);
         }
         this.pollingJob = null;
-        UpnpIOService localService = service;
-        if (localService != null) {
-            localService.unregisterParticipant(this);
+        UpnpIOService service = this.service;
+        if (service != null) {
+            service.unregisterParticipant(this);
         }
     }
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -133,7 +133,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.debug("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -175,7 +175,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
         String actionService = DEVICEACTION;
         String wemoURL = getWemoURL(localHost, actionService);
         if (wemoURL == null) {
-            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.debug("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -166,8 +166,10 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
                         logger.trace("wemoCall with response '{}' for device '{}'", wemoCallResponse,
                                 getThing().getUID());
                     }
+                    updateStatus(ThingStatus.ONLINE);
                 } catch (Exception e) {
                     logger.error("Failed to send command '{}' for device '{}' ", command, getThing().getUID(), e);
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 }
             }
         }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -114,7 +114,6 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }
-                updateStatus(ThingStatus.ONLINE);
                 updateWemoState();
             } catch (Exception e) {
                 logger.debug("Exception during poll: {}", e.getMessage(), e);
@@ -242,11 +241,13 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
                             break;
                     }
                 }
+                updateStatus(ThingStatus.ONLINE);
             } catch (Exception e) {
                 logger.warn("Failed to parse attributeList for WeMo Maker '{}'", this.getThing().getUID(), e);
             }
         } catch (Exception e) {
             logger.warn("Failed to get attributes for device '{}'", getThing().getUID(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -132,7 +132,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to send command '{}' for device '{}': IP address missing", command,
+            logger.warn("Failed to send command '{}' for device '{}': IP address missing", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
@@ -140,7 +140,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
         }
         String wemoURL = getWemoURL(localHost, BASICACTION);
         if (wemoURL == null) {
-            logger.error("Failed to send command '{}' for device '{}': URL cannot be created", command,
+            logger.warn("Failed to send command '{}' for device '{}': URL cannot be created", command,
                     getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
@@ -161,7 +161,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
                     wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
                     updateStatus(ThingStatus.ONLINE);
                 } catch (Exception e) {
-                    logger.error("Failed to send command '{}' for device '{}' ", command, getThing().getUID(), e);
+                    logger.warn("Failed to send command '{}' for device '{}' ", command, getThing().getUID(), e);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                 }
             }
@@ -174,7 +174,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
     protected void updateWemoState() {
         String localHost = getHost();
         if (localHost.isEmpty()) {
-            logger.error("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': IP address missing", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-ip");
             return;
@@ -182,7 +182,7 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
         String actionService = DEVICEACTION;
         String wemoURL = getWemoURL(localHost, actionService);
         if (wemoURL == null) {
-            logger.error("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
+            logger.warn("Failed to get actual state for device '{}': URL cannot be created", getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/config-status.error.missing-url");
             return;
@@ -249,10 +249,10 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
                     }
                 }
             } catch (Exception e) {
-                logger.error("Failed to parse attributeList for WeMo Maker '{}'", this.getThing().getUID(), e);
+                logger.warn("Failed to parse attributeList for WeMo Maker '{}'", this.getThing().getUID(), e);
             }
         } catch (Exception e) {
-            logger.error("Failed to get attributes for device '{}'", getThing().getUID(), e);
+            logger.warn("Failed to get attributes for device '{}'", getThing().getUID(), e);
         }
     }
 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/http/WemoHttpCall.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/http/WemoHttpCall.java
@@ -19,7 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.wemo.internal.WemoBindingConstants;
 import org.openhab.core.io.net.http.HttpUtil;
 import org.slf4j.Logger;
@@ -35,20 +34,18 @@ public class WemoHttpCall {
 
     private final Logger logger = LoggerFactory.getLogger(WemoHttpCall.class);
 
-    public @Nullable String executeCall(String wemoURL, String soapHeader, String content) {
-        try {
-            Properties wemoHeaders = new Properties();
-            wemoHeaders.setProperty("CONTENT-TYPE", WemoBindingConstants.HTTP_CALL_CONTENT_HEADER);
-            wemoHeaders.put("SOAPACTION", soapHeader);
+    public String executeCall(String wemoURL, String soapHeader, String content) throws IOException {
+        Properties wemoHeaders = new Properties();
+        wemoHeaders.setProperty("CONTENT-TYPE", WemoBindingConstants.HTTP_CALL_CONTENT_HEADER);
+        wemoHeaders.put("SOAPACTION", soapHeader);
 
-            InputStream wemoContent = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        InputStream wemoContent = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
 
-            String wemoCallResponse = HttpUtil.executeUrl("POST", wemoURL, wemoHeaders, wemoContent, null, 2000);
-            return wemoCallResponse;
-        } catch (IOException e) {
-            // throw new IllegalStateException("Could not call WeMo", e);
-            logger.debug("Could not make HTTP call to WeMo");
-            return null;
-        }
+        logger.trace("Performing HTTP call for URL: '{}', header: '{}', request body: '{}'", wemoURL, soapHeader,
+                content);
+        String responseBody = HttpUtil.executeUrl("POST", wemoURL, wemoHeaders, wemoContent, null, 2000);
+        logger.trace("HTTP response body: '{}'", responseBody);
+
+        return responseBody;
     }
 }

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoLinkDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoLinkDiscoveryServiceOSGiTest.java
@@ -50,7 +50,7 @@ public class WemoLinkDiscoveryServiceOSGiTest extends GenericWemoLightOSGiTestPa
 
     @Test
     public void assertSupportedThingIsDiscovered()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         String model = WemoBindingConstants.THING_TYPE_MZ100.getId();
         addUpnpDevice(SERVICE_ID, SERVICE_NUMBER, model);
 

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
@@ -69,7 +69,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
 
     @Test
     public void assertThatThingHandlesOnOffCommandCorrectly()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = OnOffType.OFF;
 
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
@@ -105,7 +105,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
 
     @Test
     public void assertThatThingHandlesREFRESHCommandCorrectly()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = RefreshType.REFRESH;
 
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoLightHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoLightHandlerOSGiTest.java
@@ -65,7 +65,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
 
     @Test
     public void handleONcommandForBRIGHTNESSchannel()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = OnOffType.ON;
         String channelID = WemoBindingConstants.CHANNEL_BRIGHTNESS;
 
@@ -80,7 +80,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
 
     @Test
     public void handlePercentCommandForBRIGHTNESSChannel()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         // Set brightness value to 20 Percent
         Command command = new PercentType(20);
         String channelID = WemoBindingConstants.CHANNEL_BRIGHTNESS;
@@ -95,7 +95,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
 
     @Test
     public void handleIncreaseCommandForBRIGHTNESSchannel()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         // The value is increased by 5 Percents by default
         Command command = IncreaseDecreaseType.INCREASE;
         String channelID = WemoBindingConstants.CHANNEL_BRIGHTNESS;
@@ -110,7 +110,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
 
     @Test
     public void handleDecreaseCommandForBRIGHTNESSchannel()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         // The value can not be decreased below 0
         Command command = IncreaseDecreaseType.DECREASE;
         String channelID = WemoBindingConstants.CHANNEL_BRIGHTNESS;
@@ -123,7 +123,8 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
     }
 
     @Test
-    public void handleOnCommandForSTATEChannel() throws MalformedURLException, URISyntaxException, ValidationException {
+    public void handleOnCommandForSTATEChannel()
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = OnOffType.ON;
         String channelID = WemoBindingConstants.CHANNEL_STATE;
 
@@ -137,7 +138,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
 
     @Test
     public void handleREFRESHCommandForChannelSTATE()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = RefreshType.REFRESH;
         String channelID = WemoBindingConstants.CHANNEL_STATE;
 
@@ -149,7 +150,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
     }
 
     private void assertRequestForCommand(String channelID, Command command, String action, String value,
-            String capitability) throws MalformedURLException, URISyntaxException, ValidationException {
+            String capitability) throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Thing bridge = createBridge(BRIDGE_TYPE_UID);
 
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
@@ -70,7 +70,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
 
     @Test
     public void assertThatThingHandlesOnOffCommandCorrectly()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = OnOffType.OFF;
 
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
@@ -106,7 +106,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
 
     @Test
     public void assertThatThingHandlesREFRESHCommand()
-            throws MalformedURLException, URISyntaxException, ValidationException {
+            throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = RefreshType.REFRESH;
 
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Continuation of #12101:
- Service subscription consolidated in base class (removing a lot of duplicate code).
- Fix status wrongly set to **ONLINE** when exception is thrown.
- Fix exception thrown from `handleCommand()` - set status **OFFLINE** instead.
- Rework error handling for `WemoHttpCall`: Duplicated logging moved inside and throws exception rather than returning null.
- Decrease log level from **error** to **warning** for communication errors and avoid warning every minute while a device is offline.
- Improve reliability of GENA events by renewing subscriptions automatically.

Review notes:
- Reading commit by commit might be helpful to understand the process/distinct steps.