### PR TITLE
[mqtt.generic] Fix default configuration and docs for color_mode

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -129,7 +129,7 @@ You can connect this channel to a Contact or Switch item.
 
 ### Channel Type "color"
 
-* __color_mode__: A required string that defines the color representation: "hsb", "rgb" or "xyY" (x,y,brightness).
+* __color_mode__: An optional string that defines the color representation: `HSB`, `RGB` or `XYY` (x,y,brightness). Defaults to `HSB` when not specified.
 * __on__: An optional string (like "BRIGHT") that is recognized as on state. (ON will always be recognized.)
 * __off__: An optional string (like "DARK") that is recognized as off state. (OFF will always be recognized.)
 * __onBrightness__: If you connect this channel to a Switch item and turn it on,

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelConfig.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelConfig.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.mqtt.generic.mapping.ColorMode;
 
 /**
  * A user can add custom channels to an MQTT Thing.
@@ -56,5 +57,5 @@ public class ChannelConfig {
     public @Nullable String stop;
 
     public int onBrightness = 10;
-    public String colorMode = "";
+    public String colorMode = ColorMode.HSB.toString();
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -165,7 +165,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
                     stateDescProvider.setDescription(channel.getUID(), description);
                 }
             } catch (IllegalArgumentException e) {
-                logger.warn("Channel configuration error", e);
+                logger.warn("Configuration error for channel '{}'", channel.getUID(), e);
                 configErrors.add(channel.getUID());
             }
         }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ValueFactory.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ValueFactory.java
@@ -61,7 +61,13 @@ public class ValueFactory {
                 value = new ColorValue(ColorMode.RGB, config.on, config.off, config.onBrightness);
                 break;
             case MqttBindingConstants.COLOR:
-                value = new ColorValue(ColorMode.valueOf(config.colorMode), config.on, config.off, config.onBrightness);
+                ColorMode colorMode;
+                try {
+                    colorMode = ColorMode.valueOf(config.colorMode);
+                } catch (IllegalArgumentException exception) {
+                    throw new IllegalArgumentException("Invalid color mode: " + config.colorMode, exception);
+                }
+                value = new ColorValue(colorMode, config.on, config.off, config.onBrightness);
                 break;
             case MqttBindingConstants.SWITCH:
                 value = new OnOffValue(config.on, config.off);


### PR DESCRIPTION
Fix #10117 

The current documentation uses lower case color_mode which will cause an error. This PR updates the docs to use upper case. Furthermore, the default of "HSB" is assumed when color_mode is empty or not specified. This fixes the bug in the GUI when the user accepts the default color_mode.

