### PR TITLE
[mqtt] publishMQTT Action accepts a bytearray payload

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -220,6 +220,7 @@ Once this action instance is retrieved, you can invoke the `publishMQTT(String t
 ```
 mqttActions.publishMQTT("mytopic","myvalue", true)
 ```
+Alternatively, `publishMQTT(String topic, byte[] value, Boolean retained)` can publish a byte array data.
 
 The retained argument is optional and if not supplied defaults to `false`.
 

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
@@ -107,4 +107,13 @@ public class MQTTActions implements ThingActions {
             @Nullable Boolean retain) {
         ((MQTTActions) actions).publishMQTT(topic, value, retain);
     }
+
+    public static void publishMQTT(ThingActions actions, @Nullable String topic, byte[] value) {
+        publishMQTT(actions, topic, value, null);
+    }
+
+    public static void publishMQTT(ThingActions actions, @Nullable String topic, byte[] value,
+            @Nullable Boolean retain) {
+        ((MQTTActions) actions).publishMQTT(topic, value, retain);
+    }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
@@ -57,6 +57,25 @@ public class MQTTActions implements ThingActions {
             @ActionInput(name = "topic", label = "@text/actionInputTopicLabel", description = "@text/actionInputTopicDesc") @Nullable final String topic,
             @ActionInput(name = "value", label = "@text/actionInputValueLabel", description = "@text/actionInputValueDesc") @Nullable final String value,
             @ActionInput(name = "retain", label = "@text/actionInputRetainlabel", description = "@text/actionInputRetainDesc") @Nullable final Boolean retain) {
+        if (value == null) {
+            logger.debug("skipping MQTT publishing to topic '{}' due to null value.", topic);
+            return;
+        }
+        publishMQTT(topic, value.getBytes(), retain);
+    }
+
+    @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")
+    public void publishMQTT(
+            @ActionInput(name = "topic", label = "@text/actionInputTopicLabel", description = "@text/actionInputTopicDesc") @Nullable final String topic,
+            @ActionInput(name = "value", label = "@text/actionInputValueLabel", description = "@text/actionInputValueDesc") final byte[] value) {
+        publishMQTT(topic, value, null);
+    }
+
+    @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")
+    public void publishMQTT(
+            @ActionInput(name = "topic", label = "@text/actionInputTopicLabel", description = "@text/actionInputTopicDesc") @Nullable final String topic,
+            @ActionInput(name = "value", label = "@text/actionInputValueLabel", description = "@text/actionInputValueDesc") final byte[] value,
+            @ActionInput(name = "retain", label = "@text/actionInputRetainlabel", description = "@text/actionInputRetainDesc") @Nullable final Boolean retain) {
         AbstractBrokerHandler brokerHandler = handler;
         if (brokerHandler == null) {
             logger.warn("MQTT Action service ThingHandler is null!");
@@ -67,22 +86,17 @@ public class MQTTActions implements ThingActions {
             logger.warn("MQTT Action service ThingHandler connection is null!");
             return;
         }
-        if (value == null) {
-            logger.debug("skipping MQTT publishing to topic '{}' due to null value.", topic);
-            return;
-        }
         if (topic == null) {
             logger.debug("skipping MQTT publishing of value '{}' as topic is null.", value);
             return;
         }
 
-        connection.publish(topic, value.getBytes(), connection.getQos(), retain != null && retain.booleanValue())
-                .thenRun(() -> {
-                    logger.debug("MQTT publish to {} performed", topic);
-                }).exceptionally(e -> {
-                    logger.warn("MQTT publish to {} failed!", topic);
-                    return null;
-                });
+        connection.publish(topic, value, connection.getQos(), retain != null && retain.booleanValue()).thenRun(() -> {
+            logger.debug("MQTT publish to {} performed", topic);
+        }).exceptionally(e -> {
+            logger.warn("MQTT publish to {} failed!", topic);
+            return null;
+        });
     }
 
     public static void publishMQTT(ThingActions actions, @Nullable String topic, @Nullable String value) {


### PR DESCRIPTION
Resolve #10762

This PR adds variants of publishMQTT that accept byte array instead of String.
