### PR TITLE
[hdpowerview] Add shade identify command

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -92,7 +92,7 @@ All of these channels appear in the binding, but only those which have a physica
 | position       | Rollershutter            | The vertical position of the shade's rail -- see [next chapter](#Roller-Shutter-Up/Down-Position-vs.-Open/Close-State). Up/Down commands will move the rail completely up or completely down. Percentage commands will move the rail to an intermediate position. Stop commands will halt any current movement of the rail. |
 | secondary      | Rollershutter            | The vertical position of the secondary rail (if any). Its function is similar to the `position` channel above -- but see [next chapter](#Roller-Shutter-Up/Down-Position-vs.-Open/Close-State). |
 | vane           | Dimmer                   | The degree of opening of the slats or vanes. Setting this to a non-zero value will first move the shade `position` fully down, since the slats or vanes can only have a defined state if the shade is in its down position -- see [Interdependency between Channel positions](#Interdependency-between-Channel-positions). |
-| command        | String                   | Send a command to the shade. Valid values are: `CALIBRATE` |
+| command        | String                   | Send a command to the shade. Valid values are: `CALIBRATE`, `IDENTIFY` |
 | lowBattery     | Switch                   | Indicates ON when the battery level of the shade is low, as determined by the hub's internal rules. |
 | batteryLevel   | Number                   | Battery level (10% = low, 50% = medium, 100% = high)
 | batteryVoltage | Number:ElectricPotential | Battery voltage reported by the shade. |

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 import org.openhab.binding.hdpowerview.internal.api.requests.RepeaterBlinking;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeCalibrate;
+import org.openhab.binding.hdpowerview.internal.api.requests.ShadeJog;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeMove;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeStop;
 import org.openhab.binding.hdpowerview.internal.api.responses.FirmwareVersion;
@@ -243,6 +244,22 @@ public class HDPowerViewWebTargets {
     public ShadeData stopShade(int shadeId)
             throws HubInvalidResponseException, HubProcessingException, HubMaintenanceException {
         String jsonRequest = gson.toJson(new ShadeStop());
+        String jsonResponse = invoke(HttpMethod.PUT, shades + Integer.toString(shadeId), null, jsonRequest);
+        return shadeDataFromJson(jsonResponse);
+    }
+
+    /**
+     * Instructs the hub to jog a specific shade
+     *
+     * @param shadeId id of the shade to be jogged
+     * @return ShadeData class instance
+     * @throws HubInvalidResponseException if response is invalid
+     * @throws HubProcessingException if there is any processing error
+     * @throws HubMaintenanceException if the hub is down for maintenance
+     */
+    public ShadeData jogShade(int shadeId)
+            throws HubInvalidResponseException, HubProcessingException, HubMaintenanceException {
+        String jsonRequest = gson.toJson(new ShadeJog());
         String jsonResponse = invoke(HttpMethod.PUT, shades + Integer.toString(shadeId), null, jsonRequest);
         return shadeDataFromJson(jsonResponse);
     }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeJog.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/ShadeJog.java
@@ -15,32 +15,16 @@ package org.openhab.binding.hdpowerview.internal.api.requests;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * A motion directive for a shade
+ * A request to jog a shade for identification
  *
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-class ShadeMotion {
+public class ShadeJog {
 
-    public enum Type {
-        STOP("stop"),
-        JOG("jog"),
-        CALIBRATE("calibrate");
+    public ShadeMotion shade;
 
-        private String motion;
-
-        Type(String motion) {
-            this.motion = motion;
-        }
-
-        public String getMotion() {
-            return this.motion;
-        }
-    }
-
-    public String motion;
-
-    public ShadeMotion(Type motionType) {
-        this.motion = motionType.getMotion();
+    public ShadeJog() {
+        this.shade = new ShadeMotion(ShadeMotion.Type.JOG);
     }
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -72,6 +72,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
     }
 
     private static final String COMMAND_CALIBRATE = "CALIBRATE";
+    private static final String COMMAND_IDENTIFY = "IDENTIFY";
 
     private final Logger logger = LoggerFactory.getLogger(HDPowerViewShadeHandler.class);
     private final ShadeCapabilitiesDatabase db = new ShadeCapabilitiesDatabase();
@@ -226,7 +227,10 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
 
             case CHANNEL_SHADE_COMMAND:
                 if (command instanceof StringType) {
-                    if (COMMAND_CALIBRATE.equals(((StringType) command).toString())) {
+                    if (COMMAND_IDENTIFY.equals(((StringType) command).toString())) {
+                        logger.debug("Identify shade {}", shadeId);
+                        identifyShade(webTargets, shadeId);
+                    } else if (COMMAND_CALIBRATE.equals(((StringType) command).toString())) {
                         logger.debug("Calibrate shade {}", shadeId);
                         calibrateShade(webTargets, shadeId);
                     }
@@ -445,6 +449,11 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         // Positions in response from stop motion is not updated to to actual positions yet,
         // so we need to request hard refresh.
         requestRefreshShadePosition();
+    }
+
+    private void identifyShade(HDPowerViewWebTargets webTargets, int shadeId)
+            throws HubInvalidResponseException, HubProcessingException, HubMaintenanceException {
+        updateShadePositions(webTargets.jogShade(shadeId));
     }
 
     private void calibrateShade(HDPowerViewWebTargets webTargets, int shadeId)

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
@@ -40,6 +40,7 @@ channel-type.hdpowerview.repeater-identify.description = Flash repeater to ident
 channel-type.hdpowerview.repeater-identify.command.option.IDENTIFY = Identify
 channel-type.hdpowerview.shade-command.label = Command
 channel-type.hdpowerview.shade-command.description = Send a command to the shade
+channel-type.hdpowerview.shade-command.command.option.IDENTIFY = Identify
 channel-type.hdpowerview.shade-command.command.option.CALIBRATE = Calibrate
 channel-type.hdpowerview.shade-position.label = Position
 channel-type.hdpowerview.shade-position.description = The vertical position of the shade

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview_da.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview_da.properties
@@ -12,7 +12,6 @@ channel-type.hdpowerview.repeater-identify.description = Identificer ved at lade
 channel-type.hdpowerview.repeater-identify.command.option.IDENTIFY = Identificer
 channel-type.hdpowerview.shade-command.label = Kommando
 channel-type.hdpowerview.shade-command.description = Send en kommando til gardinet
-channel-type.hdpowerview.shade-command.command.option.IDENTIFY = Identificer
 channel-type.hdpowerview.shade-command.command.option.CALIBRATE = Kalibrer
 
 # dynamic channels

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview_da.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview_da.properties
@@ -12,6 +12,7 @@ channel-type.hdpowerview.repeater-identify.description = Identificer ved at lade
 channel-type.hdpowerview.repeater-identify.command.option.IDENTIFY = Identificer
 channel-type.hdpowerview.shade-command.label = Kommando
 channel-type.hdpowerview.shade-command.description = Send en kommando til gardinet
+channel-type.hdpowerview.shade-command.command.option.IDENTIFY = Identificer
 channel-type.hdpowerview.shade-command.command.option.CALIBRATE = Kalibrer
 
 # dynamic channels

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
@@ -127,6 +127,7 @@
 		<description>Send a command to the shade</description>
 		<command>
 			<options>
+				<option value="IDENTIFY">Identify</option>
 				<option value="CALIBRATE">Calibrate</option>
 			</options>
 		</command>


### PR DESCRIPTION
Fixes #12174

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Add a command for identifying a shade by jogging it.

Extends #12138 to have more than one command and provides same functionality for shades as introduced for repeaters in #12061.