### PR TITLE
[rfxcom] Better support for Legrand CAD protocol

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -59,6 +59,7 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
         EURODOMEST(9),
         LIVOLO_APPLIANCE(10),
         MDREMOTE_107(12),
+        LEGRAND_CAD(13),
         AVANTEK(14),
         IT(15),
         MDREMOTE_108(16),
@@ -118,7 +119,8 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
         TOGGLE_6(0x0B, LIVOLO_APPLIANCE),
         TOGGLE_7(0x06, LIVOLO_APPLIANCE),
         TOGGLE_8(0x0A, LIVOLO_APPLIANCE),
-        TOGGLE_9(0x05, LIVOLO_APPLIANCE);
+        TOGGLE_9(0x05, LIVOLO_APPLIANCE),
+        TOGGLE(0x00, LEGRAND_CAD);
 
         private final int command;
         private final List<SubType> supportedBySubTypes;
@@ -178,9 +180,16 @@ public class RFXComLighting5Message extends RFXComDeviceMessageImpl<RFXComLighti
         subType = fromByte(SubType.class, super.subType);
 
         sensorId = (data[4] & 0xFF) << 16 | (data[5] & 0xFF) << 8 | (data[6] & 0xFF);
-        unitCode = data[7];
 
-        command = fromByte(Commands.class, data[8], subType);
+        switch (subType) {
+            case LEGRAND_CAD:
+                unitCode = 0x01;
+                command = Commands.TOGGLE;
+                break;
+            default:
+                unitCode = data[7];
+                command = fromByte(Commands.class, data[8], subType);
+        }
 
         dimmingLevel = data[9];
         signalLevel = (byte) ((data[10] & 0xF0) >> 4);


### PR DESCRIPTION
# Title

Better support for Legrand CAD protocol

# Description

Improvement: Le Grand CAD is a relatively old protocol, supported by the RFXComXL device. The protocol as applies by LeGrand doesn't use certain fields such as Unitcode and a Command. Whenever a CAD message is sent, it is always of type TOGGLE (On or Off doesn't exist). This does cause a couple of challenges within OH3, but with this patch OH at least doesn't throw exceptions anymore when a CAD command is received.

Signed-off-by: Jan Penninkhof <jan@penninkhof.com>