### PR TITLE
[homematic] Remove state description step size handling

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
@@ -249,7 +249,6 @@ public class DisplayTextVirtualDatapoint extends AbstractVirtualDatapointHandler
                                 HmValueType.INTEGER, 1, false);
                         bd.setMinValue(10);
                         bd.setMaxValue(160);
-                        bd.setStep(10);
                         addEnumDisplayDatapoint(device, channel.getNumber(), DATAPOINT_NAME_DISPLAY_LED, Led.class);
                     }
                     addDatapoint(device, channel.getNumber(), DATAPOINT_NAME_DISPLAY_SUBMIT, HmValueType.BOOL, false,

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
@@ -31,7 +31,6 @@ public class HmDatapoint implements Cloneable {
     private HmParamsetType paramsetType;
     private Number minValue;
     private Number maxValue;
-    private Number step;
     private String[] options;
     private boolean readOnly;
     private boolean readable;
@@ -190,20 +189,6 @@ public class HmDatapoint implements Cloneable {
      */
     public void setMinValue(Number minValue) {
         this.minValue = minValue;
-    }
-
-    /**
-     * Returns the step size.
-     */
-    public Number getStep() {
-        return step;
-    }
-
-    /**
-     * Sets the step size.
-     */
-    public void setStep(Number step) {
-        this.step = step;
     }
 
     /**
@@ -415,7 +400,6 @@ public class HmDatapoint implements Cloneable {
         dp.setChannel(channel);
         dp.setMinValue(minValue);
         dp.setMaxValue(maxValue);
-        dp.setStep(step);
         dp.setOptions(options);
         dp.setInfo(info);
         dp.setUnit(unit);
@@ -428,9 +412,9 @@ public class HmDatapoint implements Cloneable {
 
     @Override
     public String toString() {
-        return String.format("%s[name=%s,value=%s,defaultValue=%s,type=%s,minValue=%s,maxValue=%s,step=%s,options=%s,"
+        return String.format("%s[name=%s,value=%s,defaultValue=%s,type=%s,minValue=%s,maxValue=%s,options=%s,"
                 + "readOnly=%b,readable=%b,unit=%s,description=%s,info=%s,paramsetType=%s,virtual=%b,trigger=%b]",
-                getClass().getSimpleName(), name, value, defaultValue, type, minValue, maxValue, step,
+                getClass().getSimpleName(), name, value, defaultValue, type, minValue, maxValue,
                 (options == null ? null : String.join(";", options)), readOnly, readable, unit, description, info,
                 paramsetType, virtual, trigger);
     }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -278,21 +278,14 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
             if (dp.isNumberType()) {
                 BigDecimal min = MetadataUtils.createBigDecimal(dp.getMinValue());
                 BigDecimal max = MetadataUtils.createBigDecimal(dp.getMaxValue());
-                BigDecimal step = MetadataUtils.createBigDecimal(dp.getStep());
                 if (ITEM_TYPE_DIMMER.equals(itemType)
                         && (max.compareTo(new BigDecimal("1.0")) == 0 || max.compareTo(new BigDecimal("1.01")) == 0)) {
                     // For dimmers with a max value of 1.01 or 1.0 the values must be corrected
                     min = MetadataUtils.createBigDecimal(0);
                     max = MetadataUtils.createBigDecimal(100);
-                    step = MetadataUtils.createBigDecimal(1);
-                } else {
-                    if (step == null) {
-                        step = MetadataUtils
-                                .createBigDecimal(dp.isFloatType() ? Float.valueOf(0.1f) : Long.valueOf(1L));
-                    }
                 }
-                stateFragment.withMinimum(min).withMaximum(max).withStep(step)
-                        .withPattern(MetadataUtils.getStatePattern(dp)).withReadOnly(dp.isReadOnly());
+                stateFragment.withMinimum(min).withMaximum(max).withPattern(MetadataUtils.getStatePattern(dp))
+                        .withReadOnly(dp.isReadOnly());
             } else {
                 stateFragment.withPattern(MetadataUtils.getStatePattern(dp)).withReadOnly(dp.isReadOnly());
             }
@@ -361,8 +354,6 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                         }
                         builder.withMinimum(MetadataUtils.createBigDecimal(dp.getMinValue()));
                         builder.withMaximum(MetadataUtils.createBigDecimal(maxValue));
-                        builder.withStepSize(MetadataUtils
-                                .createBigDecimal(dp.isFloatType() ? Float.valueOf(0.1f) : Long.valueOf(1L)));
                         builder.withUnitLabel(MetadataUtils.getUnit(dp));
                     }
 


### PR DESCRIPTION
The RPC protocol doesn't provide this value, so it always was made up
more or less arbitrarily. Since the UI now uses this value for
validation purposes, there are cases where valid values can not be
entered due to this step size (particularly for datapoints with more
than 1 decimal digit).

See #12183 for a concrete breakage example.

Fixes #12183
