### PR TITLE
[mqtt] Fix translation file names

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt.properties
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt.properties
@@ -10,6 +10,12 @@ thing-type.mqtt.broker.description = A connection to a MQTT broker
 
 # thing types config
 
+thing-type.config.mqtt.broker.birthMessage.label = Birth Message
+thing-type.config.mqtt.broker.birthMessage.description = The message to send to the broker when a connection is established.
+thing-type.config.mqtt.broker.birthRetain.label = Birth Message Retain
+thing-type.config.mqtt.broker.birthRetain.description = True if the birth message should be retained (defaults to true)
+thing-type.config.mqtt.broker.birthTopic.label = Birth Topic
+thing-type.config.mqtt.broker.birthTopic.description = Defaults to empty and therefore disables the birth message.
 thing-type.config.mqtt.broker.certificate.label = Certificate Hash
 thing-type.config.mqtt.broker.certificate.description = If **certificatepin** is set this hash is used to verify the connection. Clear to allow a new certificate pinning on the next connection attempt. If empty will be filled automatically by the next successful connection. An example input would be `SHA-256:83F9171E06A313118889F7D79302BD1B7A2042EE0CFD029ABF8DD06FFA6CD9D3`.
 thing-type.config.mqtt.broker.certificatepin.label = Certificate Pinning
@@ -49,6 +55,12 @@ thing-type.config.mqtt.broker.reconnectTime.label = Reconnect Time
 thing-type.config.mqtt.broker.reconnectTime.description = Reconnect time in ms. If a connection is lost, the binding will wait this time before it tries to reconnect.
 thing-type.config.mqtt.broker.secure.label = Secure Connection
 thing-type.config.mqtt.broker.secure.description = Uses TLS/SSL to establish a secure connection to the broker.
+thing-type.config.mqtt.broker.shutdownMessage.label = Shutdown Message
+thing-type.config.mqtt.broker.shutdownMessage.description = The message to send to the broker before the connection terminates.
+thing-type.config.mqtt.broker.shutdownRetain.label = Shutdown Message Retain
+thing-type.config.mqtt.broker.shutdownRetain.description = True if the shutdown message should be retained (defaults to true)
+thing-type.config.mqtt.broker.shutdownTopic.label = Shutdown Topic
+thing-type.config.mqtt.broker.shutdownTopic.description = Defaults to empty and therefore disables the shutdown message.
 thing-type.config.mqtt.broker.username.label = Username
 thing-type.config.mqtt.broker.username.description = The MQTT username
 
@@ -75,6 +87,4 @@ actionInputRetainDesc = Retain message
 actionLabel = publish an MQTT message
 actionDesc = Publishes a value to the given MQTT topic.
 offline.notextualconfig = The system connection with the name {0} doesn't exist anymore.
-offline.dyninsteadoftextual = A binding owned connection was found instead of a system connection for the broker name: {0}.
-offline.textualinsteadofdny = A system connection was found instead of a dynamic connection for the broker name: {0}.
 offline.sharedremoved = Another binding unexpectedly removed the internal broker connection.

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt_de.properties
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt_de.properties
@@ -2,8 +2,6 @@ binding.mqtt.name = MQTT Binding
 binding.mqtt.description = Erlaubt die Verwaltung von MQTT Verbindungen und das Verknüpfen von MQTT Topics
 
 offline.notextualconfig=Die Systemverbindung mit dem Namen {0} existiert nicht mehr.
-offline.dyninsteadoftextual=Eine dynamische Verbindung wurde gefunden, statt der erwarteten Systemverbindung: {0}.
-offline.textualinsteadofdny=Eine Systemverbindung wurde gefunden, statt der erwarteten dynamischen Verbindung: {0}.
 offline.sharedremoved=Eine andere Erweiterung hat unerwartet die Broker Verbindung entfernt.
 
 actionLabel=sende eine MQTT Nachricht

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt_hu.properties
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt_hu.properties
@@ -75,6 +75,4 @@ actionInputRetainDesc = Üzenet megtartása
 actionLabel = MQTT üzenet küldése
 actionDesc = Egy megadott MQTT témára küldött üzenet.
 offline.notextualconfig = A {0} nevű rendszerkapcsolat nem létezik.
-offline.dyninsteadoftextual = A {0} nevű brókerhez kötés alapú kapcsolat léteik, rendszerkapcsolat helyett.
-offline.textualinsteadofdny = A {0} nevű brókerhez dinamikus kapcsolat léteik, rendszerkapcsolat helyett.
 offline.sharedremoved = Egy másik kötés váratlanul eltávolított a belső bróker kapcsolatot.

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt_it.properties
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt_it.properties
@@ -75,6 +75,4 @@ actionInputRetainDesc = Messaggio da Conservare
 actionLabel = pubblica un messaggio MQTT
 actionDesc = Pubblica un valore sul topic MQTT specificato.
 offline.notextualconfig = La connessione di sistema con il nome {0} non esiste più.
-offline.dyninsteadoftextual = È stata trovata una connessione associata al binding invece di una connessione di sistema per il nome del broker\: {0}.
-offline.textualinsteadofdny = È stata trovata una connessione di sistema invece di una connessione dinamica per il broker di nome\: {0}.
 offline.sharedremoved = Un altro binding ha rimosso inaspettatamente la connessione interna del broker.


### PR DESCRIPTION
It was discovered in #12152 that the i18n properties file names were wrong. As a result, it hasn't benefited from the translated files. This PR fixes the file name and also include the new entries that were added in #12152



