### PR TITLE
[mqtt] Remove redundant call to connectionStateChanged upon connection

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -114,8 +114,6 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
         }).thenAccept(v -> {
             if (!v) {
                 connectionStateChanged(MqttConnectionState.DISCONNECTED, new TimeoutException("Timeout"));
-            } else {
-                connectionStateChanged(MqttConnectionState.CONNECTED, null);
             }
         });
         connectionFuture.complete(connection);

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -59,19 +59,18 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
     @Override
     public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
         super.connectionStateChanged(state, error);
-        // Store generated client ID if none was set by the user
         final MqttBrokerConnection connection = this.connection;
-        String clientID = config.clientID;
         if (connection != null && state == MqttConnectionState.CONNECTED) {
+            String clientID = config.clientID;
             if (clientID == null || clientID.isBlank()) {
+                // Store generated client ID if none was set by the user
                 clientID = connection.getClientId();
                 config.clientID = clientID;
                 Configuration editConfig = editConfiguration();
                 editConfig.put("clientid", clientID);
                 updateConfiguration(editConfig);
-            } else {
-                publish(config.birthTopic, config.birthMessage, config.birthRetain);
             }
+            publish(config.birthTopic, config.birthMessage, config.birthRetain);
         }
     }
 


### PR DESCRIPTION
BrokerHandler::connectionStateChanged() was being called twice upon each connection, resulting in updateState() and channel triggers being called twice. Furthermore, the birthMessage added in #12152 got published twice when a clientID is configured.

This is because connectionStateChanged is called by `MqttBrokerConnection` as its connection observer, as registered in https://github.com/openhab/openhab-addons/blob/97db73938d37d60a31755681e84d979e2e023777/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java#L109

So the additional call to connectionStateChanged in here is redundant: https://github.com/openhab/openhab-addons/blob/97db73938d37d60a31755681e84d979e2e023777/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java#L118 

This PR removed the redundant call to connectionStateChanged and fixed the birthMessage so it would be sent out just once.