### PR TITLE
[homekit] make network onChange method synchronized

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -291,8 +291,8 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
     }
 
     @Override
-    public void onChanged(final List<CidrAddress> added, final List<CidrAddress> removed) {
-        logger.trace("restarting HomeKit bridge on network interface changes.");
+    public synchronized void onChanged(final List<CidrAddress> added, final List<CidrAddress> removed) {
+        logger.trace("HomeKit bridge reacting on network interface changes.");
         removed.forEach(i -> {
             logger.trace("removed interface {}", i.getAddress().toString());
             if (i.getAddress().equals(networkInterface)) {


### PR DESCRIPTION
as discussed https://github.com/openhab/openhab-addons/pull/12072#issuecomment-1029225393

it could happen that on very fast network changes the onChange method get called before the previous "onChange" method has finished the homekit bridge restart.  this could lead to reset of homekit configuration in home app

this PR adds synchronized to ensure that only only one onChange is executed at the same time. The notification is done in openhab core via SafeCaller thread so that synchronized will not block openhab core


Signed-off-by: Eugen Freiter <freiter@gmx.de>
