### PR TITLE
[wemo] Fix already configured devices in inbox

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+		https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:wemo:device">
+		<parameter name="udn" type="text" required="true">
+			<label>Unique Device Name</label>
+			<description>The UDN identifies the WeMo Device</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/i18n/wemo.properties
+++ b/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/i18n/wemo.properties
@@ -32,20 +32,10 @@ thing-type.config.wemo.CoffeeMaker.udn.label = Unique Device Name
 thing-type.config.wemo.CoffeeMaker.udn.description = The UDN identifies the WeMo Device
 thing-type.config.wemo.MZ100.deviceID.label = Device ID
 thing-type.config.wemo.MZ100.deviceID.description = The device ID identifies one certain WeMo light.
-thing-type.config.wemo.Maker.udn.label = Unique Device Name
-thing-type.config.wemo.Maker.udn.description = The UDN identifies the WeMo Device
 thing-type.config.wemo.bridge.udn.label = Unique Device Name
 thing-type.config.wemo.bridge.udn.description = The UDN identifies the WeMo Link Device
-thing-type.config.wemo.dimmer.udn.label = Unique Device Name
-thing-type.config.wemo.dimmer.udn.description = The UDN identifies the WeMo Device
-thing-type.config.wemo.insight.udn.label = Unique Device Name
-thing-type.config.wemo.insight.udn.description = The UDN identifies the WeMo Device
-thing-type.config.wemo.lightswitch.udn.label = Unique Device Name
-thing-type.config.wemo.lightswitch.udn.description = The UDN identifies the WeMo Device
-thing-type.config.wemo.motion.udn.label = Unique Device Name
-thing-type.config.wemo.motion.udn.description = The UDN identifies the WeMo Device
-thing-type.config.wemo.socket.udn.label = Unique Device Name
-thing-type.config.wemo.socket.udn.description = The UDN identifies the WeMo Device
+thing-type.config.wemo.device.udn.label = Unique Device Name
+thing-type.config.wemo.device.udn.description = The UDN identifies the WeMo Device
 
 # channel types
 

--- a/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -12,12 +12,7 @@
 			<channel id="state" typeId="state"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text" required="true">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="insight">
@@ -40,12 +35,7 @@
 
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text" required="true">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="lightswitch">
@@ -56,12 +46,7 @@
 			<channel id="state" typeId="state"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text" required="true">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="motion">
@@ -73,12 +58,7 @@
 			<channel id="lastMotionDetected" typeId="lastMotionDetected"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text" required="true">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<!-- Standard WeMo Bulb with E27 socket -->
@@ -117,12 +97,7 @@
 			<channel id="sensor" typeId="sensor"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text" required="true">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="CoffeeMaker">
@@ -148,8 +123,7 @@
 			</parameter>
 			<parameter name="pollingInterval" type="integer" required="false" min="15" max="180">
 				<label>Polling Interval</label>
-				<description>Interval polling the WeMo Coffee Maker.
-				</description>
+				<description>Interval polling the WeMo Coffee Maker.</description>
 				<default>60</default>
 			</parameter>
 		</config-description>
@@ -170,12 +144,7 @@
 			<channel id="nightModeBrightness" typeId="nightModeBrightness"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text" required="true">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="Crockpot">
@@ -190,13 +159,7 @@
 			<channel id="cookedTime" typeId="cookedTime"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-				<required>true</required>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="Purifier">
@@ -212,13 +175,7 @@
 			<channel id="filterPresent" typeId="filterPresent"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-				<required>true</required>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="Humidifier">
@@ -234,13 +191,7 @@
 			<channel id="expiredFilterTime" typeId="expiredFilterTime"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-				<required>true</required>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<thing-type id="Heater">
@@ -255,13 +206,7 @@
 			<channel id="heatingRemaining" typeId="heatingRemaining"/>
 		</channels>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the WeMo Device</description>
-				<required>true</required>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
 	<channel-type id="state">

--- a/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -12,6 +12,8 @@
 			<channel id="state" typeId="state"/>
 		</channels>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
@@ -32,8 +34,9 @@
 			<channel id="energyTotal" typeId="energyTotal"/>
 			<channel id="standByLimit" typeId="standByLimit"/>
 			<channel id="onStandBy" typeId="onStandBy"/>
-
 		</channels>
+
+		<representation-property>udn</representation-property>
 
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
@@ -46,6 +49,8 @@
 			<channel id="state" typeId="state"/>
 		</channels>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
@@ -57,6 +62,8 @@
 			<channel id="motionDetection" typeId="motionDetection"/>
 			<channel id="lastMotionDetected" typeId="lastMotionDetected"/>
 		</channels>
+
+		<representation-property>udn</representation-property>
 
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
@@ -97,6 +104,8 @@
 			<channel id="sensor" typeId="sensor"/>
 		</channels>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
@@ -115,6 +124,8 @@
 			<channel id="brewed" typeId="brewed"/>
 			<channel id="lastCleaned" typeId="lastCleaned"/>
 		</channels>
+
+		<representation-property>udn</representation-property>
 
 		<config-description>
 			<parameter name="udn" type="text" required="true">
@@ -144,6 +155,8 @@
 			<channel id="nightModeBrightness" typeId="nightModeBrightness"/>
 		</channels>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
@@ -158,6 +171,8 @@
 			<channel id="highCookTime" typeId="highCookTime"/>
 			<channel id="cookedTime" typeId="cookedTime"/>
 		</channels>
+
+		<representation-property>udn</representation-property>
 
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
@@ -175,6 +190,8 @@
 			<channel id="filterPresent" typeId="filterPresent"/>
 		</channels>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
@@ -191,6 +208,8 @@
 			<channel id="expiredFilterTime" typeId="expiredFilterTime"/>
 		</channels>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>
 
@@ -205,6 +224,8 @@
 			<channel id="autoOffTime" typeId="autoOffTime"/>
 			<channel id="heatingRemaining" typeId="heatingRemaining"/>
 		</channels>
+
+		<representation-property>udn</representation-property>
 
 		<config-description-ref uri="thing-type:wemo:device"/>
 	</thing-type>


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix entries in inbox for already configured devices, and reduce redundancy in thing-type XML definitions by introducing a shared `config-description` for UDN.