### PR TITLE
[mqtt] Remove references to the System Broker

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,6 @@
 	<thing-type id="rgb_cct">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Milight RGBCCT</label>
 		<description>Led globe with full Colour, and both cool and warm whites.</description>
@@ -26,7 +25,6 @@
 	<thing-type id="fut089">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Milight FUT089</label>
 		<description>Use this when your remote is the newer 8 group type called FUT089 and your globes are rgb_cct</description>
@@ -45,7 +43,6 @@
 	<thing-type id="fut091">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Milight FUT091</label>
 		<description>Use this when your remote is the newer fut091 and your globes are cct</description>
@@ -61,7 +58,6 @@
 	<thing-type id="cct">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Milight CCT</label>
 		<description>Led globe with both cool and warm white controls</description>
@@ -77,7 +73,6 @@
 	<thing-type id="rgbw">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Milight RGBW</label>
 		<description>RGB Globe with a fixed white</description>
@@ -95,7 +90,6 @@
 	<thing-type id="rgb">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Milight RGB</label>
 		<description>RGB Globe with no white</description>

--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -212,15 +212,16 @@ This binding includes a rule action, which allows one to publish MQTT messages f
 There is a separate instance for each MQTT broker (i.e. bridge), which can be retrieved through
 
 ```
-val mqttActions = getActions("mqtt","mqtt:systemBroker:embedded-mqtt-broker")
+val mqttActions = getActions("mqtt","mqtt:broker:myBroker")
 ```
 
-where the first parameter always has to be `mqtt` and the second (`mqtt:systemBroker:embedded-mqtt-broker`) is the Thing UID of the broker that should be used.
+where the first parameter always has to be `mqtt` and the second (`mqtt:broker:myBroker`) is the Thing UID of the broker that should be used.
 Once this action instance is retrieved, you can invoke the `publishMQTT(String topic, String value, Boolean retained)` method on it:
 
 ```
 mqttActions.publishMQTT("mytopic","myvalue", true)
 ```
+
 Alternatively, `publishMQTT(String topic, byte[] value, Boolean retained)` can publish a byte array data.
 
 The retained argument is optional and if not supplied defaults to `false`.
@@ -231,8 +232,8 @@ The retained argument is optional and if not supplied defaults to `false`.
 
 ```
 mqtt:broker:mySecureBroker [ host="192.168.0.41", secure=true, certificatepin=true, publickeypin=true ]
-mqtt:broker:myUnsecureBroker [ host="192.168.0.42", secure=false ]
-mqtt:broker:myAuthentificatedBroker [ host="192.168.0.43",secure=true, username="user", password="password" ]
+mqtt:broker:myInsecureBroker [ host="192.168.0.42", secure=false ]
+mqtt:broker:myAuthenticatedBroker [ host="192.168.0.43",secure=true, username="user", password="password" ]
 mqtt:broker:pinToPublicKey [ host="192.168.0.44", secure=true , publickeypin=true, publickey="SHA-256:9a6f30e67ae9723579da2575c35daf7da3b370b04ac0bde031f5e1f5e4617eb8" ]
 ```
 
@@ -248,9 +249,9 @@ Files can also be used to create topic things and channels and to combine them w
 *mqtt.things* file:
 
 ```
-Bridge mqtt:broker:myUnsecureBroker [ host="192.168.0.42", secure=false ]
+Bridge mqtt:broker:myInsecureBroker [ host="192.168.0.42", secure=false ]
 
-Thing mqtt:topic:mything "mything" (mqtt:broker:myUnsecureBroker) {
+Thing mqtt:topic:mything "mything" (mqtt:broker:myInsecureBroker) {
     Channels:
     Type switch : lamp "Kitchen Lamp" [ stateTopic="lamp/enabled", commandTopic="lamp/enabled/set" ]
     Type switch : fancylamp "Fancy Lamp" [ stateTopic="fancy/lamp/state", commandTopic="fancy/lamp/command", on="i-am-on", off="i-am-off" ]
@@ -263,7 +264,7 @@ Thing mqtt:topic:mything "mything" (mqtt:broker:myUnsecureBroker) {
 If the availability status is available, it can be configured to set the Thing status:
 
 ```
-Thing mqtt:topic:bedroom1-switch (mqtt:broker:myUnsecureBroker) [ availabilityTopic="tele/bedroom1-switch/LWT", payloadAvailable="Online", payloadNotAvailable="Offline" ] {
+Thing mqtt:topic:bedroom1-switch (mqtt:broker:myInsecureBroker) [ availabilityTopic="tele/bedroom1-switch/LWT", payloadAvailable="Online", payloadNotAvailable="Offline" ] {
     Channels:
          Type switch        : power        [ stateTopic="stat/bedroom1-switch/RESULT", transformationPattern="REGEX:(.*POWER.*)∩JSONPATH:$.POWER", commandTopic="cmnd/bedroom1-switch/POWER" ]
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/OH-INF/thing/generic-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/OH-INF/thing/generic-thing.xml
@@ -8,7 +8,6 @@
 		extensible="string,number,dimmer,switch,contact,colorRGB,colorHSB,color,datetime,image,location,rollershutter,trigger">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Generic MQTT Thing</label>
 		<description>You need a configured Broker first. Dynamically add channels of various types to this Thing. Link

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/thing/homeassistant-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/thing/homeassistant-thing.xml
@@ -7,7 +7,6 @@
 	<thing-type id="homeassistant">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>HomeAssistant MQTT Component</label>
 		<description>You need a configured Broker first. This Thing represents a device, that follows the "HomeAssistant MQTT

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/thing/homie-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/thing/homie-thing.xml
@@ -7,7 +7,6 @@
 	<thing-type id="homie300">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker"/>
-			<bridge-type-ref id="systemBroker"/>
 		</supported-bridge-type-refs>
 		<label>Homie MQTT Device</label>
 		<description>You need a configured Broker first. This thing represents a device, that follows the "MQTT Homie


### PR DESCRIPTION
There were some remaining references to systemBroker inside the XML files that I didn't catch in #12157 

Also fixed some typos in mqtt readme