### PR TITLE
[hdpowerview] Fix for capabilities:1 shades

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -41,7 +41,7 @@ public class ShadeCapabilitiesDatabase {
     private static final Map<Integer, Capabilities> CAPABILITIES_DATABASE = Arrays.asList(
     // @formatter:off
             new Capabilities(0).primary().tiltOnClosed()                      .text("Bottom Up"),
-            new Capabilities(1).primary().tiltAnywhere()                      .text("Bottom Up Tilt 90°"),
+            new Capabilities(1).primary().tiltOnClosed()                      .text("Bottom Up Tilt 90°"),
             new Capabilities(2).primary().tiltAnywhere().tilt180()            .text("Bottom Up Tilt 180°"),
             new Capabilities(3).primary().tiltOnClosed()                      .text("Vertical"),
             new Capabilities(4).primary().tiltAnywhere().tilt180()            .text("Vertical Tilt 180°"),

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
@@ -44,7 +44,7 @@ public class ShadePositionTest {
 
         assertTrue(db.getCapabilities(0).supportsPrimary());
         assertTrue(db.getCapabilities(0).supportsTiltOnClosed());
-        assertTrue(db.getCapabilities(1).supportsTiltAnywhere());
+        assertTrue(db.getCapabilities(1).supportsTiltOnClosed());
         assertTrue(db.getCapabilities(2).supportsTilt180());
         assertTrue(db.getCapabilities(3).supportsTiltOnClosed());
         assertTrue(db.getCapabilities(4).supportsTilt180());


### PR DESCRIPTION
Two users have reported that Capabilities:1 shades are 'TiltOnClosed' and not 'TiltAnywhere'.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
