### PR TITLE
[luxtronikheatpump] wrong channel name for setting hot water target temperature

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/README.md
+++ b/bundles/org.openhab.binding.luxtronikheatpump/README.md
@@ -284,7 +284,7 @@ The following channels are also writable:
 | channel  | type   | advanced | description                  |
 |----------|--------|----------|------------------------------|
 | temperatureHeatingParallelShift | Number:Temperature |   | Heating temperature (parallel shift) |
-| temperatureHotWaterTarget | Number:Temperature |   | Hot water target temperature |
+| temperatureHotWaterCoverage | Number:Temperature |   | Hot water target temperature |
 | heatingMode | Number |   | Heating mode |
 | hotWaterMode | Number |   | Hot water operating mode |
 | thermalDisinfectionMonday | Switch |  x  | Thermal disinfection (Monday) |


### PR DESCRIPTION
The channel "temperatureHotWaterTarget" seems to be disfunctional - at least for writing back to the heat pump.

One has to link the channel "temperatureHotWaterCoverage" to some setpoint item, in order to be able to control the hot water temperature on heatpump.

I propose the following docu change
    temperatureHotWaterTarget => temperatureHotWaterCoverage 

Eventually clarify misleading channel name "temperatureHotWaterTarget" - seems to be a read only chanel currently !?
