### PR TITLE
[mqtt.homie] remove unused constants in tests

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/ThingChannelConstants.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/ThingChannelConstants.java
@@ -14,16 +14,7 @@ package org.openhab.binding.mqtt.homie.internal.handler;
 
 import static org.openhab.binding.mqtt.homie.generic.internal.MqttBindingConstants.*;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.openhab.core.config.core.Configuration;
-import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * Static test definitions, like thing, bridge and channel definitions
@@ -31,59 +22,5 @@ import org.openhab.core.thing.type.ChannelTypeUID;
  * @author David Graeff - Initial contribution
  */
 public class ThingChannelConstants {
-    // Common ThingUID and ChannelUIDs
     public static final ThingUID TEST_HOMIE_THING = new ThingUID(HOMIE300_MQTT_THING, "device123");
-
-    public static final ChannelTypeUID UNKNOWN_CHANNEL = new ChannelTypeUID(BINDING_ID, "unknown");
-
-    public static final String JSON_PATH_JSON = "{ \"device\": { \"status\": { \"temperature\": 23.2 }}}";
-    public static final String JSON_PATH_PATTERN = "$.device.status.temperature";
-
-    public static final List<Channel> THING_CHANNEL_LIST = new ArrayList<>();
-    public static final List<Channel> THING_CHANNEL_LIST_WITH_JSON = new ArrayList<>();
-
-    static Configuration textConfiguration() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("stateTopic", "test/state");
-        data.put("commandTopic", "test/command");
-        return new Configuration(data);
-    }
-
-    static Configuration textConfigurationWithJson() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("stateTopic", "test/state");
-        data.put("commandTopic", "test/command");
-        data.put("transformationPattern", "JSONPATH:" + JSON_PATH_PATTERN);
-        return new Configuration(data);
-    }
-
-    private static Configuration numberConfiguration() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("stateTopic", "test/state");
-        data.put("commandTopic", "test/command");
-        data.put("min", BigDecimal.valueOf(1));
-        data.put("max", BigDecimal.valueOf(99));
-        data.put("step", BigDecimal.valueOf(2));
-        data.put("isDecimal", true);
-        return new Configuration(data);
-    }
-
-    private static Configuration percentageConfiguration() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("stateTopic", "test/state");
-        data.put("commandTopic", "test/command");
-        data.put("on", "ON");
-        data.put("off", "OFF");
-        return new Configuration(data);
-    }
-
-    private static Configuration onoffConfiguration() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("stateTopic", "test/state");
-        data.put("commandTopic", "test/command");
-        data.put("on", "ON");
-        data.put("off", "OFF");
-        data.put("inverse", true);
-        return new Configuration(data);
-    }
 }


### PR DESCRIPTION
I plan on doing some more work in this binding, but want to clean up
the tests a bit first so I have less distraction while writing new tests.
These constants seem to be copy/pasted from the mqtt.generic binding
tests, and then never used.

