### PR TITLE
[insteon] Prevent null values from being inferred when printing to console

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.insteon.internal.handler;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -244,10 +243,9 @@ public class InsteonNetworkHandler extends BaseBridgeHandler {
     }
 
     private void display(Console console, Map<String, String> info) {
-        ArrayList<String> ids = new ArrayList<>(info.keySet());
-        Collections.sort(ids);
-        for (String id : ids) {
-            console.println(info.get(id));
-        }
+        info.entrySet().stream() //
+                .sorted(Entry.comparingByKey()) //
+                .map(Entry::getValue) //
+                .forEach(console::println);
     }
 }


### PR DESCRIPTION
This prevents the null analysis from inferring null values when printing to a Console.

Related to openhab/openhab-core#2742