### PR TITLE
[OmniLink] Refactor parts of code

### DIFF
--- a/bundles/org.openhab.binding.omnilink/README.md
+++ b/bundles/org.openhab.binding.omnilink/README.md
@@ -88,7 +88,7 @@ The devices support some of the following channels:
 | `zone_volume`               | Dimmer               | Volume level of this audio zone.                                                     | `audio_zone`                                        |
 | `zone_source`               | Number               | Source for this audio zone.                                                          | `audio_zone`                                        |
 | `zone_control`              | Player               | Control the audio zone, e.g. start/stop/next/previous.                               | `audio_zone`                                        |
-| `sysdate`                   | DateTime             | Set controller date/time.                                                            | `controller`                                        |
+| `system_date`               | DateTime             | Set controller date/time.                                                            | `controller`                                        |
 | `last_log`                  | String               | Last log message on the controller, represented in JSON.                             | `controller`                                        |
 | `enable_disable_beeper`     | Switch               | Enable/Disable the beeper for this/all console(s).                                   | `controller`, `console`                             |
 | `beep`                      | Switch               | Send a beep command to this/all console(s).                                          | `controller`, `console`                             |
@@ -253,7 +253,7 @@ Switch   MainButton   "Toggle button [%s]"   <switch>   {channel="omnilink:butto
 /*
  * Other OmniPro items
  */
-DateTime   OmniProTime   "Last Time Update [%1$ta %1$tR]"   <time>   {channel="omnilink:controller:home:sysdate"}
+DateTime   OmniProTime   "Last Time Update [%1$ta %1$tR]"   <time>   {channel="omnilink:controller:home:system_date"}
 ```
 
 ### Example `therm-status.map`

--- a/bundles/org.openhab.binding.omnilink/pom.xml
+++ b/bundles/org.openhab.binding.omnilink/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.digitaldan</groupId>
       <artifactId>jomnilink</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.omnilink/pom.xml
+++ b/bundles/org.openhab.binding.omnilink/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.digitaldan</groupId>
       <artifactId>jomnilink</artifactId>
-      <version>1.4.3</version>
+      <version>1.4.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/OmnilinkBindingConstants.java
+++ b/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/OmnilinkBindingConstants.java
@@ -104,7 +104,7 @@ public class OmnilinkBindingConstants {
     public static final String CHANNEL_ROOM_SCENE_D = "scene_d";
     public static final String CHANNEL_ROOM_STATE = "state";
 
-    public static final String CHANNEL_SYSTEMDATE = "sysdate";
+    public static final String CHANNEL_SYSTEMDATE = "system_date";
     public static final String CHANNEL_EVENT_LOG = "last_log";
 
     // buttons
@@ -163,8 +163,7 @@ public class OmnilinkBindingConstants {
     public static final String TRIGGER_CHANNEL_ENERGY_COST_EVENT = "energy_cost_event";
     public static final String TRIGGER_CHANNEL_CAMERA_TRIGGER_EVENT = "camera_trigger_event";
     public static final String TRIGGER_CHANNEL_ACCESS_CONTROL_READER_EVENT = "access_control_reader_event";
-    public static final String TRIGGER_CHANNEL_AREA_ALL_ON_OFF_EVENT = "all_on_off_Event";
-    public static final String TRIGGER_CHANNEL_ZONE_STATE_EVENT = "zone_state_Event";
+    public static final String TRIGGER_CHANNEL_AREA_ALL_ON_OFF_EVENT = "all_on_off_event";
     public static final String TRIGGER_CHANNEL_SWITCH_PRESS_EVENT = "switch_press_event";
     public static final String TRIGGER_CHANNEL_UPB_LINK_ACTIVATED_EVENT = "upb_link_activated_event";
     public static final String TRIGGER_CHANNEL_UPB_LINK_DEACTIVATED_EVENT = "upb_link_deactivated_event";
@@ -173,8 +172,8 @@ public class OmnilinkBindingConstants {
     public static final String THING_PROPERTIES_NAME = "name";
     public static final String THING_PROPERTIES_NUMBER = "number";
     public static final String THING_PROPERTIES_AREA = "area";
-    public static final String THING_PROPERTIES_AUTO_START = "autostart";
-    public static final String THING_PROPERTIES_PHONE_NUMBER = "phoneNumber";
+    public static final String THING_PROPERTIES_AUTOSTART = "autostart";
+    public static final String THING_PROPERTIES_PHONE_NUMBER = "phone_number";
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_OMNI_AREA,
             THING_TYPE_LUMINA_AREA, THING_TYPE_ZONE, THING_TYPE_BRIDGE, THING_TYPE_FLAG, THING_TYPE_ROOM,

--- a/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/AudioSourceHandler.java
+++ b/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/AudioSourceHandler.java
@@ -64,7 +64,7 @@ public class AudioSourceHandler extends AbstractOmnilinkHandler {
         final OmnilinkBridgeHandler bridgeHandler = getOmnilinkBridgeHandler();
         if (bridgeHandler != null) {
             updateStatus(ThingStatus.ONLINE);
-            if (((Boolean) getThing().getConfiguration().get(THING_PROPERTIES_AUTO_START)).booleanValue()) {
+            if (((Boolean) getThing().getConfiguration().get(THING_PROPERTIES_AUTOSTART)).booleanValue()) {
                 logger.debug("Autostart enabled, scheduling polling for Audio Source: {}", thingID);
                 schedulePolling();
             } else {

--- a/bundles/org.openhab.binding.omnilink/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.omnilink/src/main/resources/OH-INF/thing/bridge.xml
@@ -9,7 +9,7 @@
 		<label>OmniLink Controller</label>
 		<description>An OmniLink controller.</description>
 		<channels>
-			<channel id="sysdate" typeId="sysDate"/>
+			<channel id="system_date" typeId="system_date"/>
 			<channel id="enable_disable_beeper" typeId="console_enable_disable_beeper">
 				<label>Console Beepers</label>
 			</channel>
@@ -55,7 +55,7 @@
 
 
 	<!-- Controller Channels -->
-	<channel-type id="sysDate">
+	<channel-type id="system_date">
 		<item-type>DateTime</item-type>
 		<label>Date/Time</label>
 		<description>Set controller date/time.</description>


### PR DESCRIPTION
This also removes an unused trigger channel definition that was in
OmnilinkBindingConstants.java.

Related-to [openhab-distro#1367](https://github.com/openhab/openhab-distro/pull/1367)

Signed-off-by: Ethan Dye <mrtops03@gmail.com>