### PR TITLE
[hdpowerview] Fix regression when bridge is offline while initializing child things

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewRepeaterHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewRepeaterHandler.java
@@ -79,7 +79,12 @@ public class HDPowerViewRepeaterHandler extends AbstractHubbedThingHandler {
                     "@text/offline.conf-error.invalid-bridge-handler");
             return;
         }
-        updateStatus(ThingStatus.UNKNOWN);
+        ThingStatus bridgeStatus = bridge.getStatus();
+        if (bridgeStatus == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.UNKNOWN);
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
         scheduleRefreshJob();
     }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -109,7 +109,12 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
                     "@text/offline.conf-error.invalid-bridge-handler");
             return;
         }
-        updateStatus(ThingStatus.UNKNOWN);
+        ThingStatus bridgeStatus = bridge.getStatus();
+        if (bridgeStatus == ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.UNKNOWN);
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix recent regression because of misunderstanding: https://github.com/openhab/openhab-addons/pull/12061#discussion_r791120507

This pull request reverts:
- Repeater: d7e10c565a16ca40d8f04c386312449aeb5b878d
- Shade: 7626a88cabbc5337106cc0a8373be57d6fdfc711 (last change)

The logic is actually needed. The problem can be reproduced by configuring an invalid IP address for the bridge. This causes the bridge to be correctly marked as **OFFLINE**, but the shade/repeater things will be left in status **UNKNOWN**, when they should in fact also be **OFFLINE** with **BRIDGE_OFFLINE**.