### PR TITLE
[homekit] update java hap library

### DIFF
--- a/bundles/org.openhab.io.homekit/pom.xml
+++ b/bundles/org.openhab.io.homekit/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.github.hap-java</groupId>
       <artifactId>hap</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.hapjava.accessories.HomekitAccessory;
+import io.github.hapjava.server.HomekitAccessoryCategories;
 import io.github.hapjava.server.impl.HomekitRoot;
 import io.github.hapjava.server.impl.HomekitServer;
 import io.github.hapjava.server.impl.crypto.HAPSetupCodeUtils;
@@ -175,9 +176,10 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
     private void startBridge() throws IOException {
         final @Nullable HomekitServer homekitServer = this.homekitServer;
         if (homekitServer != null && bridge == null) {
-            final HomekitRoot bridge = homekitServer.createBridge(authInfo, HomekitAccessoryCategory.BRIDGE,
-                    settings.name, HomekitSettings.MANUFACTURER, HomekitSettings.MODEL, HomekitSettings.SERIAL_NUMBER,
-                    FrameworkUtil.getBundle(getClass()).getVersion().toString(), HomekitSettings.HARDWARE_REVISION);
+            final HomekitRoot bridge = homekitServer.createBridge(authInfo, settings.name,
+                    HomekitAccessoryCategories.BRIDGES, HomekitSettings.MANUFACTURER, HomekitSettings.MODEL,
+                    HomekitSettings.SERIAL_NUMBER, FrameworkUtil.getBundle(getClass()).getVersion().toString(),
+                    HomekitSettings.HARDWARE_REVISION);
             changeListener.setBridge(bridge);
             this.bridge = bridge;
             bridge.setConfigurationIndex(changeListener.getConfigurationRevision());

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -175,8 +175,8 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
     private void startBridge() throws IOException {
         final @Nullable HomekitServer homekitServer = this.homekitServer;
         if (homekitServer != null && bridge == null) {
-            final HomekitRoot bridge = homekitServer.createBridge(authInfo, settings.name, HomekitSettings.MANUFACTURER,
-                    HomekitSettings.MODEL, HomekitSettings.SERIAL_NUMBER,
+            final HomekitRoot bridge = homekitServer.createBridge(authInfo, HomekitAccessoryCategory.BRIDGE,
+                    settings.name, HomekitSettings.MANUFACTURER, HomekitSettings.MODEL, HomekitSettings.SERIAL_NUMBER,
                     FrameworkUtil.getBundle(getClass()).getVersion().toString(), HomekitSettings.HARDWARE_REVISION);
             changeListener.setBridge(bridge);
             this.bridge = bridge;
@@ -297,7 +297,7 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
             logger.trace("removed interface {}", i.getAddress().toString());
             if (i.getAddress().equals(networkInterface)) {
                 final @Nullable HomekitRoot bridge = this.bridge;
-                if (this.bridge != null) {
+                if (bridge != null) {
                     bridge.stop();
                     this.bridge = null;
                 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -649,8 +649,14 @@ public class HomekitCharacteristicFactory {
 
     private static RotationSpeedCharacteristic createRotationSpeedCharacteristic(HomekitTaggedItem item,
             HomekitAccessoryUpdater updater) {
-        return new RotationSpeedCharacteristic(getIntSupplier(item, 0), setPercentConsumer(item),
-                getSubscriber(item, ROTATION_SPEED, updater), getUnsubscriber(item, ROTATION_SPEED, updater));
+        return new RotationSpeedCharacteristic(
+                item.getConfigurationAsDouble(HomekitTaggedItem.MIN_VALUE,
+                        RotationSpeedCharacteristic.DEFAULT_MIN_VALUE),
+                item.getConfigurationAsDouble(HomekitTaggedItem.MAX_VALUE,
+                        RotationSpeedCharacteristic.DEFAULT_MAX_VALUE),
+                item.getConfigurationAsDouble(HomekitTaggedItem.STEP, RotationSpeedCharacteristic.DEFAULT_STEP),
+                getDoubleSupplier(item, 0), setDoubleConsumer(item), getSubscriber(item, ROTATION_SPEED, updater),
+                getUnsubscriber(item, ROTATION_SPEED, updater));
     }
 
     private static SetDurationCharacteristic createDurationCharacteristic(HomekitTaggedItem taggedItem,


### PR DESCRIPTION
update to the latest java-hap library. 
the new java-hap release includes few bug fixes as well as support for new accessories like television, which can be made available to openhab. 
full change log https://github.com/hap-java/HAP-Java/releases/tag/hap-2.0.1

this PR only upgrades the library and makes following changes, required by the new release:
- add homekit category which was hard-coded previously in the hap library
- change rotation speed from int to double, which was wrong in previous hap lib. according to apple spec it must be double/float

plus small fix for bridge null check mentioned here https://github.com/openhab/openhab-addons/pull/12072#discussion_r792966654

Signed-off-by: Eugen Freiter <freiter@gmx.de>
