### PR TITLE
[sonyprojector] Fix tags for channel type powerstate

### DIFF
--- a/bundles/org.openhab.binding.sonyprojector/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.sonyprojector/src/main/resources/OH-INF/thing/channels.xml
@@ -10,7 +10,6 @@
 		<description>Current detailed power state of the projector</description>
 		<tags>
 			<tag>Status</tag>
-			<tag>Power</tag>
 		</tags>
 		<state readOnly="true">
 			<options>


### PR DESCRIPTION
Related to #12262

Signed-off-by: Laurent Garnier <lg.hc@free.fr>