### PR TITLE
[porcupineks] fix hang of dialog processing

### DIFF
--- a/bundles/org.openhab.voice.porcupineks/src/main/java/org/openhab/voice/porcupineks/internal/PorcupineKSService.java
+++ b/bundles/org.openhab.voice.porcupineks/src/main/java/org/openhab/voice/porcupineks/internal/PorcupineKSService.java
@@ -318,6 +318,8 @@ public class PorcupineKSService implements KSService {
                     Thread.sleep(100);
                     continue;
                 }
+                // do not monopolize the thread
+                Thread.sleep(0);
                 // copy into 16-bit buffer
                 captureBuffer.asShortBuffer().get(porcupineBuffer);
                 // process with porcupine


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

I was facing hangs on the execution of the stt services. It was due to porcupine blocking the thread, this changes solved it.
Please @lolodomo merge this when you have a moment.