### PR TITLE
[danfossairunit] Fix null annotation issues

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/discovery/DanfossAirUnitDiscoveryService.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/discovery/DanfossAirUnitDiscoveryService.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -82,6 +83,7 @@ public class DanfossAirUnitDiscoveryService extends AbstractDiscoveryService {
         try (DatagramSocket socket = new DatagramSocket()) {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces.hasMoreElements()) {
+                @Nullable
                 NetworkInterface networkInterface = interfaces.nextElement();
                 if (networkInterface.isLoopback() || !networkInterface.isUp()) {
                     continue;

--- a/bundles/org.openhab.binding.danfossairunit/src/test/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitTest.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/test/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnitTest.java
@@ -20,8 +20,11 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -34,14 +37,11 @@ import org.openhab.core.test.java.JavaTest;
  * 
  * @author Jacob Laursen - Initial contribution
  */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
 public class DanfossAirUnitTest extends JavaTest {
 
-    private CommunicationController communicationController;
-
-    @BeforeEach
-    private void setUp() {
-        this.communicationController = mock(CommunicationController.class);
-    }
+    private @NonNullByDefault({}) @Mock CommunicationController communicationController;
 
     @Test
     public void getUnitNameIsReturned() throws IOException {


### PR DESCRIPTION
Fix two issues:

```
[INFO] openhab-addons\bundles\org.openhab.binding.danfossairunit\src\main\java\org\openhab\binding\danfossairunit\internal\discovery\DanfossAirUnitDiscoveryService.java:[85,53] Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'java.util.Enumeration<java.net.@NonNull NetworkInterface>'. Type 'java.util.Enumeration<E>' doesn't seem to be designed with null type annotations in mind
[INFO] openhab-addons\bundles\org.openhab.binding.danfossairunit\src\test\java\org\openhab\binding\danfossairunit\internal\DanfossAirUnitTest.java:[43,40] Unsafe interpretation of method return type as '@NonNull' based on substitution 'T=org.openhab.binding.danfossairunit.internal.@NonNull CommunicationController'. Declaring type 'org.mockito.Mockito' doesn't seem to be designed with null type annotations in mind
```
