### PR TITLE
[homekit] fix "No Response" issue due missing pairing information

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -34,7 +34,6 @@ import org.openhab.core.items.ItemRegistryChangeListener;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.storage.Storage;
-import org.openhab.core.storage.StorageService;
 import org.openhab.io.homekit.internal.accessories.HomekitAccessoryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,11 +77,11 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
     private final Debouncer applyUpdatesDebouncer;
 
     HomekitChangeListener(ItemRegistry itemRegistry, HomekitSettings settings, MetadataRegistry metadataRegistry,
-            StorageService storageService) {
+            Storage<String> storage) {
         this.itemRegistry = itemRegistry;
         this.settings = settings;
         this.metadataRegistry = metadataRegistry;
-        storage = storageService.getStorage(HomekitAuthInfoImpl.STORAGE_KEY);
+        this.storage = storage;
         this.applyUpdatesDebouncer = new Debouncer("update-homekit-devices", scheduler, Duration.ofMillis(1000),
                 Clock.systemUTC(), this::applyUpdates);
         metadataChangeListener = new RegistryChangeListener<Metadata>() {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -37,6 +37,7 @@ import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.net.CidrAddress;
 import org.openhab.core.net.NetworkAddressChangeListener;
 import org.openhab.core.net.NetworkAddressService;
+import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
 import org.openhab.io.homekit.Homekit;
 import org.osgi.framework.Constants;
@@ -70,6 +71,7 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
 
     private final NetworkAddressService networkAddressService;
     private final ConfigurationAdmin configAdmin;
+    private final Storage<String> storage;
 
     private HomekitAuthInfoImpl authInfo;
     private HomekitSettings settings;
@@ -92,11 +94,11 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
         this.configAdmin = configAdmin;
         this.settings = processConfig(properties);
         this.mdnsClient = mdnsClient;
+        this.storage = storageService.getStorage(HomekitAuthInfoImpl.STORAGE_KEY);
         networkAddressService.addNetworkAddressChangeListener(this);
-        this.changeListener = new HomekitChangeListener(itemRegistry, settings, metadataRegistry, storageService);
+        this.changeListener = new HomekitChangeListener(itemRegistry, settings, metadataRegistry, storage);
         try {
-            authInfo = new HomekitAuthInfoImpl(storageService.getStorage(HomekitAuthInfoImpl.STORAGE_KEY), settings.pin,
-                    settings.setupId, settings.blockUserDeletion);
+            authInfo = new HomekitAuthInfoImpl(storage, settings.pin, settings.setupId, settings.blockUserDeletion);
             startHomekitServer();
         } catch (IOException | InvalidAlgorithmParameterException e) {
             logger.warn("cannot activate HomeKit binding. {}", e.getMessage());


### PR DESCRIPTION
there are many reports (almost since 2 years) about missing "user" entry in homekit.json which leads to repairing need. this issue was difficult to reproduce and often disappeared after some time. 
finally the root cause found  - different storage caches.

2 classes write to homekit.json storage:
- HomekitChangeListener writes number of accessories and configuration version 
- HomekitAuthInfoImpl writes "user" entry after device pairing

on binding start both classes got their own Storage instance via StorageService.getStorage("homekit.json") call. 

however, JsonStorageService.getStorage reads homekit.json every time into a new cache object (map) 
https://github.com/openhab/openhab-core/blob/44da7a4e0ee0b7b1f33c49f3f13f6cf9c2747058/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java#L130

as result, HomekitChangeListener and HomekitAuthInfoImpl had 2 different cache instances. 

On pairing, HomekitAuthInfoImpl added "user" entry to its cache and flushed/wrote the cache to homekit.json. homekit.json had "user" entry. But this was not reflected in HomekitChangeListener storage cache, i.e. "user" entry was missing in HomekitChangeListener cache.

now, if one would change item configuration, HomekitChangeListener would update configuration number in his storage cache and flushed to homekit.json. as result, user entry was removed from homekit.json. On next restart, HomekitAuthInfoImpl would report missing pairing information.

if homekit binding was restarted after pairing and before changes to items, then HomekitChangeListener got the cache with "user" entry and the issue disappeared. 

this PR ensures that getStorage is called only once and both classes use the same instance of Storage/Cache.

Signed-off-by: Eugen Freiter <freiter@gmx.de>

