### PR TITLE
[hdpowerview] Add support for setting repeater LED color and brightness

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -105,6 +105,8 @@ All of these channels appear in the binding, but only those which have a physica
 
 | Channel         | Item Type | Description                   |
 |-----------------|-----------|-------------------------------|
+| color           | Color     | Controls the color of the LED ring. A switch item can be linked: ON = white, OFF = turn off |
+| brightness      | Dimmer    | Controls the brightness of the LED ring. |
 | identify        | String    | Flash repeater to identify. Valid values are: `IDENTIFY` |
 | blinkingEnabled | Switch    | Blink during commands.        |
 
@@ -238,6 +240,8 @@ Number Living_Room_Shade_SignalStrength "Living Room Shade Signal Strength" {cha
 Repeater items:
 
 ```
+Color Bedroom_Repeater_Color "Bedroom Repeater Color" {channel="hdpowerview:repeater:home:r16384:color"}
+Dimmer Bedroom_Repeater_Brightness "Bedroom Repeater Brightness" {channel="hdpowerview:repeater:home:r16384:brightness"}
 String Bedroom_Repeater_Identify "Bedroom Repeater Identify" {channel="hdpowerview:repeater:home:r16384:identify"}
 Switch Bedroom_Repeater_BlinkingEnabled "Bedroom Repeater Blinking Enabled [%s]" {channel="hdpowerview:repeater:home:r16384:blinkingEnabled"}
 ```
@@ -272,6 +276,9 @@ Frame label="Living Room" {
     Text item=Living_Room_Shade_Battery_Voltage
 }
 Frame label="Bedroom" {
+    Colorpicker item=PowerViewRepeater_Color
+    Switch item=PowerViewRepeater_Color
+    Slider item=PowerViewRepeater_Brightness
     Switch item=Bedroom_Repeater_Identify mappings=[IDENTIFY="Identify"]
     Switch item=Bedroom_Repeater_BlinkingEnabled
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
@@ -47,6 +47,8 @@ public class HDPowerViewBindingConstants {
     public static final String CHANNEL_SHADE_BATTERY_VOLTAGE = "batteryVoltage";
     public static final String CHANNEL_SHADE_SIGNAL_STRENGTH = "signalStrength";
 
+    public static final String CHANNEL_REPEATER_COLOR = "color";
+    public static final String CHANNEL_REPEATER_BRIGHTNESS = "brightness";
     public static final String CHANNEL_REPEATER_IDENTIFY = "identify";
     public static final String CHANNEL_REPEATER_BLINKING_ENABLED = "blinkingEnabled";
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -26,8 +26,10 @@ import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
+import org.openhab.binding.hdpowerview.internal.api.Color;
 import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 import org.openhab.binding.hdpowerview.internal.api.requests.RepeaterBlinking;
+import org.openhab.binding.hdpowerview.internal.api.requests.RepeaterColor;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeCalibrate;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeJog;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeMove;
@@ -506,6 +508,22 @@ public class HDPowerViewWebTargets {
     public RepeaterData enableRepeaterBlinking(int repeaterId, boolean enable)
             throws HubInvalidResponseException, HubProcessingException, HubMaintenanceException {
         String jsonRequest = gson.toJson(new RepeaterBlinking(repeaterId, enable));
+        String jsonResponse = invoke(HttpMethod.PUT, repeaters + repeaterId, null, jsonRequest);
+        return repeaterDataFromJson(jsonResponse);
+    }
+
+    /**
+     * Sets color and brightness for a repeater
+     *
+     * @param repeaterId id of the repeater for which to set color and brightness
+     * @return RepeaterData class instance
+     * @throws HubInvalidResponseException if response is invalid
+     * @throws HubProcessingException if there is any processing error
+     * @throws HubMaintenanceException if the hub is down for maintenance
+     */
+    public RepeaterData setRepeaterColor(int repeaterId, Color color)
+            throws HubInvalidResponseException, HubProcessingException, HubMaintenanceException {
+        String jsonRequest = gson.toJson(new RepeaterColor(repeaterId, color));
         String jsonResponse = invoke(HttpMethod.PUT, repeaters + repeaterId, null, jsonRequest);
         return repeaterDataFromJson(jsonResponse);
     }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Color.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Color.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.HSBType;
+
+/**
+ * Color and brightness information for HD PowerView repeater
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class Color {
+    public int brightness;
+    public int red;
+    public int green;
+    public int blue;
+
+    public Color(int brightness, HSBType hsbType) {
+        this.brightness = brightness;
+        int rgb = hsbType.getRGB();
+        java.awt.Color color = new java.awt.Color(rgb);
+        this.red = color.getRed();
+        this.green = color.getGreen();
+        this.blue = color.getBlue();
+    }
+
+    public Color(int brightness, java.awt.Color color) {
+        this.brightness = brightness;
+        this.red = color.getRed();
+        this.green = color.getGreen();
+        this.blue = color.getBlue();
+    }
+
+    public Color(int brightness, int red, int green, int blue) {
+        this.brightness = brightness;
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d.%d/%d%%", red, green, blue, brightness);
+    }
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Color.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Color.java
@@ -31,16 +31,16 @@ public class Color {
         this.brightness = brightness;
         int rgb = hsbType.getRGB();
         java.awt.Color color = new java.awt.Color(rgb);
-        this.red = color.getRed();
-        this.green = color.getGreen();
-        this.blue = color.getBlue();
+        red = color.getRed();
+        green = color.getGreen();
+        blue = color.getBlue();
     }
 
     public Color(int brightness, java.awt.Color color) {
         this.brightness = brightness;
-        this.red = color.getRed();
-        this.green = color.getGreen();
-        this.blue = color.getBlue();
+        red = color.getRed();
+        green = color.getGreen();
+        blue = color.getBlue();
     }
 
     public Color(int brightness, int red, int green, int blue) {

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/RepeaterColor.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/requests/RepeaterColor.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api.requests;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hdpowerview.internal.api.Color;
+
+/**
+ * Color state of a single Repeater for being updated by an HD PowerView Hub
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class RepeaterColor {
+    public Repeater repeater;
+
+    public class Repeater {
+        public int id;
+        public Color color;
+
+        public Repeater(int id, Color color) {
+            this.id = id;
+            this.color = color;
+        }
+    }
+
+    public RepeaterColor(int id, Color color) {
+        repeater = new Repeater(id, color);
+    }
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/RepeaterData.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/RepeaterData.java
@@ -16,6 +16,7 @@ import java.util.Base64;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hdpowerview.internal.api.Color;
 import org.openhab.binding.hdpowerview.internal.api.Firmware;
 
 /**
@@ -31,6 +32,7 @@ public class RepeaterData {
     public int groupId;
     public boolean blinkEnabled;
     public @Nullable Firmware firmware;
+    public @Nullable Color color;
 
     public String getName() {
         return new String(Base64.getDecoder().decode(name));

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
@@ -7,6 +7,8 @@ binding.hdpowerview.description = The Hunter Douglas PowerView binding provides 
 
 thing-type.hdpowerview.hub.label = PowerView Hub
 thing-type.hdpowerview.hub.description = Hunter Douglas (Luxaflex) PowerView Hub
+thing-type.hdpowerview.repeater.channel.brightness.description = Controls the brightness of the LED ring
+thing-type.hdpowerview.repeater.channel.color.description = Controls the color of the LED ring
 thing-type.hdpowerview.repeater.label = PowerView Repeater
 thing-type.hdpowerview.repeater.description = Hunter Douglas (Luxaflex) PowerView Repeater
 thing-type.hdpowerview.shade.label = PowerView Shade

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
@@ -90,6 +90,12 @@
 		<description>Hunter Douglas (Luxaflex) PowerView Repeater</description>
 
 		<channels>
+			<channel id="color" typeId="system.color">
+				<description>Controls the color of the LED ring</description>
+			</channel>
+			<channel id="brightness" typeId="system.brightness">
+				<description>Controls the brightness of the LED ring</description>
+			</channel>
 			<channel id="identify" typeId="repeater-identify"/>
 			<channel id="blinkingEnabled" typeId="repeater-blinking-enabled"/>
 		</channels>


### PR DESCRIPTION
Fixes #12307

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Add support for setting repeater LED color and brightness. The PowerView app has a few pre-defined colors, but this PR makes it possible to freely select any RGB color.