### PR TITLE
[hueemulation] Provide non-null context to TriggerHandlerCallback

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/AbsoluteDateTimeTriggerHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/AbsoluteDateTimeTriggerHandler.java
@@ -19,6 +19,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.util.Map;
 
 import org.openhab.core.automation.ModuleHandlerCallback;
 import org.openhab.core.automation.Trigger;
@@ -106,7 +107,7 @@ public class AbsoluteDateTimeTriggerHandler extends BaseTriggerModuleHandler imp
 
     @Override
     public void run() {
-        ((TriggerHandlerCallback) callback).triggered(module, null);
+        ((TriggerHandlerCallback) callback).triggered(module, Map.of());
         schedule = null;
     }
 }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/TimerTriggerHandler.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/automation/TimerTriggerHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.io.hueemulation.internal.automation;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * As soon as that time has run up, it will trigger.
  * <p>
  * A random factor and repeat times can also be configured.
- * 
+ *
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
@@ -114,7 +115,7 @@ public class TimerTriggerHandler extends BaseTriggerModuleHandler implements Cal
 
     @Override
     public Duration call() {
-        ((TriggerHandlerCallback) callback).triggered(module, null);
+        ((TriggerHandlerCallback) callback).triggered(module, Map.of());
         config.repeat -= 1;
         if (config.repeat == 0) {
             schedule = null;


### PR DESCRIPTION
This prevents NPEs and a compilation issue when openhab/openhab-core#2763 is merged.