### PR TITLE
[hdpowerview] Remove unnecessary init checks and fix Thing status detail 

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -311,7 +311,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
             // exceptions are logged in HDPowerViewWebTargets
         } catch (HubException e) {
             logger.warn("Error connecting to bridge: {}", e.getMessage());
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, e.getMessage());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewRepeaterHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewRepeaterHandler.java
@@ -67,18 +67,9 @@ public class HDPowerViewRepeaterHandler extends AbstractHubbedThingHandler {
     public void initialize() {
         repeaterId = getConfigAs(HDPowerViewRepeaterConfiguration.class).id;
         logger.debug("Initializing repeater handler for repeater {}", repeaterId);
-        if (repeaterId <= 0) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "@text/offline.conf-error.invalid-id");
-            return;
-        }
         Bridge bridge = getBridge();
         if (bridge == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
-            return;
-        }
-        if (!(bridge.getHandler() instanceof HDPowerViewHubHandler)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error.invalid-bridge-handler");
             return;
         }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -94,21 +94,13 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         isDisposing = false;
         shadeId = getConfigAs(HDPowerViewShadeConfiguration.class).id;
         logger.debug("Initializing shade handler for shade {}", shadeId);
-        if (shadeId <= 0) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "@text/offline.conf-error.invalid-id");
-            return;
-        }
         Bridge bridge = getBridge();
         if (bridge == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
-            return;
-        }
-        if (!(bridge.getHandler() instanceof HDPowerViewHubHandler)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error.invalid-bridge-handler");
             return;
         }
+
         updateStatus(ThingStatus.UNKNOWN);
     }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
@@ -52,7 +52,6 @@ channel-type.hdpowerview.shade-vane.description = The opening of the slats in th
 # thing status descriptions
 
 offline.conf-error.no-host-address = Host address must be set
-offline.conf-error.invalid-id = Configuration 'id' not a valid integer
 offline.conf-error.invalid-bridge-handler = Invalid bridge handler
 offline.gone.shade-unknown-to-hub = Shade is unknown to Hub
 


### PR DESCRIPTION
This PR is based on #12330.

@jlaur @andrewfg I made the following changes:

- Change the Thing status detail of the *bridge* to COMMUNICATION_ERROR. It was BRIDGE_OFFLINE, which is only intended for *child* Things showing they cannot go online, because their bridge is offline.
- Remove the configuration validation. This is done also for textual configuration from OH 3.3.0 on by using the XML constraints.
- Remove the check in the Things' `initialize()` if the Bridge type is correct. The UI doesn't let you configure a wrong type and the syntax of the .things file doesn't let you specify a wrong type either, because you can't even configure the binding ID for child Things. For example, use a Bridge of the LCN binding and configure a shade. The child Thing definition is ignored by the framework:
```
Bridge lcn:pckGateway:myPCHK [ hostname="serial-raspi", port=4114, username="lcn", password="p", mode="native200" ] {
    Thing shade s50150 "Living Room Shade" @ "Living Room" [id="501"]
}
```
- Set the Thing status detail to CONFIGURATION_ERROR, when the user didn't configure a bridge.