### PR TITLE
[tradfri] fix null pointer exception when sending command to a device that is offline

### DIFF
--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriThingHandler.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriThingHandler.java
@@ -135,8 +135,12 @@ public abstract class TradfriThingHandler extends BaseThingHandler implements Co
     }
 
     protected void set(String payload) {
-        logger.debug("Sending payload: {}", payload);
-        coapClient.asyncPut(payload, this, scheduler);
+        if (coapClient != null) {
+            logger.debug("Sending payload: {}", payload);
+            coapClient.asyncPut(payload, this, scheduler);
+        } else {
+            logger.debug("coapClient is null!");
+        }
     }
 
     protected void updateDeviceProperties(TradfriDeviceData state) {


### PR DESCRIPTION
This fixes the following error when a Tradfri device is offline:

```
2022-02-22 09:43:07.970 [DEBUG] [internal.handler.TradfriThingHandler] - Sending payload: {"3312":[{"5850":0}],"3":null}
2022-02-22 09:43:07.981 [ERROR] [nal.common.AbstractInvocationHandler] - An error occurred while calling method 'ThingHandler.handleCommand()' on 'org.openhab.binding.tradfri.internal.handler.TradfriPlugHandler@e7b2d8': null
java.lang.NullPointerException: null
        at org.openhab.binding.tradfri.internal.handler.TradfriThingHandler.set(TradfriThingHandler.java:139) ~[?:?]
        at org.openhab.binding.tradfri.internal.handler.TradfriPlugHandler.setState(TradfriPlugHandler.java:58) ~[?:?]
        at org.openhab.binding.tradfri.internal.handler.TradfriPlugHandler.handleCommand(TradfriPlugHandler.java:73) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.openhab.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:154) [bundleFile:?]
        at org.openhab.core.internal.common.InvocationHandlerSync.invoke(InvocationHandlerSync.java:59) [bundleFile:?]
        at com.sun.proxy.$Proxy489.handleCommand(Unknown Source) [?:?]
        at org.openhab.core.thing.internal.profiles.ProfileCallbackImpl.handleCommand(ProfileCallbackImpl.java:80) [bundleFile:?]
        at org.openhab.core.thing.internal.profiles.SystemDefaultProfile.onCommandFromItem(SystemDefaultProfile.java:48) [bundleFile:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.openhab.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:154) [bundleFile:?]
        at org.openhab.core.internal.common.Invocation.call(Invocation.java:52) [bundleFile:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```
It now logs:
```
2022-02-22 09:58:52.159 [DEBUG] [internal.handler.TradfriThingHandler] - coapClient is null!
```