### PR TITLE
Add Java 17 to GHA CI build matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '11' ]
+        java: [ '11', '17' ]
         maven: [ '3.8.4']
         os: [ 'ubuntu-20.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})

--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,7 @@ Import-Package: \\
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11.0,12.0)</version>
+                  <version>[11.0,18.0)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
This adds Java 17 to the GitHub Actions CI build matrix so we can make sure the build keeps working with both Java 11 and Java 17. It also updates the required Java version range used by the enforcer plugin so it is also possible to build with the supported Java versions.