### PR TITLE
new goechargerapiv2 binding

### DIFF
--- a/bundles/org.openhab.binding.goechargerapiv2/NOTICE
+++ b/bundles/org.openhab.binding.goechargerapiv2/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.goechargerapiv2/README.md
+++ b/bundles/org.openhab.binding.goechargerapiv2/README.md
@@ -1,0 +1,129 @@
+# GoEChargerAPIv2 Binding
+
+This Binding reads and writes data from the [Go-eCharger](https://go-e.co/) HOME+ and HOMEfix with API version 2 (Hardware version 3).
+The HOME+ is a mobile wallbox for charging EVs, HOMEfix is a mounted wallbox and they have an open REST API for reading and writing data and configuration.
+
+## Supported Things
+
+This binding supports Go-eCharger HOME+ and HOMEfix with API version 2 (Hardware version 3) with 11kW or 22kW.
+
+## Thing Configuration
+
+The thing has two configuration parameters:
+
+| Parameter       | Description                                   | Required |
+|-----------------|-----------------------------------------------|----------|
+| ip              | The IP-address of your Go-eCharger            | yes      |
+| refreshInterval | Interval to read data, default 5 (in seconds) | no       |
+
+### `demo` Thing Configuration
+
+demo.things
+
+```
+Thing goecharger:goe:garage [ip="192.168.1.6",refreshInterval=5]
+```
+
+## Channels
+
+Currently available channels are 
+| Channel ID               | Item Type                | Description                                                   | Writable |
+|--------------------------|--------------------------|---------------------------------------------------------------|          |
+| maxCurrent               | Number:ElectricCurrent   | Maximum current allowed to use for charging                   | yes      |
+| chargingPhases           | Number                   | Amount of phases currently used for charging                  | yes      |
+| pwmSignal                | String                   | Signal status for PWM signal                                  | no       |
+| error                    | String                   | Error code of charger                                         | no       |
+| voltageL1                | Number:ElectricPotential | Voltage on L1                                                 | no       |
+| voltageL2                | Number:ElectricPotential | Voltage on L2                                                 | no       |
+| voltageL3                | Number:ElectricPotential | Voltage on L3                                                 | no       |
+| currentL1                | Number:ElectricCurrent   | Current on L1                                                 | no       |
+| currentL2                | Number:ElectricCurrent   | Current on L2                                                 | no       |
+| currentL3                | Number:ElectricCurrent   | Current on L3                                                 | no       |
+| powerL1                  | Number:Power             | Power on L1                                                   | no       |
+| powerL2                  | Number:Power             | Power on L2                                                   | no       |
+| powerL3                  | Number:Power             | Power on L2                                                   | no       |
+| sessionChargeEnergyLimit | Number:Energy            | Wallbox stops charging after defined value, disable with 0    | yes      |
+| sessionChargedEnergy     | Number:Energy            | Amount of energy that has been charged in this session        | no       |
+| totalChargedEnergy       | Number:Energy            | Amount of energy that has been charged since installation     | no       |
+| allowCharging            | Switch                   | If `ON` charging is allowed                                   | no       |
+| cableCurrent             | Number:ElectricCurrent   | Specifies the max current that can be charged with that cable | no       |
+| temperature1             | Number:Temperature       | Temperature 1 of the Go-eCharger                              | no       |
+| temperature2             | Number:Temperature       | Temperature 2 of the Go-eCharger                              | no       |
+| firmware                 | String                   | Firmware Version                                              | no       |
+
+## Full Example
+
+demo.items
+
+```
+Number:ElectricCurrent     GoEChargerMaxCurrent                 "Maximum current"                       {channel="goechargerapiv2:goeapiv2:garage:maxCurrent"}
+Number                     GoEChargerChargingPhases             "Charging phases"                       {channel="goechargerapiv2:goeapiv2:garage:chargingPhases"}
+String                     GoEChargerPwmSignal                  "Pwm signal status"                     {channel="goechargerapiv2:goeapiv2:garage:pwmSignal"}
+String                     GoEChargerError                      "Error code"                            {channel="goechargerapiv2:goeapiv2:garage:error"}
+Number:ElectricPotential   GoEChargerVoltageL1                  "Voltage l1"                            {channel="goechargerapiv2:goeapiv2:garage:voltageL1"}
+Number:ElectricPotential   GoEChargerVoltageL2                  "Voltage l2"                            {channel="goechargerapiv2:goeapiv2:garage:voltageL2"}
+Number:ElectricPotential   GoEChargerVoltageL3                  "Voltage l3"                            {channel="goechargerapiv2:goeapiv2:garage:voltageL3"}
+Number:ElectricCurrent     GoEChargerCurrentL1                  "Current l1"                            {channel="goechargerapiv2:goeapiv2:garage:currentL1"}
+Number:ElectricCurrent     GoEChargerCurrentL2                  "Current l2"                            {channel="goechargerapiv2:goeapiv2:garage:currentL2"}
+Number:ElectricCurrent     GoEChargerCurrentL3                  "Current l3"                            {channel="goechargerapiv2:goeapiv2:garage:currentL3"}
+Number:Power               GoEChargerPowerL1                    "Power l1"                              {channel="goechargerapiv2:goeapiv2:garage:powerL1"}
+Number:Power               GoEChargerPowerL2                    "Power l2"                              {channel="goechargerapiv2:goeapiv2:garage:powerL2"}
+Number:Power               GoEChargerPowerL3                    "Power l3"                              {channel="goechargerapiv2:goeapiv2:garage:powerL3"}
+Number:Energy              GoEChargerSessionChargeEnergyLimit   "Current session charge energy limit"   {channel="goechargerapiv2:goeapiv2:garage:sessionChargeEnergyLimit"}
+Number:Energy              GoEChargerSessionChargedEnergy       "Current session charged energy"        {channel="goechargerapiv2:goeapiv2:garage:sessionChargedEnergy"}
+Number:Energy              GoEChargerTotalChargedEnergy         "Total charged energy"                  {channel="goechargerapiv2:goeapiv2:garage:totalChargedEnergy"}
+Switch                     GoEChargerAllowCharging              "Allow charging"                        {channel="goechargerapiv2:goeapiv2:garage:allowCharging"}
+Number:ElectricCurrent     GoEChargerCableCurrent               "Cable encoding"                        {channel="goechargerapiv2:goeapiv2:garage:cableCurrent"}
+Number:Temperature         GoEChargerTemperature1               "Temperature 1"                         {channel="goechargerapiv2:goeapiv2:garage:temperature1"}
+Number:Temperature         GoEChargerTemperature2               "Temperature 2"                         {channel="goechargerapiv2:goeapiv2:garage:temperature2"}
+String                     GoEChargerFirmware                   "Firmware"                              {channel="goechargerapiv2:goeapiv2:garage:firmware"}
+```
+
+## Rule for setting maxCurrent of the charger
+
+You can easily define rules to charge with photovoltaik power alone.
+Here is a sample how such a rule could look like:
+
+```
+rule "Set charging limit for go-eCharger"
+when
+    Time cron "*/3 * * ? * *" // Trigger every 3 seconds, or alternative when Total_power_fast changed
+then
+    var totalPowerOutputInWatt = Total_power_fast.state as DecimalType * 1000
+    if (totalPowerOutputInWatt > 0) {
+        totalPowerOutputInWatt = 0
+    }
+
+    totalPowerOutputInWatt = totalPowerOutputInWatt * -1
+
+    var maxAmp3Phases = (totalPowerOutputInWatt / 3) / 230
+    if (maxAmp3Phases > 16.0) {
+        maxAmp3Phases = 16.0
+    }
+    var maxAmp1Phase = totalPowerOutputInWatt / 230;
+
+    if (maxAmp3Phases.intValue >= 6) {
+        // 3 phases
+        if ((GoEChargerChargingPhases.state as Number) != 3) {
+            GoEChargerChargingPhases.sendCommand(3);
+        }
+
+        if ((GoEChargerMaxCurrent.state as Number).intValue != maxAmp3Phases.intValue) {
+            GoEChargerMaxCurrent.sendCommand(maxAmp3Phases.intValue)
+        }
+    } else {
+        if (maxAmp1Phase.intValue >= 6 ) {
+            // switch to 1 phase -> check if this is useful
+            if ((GoEChargerChargingPhases.state as Number) != 1) {
+                GoEChargerChargingPhases.sendCommand(1)
+            }
+
+            if ((GoEChargerMaxCurrent.state as Number).intValue != maxAmp1Phase.intValue) {
+                GoEChargerMaxCurrent.sendCommand(maxAmp1Phase.intValue)
+            }
+        } else {
+            // switch off
+        }
+    }
+end
+```

--- a/bundles/org.openhab.binding.goechargerapiv2/pom.xml
+++ b/bundles/org.openhab.binding.goechargerapiv2/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.goechargerapiv2</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: GoEChargerAPIv2 Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.goechargerapiv2-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-goechargerapiv2" description="GoEChargerAPIv2 Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.goechargerapiv2/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/GoEChargerAPIv2BindingConstants.java
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/GoEChargerAPIv2BindingConstants.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.goechargerapiv2.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link GoEChargerAPIv2BindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Reinhard Plaim - Initial contribution
+ */
+@NonNullByDefault
+public class GoEChargerAPIv2BindingConstants {
+
+    private static final String BINDING_ID = "goechargerapiv2";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_GOEAPIV2 = new ThingTypeUID(BINDING_ID, "goeapiv2");
+
+    // List of all Channel ids
+    // writeable
+    public static final String MAX_CURRENT = "maxCurrent"; // amp
+    public static final String SESSION_CHARGE_CONSUMPTION_LIMIT = "sessionChargeEnergyLimit"; // dwo
+    public static final String CHARGING_PHASES = "chargingPhases"; // psm
+    // read only
+    public static final String SESSION_CHARGE_CONSUMPTION = "sessionChargedEnergy"; // wh
+    public static final String ALLOW_CHARGING = "allowCharging"; // alw
+    public static final String PWM_SIGNAL = "pwmSignal"; // car
+    public static final String ERROR = "error"; // err
+    public static final String CABLE_ENCODING = "cableCurrent"; // cbl
+    public static final String PHASES = "phases"; // pha
+    public static final String TEMPERATURE1 = "temperature1"; // tma
+    public static final String TEMPERATURE2 = "temperature2"; // tma
+    public static final String TOTAL_CONSUMPTION = "totalChargedEnergy"; // eto
+    public static final String FIRMWARE = "firmware"; // fwv
+    public static final String VOLTAGE_L1 = "voltageL1";
+    public static final String VOLTAGE_L2 = "voltageL2";
+    public static final String VOLTAGE_L3 = "voltageL3";
+    public static final String CURRENT_L1 = "currentL1";
+    public static final String CURRENT_L2 = "currentL2";
+    public static final String CURRENT_L3 = "currentL3";
+    public static final String POWER_L1 = "powerL1";
+    public static final String POWER_L2 = "powerL2";
+    public static final String POWER_L3 = "powerL3";
+    // api URIs
+    public static final String API_URL = "http://%IP%/api/status";
+    public static final String SET_URL = "http://%IP%/api/set?%KEY%=%VALUE%";
+}

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/GoEChargerAPIv2Configuration.java
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/GoEChargerAPIv2Configuration.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.goechargerapiv2.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link GoEChargerAPIv2Configuration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Reinhard Plaim - Initial contribution
+ */
+@NonNullByDefault
+public class GoEChargerAPIv2Configuration {
+
+    public @Nullable String ip;
+    public Integer refreshInterval = 5;
+}

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/GoEChargerAPIv2HandlerFactory.java
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/GoEChargerAPIv2HandlerFactory.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.goechargerapiv2.internal;
+
+import static org.openhab.binding.goechargerapiv2.internal.GoEChargerAPIv2BindingConstants.*;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.goechargerapiv2.internal.handler.GoEChargerAPIv2Handler;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link GoEChargerAPIv2HandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Reinhard Plaim - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.goechargerapiv2", service = ThingHandlerFactory.class)
+public class GoEChargerAPIv2HandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_GOEAPIV2);
+    private final HttpClient httpClient;
+
+    @Activate
+    public GoEChargerAPIv2HandlerFactory(final @Reference HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_GOEAPIV2.equals(thingTypeUID)) {
+            return new GoEChargerAPIv2Handler(thing, httpClient);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/api/GoEChargerAPIv2StatusResponseDTO.java
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/api/GoEChargerAPIv2StatusResponseDTO.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.goechargerapiv2.internal.api;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link GoEChargerAPIv2StatusResponseDTO} class represents a json response from the
+ * charger.
+ *
+ * @author Reinhard Plaim - Initial contribution
+ */
+public class GoEChargerAPIv2StatusResponseDTO {
+    @SerializedName("mod")
+    public String version;
+
+    @SerializedName("car")
+    public Integer pwmSignal;
+
+    @SerializedName("amp")
+    public Integer maxCurrent;
+
+    @SerializedName("psm")
+    public Integer chargingPhases;
+
+    @SerializedName("nrg")
+    public Integer[] energy;
+
+    @SerializedName("err")
+    public Integer errorCode;
+
+    @SerializedName("alw")
+    public Boolean allowCharging;
+
+    @SerializedName("cbl")
+    public Integer cableEncoding;
+
+    @SerializedName("tma")
+    public Double[] temperature;
+
+    @SerializedName("wh")
+    public Long sessionChargeConsumption;
+
+    @SerializedName("dwo")
+    public Integer sessionChargeConsumptionLimit;
+
+    @SerializedName("eto")
+    public Long totalChargeConsumption;
+
+    @SerializedName("fwv")
+    public String firmware;
+}

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/handler/GoEChargerAPIv2Handler.java
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/java/org/openhab/binding/goechargerapiv2/internal/handler/GoEChargerAPIv2Handler.java
@@ -1,0 +1,410 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.goechargerapiv2.internal.handler;
+
+import static org.openhab.binding.goechargerapiv2.internal.GoEChargerAPIv2BindingConstants.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import javax.measure.quantity.ElectricCurrent;
+import javax.measure.quantity.Energy;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.goechargerapiv2.internal.GoEChargerAPIv2BindingConstants;
+import org.openhab.binding.goechargerapiv2.internal.GoEChargerAPIv2Configuration;
+import org.openhab.binding.goechargerapiv2.internal.api.GoEChargerAPIv2StatusResponseDTO;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link GoEChargerAPIv2Handler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Reinhard Plaim - Initial contribution
+ */
+@NonNullByDefault
+public class GoEChargerAPIv2Handler extends BaseThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(GoEChargerAPIv2Handler.class);
+
+    private @Nullable GoEChargerAPIv2Configuration config;
+
+    private List<String> allChannels = new ArrayList<>();
+
+    private final Gson gson = new Gson();
+
+    private @Nullable ScheduledFuture<?> refreshJob;
+
+    private final HttpClient httpClient;
+
+    private String filter = "";
+
+    public GoEChargerAPIv2Handler(Thing thing, HttpClient httpClient) {
+        super(thing);
+        this.httpClient = httpClient;
+    }
+
+    private State getValue(String channelId, GoEChargerAPIv2StatusResponseDTO goeResponse) {
+        switch (channelId) {
+            case MAX_CURRENT:
+                if (goeResponse.maxCurrent == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.maxCurrent, Units.AMPERE);
+            case CHARGING_PHASES:
+                if (goeResponse.chargingPhases == null) {
+                    return UnDefType.UNDEF;
+                }
+                var phases = 1;
+                if (goeResponse.chargingPhases == 2) {
+                    phases = 3;
+                }
+                return new DecimalType(phases);
+            case PWM_SIGNAL:
+                if (goeResponse.pwmSignal == null) {
+                    return UnDefType.UNDEF;
+                }
+                String pwmSignal = null;
+                switch (goeResponse.pwmSignal) {
+                    case 0:
+                        pwmSignal = "UNKNOWN/ERROR";
+                    case 1:
+                        pwmSignal = "IDLE";
+                        break;
+                    case 2:
+                        pwmSignal = "CHARGING";
+                        break;
+                    case 3:
+                        pwmSignal = "WAITING_FOR_CAR";
+                        break;
+                    case 4:
+                        pwmSignal = "COMPLETE";
+                        break;
+                    case 5:
+                        pwmSignal = "ERROR";
+                    default:
+                }
+                return new StringType(pwmSignal);
+            case ERROR:
+                if (goeResponse.errorCode == null) {
+                    return UnDefType.UNDEF;
+                }
+                String error = null;
+                switch (goeResponse.errorCode) {
+                    case 0:
+                        error = "UNKNOWN/ERROR";
+                    case 1:
+                        error = "IDLE";
+                        break;
+                    case 2:
+                        error = "CHARGING";
+                        break;
+                    case 3:
+                        error = "WAITING_FOR_CAR";
+                        break;
+                    case 4:
+                        error = "COMPLETE";
+                        break;
+                    case 5:
+                        error = "ERROR";
+                    default:
+                }
+                return new StringType(error);
+            case ALLOW_CHARGING:
+                return goeResponse.allowCharging == true ? OnOffType.ON : OnOffType.OFF;
+            case CABLE_ENCODING:
+                if (goeResponse.cableEncoding == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.cableEncoding, Units.AMPERE);
+            case TEMPERATURE1:
+                if (goeResponse.temperature == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.temperature[0], SIUnits.CELSIUS);
+            case TEMPERATURE2:
+                if (goeResponse.temperature == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.temperature[1], SIUnits.CELSIUS);
+            case SESSION_CHARGE_CONSUMPTION:
+                if (goeResponse.sessionChargeConsumption == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>((Double) (goeResponse.sessionChargeConsumption / 1000d), Units.KILOWATT_HOUR);
+            case SESSION_CHARGE_CONSUMPTION_LIMIT:
+                if (goeResponse.sessionChargeConsumptionLimit == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>((Double) (goeResponse.sessionChargeConsumptionLimit / 1000d),
+                        Units.KILOWATT_HOUR);
+            case TOTAL_CONSUMPTION:
+                if (goeResponse.totalChargeConsumption == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>((Double) (goeResponse.totalChargeConsumption / 1000d), Units.KILOWATT_HOUR);
+            case FIRMWARE:
+                if (goeResponse.firmware == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new StringType(goeResponse.firmware);
+            case VOLTAGE_L1:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.energy[0], Units.VOLT);
+            case VOLTAGE_L2:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.energy[1], Units.VOLT);
+            case VOLTAGE_L3:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.energy[2], Units.VOLT);
+            case CURRENT_L1:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                // values come in as A*10, 41 means 4.1A -> TODO: still for api v2?
+                return new QuantityType<>((Double) (goeResponse.energy[4] / 10d), Units.AMPERE);
+            case CURRENT_L2:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>((Double) (goeResponse.energy[5] / 10d), Units.AMPERE);
+            case CURRENT_L3:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>((Double) (goeResponse.energy[6] / 10d), Units.AMPERE);
+            case POWER_L1:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                // values come in as kW*10, 41 means 4.1kW -> TODO: still for api v2?
+                return new QuantityType<>(goeResponse.energy[7] * 100, Units.WATT);
+            case POWER_L2:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.energy[8] * 100, Units.WATT);
+            case POWER_L3:
+                if (goeResponse.energy == null) {
+                    return UnDefType.UNDEF;
+                }
+                return new QuantityType<>(goeResponse.energy[9] * 100, Units.WATT);
+        }
+        return UnDefType.UNDEF;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            // we can not update single channels and refresh is triggered automatically
+            // anyways
+            return;
+        }
+
+        String key = null;
+        String value = null;
+        switch (channelUID.getId()) {
+            case MAX_CURRENT:
+                key = "amp";
+                if (command instanceof DecimalType) {
+                    value = String.valueOf(((DecimalType) command).intValue());
+                } else if (command instanceof QuantityType<?>) {
+                    value = String.valueOf(((QuantityType<ElectricCurrent>) command).toUnit(Units.AMPERE).intValue());
+                }
+                break;
+            case SESSION_CHARGE_CONSUMPTION_LIMIT:
+                key = "dwo";
+                if (command instanceof DecimalType) {
+                    value = String.valueOf(((DecimalType) command).intValue() * 1000);
+                } else if (command instanceof QuantityType<?>) {
+                    value = String
+                            .valueOf(((QuantityType<Energy>) command).toUnit(Units.KILOWATT_HOUR).intValue() * 1000);
+                }
+                break;
+            case CHARGING_PHASES:
+                key = "psm";
+                if (command instanceof DecimalType) {
+                    var phases = 1;
+                    var help = (DecimalType) command;
+                    if (help.intValue() == 3) {
+                        phases = 2; // set value 2 for 3 phases
+                    }
+                    value = String.valueOf(phases);
+                }
+                break;
+            default:
+        }
+        if (key != null && value != null) {
+            sendData(key, value);
+        } else {
+            logger.warn("Could not update channel {} with key {} and value {}", channelUID.getId(), key, value);
+        }
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(GoEChargerAPIv2Configuration.class);
+        allChannels = getThing().getChannels().stream().map(channel -> channel.getUID().getId())
+                .collect(Collectors.toList());
+
+        logger.info("Number of channels found: {}", allChannels.size());
+
+        filter = "?filter=";
+        var declaredFields = GoEChargerAPIv2StatusResponseDTO.class.getDeclaredFields();
+        for (var field : declaredFields) {
+            filter += field.getAnnotation(SerializedName.class).value() + ",";
+        }
+        filter = filter.substring(0, filter.length() - 1);
+
+        updateStatus(ThingStatus.UNKNOWN);
+
+        startAutomaticRefresh();
+        logger.debug("Finished initializing!");
+
+        // These logging types should be primarily used by bindings
+        // logger.trace("Example trace message");
+        // logger.debug("Example debug message");
+        // logger.warn("Example warn message");
+        //
+        // Logging to INFO should be avoided normally.
+        // See https://www.openhab.org/docs/developer/guidelines.html#f-logging
+    }
+
+    private String getUrl(String type) {
+        return type.replace("%IP%", StringUtils.trimToEmpty(config.ip));
+    }
+
+    private void sendData(String key, String value) {
+        String urlStr = getUrl(GoEChargerAPIv2BindingConstants.SET_URL).replace("%KEY%", key).replace("%VALUE%", value);
+        logger.debug("sendData GET URL = {}", urlStr);
+
+        try {
+            ContentResponse contentResponse = httpClient.newRequest(urlStr).method(HttpMethod.GET)
+                    .timeout(5, TimeUnit.SECONDS).send();
+
+            String response = contentResponse.getContentAsString();
+            logger.debug("sendData GET Response: {}", response);
+
+            var statusCode = contentResponse.getStatus();
+            if (!(statusCode == 200 || statusCode == 204)) {
+                logger.error("Could not send data: {}, StatusCode: {}", response, statusCode);
+            }
+        } catch (InterruptedException | TimeoutException | ExecutionException | JsonSyntaxException e) {
+            logger.error("Could not send data: {}, {}", urlStr, e.toString());
+        }
+    }
+
+    /**
+     * Request new data from Go-E charger
+     *
+     * @return the Go-E charger object mapping the JSON response or null in case of
+     *         error
+     * @throws ExecutionException
+     * @throws TimeoutException
+     * @throws InterruptedException
+     */
+    @Nullable
+    private GoEChargerAPIv2StatusResponseDTO getGoEData()
+            throws InterruptedException, TimeoutException, ExecutionException, JsonSyntaxException {
+        String urlStr = getUrl(GoEChargerAPIv2BindingConstants.API_URL);
+        urlStr = urlStr + filter;
+
+        logger.debug("getGoEData GET URL = {}", urlStr);
+
+        ContentResponse contentResponse = httpClient.newRequest(urlStr).method(HttpMethod.GET)
+                .timeout(5, TimeUnit.SECONDS).send();
+
+        String response = contentResponse.getContentAsString();
+        logger.debug("getGoEData GET Response: {}", response);
+        return gson.fromJson(response, GoEChargerAPIv2StatusResponseDTO.class);
+    }
+
+    private void updateChannelsAndStatus(@Nullable GoEChargerAPIv2StatusResponseDTO goeResponse,
+            @Nullable String message) {
+        if (goeResponse == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, message);
+            allChannels.forEach(channel -> updateState(channel, UnDefType.UNDEF));
+        } else {
+            updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
+            allChannels.forEach(channel -> {
+                updateState(channel, getValue(channel, goeResponse));
+            });
+        }
+    }
+
+    private void refresh() {
+        // Request new GoE data
+        try {
+            GoEChargerAPIv2StatusResponseDTO goeResponse = getGoEData();
+            updateChannelsAndStatus(goeResponse, null);
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            updateChannelsAndStatus(null, e.getMessage());
+        }
+    }
+
+    private void startAutomaticRefresh() {
+        if (refreshJob == null || refreshJob.isCancelled()) {
+            GoEChargerAPIv2Configuration config = getConfigAs(GoEChargerAPIv2Configuration.class);
+            int delay = config.refreshInterval;
+            logger.debug("Running refresh job with delay {} s", delay);
+            refreshJob = scheduler.scheduleWithFixedDelay(this::refresh, 0, delay, TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("Disposing the Go-E Charger APIv2 handler.");
+
+        final ScheduledFuture<?> refreshJob = this.refreshJob;
+        if (refreshJob != null && !refreshJob.isCancelled()) {
+            refreshJob.cancel(true);
+            this.refreshJob = null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="goechargerapiv2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>GoEChargerAPIv2 Binding</name>
+	<description>This is the binding for GoEChargerAPIv2.</description>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/resources/OH-INF/i18n/goechargerapiv2.properties
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/resources/OH-INF/i18n/goechargerapiv2.properties
@@ -1,0 +1,71 @@
+# binding
+
+binding.goechargerv3.name = Go-eCharger Binding API v2
+binding.goechargerv3.description = This is the binding for Go-eCharger hardware revision 3 (API version 2).
+
+# thing types
+
+thing-type.goechargerv3.goev3.label = Go-eCharger
+thing-type.goechargerv3.goev3.description = Go-eCharger thing that represents the wallbox configuration and readings
+
+# thing types config
+
+thing-type.config.goechargerv3.goev3.ip.label = IP Address
+thing-type.config.goechargerv3.goev3.ip.description = The IP address of the Go-eCharger
+thing-type.config.goechargerv3.goev3.refreshInterval.label = Refresh Interval
+thing-type.config.goechargerv3.goev3.refreshInterval.description = Refresh interval for acquiring data from Go-eCharger in seconds
+
+# channel types
+
+channel-type.goechargerv3.alw.label = Allow Charging
+channel-type.goechargerv3.alw.description = If true charging is allowed
+channel-type.goechargerv3.cbl.label = Cable Encoding
+channel-type.goechargerv3.cbl.description = Specifies the max amps that can be charged with that cable
+channel-type.goechargerv3.cl1.label = Current L1
+channel-type.goechargerv3.cl1.description = Current on L1
+channel-type.goechargerv3.cl2.label = Current L2
+channel-type.goechargerv3.cl2.description = Current on L2
+channel-type.goechargerv3.cl3.label = Current L3
+channel-type.goechargerv3.cl3.description = Current on L3
+channel-type.goechargerv3.amp.label = Maximum Current
+channel-type.goechargerv3.amp.description = Maximum current per phase allowed to use for charging
+channel-type.goechargerv3.err.label = Error Code
+channel-type.goechargerv3.err.description = The error code
+channel-type.goechargerv3.err.state.option.UNKNOWN = Unknown/Error
+channel-type.goechargerv3.err.state.option.IDLE = Idle
+channel-type.goechargerv3.err.state.option.CHARGING = Charging
+channel-type.goechargerv3.err.state.option.WAITING_FOR_CAR = Waiting for car
+channel-type.goechargerv3.err.state.option.COMPLETE = Charging done (car connected)
+
+channel-type.goechargerv3.eto.label = Total Charged Energy
+channel-type.goechargerv3.eto.description = Amount of energy that has been charged since installation
+channel-type.goechargerv3.fwv.label = Firmware
+channel-type.goechargerv3.fwv.description = Firmware Version
+channel-type.goechargerv3.psm.label = Charging Phases
+channel-type.goechargerv3.psm.description = Amount of phases currently used for charging
+channel-type.goechargerv3.pl1.label = Power L1
+channel-type.goechargerv3.pl1.description = Power on L1
+channel-type.goechargerv3.pl2.label = Power L2
+channel-type.goechargerv3.pl2.description = Power on L2
+channel-type.goechargerv3.pl3.label = Power L3
+channel-type.goechargerv3.pl3.description = Power on L3
+channel-type.goechargerv3.pwm.label = PWM signal status
+channel-type.goechargerv3.pwm.description = Pulse-width modulation signal status
+channel-type.goechargerv3.pwm.state.option.UNKNOWN = Unknown/Error
+channel-type.goechargerv3.pwm.state.option.IDLE = Idle
+channel-type.goechargerv3.pwm.state.option.CHARGING = Charging
+channel-type.goechargerv3.pwm.state.option.WAITING_FOR_CAR = Waiting for car
+channel-type.goechargerv3.pwm.state.option.COMPLETE = Charging done (car connected)
+channel-type.goechargerv3.pwm.state.option.ERROR = Error
+channel-type.goechargerv3.dwo.label = Current Session Charge Energy Limit
+channel-type.goechargerv3.dwo.description = Wallbox stops charging after defined value, deactivate with value 0
+channel-type.goechargerv3.wh.label = Current Session Charged Energy
+channel-type.goechargerv3.wh.description = Amount of energy that has been charged in this session
+channel-type.goechargerv3.tma.label = Temperature
+channel-type.goechargerv3.tma.description = Temperature of the Go-eCharger
+channel-type.goechargerv3.vl1.label = Voltage L1
+channel-type.goechargerv3.vl1.description = Voltage on L1
+channel-type.goechargerv3.vl2.label = Voltage L2
+channel-type.goechargerv3.vl2.description = Voltage on L2
+channel-type.goechargerv3.vl3.label = Voltage L3
+channel-type.goechargerv3.vl3.description = Voltage on L3

--- a/bundles/org.openhab.binding.goechargerapiv2/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.goechargerapiv2/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="goechargerapiv2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="goeapiv2">
+		<label>GoECharger APIv2</label>
+		<description>Go-eCharger API version 2 thing that represents the wallbox configuration and readings</description>
+
+		<channels>
+			<channel id="maxCurrent" typeId="amp"/>
+			<channel id="chargingPhases" typeId="psm"/>
+			<channel id="pwmSignal" typeId="pwm"/>
+			<channel id="error" typeId="err"/>
+			<channel id="voltageL1" typeId="vl1"/>
+			<channel id="voltageL2" typeId="vl2"/>
+			<channel id="voltageL3" typeId="vl3"/>
+			<channel id="currentL1" typeId="cl1"/>
+			<channel id="currentL2" typeId="cl2"/>
+			<channel id="currentL3" typeId="cl3"/>
+			<channel id="powerL1" typeId="pl1"/>
+			<channel id="powerL2" typeId="pl2"/>
+			<channel id="powerL3" typeId="pl3"/>
+			<channel id="sessionChargeEnergyLimit" typeId="dwo"/>
+			<channel id="sessionChargedEnergy" typeId="wh"/>
+			<channel id="totalChargedEnergy" typeId="eto"/>
+			<channel id="allowCharging" typeId="alw"/>
+			<channel id="cableCurrent" typeId="cbl"/>
+			<channel id="temperature1" typeId="tma"/>
+			<channel id="temperature2" typeId="tma"/>
+			<channel id="firmware" typeId="fwv"/>
+		</channels>
+
+		<config-description>
+			<parameter name="ip" type="text" required="true">
+				<label>Network-Address</label>
+				<description>Hostname or IP address of the GoECharger</description>
+				<context>network-address</context>
+			</parameter>
+			<parameter name="refreshInterval" type="integer" unit="s" min="1">
+				<label>Refresh Interval</label>
+				<description>Interval the GoECharger is polled in sec.</description>
+				<unitLabel>s</unitLabel>
+				<default>5</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="amp">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Maximum Current</label>
+		<description>Maximum current per phase allowed to use for charging</description>
+		<state pattern="%d %unit%" readOnly="false"/>
+	</channel-type>
+	<channel-type id="psm">
+		<item-type>Number</item-type>
+		<label>Charging Phases Count</label>
+		<description>Amount of phases currently used for charging</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="pwm">
+		<item-type>String</item-type>
+		<label>PWM signal status</label>
+		<description>Pulse-width modulation signal status</description>
+		<state readOnly="true">
+			<options>
+				<option value="UNKNOWN/ERROR">Unknown/Error</option>
+				<option value="IDLE">Idle</option>
+				<option value="CHARGING">Charging</option>
+				<option value="WAITING_FOR_CAR">Waiting for car</option>
+				<option value="COMPLETE">Complete</option>
+				<option value="ERROR">Error</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="err">
+		<item-type>String</item-type>
+		<label>Error Code</label>
+		<description>Error code of Go-eCharger</description>
+		<state readOnly="true">
+			<options>
+				<option value="UNKNOWN/ERROR">Unknown/Error</option>
+				<option value="IDLE">Idle</option>
+				<option value="CHARGING">Charging</option>
+				<option value="WAITING_FOR_CAR">Waiting for car</option>
+				<option value="COMPLETE">Complete</option>
+				<option value="ERROR">Error</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="vl1">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>Voltage L1</label>
+		<description>Voltage on L1</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="vl2">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>Voltage L2</label>
+		<description>Voltage on L2</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="vl3">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>Voltage L3</label>
+		<description>Voltage on L3</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="cl1">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Current L1</label>
+		<description>Current on L1</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="cl2">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Current L2</label>
+		<description>Current on L2</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="cl3">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Current L3</label>
+		<description>Current on L3</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="pl1">
+		<item-type>Number:Power</item-type>
+		<label>Power L1</label>
+		<description>Power on L1</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="pl2">
+		<item-type>Number:Power</item-type>
+		<label>Power L2</label>
+		<description>Power on L2</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="pl3">
+		<item-type>Number:Power</item-type>
+		<label>Power L3</label>
+		<description>Power on L3</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="dwo">
+		<item-type>Number:Energy</item-type>
+		<label>Current Session Charge Energy Limit</label>
+		<description>Wallbox stops charging after defined value, deactivate with value 0</description>
+		<state pattern="%.1f %unit%" readOnly="false"/>
+	</channel-type>
+	<channel-type id="wh">
+		<item-type>Number:Energy</item-type>
+		<label>Current Session Charged Energy</label>
+		<description>Amount of energy that has been charged in this session</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="eto">
+		<item-type>Number:Energy</item-type>
+		<label>Total Charged Energy</label>
+		<description>Amount of energy that has been charged since installation</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="alw">
+		<item-type>Switch</item-type>
+		<label>Allow Charging</label>
+		<description>If true charging is allowed</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="cbl">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Cable Encoding</label>
+		<description>Specifies the max amps that can be charged with that cable</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="tma">
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature1</label>
+		<description>Temperature 1 of the Go-eCharger</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="tma">
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature2</label>
+		<description>Temperature 2 of the Go-eCharger</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="fwv">
+		<item-type>String</item-type>
+		<label>Firmware</label>
+		<description>Firmware Version</description>
+		<state readOnly="true"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -138,6 +138,7 @@
     <module>org.openhab.binding.gce</module>
     <module>org.openhab.binding.generacmobilelink</module>
     <module>org.openhab.binding.goecharger</module>
+	<module>org.openhab.binding.goechargerapiv2</module>
     <module>org.openhab.binding.gpio</module>
     <module>org.openhab.binding.globalcache</module>
     <module>org.openhab.binding.gpstracker</module>


### PR DESCRIPTION
# Title

new goechargerapiv2 binding

# Description

This Binding reads and writes data from the [Go-eCharger](https://go-e.co/) HOME+ and HOMEfix with API version 2 (Hardware version 3).
The HOME+ is a mobile wallbox for charging EVs, HOMEfix is a mounted wallbox and they have an open REST API for reading and writing data and configuration.

Signed-off-by: Reinhard Plaim <reinhardplaim@gmail.com>