### PR TITLE
[jrubyscripting] Filter out empty require options

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -198,16 +198,16 @@ public class JRubyScriptEngineConfiguration {
             return;
         }
 
-        String[] scripts = requireConfigElement.getValue().get().split(",");
-        for (String script : scripts) {
-            final String requireStatement = String.format("require '%s'", script.trim());
-            try {
-                logger.trace("Injecting require statement: {}", requireStatement);
-                engine.eval(requireStatement);
-            } catch (ScriptException e) {
-                logger.warn("Error evaluating statement {}: {}", requireStatement, e.getMessage());
-            }
-        }
+        Stream.of(requireConfigElement.getValue().get().split(",")).map(s -> s.trim()).filter(s -> !s.isEmpty())
+                .forEach(script -> {
+                    final String requireStatement = String.format("require '%s'", script);
+                    try {
+                        logger.trace("Injecting require statement: {}", requireStatement);
+                        engine.eval(requireStatement);
+                    } catch (ScriptException e) {
+                        logger.warn("Error evaluating statement {}: {}", requireStatement, e.getMessage());
+                    }
+                });
     }
 
     /**


### PR DESCRIPTION
Found a small issue when dealing with empty or erroneous data. Avoid injecting require statement when the script name is empty.