### PR TITLE
[rrd4j] Upgrade to rrd4j 3.8.1

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/pom.xml
+++ b/bundles/org.openhab.persistence.rrd4j/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.rrd4j</groupId>
       <artifactId>rrd4j</artifactId>
-      <version>3.8</version>
+      <version>3.8.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This should prevent a resource leak when generating graphs.

See: https://github.com/rrd4j/rrd4j/blob/master/changelog.txt