### PR TITLE
[ipcamera] Fix Digest bug and Doorbird fixes.

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -213,7 +213,7 @@ public class IpCameraHandler extends BaseThingHandler {
             try {
                 if (msg instanceof HttpResponse) {
                     HttpResponse response = (HttpResponse) msg;
-                    if (response.status().code() != 401) {
+                    if (response.status().code() == 200) {
                         if (!response.headers().isEmpty()) {
                             for (String name : response.headers().names()) {
                                 // Some cameras use first letter uppercase and others dont.
@@ -253,7 +253,7 @@ public class IpCameraHandler extends BaseThingHandler {
                             }
                         }
                     } else {
-                        // 401 errors already handled in pipeline by MyNettyAuthHandler.java
+                        // Non 200 OK replies are logged and handled in pipeline by MyNettyAuthHandler.java
                         return;
                     }
                 }
@@ -570,7 +570,7 @@ public class IpCameraHandler extends BaseThingHandler {
         if (!"PUT".equals(httpMethod) || (useDigestAuth && digestString == null)) {
             request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, new HttpMethod(httpMethod), httpRequestURL);
             request.headers().set("Host", cameraConfig.getIp() + ":" + port);
-            request.headers().set("Connection", HttpHeaderValues.KEEP_ALIVE);
+            request.headers().set("Connection", HttpHeaderValues.CLOSE);
         } else {
             request = putRequestWithBody;
         }
@@ -1648,7 +1648,8 @@ public class IpCameraHandler extends BaseThingHandler {
     }
 
     private void tryConnecting() {
-        if (!thing.getThingTypeUID().getId().equals(GENERIC_THING)) {
+        if (!thing.getThingTypeUID().getId().equals(GENERIC_THING)
+                && !thing.getThingTypeUID().getId().equals(DOORBIRD_THING)) {
             onvifCamera = new OnvifConnection(this, cameraConfig.getIp() + ":" + cameraConfig.getOnvifPort(),
                     cameraConfig.getUser(), cameraConfig.getPassword());
             onvifCamera.setSelectedMediaProfile(cameraConfig.getOnvifMediaProfile());


### PR DESCRIPTION
These changes fix an issue reported on the forum here and some general bugs I noticed whilst looking over the users logs and the code:
https://community.openhab.org/t/ipcamera-blank-imageurl-channel/133457/14

Changes are:
1. Doorbird is not ONVIF so this stops the binding trying to connect with ONVIF.
2. Digest was reporting to the camera to `keep alive` the connection right before the binding closed the connection right before making a new connection. This appears to throw off the camera which only allows a single connection at a time for some Doorbird cameras.
3. When a non 200 OK reply came in like a 500 busy error code, the binding was trying to still capture a snapshot.

Signed-off-by: Matthew Skinner <matt@pcmus.com>