### PR TITLE
[deconz] Fix compiler warning

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/DeconzDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/DeconzDynamicStateDescriptionProvider.java
@@ -24,6 +24,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseDynamicStateDescriptionProvider;
 import org.openhab.core.thing.events.ThingEventFactory;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
 import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.StateDescriptionFragment;
@@ -58,6 +59,7 @@ public class DeconzDynamicStateDescriptionProvider extends BaseDynamicStateDescr
         if (!stateDescriptionFragment.equals(oldStateDescriptionFragment)) {
             logger.trace("adding state description for channel {}", channelUID);
             stateDescriptionFragments.put(channelUID, stateDescriptionFragment);
+            ItemChannelLinkRegistry itemChannelLinkRegistry = this.itemChannelLinkRegistry;
             postEvent(ThingEventFactory.createChannelDescriptionChangedEvent(channelUID,
                     itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
                     stateDescriptionFragment, oldStateDescriptionFragment));

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
@@ -175,7 +175,8 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
         String url = buildUrl(config.getHostWithoutPort(), config.httpPort, config.apikey);
         return http.get(url, config.timeout).thenApply(r -> {
             if (r.getResponseCode() == 403) {
-                return Optional.ofNullable((BridgeFullState) null);
+                Optional<BridgeFullState> emptyBridgeFullState = Optional.empty();
+                return emptyBridgeFullState;
             } else if (r.getResponseCode() == 200) {
                 return Optional.ofNullable(gson.fromJson(r.getBody(), BridgeFullState.class));
             } else {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
@@ -175,8 +175,7 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
         String url = buildUrl(config.getHostWithoutPort(), config.httpPort, config.apikey);
         return http.get(url, config.timeout).thenApply(r -> {
             if (r.getResponseCode() == 403) {
-                Optional<BridgeFullState> emptyBridgeFullState = Optional.empty();
-                return emptyBridgeFullState;
+                return Optional.<BridgeFullState> empty();
             } else if (r.getResponseCode() == 200) {
                 return Optional.ofNullable(gson.fromJson(r.getBody(), BridgeFullState.class));
             } else {


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix one (only remaining) compiler warning:

**DeconzDynamicStateDescriptionProvider.java:**
```
[WARNING] openhab-addons\bundles\org.openhab.binding.deconz\src\main\java\org\openhab\binding\deconz\internal\DeconzDynamicStateDescriptionProvider.java:[62,55] Potential null pointer access: this expression has a '@Nullable' type
```

And two compiler info:

**DeconzBridgeHandler.java:**
```
[INFO] openhab-addons\bundles\org.openhab.binding.deconz\src\main\java\org\openhab\binding\deconz\internal\handler\DeconzBridgeHandler.java:[178,24] Unsafe null type conversion (type annotations): The value of type 'java.util.@NonNull Optional<org.openhab.binding.deconz.internal.dto.@NonNull BridgeFullState>' is made accessible using the less-annotated type 'java.util.@NonNull Optional<org.openhab.binding.deconz.internal.dto.BridgeFullState>'
[INFO] openhab-addons\bundles\org.openhab.binding.deconz\src\main\java\org\openhab\binding\deconz\internal\handler\DeconzBridgeHandler.java:[180,24] Unsafe null type conversion (type annotations): The value of type 'java.util.@NonNull Optional<org.openhab.binding.deconz.internal.dto.@NonNull BridgeFullState>' is made accessible using the less-annotated type 'java.util.@NonNull Optional<org.openhab.binding.deconz.internal.dto.BridgeFullState>'
```