### PR TITLE
[pulseaudio] fix null pointer exception and ensure source bg task stops

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -138,7 +138,7 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
             this.pipeWriteTask = executor.submit(() -> {
                 int lengthRead;
                 byte[] buffer = new byte[1024];
-                while (true) {
+                while (pipeOutputs.size() > 0) {
                     var stream = getSourceInputStream();
                     if (stream != null) {
                         try {
@@ -156,6 +156,7 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                         logger.warn("Unable to get source input stream");
                     }
                 }
+                this.pipeWriteTask = null;
             });
         }
     }

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -138,7 +138,7 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
             this.pipeWriteTask = executor.submit(() -> {
                 int lengthRead;
                 byte[] buffer = new byte[1024];
-                while (pipeOutputs.size() > 0) {
+                while (!pipeOutputs.isEmpty()) {
                     var stream = getSourceInputStream();
                     if (stream != null) {
                         try {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.pulseaudio.internal.PulseAudioBindingConfiguration;
 import org.openhab.binding.pulseaudio.internal.PulseAudioBindingConfigurationListener;
 import org.openhab.binding.pulseaudio.internal.PulseaudioBindingConstants;
@@ -115,7 +116,7 @@ public class PulseaudioBridgeHandler extends BaseBridgeHandler implements PulseA
         }
     }
 
-    public AbstractAudioDeviceConfig getDevice(String name) {
+    public @Nullable AbstractAudioDeviceConfig getDevice(String name) {
         return client.getGenericAudioItem(name);
     }
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -421,6 +421,7 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
      * If no module is listening, then it will command the module to load on the pulse audio server,
      *
      * @return the port on which the pulseaudio server is listening for this sink
+     * @throws IOException when device info is not available
      * @throws InterruptedException when interrupted during the loading module wait
      */
     public int getSimpleTcpPort() throws IOException, InterruptedException {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -281,6 +281,10 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
                     // refresh to get the current volume level
                     bridge.getClient().update();
                     device = bridge.getDevice(name);
+                    if (device == null) {
+                        logger.warn("missing device info, aborting");
+                        return;
+                    }
                     int oldVolume = device.getVolume();
                     int newVolume = oldVolume;
                     if (command.equals(IncreaseDecreaseType.INCREASE)) {
@@ -358,11 +362,12 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
     public int getLastVolume() {
         if (savedVolume == null) {
             PulseaudioBridgeHandler bridge = getPulseaudioBridgeHandler();
-            AbstractAudioDeviceConfig device = bridge.getDevice(name);
             // refresh to get the current volume level
             bridge.getClient().update();
-            device = bridge.getDevice(name);
-            savedVolume = device.getVolume();
+            AbstractAudioDeviceConfig device = bridge.getDevice(name);
+            if (device != null) {
+                savedVolume = device.getVolume();
+            }
         }
         return savedVolume == null ? 50 : savedVolume;
     }
@@ -370,6 +375,10 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
     public void setVolume(int volume) {
         PulseaudioBridgeHandler bridge = getPulseaudioBridgeHandler();
         AbstractAudioDeviceConfig device = bridge.getDevice(name);
+        if (device == null) {
+            logger.warn("missing device info, aborting");
+            return;
+        }
         bridge.getClient().setVolumePercent(device, volume);
         updateState(VOLUME_CHANNEL, new PercentType(volume));
         savedVolume = volume;
@@ -414,9 +423,12 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
      * @return the port on which the pulseaudio server is listening for this sink
      * @throws InterruptedException when interrupted during the loading module wait
      */
-    public int getSimpleTcpPort() throws InterruptedException {
+    public int getSimpleTcpPort() throws IOException, InterruptedException {
         var bridgeHandler = getPulseaudioBridgeHandler();
         AbstractAudioDeviceConfig device = bridgeHandler.getDevice(name);
+        if (device == null) {
+            throw new IOException("missing device info, device appears to be offline");
+        }
         String simpleTcpPortPrefName = (device instanceof Source) ? DEVICE_PARAMETER_AUDIO_SOURCE_PORT
                 : DEVICE_PARAMETER_AUDIO_SINK_PORT;
         BigDecimal simpleTcpPortPref = ((BigDecimal) getThing().getConfiguration().get(simpleTcpPortPrefName));


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

@lolodomo this is a small change to ensure the bg task for the source stops if no more streams are open.
I don't know how this can happen but it happened for me once.

Also includes a fix for null pointer exception that is raised when you have a Sink/Source with the register of the openHAB Sink/Source option enabled, and it is not offline (disconnected from the pulseaudio server).
I discover this earlier when I change the speaker for a new one, a Jabra I bought from amazon warehouse.
