### PR TITLE
[wemo] Fix thing status transitions

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -85,11 +85,10 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
             addSubscription(DEVICEEVENT);
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/config-status.error.missing-udn");
-            logger.debug("Cannot initalize WemoCoffeeHandler. UDN not set.");
         }
     }
 
@@ -113,10 +112,9 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                 logger.debug("Polling job");
 
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCrockpotHandler.java
@@ -76,11 +76,10 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
             addSubscription(BASICEVENT);
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/config-status.error.missing-udn");
-            logger.debug("Cannot initalize WemoCrockpotHandler. UDN not set.");
         }
     }
 
@@ -103,10 +102,9 @@ public class WemoCrockpotHandler extends WemoBaseThingHandler {
             try {
                 logger.debug("Polling job");
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoDimmerHandler.java
@@ -89,11 +89,10 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
             addSubscription(BASICEVENT);
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/config-status.error.missing-udn");
-            logger.debug("Cannot initalize WemoDimmerHandler. UDN not set.");
         }
     }
 
@@ -117,10 +116,9 @@ public class WemoDimmerHandler extends WemoBaseThingHandler {
             try {
                 logger.debug("Polling job");
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -176,8 +176,10 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
                 logger.trace("New state '{}' for device '{}' received", value, getThing().getUID());
                 this.onValueReceived(variable, value, actionService + "1");
             }
+            updateStatus(ThingStatus.ONLINE);
         } catch (Exception e) {
             logger.warn("Failed to get actual state for device '{}': {}", getThing().getUID(), e.getMessage());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -72,11 +72,10 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
             }
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/config-status.error.missing-udn");
-            logger.debug("Cannot initalize WemoHandler. UDN not set.");
         }
     }
 
@@ -100,10 +99,9 @@ public abstract class WemoHandler extends WemoBaseThingHandler {
             try {
                 logger.debug("Polling job");
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -90,11 +90,10 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
             addSubscription(BASICEVENT);
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/config-status.error.missing-udn");
-            logger.debug("Cannot initalize WemoHolmesHandler. UDN not set.");
         }
     }
 
@@ -118,10 +117,9 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
             try {
                 logger.debug("Polling job");
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -87,7 +87,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
             addSubscription(BRIDGEEVENT);
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, DEFAULT_REFRESH_INITIAL_DELAY,
                     DEFAULT_REFRESH_INTERVAL_SECONDS, TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.BRIDGE_OFFLINE);
         }
@@ -98,7 +98,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.ONLINE)) {
             updateStatus(ThingStatus.ONLINE);
         } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.BRIDGE_OFFLINE);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
             ScheduledFuture<?> job = this.pollingJob;
             if (job != null && !job.isCancelled()) {
                 job.cancel(true);
@@ -143,10 +143,9 @@ public class WemoLightHandler extends WemoBaseThingHandler {
             try {
                 logger.debug("Polling job");
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -77,11 +77,10 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
             logger.debug("Initializing WemoMakerHandler for UDN '{}'", configuration.get(UDN));
             pollingJob = scheduler.scheduleWithFixedDelay(this::poll, 0, DEFAULT_REFRESH_INTERVAL_SECONDS,
                     TimeUnit.SECONDS);
-            updateStatus(ThingStatus.ONLINE);
+            updateStatus(ThingStatus.UNKNOWN);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/config-status.error.missing-udn");
-            logger.debug("Cannot initalize WemoMakerHandler. UDN not set.");
         }
     }
 
@@ -105,10 +104,9 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
             try {
                 logger.debug("Polling job");
                 // Check if the Wemo device is set in the UPnP service registry
-                // If not, set the thing state to ONLINE/CONFIG-PENDING and wait for the next poll
                 if (!isUpnpDeviceRegistered()) {
                     logger.debug("UPnP device {} not yet registered", getUDN());
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "@text/config-status.pending.device-not-registered [\"" + getUDN() + "\"]");
                     return;
                 }

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
@@ -75,7 +75,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.ONLINE));
+            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
         });
 
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will
@@ -111,7 +111,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.ONLINE));
+            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
         });
 
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
@@ -111,7 +111,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
+            assertThat(thing.getStatus(), is(ThingStatus.OFFLINE));
         });
 
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoLightHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoLightHandlerOSGiTest.java
@@ -160,7 +160,7 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
         });
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.ONLINE));
+            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
         });
 
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
@@ -76,7 +76,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
+            assertThat(thing.getStatus(), is(ThingStatus.OFFLINE));
         });
 
         // The Device is registered as UPnP Device after the initialization, this will ensure that the polling job will
@@ -112,7 +112,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
+            assertThat(thing.getStatus(), is(ThingStatus.OFFLINE));
         });
 
         // The Device is registered as UPnP Device after the initialization, this will ensure that the polling job will

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
@@ -76,7 +76,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.ONLINE));
+            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
         });
 
         // The Device is registered as UPnP Device after the initialization, this will ensure that the polling job will
@@ -112,7 +112,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         Thing thing = createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert(() -> {
-            assertThat(thing.getStatus(), is(ThingStatus.ONLINE));
+            assertThat(thing.getStatus(), is(ThingStatus.UNKNOWN));
         });
 
         // The Device is registered as UPnP Device after the initialization, this will ensure that the polling job will


### PR DESCRIPTION
Fixes #12415

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Previously transitions for a turned off device would be:
```
2022-03-04 22:11:46.481 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'wemo:insight:insight1' changed from UNINITIALIZED (HANDLER_MISSING_ERROR) to INITIALIZING
2022-03-04 22:11:46.505 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'wemo:insight:insight1' changed from INITIALIZING to ONLINE
2022-03-04 22:11:57.366 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'wemo:insight:insight1' changed from ONLINE to ONLINE (CONFIGURATION_PENDING): UPnP device is not registered yet.
```

Now:
```
2022-03-04 22:25:21.030 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'wemo:insight:insight1' changed from UNINITIALIZED (HANDLER_MISSING_ERROR) to INITIALIZING
2022-03-04 22:25:21.067 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'wemo:insight:insight1' changed from INITIALIZING to UNKNOWN
2022-03-04 22:26:41.846 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'wemo:insight:insight1' changed from UNKNOWN to OFFLINE: UPnP device is not registered yet.
```