### PR TITLE
GHA CI build workflow improvements

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         java: [ '11', '17' ]
         maven: [ '3.8.4']
@@ -55,11 +56,13 @@ jobs:
           maven-version: ${{ matrix.maven }}
 
       - name: Register Problem Matchers
+        if: ${{ matrix.java == '11' }}
         id: problem_matchers
         run: |
           echo "::add-matcher::.github/openhab-compile-problems.json"
 
       - name: Get Changed Files
+        if: github.head_ref != ''
         id: files
         uses: Ana06/get-changed-files@v2.0.0
         with:
@@ -91,8 +94,8 @@ jobs:
           path: target/summary_report.html
 
       - name: Report SAT Errors as Annotations
+        if: ${{ matrix.java == '11' && always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
         uses: ghys/checkstyle-github-action@main
-        if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
         with:
           title: CheckStyle Violations
           path: '**/checkstyle-result.xml'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <img align="right" width="220" src="./logo.png" />
 
-[![Build Status](https://ci.openhab.org/job/openHAB-Addons/badge/icon)](https://ci.openhab.org/job/openHAB-Addons/)
+[![GitHub Actions Build Status](https://github.com/openhab/openhab-addons/actions/workflows/ci-build.yml/badge.svg?branch=main)](https://github.com/openhab/openhab-addons/actions/workflows/ci-build.yml)
+[![Jenkins Build Status](https://ci.openhab.org/job/openHAB-Addons/badge/icon)](https://ci.openhab.org/job/openHAB-Addons/)
 [![EPL-2.0](https://img.shields.io/badge/license-EPL%202-green.svg)](https://opensource.org/licenses/EPL-2.0)
 [![Crowdin](https://badges.crowdin.net/openhab-addons/localized.svg)](https://crowdin.com/project/openhab-addons)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=2164344)](https://www.bountysource.com/teams/openhab/issues?tracker_ids=2164344)


### PR DESCRIPTION
* Add error annotations only in Java 11 matrix build to prevent duplicates
* Make sure Java 11 build is not cancelled when Java 17 build fails so it can add annotations by using `fail-fast: false`
* Use changed files only for incremental PR builds so a full build is done for changes merged into 'main' branch
* Add GHA build status badge