### PR TITLE
[pulseaudio] source: use thread safe collection and force reconnection

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -14,6 +14,7 @@ package org.openhab.binding.pulseaudio.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.Socket;
@@ -153,6 +154,10 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                                         output.flush();
                                     }
                                 } catch (IOException e) {
+                                    if (e instanceof InterruptedIOException && pipeOutputs.isEmpty()) {
+                                        // task has been ended while writing
+                                        return;
+                                    }
                                     logger.warn("IOException while writing to from pulse source pipe: {}",
                                             getExceptionMessage(e));
                                 } catch (RuntimeException e) {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -154,14 +154,14 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                                     }
                                 } catch (IOException e) {
                                     logger.warn("IOException while writing to from pulse source pipe: {}",
-                                            e.getMessage());
+                                            getExceptionMessage(e));
                                 } catch (RuntimeException e) {
                                     logger.warn("RuntimeException while writing to pulse source pipe: {}",
-                                            e.getMessage());
+                                            getExceptionMessage(e));
                                 }
                             }
                         } catch (IOException e) {
-                            logger.warn("IOException while reading from pulse source: {}", e.getMessage());
+                            logger.warn("IOException while reading from pulse source: {}", getExceptionMessage(e));
                             if (readRetries == 0) {
                                 // force reconnection on persistent IOException
                                 super.disconnect();
@@ -169,7 +169,7 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                                 readRetries--;
                             }
                         } catch (RuntimeException e) {
-                            logger.warn("RuntimeException while reading from pulse source: {}", e.getMessage());
+                            logger.warn("RuntimeException while reading from pulse source: {}", getExceptionMessage(e));
                         }
                     } else {
                         logger.warn("Unable to get source input stream");
@@ -198,6 +198,15 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
             pipeWriteTask.cancel(true);
             this.pipeWriteTask = null;
         }
+    }
+
+    private @Nullable String getExceptionMessage(Exception e) {
+        String message = e.getMessage();
+        var cause = e.getCause();
+        if (message == null && cause != null) {
+            message = cause.getMessage();
+        }
+        return message;
     }
 
     private @Nullable InputStream getSourceInputStream() {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -175,17 +175,18 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                         logger.warn("Unable to get source input stream");
                     }
                 }
+                this.pipeWriteTask = null;
             });
         }
     }
 
     private synchronized void unregisterPipe(PipedOutputStream pipeOutput) {
         this.pipeOutputs.remove(pipeOutput);
-        stopPipeWriteTask();
         try {
             Thread.sleep(0);
         } catch (InterruptedException ignored) {
         }
+        stopPipeWriteTask();
         try {
             pipeOutput.close();
         } catch (IOException ignored) {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -85,7 +85,6 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                     }
                     setIdle(true);
                     var pipeOutput = new PipedOutputStream();
-                    registerPipe(pipeOutput);
                     var pipeInput = new PipedInputStream(pipeOutput, 1024 * 10) {
                         @Override
                         public void close() throws IOException {
@@ -93,6 +92,7 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                             super.close();
                         }
                     };
+                    registerPipe(pipeOutput);
                     // get raw audio from the pulse audio socket
                     return new PulseAudioStream(sourceFormat, pipeInput, (idle) -> {
                         setIdle(idle);


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

Use thread safe collection for storing the source pipe output references.
Also added a forced disconnection after the 3 consecutive IOExceptions while reading the socket input to force a reconnection.
Possible fix for https://github.com/openhab/openhab-addons/issues/12432.
 
@lolodomo can you try to reproduce the error with this version?