### PR TITLE
[pushover] Add featured integration paragraph

### DIFF
--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -10,7 +10,7 @@ Once you have the token, you need a user key (or group key) and optionally a dev
 There is only one Thing available - the `pushover-account`.
 You are able to create multiple instances of this Thing to broadcast to different users, groups or devices.
 
-openHAB is listed as a *featured application* on the [pushover homepage](https://pushover.net/apps).
+openHAB is listed as a *featured application* on the [Pushover homepage](https://pushover.net/apps).
 It provides a clone function to directly add a *prefilled* application to your pushover account and retrieve an api key.
 You can reach it via [https://pushover.net/apps/clone/openHAB](https://pushover.net/apps/clone/openHAB)
 

--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -11,7 +11,7 @@ There is only one Thing available - the `pushover-account`.
 You are able to create multiple instances of this Thing to broadcast to different users, groups or devices.
 
 openHAB is listed as a *featured application* on the [Pushover homepage](https://pushover.net/apps).
-It provides a clone function to directly add a *prefilled* application to your pushover account and retrieve an api key.
+It provides a clone function to directly add a *prefilled* application to your Pushover account and retrieve an API key.
 You can reach it via [https://pushover.net/apps/clone/openHAB](https://pushover.net/apps/clone/openHAB)
 
 ## Thing Configuration

--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -10,6 +10,10 @@ Once you have the token, you need a user key (or group key) and optionally a dev
 There is only one Thing available - the `pushover-account`.
 You are able to create multiple instances of this Thing to broadcast to different users, groups or devices.
 
+openHAB is listed as a *featured application* on the [pushover homepage](https://pushover.net/apps).
+It provides a clone function to directly add a *prefilled* application to your pushover account and retrieve an api key.
+You can reach it via [https://pushover.net/apps/clone/openHAB](https://pushover.net/apps/clone/openHAB)
+
 ## Thing Configuration
 
 | Configuration Parameter | Type    | Description                                                                                                                                                                                                                                                                                                   |


### PR DESCRIPTION
I have requested openHAB as a featured integration for pushover via support and it got accepted.
So we are listed on their website now and have a cloneable application.
(This is basically just a prefilled website form including the openHAB logo.)

Therefore i added a little paragraph including the clone url.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>