### PR TITLE
bump compiler tooling

### DIFF
--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -37,7 +37,7 @@ Fragment-Host: org.openhab.binding.astro
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -56,7 +56,7 @@ Fragment-Host: org.openhab.binding.avmfritz
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -52,7 +52,7 @@ Fragment-Host: org.openhab.binding.feed
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -56,7 +56,7 @@ Fragment-Host: org.openhab.binding.hue
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -49,7 +49,7 @@ Fragment-Host: org.openhab.binding.max
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
@@ -59,7 +59,7 @@ Fragment-Host: org.openhab.binding.mielecloud
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -56,7 +56,7 @@ Fragment-Host: org.openhab.binding.modbus
 	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -78,7 +78,7 @@ Fragment-Host: org.openhab.binding.nest
 	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -53,7 +53,7 @@ Fragment-Host: org.openhab.binding.ntp
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -56,7 +56,7 @@ Fragment-Host: org.openhab.binding.systeminfo
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -57,7 +57,7 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -59,7 +59,7 @@ Fragment-Host: org.openhab.binding.wemo
 	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -46,7 +46,7 @@ Fragment-Host: org.openhab.persistence.mapdb
 	junit-platform-commons;version='[1.8.1,1.8.2)',\
 	junit-platform-engine;version='[1.8.1,1.8.2)',\
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	biz.aQute.tester.junit-platform;version='[6.2.0,6.2.1)',\
 	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
     <ohc.version>3.3.0-SNAPSHOT</ohc.version>
-    <bnd.version>6.1.0</bnd.version>
+    <bnd.version>6.2.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.5</jackson.version>
@@ -292,7 +292,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
           <configuration>
             <compilerId>eclipse</compilerId>
             <compilerArguments>
@@ -310,12 +310,12 @@ Import-Package: \\
             <dependency>
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-compiler-eclipse</artifactId>
-              <version>2.8.8</version>
+              <version>2.11.1</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.23.0</version>
+              <version>3.28.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
This brings the build tools to the same versions as in core.

See: https://github.com/openhab/openhab-core/pull/2836

Signed-off-by: Jan N. Klug <github@klug.nrw>

