### PR TITLE
[openwebnet] Add support for  sending Auxiliary (AUX) commands/messages to the bus (WHO=9)

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -44,7 +44,7 @@ The following Things and OpenWebNet `WHOs` are supported:
 | Lighting                      |     `1`     |             `bus_on_off_switch`, `bus_dimmer`              | BUS switches and dimmers                                         | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers)                                                                                           |
 | Automation                    |     `2`     |                      `bus_automation`                      | BUS roller shutters, with position feedback and auto-calibration | Successfully tested: LN4672M2                                                                                                                                                                              |
 | Temperature Control           |     `4`     |  `bus_thermo_zone`, `bus_thermo_sensor`, `bus_thermo_cu`   | Thermo zones management and temperature sensors (probes).        | Successfully tested: H/LN4691, HS4692, KG4691; thermo sensors: L/N/NT4577 + 3455; Central Units (4 or 99 zones) are not fully supported yet. See [Channels - Thermo](#configuring-thermo) for more details |
-| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                     | Successfully tested: AUX configured for bulgrar-alarm unit 3486                                                                                                                                            |
+| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                     | Successfully tested: AUX configured for bulgrar-alarm unit 3486. Only sending AUX commands is supported                                                                                                    |
 | CEN & CEN+ Scenarios          | `15` & `25` | `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: scenario buttons: HC/HD/HS/L/N/NT4680                                                                                                                                                 |
 | Dry Contact and IR Interfaces |    `25`     |                    `bus_dry_contact_ir`                    | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610                                                                                                                     |
 | Energy Management             |    `18`     |                     `bus_energy_meter`                     | Energy Management                                                | Successfully tested: F520, F521                                                                                                                                                                            |
@@ -159,10 +159,14 @@ BUS Auxiliary commands  (WHO=9) can be used to send on the BUS commands to contr
 
 To control a BTicino alarm system  the alarm unit should be configured for example  as follows:
 
-Antitheft->Automations-> then toggle the Event option -> then select OPEN code
+Antitheft -> Automations -> then toggle the Event option -> then select OPEN code
 
 - Type in the AUX command you want to set, e.g. \*9\*1\*4\## (where=4)
-- Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234## (engage alarm on zones 1,2,3,4)
+- Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234## (engage alarm on zones 1,2,3,4).
+
+Please note  that,  as far as AUX command support, it is not possibile to receive messages originating from the bus. Only sending messages to the bus  is  doable.  
+Hence, for the time being,   when AUX commands  are used to control the alarm system it is not possible retrieve its status (i.e. armed or disarmed).
+
 
 
 ### Central Unit integration missing points 
@@ -175,15 +179,15 @@ Antitheft->Automations-> then toggle the Event option -> then select OPEN code
 
 ### Lighting, Automation, Power meter, CEN/CEN+ Scenario Events and Dry Contact / IR Interfaces channels
 
-| Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                         | Read/Write  |
-|-----------------------------------------|---------------------------------------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------|:-----------:|
-| `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                 |     R/W     |
-| `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                               |     R/W     |
-| `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))             |     R/W     |
-| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                               | R (TRIGGER) |
-| `sensor`                                | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`) |      R      |
-| `power`                                 | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                    |      R      |
-| `aux`                                   | `bus_aux`                                                     | String        | To send an AUX command  `ON` and `OFF`                                                                              |     R/W     |
+| Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                                                            | Read/Write  |
+|-----------------------------------------|---------------------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------:|
+| `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                                                    |     R/W     |
+| `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                                                                  |     R/W     |
+| `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))                                                |     R/W     |
+| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                                                                  | R (TRIGGER) |
+| `sensor`                                | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`)                                    |      R      |
+| `power`                                 | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                                                       |      R      |
+| `aux`                                   | `bus_aux`                                                     | String        | Possible commands: ON,OFF,TOGGLE, STOP, UP,DOWN,ENABLED, DISABLED, RESET_GEN, RESET_BI, RESET_TRI. Still, only   'ON' and `OFF'  are supported for now |     R/W     |
 
 ### Thermo channels
 
@@ -335,7 +339,7 @@ Number:Temperature  iEXT_temp                   "Temperature [%.1f %unit%]"   (g
 
 String	            iCENPlusProxyItem	        "CEN+ Proxy Item"
 
-String              iAlarm                      "Alarm Activation"		                 { channel="openwebnet:bus_aux:mybridge:Alarm_activation:aux"}
+String              iAlarm_activation            "Alarm Activation"		                 { channel="openwebnet:bus_aux:mybridge:Alarm_activation:aux"}
 
 Switch              iLR_IR_sensor               "Sensor"                            { channel="openwebnet:bus_dry_contact_ir:mybridge:LR_IR_sensor:sensor" }
 

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -155,14 +155,14 @@ The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing.
 
 #### Configuring Auxiliary (AUX)
 
-BUS Auxiliary commands  (WHO=9) can be used to send on the BUS commands to control, for example, external devices or a BTcino Alarm system. 
+BUS Auxiliary commands (WHO=9) can be used to send on the BUS commands to control, for example, external devices or a BTcino Alarm system. 
 
-To control a BTicino alarm system  the alarm unit should be configured for example  as follows:
+To control a BTicino alarm system the alarm unit should be configured for example as follows:
 
 Antitheft -> Automations -> then toggle the Event option -> then select OPEN code
 
-- Type in the AUX command you want to set, e.g. \*9\*1\*4\## (where=4)
-- Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234## (engage alarm on zones 1,2,3,4).
+- Type in the AUX command you want to set, e.g.\*9\*1\*4\## (where=4)
+- Type in the associated Open Web Net code you want to execute, e.g.\*5\*8*#1234## (engage alarm on zones 1,2,3,4).
 
 Please note that receiving AUX messages originating from the bus is not supported yet, only sending messages to the bus is supported.
 

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -38,15 +38,16 @@ The following Things and OpenWebNet `WHOs` are supported:
 
 ### For BUS/SCS
 
-| Category                      | WHO          | Thing Type IDs                                             | Description                                                      | Status                                                                                                                                                                                                     |
-| ----------------------------- | :----------: | :--------------------------------------------------------: | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Gateway Management            | `13`         | `bus_gateway`                                              | Any IP gateway supporting OpenWebNet protocol should work        | Successfully tested: F452, F453, F453AV,F454, F455, MyHOMEServer1, MyHOME_Screen10, MyHOME_Screen3,5, MH201, MH202, MH200N. Some connection stability issues/gateway resets reported with MH202            |
-| Lighting                      | `1`          | `bus_on_off_switch`, `bus_dimmer`                          | BUS switches and dimmers                                         | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers)                                                                                           |
-| Automation                    | `2`          | `bus_automation`                                           | BUS roller shutters, with position feedback and auto-calibration | Successfully tested: LN4672M2                                                                                                                                                                              |
+| Category                      | WHO          | Thing Type IDs                                             | Description                                                      | Status                                                                                               |
+| ----------------------------- | :----------: | :--------------------------------------------------------: | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Gateway Management            | `13`         | `bus_gateway`                                              | Any IP gateway supporting OpenWebNet protocol should work        | Successfully tested: F452, F453, F453AV,F454, F455, MyHOMEServer1, MyHOME_Screen10, MyHOME_Screen3,5, MH201, MH202, MH200N. Some connection stability issues/gateway resets reported with MH202  |
+| Lighting                      | `1`          | `bus_on_off_switch`, `bus_dimmer`                          | BUS switches and dimmers                                         | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers) |
+| Automation                    | `2`          | `bus_automation`                                           | BUS roller shutters, with position feedback and auto-calibration | Successfully tested: LN4672M2                                                                        |
 | Temperature Control           | `4`          | `bus_thermo_zone`, `bus_thermo_sensor`, `bus_thermo_cu`    | Thermo zones management and temperature sensors (probes).        | Successfully tested: H/LN4691, HS4692, KG4691; thermo sensors: L/N/NT4577 + 3455; Central Units (4 or 99 zones) are not fully supported yet. See [Channels - Thermo](#configuring-thermo) for more details |
-| CEN & CEN+ Scenarios          | `15` & `25`  | `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: scenario buttons: HC/HD/HS/L/N/NT4680                                                                                                                                                 |
-| Dry Contact and IR Interfaces | `25`         | `bus_dry_contact_ir`                                       | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610                                                                                                                     |
-| Energy Management             | `18`         | `bus_energy_meter`                                         | Energy Management                                                | Successfully tested: F520, F521                                                                                                                                                                            |
+| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                                                                                                                                             | Successfully tested: bulgrar-alarm  unit 3486                                        |
+| CEN & CEN+ Scenarios          | `15` & `25`  | `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: scenario buttons: HC/HD/HS/L/N/NT4680                                           |
+| Dry Contact and IR Interfaces | `25`         | `bus_dry_contact_ir`                                       | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610               |
+| Energy Management             | `18`         | `bus_energy_meter`                                         | Energy Management                                                | Successfully tested: F520, F521                                                                      |
 
 ### For ZigBee (Radio)
 
@@ -152,6 +153,18 @@ Temperature sensors can be configured defining a `bus_thermo_sensor` Thing with 
 
 The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing.
 
+#### Configuring Auxiliary (AUX)
+
+BTicino BUS AUX (WHO=9) can be detected and activated, enabling the system  to detect AUX commands allowing, for example, to control alarm systems of a BTicino installation.
+
+In order control alarm systems AUX commands should be set in the alarm unit as follows:
+
+Antitheft->Automations-> then toggle the Event option -> then select OPEN code
+
+- Type in the AUX command you want to set, e.g. \*9\*1\*4\##
+- Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234##
+
+
 ### Central Unit integration missing points 
 
 - Read setPoint temperature and current mode
@@ -162,14 +175,15 @@ The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing.
 
 ### Lighting, Automation, Power meter, CEN/CEN+ Scenario Events and Dry Contact / IR Interfaces channels
 
-| Channel Type ID (channel ID)             | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                         | Read/Write  |
-| ---------------------------------------- | ------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- | :---------: |
-| `switch` or `switch_01`/`02` for ZigBee  | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                 | R/W         |
-| `brightness`                             | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                               | R/W         |
-| `shutter`                                | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))             | R/W         |
-| `button#X`                               | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                               | R (TRIGGER) |
-| `sensor`                                 | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`) | R           |
-| `power`                                  | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                    | R           |
+| Channel Type ID (channel ID)              | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                         | Read/Write  |
+|-------------------------------------------| ------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- | :---------: |
+| `switch` or `switch_01`/`02` for ZigBee   | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                 | R/W         |
+| `brightness`                              | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                               | R/W         |
+| `shutter`                                 | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))             | R/W         |
+| `button#X`                                | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                               | R (TRIGGER) |
+| `sensor`                                  | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`) | R           |
+| `power`                                   | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                    | R           |
+| `aux`                                     | `bus_aux`                                                     | String        | To switch the device `ON` and `OFF`                       |     R/W  |
 
 ### Thermo channels
 
@@ -263,6 +277,7 @@ Bridge openwebnet:bus_gateway:mybridge "MyHOMEServer1" [ host="192.168.1.35", pa
       bus_cen_scenario_control      LR_CEN_scenario      "Living Room CEN"          [ where="51", buttons="4,3,8"]
       bus_cenplus_scenario_control  LR_CENplus_scenario  "Living Room CEN+"         [ where="212", buttons="1,5,18" ]
       bus_dry_contact_ir            LR_IR_sensor         "Living Room IR Sensor"    [ where="399" ]
+      bus_aux		            Alarm		 "Alarm"	            [ where="4"   ]
 }
 ```
 
@@ -320,7 +335,10 @@ Number:Temperature  iEXT_temp                   "Temperature [%.1f %unit%]"   (g
 
 String	            iCENPlusProxyItem	        "CEN+ Proxy Item"
 
-Switch              iLR_IR_sensor               "Sensor"                                        { channel="openwebnet:bus_dry_contact_ir:mybridge:LR_IR_sensor:sensor" }
+String              iAlarm                      "Alarm"		                        { channel="openwebnet:bus_aux:mybridge:Alarm:aux"}
+
+Switch              iLR_IR_sensor               "Sensor"                                { channel="openwebnet:bus_dry_contact_ir:mybridge:LR_IR_sensor:sensor" }
+
 
 ```
 
@@ -367,6 +385,12 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     Frame label="CEN+ Scenario activation"
     {
           Switch    item=iCENPlusProxyItem  label="My CEN+ scenario" icon="movecontrol"  mappings=[ON="Activate"]
+    }
+    
+    Frame label="Alarm"
+    {
+          Switch item=iAlarm           icon="siren"
+         
     }
 }
 ```

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -38,16 +38,16 @@ The following Things and OpenWebNet `WHOs` are supported:
 
 ### For BUS/SCS
 
-| Category                      | WHO          | Thing Type IDs                                             | Description                                                      | Status                                                                                               |
-| ----------------------------- | :----------: | :--------------------------------------------------------: | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Gateway Management            | `13`         | `bus_gateway`                                              | Any IP gateway supporting OpenWebNet protocol should work        | Successfully tested: F452, F453, F453AV,F454, F455, MyHOMEServer1, MyHOME_Screen10, MyHOME_Screen3,5, MH201, MH202, MH200N. Some connection stability issues/gateway resets reported with MH202  |
-| Lighting                      | `1`          | `bus_on_off_switch`, `bus_dimmer`                          | BUS switches and dimmers                                         | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers) |
-| Automation                    | `2`          | `bus_automation`                                           | BUS roller shutters, with position feedback and auto-calibration | Successfully tested: LN4672M2                                                                        |
-| Temperature Control           | `4`          | `bus_thermo_zone`, `bus_thermo_sensor`, `bus_thermo_cu`    | Thermo zones management and temperature sensors (probes).        | Successfully tested: H/LN4691, HS4692, KG4691; thermo sensors: L/N/NT4577 + 3455; Central Units (4 or 99 zones) are not fully supported yet. See [Channels - Thermo](#configuring-thermo) for more details |
-| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                                                                                                                                             | Successfully tested: bulgrar-alarm  unit 3486                                        |
-| CEN & CEN+ Scenarios          | `15` & `25`  | `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: scenario buttons: HC/HD/HS/L/N/NT4680                                           |
-| Dry Contact and IR Interfaces | `25`         | `bus_dry_contact_ir`                                       | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610               |
-| Energy Management             | `18`         | `bus_energy_meter`                                         | Energy Management                                                | Successfully tested: F520, F521                                                                      |
+| Category                      |     WHO     |                       Thing Type IDs                       | Description                                                      | Status                                                                                                                                                                                                     |
+|-------------------------------|:-----------:|:----------------------------------------------------------:|------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Gateway Management            |    `13`     |                       `bus_gateway`                        | Any IP gateway supporting OpenWebNet protocol should work        | Successfully tested: F452, F453, F453AV,F454, F455, MyHOMEServer1, MyHOME_Screen10, MyHOME_Screen3,5, MH201, MH202, MH200N. Some connection stability issues/gateway resets reported with MH202            |
+| Lighting                      |     `1`     |             `bus_on_off_switch`, `bus_dimmer`              | BUS switches and dimmers                                         | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers)                                                                                           |
+| Automation                    |     `2`     |                      `bus_automation`                      | BUS roller shutters, with position feedback and auto-calibration | Successfully tested: LN4672M2                                                                                                                                                                              |
+| Temperature Control           |     `4`     |  `bus_thermo_zone`, `bus_thermo_sensor`, `bus_thermo_cu`   | Thermo zones management and temperature sensors (probes).        | Successfully tested: H/LN4691, HS4692, KG4691; thermo sensors: L/N/NT4577 + 3455; Central Units (4 or 99 zones) are not fully supported yet. See [Channels - Thermo](#configuring-thermo) for more details |
+| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                     | Successfully tested: AUX configured for bulgrar-alarm unit 3486                                                                                                                                            |
+| CEN & CEN+ Scenarios          | `15` & `25` | `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: scenario buttons: HC/HD/HS/L/N/NT4680                                                                                                                                                 |
+| Dry Contact and IR Interfaces |    `25`     |                    `bus_dry_contact_ir`                    | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610                                                                                                                     |
+| Energy Management             |    `18`     |                     `bus_energy_meter`                     | Energy Management                                                | Successfully tested: F520, F521                                                                                                                                                                            |
 
 ### For ZigBee (Radio)
 
@@ -155,14 +155,14 @@ The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing.
 
 #### Configuring Auxiliary (AUX)
 
-BTicino BUS AUX (WHO=9) can be detected and activated, enabling the system  to detect AUX commands allowing, for example, to control alarm systems of a BTicino installation.
+BUS Auxiliary commands  (WHO=9) can be used to send on the BUS commands to control, for example, external devices or a BTcino Alarm system. 
 
-In order control alarm systems AUX commands should be set in the alarm unit as follows:
+To control a BTicino alarm system  the alarm unit should be configured for example  as follows:
 
 Antitheft->Automations-> then toggle the Event option -> then select OPEN code
 
-- Type in the AUX command you want to set, e.g. \*9\*1\*4\##
-- Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234##
+- Type in the AUX command you want to set, e.g. \*9\*1\*4\## (where=4)
+- Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234## (engage alarm on zones 1,2,3,4)
 
 
 ### Central Unit integration missing points 
@@ -175,15 +175,15 @@ Antitheft->Automations-> then toggle the Event option -> then select OPEN code
 
 ### Lighting, Automation, Power meter, CEN/CEN+ Scenario Events and Dry Contact / IR Interfaces channels
 
-| Channel Type ID (channel ID)              | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                         | Read/Write  |
-|-------------------------------------------| ------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- | :---------: |
-| `switch` or `switch_01`/`02` for ZigBee   | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                 | R/W         |
-| `brightness`                              | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                               | R/W         |
-| `shutter`                                 | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))             | R/W         |
-| `button#X`                                | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                               | R (TRIGGER) |
-| `sensor`                                  | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`) | R           |
-| `power`                                   | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                    | R           |
-| `aux`                                     | `bus_aux`                                                     | String        | To switch the device `ON` and `OFF`                       |     R/W  |
+| Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                         | Read/Write  |
+|-----------------------------------------|---------------------------------------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------|:-----------:|
+| `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                 |     R/W     |
+| `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                               |     R/W     |
+| `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))             |     R/W     |
+| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                               | R (TRIGGER) |
+| `sensor`                                | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`) |      R      |
+| `power`                                 | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                    |      R      |
+| `aux`                                   | `bus_aux`                                                     | String        | To send an AUX command  `ON` and `OFF`                                                                              |     R/W     |
 
 ### Thermo channels
 
@@ -277,7 +277,7 @@ Bridge openwebnet:bus_gateway:mybridge "MyHOMEServer1" [ host="192.168.1.35", pa
       bus_cen_scenario_control      LR_CEN_scenario      "Living Room CEN"          [ where="51", buttons="4,3,8"]
       bus_cenplus_scenario_control  LR_CENplus_scenario  "Living Room CEN+"         [ where="212", buttons="1,5,18" ]
       bus_dry_contact_ir            LR_IR_sensor         "Living Room IR Sensor"    [ where="399" ]
-      bus_aux		            Alarm		 "Alarm"	            [ where="4"   ]
+      bus_aux		                Alarm_activation	 "Alarm activation"         [ where="4"   ]
 }
 ```
 
@@ -335,9 +335,9 @@ Number:Temperature  iEXT_temp                   "Temperature [%.1f %unit%]"   (g
 
 String	            iCENPlusProxyItem	        "CEN+ Proxy Item"
 
-String              iAlarm                      "Alarm"		                        { channel="openwebnet:bus_aux:mybridge:Alarm:aux"}
+String              iAlarm                      "Alarm Activation"		                 { channel="openwebnet:bus_aux:mybridge:Alarm_activation:aux"}
 
-Switch              iLR_IR_sensor               "Sensor"                                { channel="openwebnet:bus_dry_contact_ir:mybridge:LR_IR_sensor:sensor" }
+Switch              iLR_IR_sensor               "Sensor"                            { channel="openwebnet:bus_dry_contact_ir:mybridge:LR_IR_sensor:sensor" }
 
 
 ```
@@ -387,9 +387,9 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
           Switch    item=iCENPlusProxyItem  label="My CEN+ scenario" icon="movecontrol"  mappings=[ON="Activate"]
     }
     
-    Frame label="Alarm"
+    Frame label="Alarm activation via AUX command"
     {
-          Switch item=iAlarm           icon="siren"
+          Switch item=iAlarm         icon="siren"
          
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -164,8 +164,7 @@ Antitheft -> Automations -> then toggle the Event option -> then select OPEN cod
 - Type in the AUX command you want to set, e.g. \*9\*1\*4\## (where=4)
 - Type in the associated  Open Web Net code you want to execute, e.g.  \*5\*8*#1234## (engage alarm on zones 1,2,3,4).
 
-Please note  that,  as far as AUX command support, it is not possibile to receive messages originating from the bus. Only sending messages to the bus  is  doable.  
-Hence, for the time being,   when AUX commands  are used to control the alarm system it is not possible retrieve its status (i.e. armed or disarmed).
+Please note that receiving AUX messages originating from the bus is not supported yet, only sending messages to the bus is supported.
 
 
 
@@ -179,15 +178,15 @@ Hence, for the time being,   when AUX commands  are used to control the alarm sy
 
 ### Lighting, Automation, Power meter, CEN/CEN+ Scenario Events and Dry Contact / IR Interfaces channels
 
-| Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                                                            | Read/Write  |
-|-----------------------------------------|---------------------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------:|
-| `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                                                    |     R/W     |
-| `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                                                                  |     R/W     |
-| `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))                                                |     R/W     |
-| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                                                                  | R (TRIGGER) |
-| `sensor`                                | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`)                                    |      R      |
-| `power`                                 | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                                                       |      R      |
-| `aux`                                   | `bus_aux`                                                     | String        | Possible commands: ON,OFF,TOGGLE, STOP, UP,DOWN,ENABLED, DISABLED, RESET_GEN, RESET_BI, RESET_TRI. Still, only   'ON' and `OFF'  are supported for now |     R/W     |
+| Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                                                     | Read/Write  |
+|-----------------------------------------|---------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|:-----------:|
+| `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                                             |     R/W     |
+| `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                                                           |     R/W     |
+| `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))                                         |     R/W     |
+| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                                                           | R (TRIGGER) |
+| `sensor`                                | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`)                             |      R      |
+| `power`                                 | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                                                |      R      |
+| `aux`                                   | `bus_aux`                                                     | String        | Possible commands: ON,OFF,TOGGLE, STOP, UP,DOWN,ENABLED, DISABLED, RESET_GEN, RESET_BI, RESET_TRI. Only   'ON' and `OFF'  are supported for now |     R/W     |
 
 ### Thermo channels
 
@@ -393,7 +392,7 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     
     Frame label="Alarm activation via AUX command"
     {
-          Switch item=iAlarm         icon="siren"
+          Switch item=iAlarm_activation         icon="siren"
          
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -10,6 +10,16 @@
     <version>3.3.0-SNAPSHOT</version>
   </parent>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <version>4.3.2</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
   <artifactId>org.openhab.binding.openwebnet</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: OpenWebNet (BTicino/Legrand) Binding</name>

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -20,6 +20,7 @@
       </plugin>
     </plugins>
   </build>
+
   <artifactId>org.openhab.binding.openwebnet</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: OpenWebNet (BTicino/Legrand) Binding</name>

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -10,7 +10,6 @@
     <version>3.3.0-SNAPSHOT</version>
   </parent>
 
-
   <artifactId>org.openhab.binding.openwebnet</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: OpenWebNet (BTicino/Legrand) Binding</name>

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -10,16 +10,6 @@
     <version>3.3.0-SNAPSHOT</version>
   </parent>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
-        <version>4.3.2</version>
-        <extensions>true</extensions>
-      </plugin>
-    </plugins>
-  </build>
 
   <artifactId>org.openhab.binding.openwebnet</artifactId>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -27,6 +27,7 @@ import org.openhab.core.thing.ThingTypeUID;
  * @author Massimo Valla - Initial contribution
  * @author Gilberto Cocchi - Thermoregulation
  * @author Andrea Conte - Energy management, Thermoregulation
+ * @author Giovanni Fabiani - Aux support
  */
 
 @NonNullByDefault
@@ -70,6 +71,8 @@ public class OpenWebNetBindingConstants {
             "bus_cenplus_scenario_control");
     public static final String THING_LABEL_BUS_CENPLUS_SCENARIO_CONTROL = "CEN+ Control";
 
+    public static final ThingTypeUID THING_TYPE_BUS_AUX = new ThingTypeUID(BINDING_ID, "bus_aux");
+    public static final String THING_LABEL_BUS_AUX = "Auxiliary";
     // ZIGBEE
     public static final ThingTypeUID THING_TYPE_ZB_ON_OFF_SWITCH = new ThingTypeUID(BINDING_ID, "zb_on_off_switch");
     public static final String THING_LABEL_ZB_ON_OFF_SWITCH = "ZigBee Switch";
@@ -99,11 +102,14 @@ public class OpenWebNetBindingConstants {
     // ## CEN/CEN+ Scenario
     public static final Set<ThingTypeUID> SCENARIO_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_CEN_SCENARIO_CONTROL,
             THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL, THING_TYPE_BUS_DRY_CONTACT_IR);
+
+    //## Aux
+    public static final Set<ThingTypeUID> AUX_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_AUX);
     // ## Groups
     public static final Set<ThingTypeUID> DEVICE_SUPPORTED_THING_TYPES = Stream
             .of(LIGHTING_SUPPORTED_THING_TYPES, AUTOMATION_SUPPORTED_THING_TYPES,
                     THERMOREGULATION_SUPPORTED_THING_TYPES, ENERGY_MANAGEMENT_SUPPORTED_THING_TYPES,
-                    SCENARIO_SUPPORTED_THING_TYPES, GENERIC_SUPPORTED_THING_TYPES)
+                    SCENARIO_SUPPORTED_THING_TYPES, GENERIC_SUPPORTED_THING_TYPES,AUX_SUPPORTED_THING_TYPES)
             .flatMap(Collection::stream).collect(Collectors.toCollection(HashSet::new));
     public static final Set<ThingTypeUID> BRIDGE_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_ZB_GATEWAY,
             THING_TYPE_BUS_GATEWAY);
@@ -145,6 +151,9 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_TYPE_CEN_BUTTON_EVENT = "cenButtonEvent";
     public static final String CHANNEL_TYPE_CEN_PLUS_BUTTON_EVENT = "cenPlusButtonEvent";
     public static final String CHANNEL_DRY_CONTACT_IR = "sensor";
+
+    // Aux
+    public static final String CHANNEL_AUX = "aux";
 
     // devices config properties
     public static final String CONFIG_PROPERTY_WHERE = "where";

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -103,13 +103,13 @@ public class OpenWebNetBindingConstants {
     public static final Set<ThingTypeUID> SCENARIO_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_CEN_SCENARIO_CONTROL,
             THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL, THING_TYPE_BUS_DRY_CONTACT_IR);
 
-    //## Aux
+    // ## Aux
     public static final Set<ThingTypeUID> AUX_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_AUX);
     // ## Groups
     public static final Set<ThingTypeUID> DEVICE_SUPPORTED_THING_TYPES = Stream
             .of(LIGHTING_SUPPORTED_THING_TYPES, AUTOMATION_SUPPORTED_THING_TYPES,
                     THERMOREGULATION_SUPPORTED_THING_TYPES, ENERGY_MANAGEMENT_SUPPORTED_THING_TYPES,
-                    SCENARIO_SUPPORTED_THING_TYPES, GENERIC_SUPPORTED_THING_TYPES,AUX_SUPPORTED_THING_TYPES)
+                    SCENARIO_SUPPORTED_THING_TYPES, GENERIC_SUPPORTED_THING_TYPES, AUX_SUPPORTED_THING_TYPES)
             .flatMap(Collection::stream).collect(Collectors.toCollection(HashSet::new));
     public static final Set<ThingTypeUID> BRIDGE_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_ZB_GATEWAY,
             THING_TYPE_BUS_GATEWAY);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Massimo Valla - Initial contribution
  * @author Andrea Conte - Energy management, Thermoregulation
  * @author Gilberto Cocchi - Thermoregulation
- *  @author Giovanni Fabiani - Auxiliary support
+ * @author Giovanni Fabiani - Auxiliary support
  */
 @NonNullByDefault
 @Component(configurationPid = "binding.openwebnet", service = ThingHandlerFactory.class)

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetAutomationHandler;
+import org.openhab.binding.openwebnet.internal.handler.OpenWebNetAuxiliaryHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetBridgeHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetEnergyHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetGenericHandler;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Massimo Valla - Initial contribution
  * @author Andrea Conte - Energy management, Thermoregulation
  * @author Gilberto Cocchi - Thermoregulation
+ *  @author Giovanni Fabiani - Auxiliary support
  */
 @NonNullByDefault
 @Component(configurationPid = "binding.openwebnet", service = ThingHandlerFactory.class)
@@ -74,6 +76,9 @@ public class OpenWebNetHandlerFactory extends BaseThingHandlerFactory {
         } else if (OpenWebNetScenarioHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
             logger.debug("creating NEW SCENARIO Handler --- {}", thing.getUID());
             return new OpenWebNetScenarioHandler(thing);
+        } else if (OpenWebNetAuxiliaryHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            logger.debug("Creating NEW AUXILIARY Handler");
+            return new OpenWebNetAuxiliaryHandler(thing);
         }
         logger.warn("ThingType {} is not supported by this binding", thing.getThingTypeUID());
         return null;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -178,6 +178,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
                 thingTypeUID = OpenWebNetBindingConstants.THING_TYPE_BUS_AUX;
                 thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_AUX;
                 deviceWho = Who.AUX;
+                break;
             }
             default:
                 logger.warn("Device type {} is not supported, default to GENERIC device (WHERE={})", deviceType, where);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author Massimo Valla - Initial contribution
  * @author Andrea Conte - Energy management, Thermoregulation
  * @author Gilberto Cocchi - Thermoregulation
+ * @author Giovanni Fabiani - Aux support
  */
 @NonNullByDefault
 public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
@@ -172,6 +173,11 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
                 thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_CENPLUS_SCENARIO_CONTROL;
                 deviceWho = Who.CEN_PLUS_SCENARIO_SCHEDULER;
                 break;
+            }
+            case SCS_AUXILIARY_TOGGLE_CONTROL: {
+                thingTypeUID = OpenWebNetBindingConstants.THING_TYPE_BUS_AUX;
+                thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_AUX;
+                deviceWho = Who.AUX;
             }
             default:
                 logger.warn("Device type {} is not supported, default to GENERIC device (WHERE={})", deviceType, where);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
@@ -23,6 +23,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
+import org.openwebnet4j.OpenGateway;
 import org.openwebnet4j.communication.OWNException;
 import org.openwebnet4j.message.Auxiliary;
 import org.openwebnet4j.message.BaseOpenMessage;
@@ -55,11 +56,21 @@ public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
     @Override
     public void initialize() {
         super.initialize();
-        try {
-            OpenMessage msg = BaseOpenMessage.parse("*#9##");
-            send(msg);
-        } catch (MalformedFrameException | UnsupportedFrameException | OWNException e) {
-            logger.warn("Exception while processing command {}: ", e.getMessage());
+        OpenWebNetBridgeHandler h = bridgeHandler;
+        if (h != null && h.isBusGateway()) {
+            OpenGateway gw = h.gateway;
+            if (gw != null && gw.isConnected()) {
+                try {
+                    OpenMessage msg = BaseOpenMessage.parse("*#9##");
+                    send(msg);
+                } catch (MalformedFrameException | UnsupportedFrameException | OWNException e) {
+                    logger.warn("Exception while processing command {}: ", e.getMessage());
+                }
+            } else {
+                logger.warn("Gateway is not connected");
+            }
+        } else {
+            logger.warn("Gateway is not available");
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.openwebnet.internal.handler;
 
+import static org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants.CHANNEL_AUX;
+
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
 import org.openwebnet4j.communication.OWNException;
@@ -31,10 +34,6 @@ import org.openwebnet4j.message.WhereAuxiliary;
 import org.openwebnet4j.message.Who;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Set;
-
-import static org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants.CHANNEL_AUX;
 
 /**
  * The {@link OpenWebNetAuxiliaryHandler} is responsible for handling Auxiliary (AUX) commands/messages

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
@@ -102,7 +102,7 @@ public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
                 // initializing
                 send(msg);
             } catch (MalformedFrameException | UnsupportedFrameException | OWNException e) {
-                logger.debug("Exception while processing command {}: ", e.getMessage());
+                logger.debug("Exception while processing command: {}", e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
         }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.openwebnet.internal.handler;
+
+import static org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants.CHANNEL_AUX;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.types.Command;
+import org.openwebnet4j.communication.OWNException;
+import org.openwebnet4j.message.Auxiliary;
+import org.openwebnet4j.message.Where;
+import org.openwebnet4j.message.WhereAuxiliary;
+import org.openwebnet4j.message.Who;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OpenWebNetAuxiliaryHandler} is responsible for handling Auxiliary (AUX) commands/messages
+ * for an OpenWebNet device.
+ * It extends the abstract {@link OpenWebNetThingHandler}.
+ *
+ * @author Massimo Valla - Initial contribution
+ * @author Giovanni Fabiani - Auxiliary message support
+ */
+@NonNullByDefault
+public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OpenWebNetAuxiliaryHandler.class);
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.AUX_SUPPORTED_THING_TYPES;
+
+    public OpenWebNetAuxiliaryHandler(Thing thing) {
+        super(thing);
+    }
+
+    /**
+     * Handles Auxiliary command for a channel
+     *
+     * @param channel the channel
+     * @param command the Command
+     */
+    @Override
+    protected void handleChannelCommand(ChannelUID channel, Command command) {
+        logger.debug("handleAuxiliaryCommand() (command={} - channel={})", command, channel);
+        Where w = deviceWhere;
+        if (w != null) {
+            if (channel.getId().equals(CHANNEL_AUX)) {
+                if (command instanceof StringType) {
+                    updateStatus(ThingStatus.ONLINE);
+                    try {
+                        if (command.toString().equals(Auxiliary.WhatAuxiliary.ON.name())) {
+                            send(Auxiliary.requestTurnOn(w.value()));
+                        } else if (command.toString().equals(Auxiliary.WhatAuxiliary.OFF.name())) {
+                            send(Auxiliary.requestTurnOff(w.value()));
+                        }
+                    } catch (OWNException e) {
+                        logger.warn("Exception while processing command {}: {}", command, e.getMessage());
+                    }
+                } else {
+                    logger.warn("Unsupported Command {}", channel);
+                    updateStatus(ThingStatus.UNKNOWN);
+                }
+            } else {
+                logger.warn("Unsupported ChannelUID {}", channel);
+            }
+        }
+    }
+
+    @Override
+    protected void requestChannelState(ChannelUID channel) {
+        super.requestChannelState(channel);
+        logger.debug("requestChannelState() thingUID={} channel={}", thing.getUID(), channel.getId());
+        if (channel.getId().equals(CHANNEL_AUX)) {
+            ThingStatus ts = getThing().getStatus();
+            if (ThingStatus.ONLINE != ts && ThingStatus.REMOVING != ts && ThingStatus.REMOVED != ts) {
+                updateStatus(ThingStatus.ONLINE);
+            }
+        }
+    }
+
+    @Override
+    protected void refreshDevice(boolean refreshAll) {
+        /*
+         * NOTICE: It is not possible to refresh the status of a
+         * WHO=9 command (for alarm control use WHO=5 instead)
+         */
+    }
+
+    @Override
+    protected Where buildBusWhere(String wStr) throws IllegalArgumentException {
+        return new WhereAuxiliary(wStr);
+    }
+
+    @Override
+    protected String ownIdPrefix() {
+        return Who.AUX.value().toString();
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
@@ -102,7 +102,7 @@ public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
                 // initializing
                 send(msg);
             } catch (MalformedFrameException | UnsupportedFrameException | OWNException e) {
-                logger.warn("Exception while processing command {}: ", e.getMessage());
+                logger.debug("Exception while processing command {}: ", e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }
         }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAuxiliaryHandler.java
@@ -21,6 +21,7 @@ import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
 import org.openwebnet4j.OpenGateway;
@@ -37,10 +38,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link OpenWebNetAuxiliaryHandler} is responsible for handling Auxiliary (AUX) commands/messages
+ * The {@link OpenWebNetAuxiliaryHandler} is responsible for sending Auxiliary (AUX) commands/messages to the bus
  * It extends the abstract {@link OpenWebNetThingHandler}.
  *
+ * NOTICE: Support for handling messages from the bus regarding alarm control has to be implemented
+ *
  * @author Giovanni Fabiani - Initial contribution
+ *
  */
 @NonNullByDefault
 public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
@@ -86,6 +90,7 @@ public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
         Where w = deviceWhere;
         if (w != null) {
             if (channel.getId().equals(CHANNEL_AUX)) {
+                updateStatus(ThingStatus.ONLINE);
                 if (command instanceof StringType) {
                     try {
                         if (command.toString().equals(Auxiliary.WhatAuxiliary.ON.name())) {
@@ -101,6 +106,7 @@ public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
                 }
             } else {
                 logger.warn("Unsupported ChannelUID {}", channel);
+                updateStatus(ThingStatus.UNKNOWN);
             }
         }
     }
@@ -129,9 +135,5 @@ public class OpenWebNetAuxiliaryHandler extends OpenWebNetThingHandler {
     @Override
     protected String ownIdPrefix() {
         return Who.AUX.value().toString();
-    }
-
-    protected void handleMessage(BaseOpenMessage msg) {
-        super.handleMessage(msg);
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -49,6 +49,7 @@ import org.openwebnet4j.USBGateway;
 import org.openwebnet4j.communication.OWNAuthException;
 import org.openwebnet4j.communication.OWNException;
 import org.openwebnet4j.message.Automation;
+import org.openwebnet4j.message.Auxiliary;
 import org.openwebnet4j.message.BaseOpenMessage;
 import org.openwebnet4j.message.CEN;
 import org.openwebnet4j.message.EnergyManagement;
@@ -497,7 +498,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         BaseOpenMessage baseMsg = (BaseOpenMessage) msg;
         // let's try to get the Thing associated with this message...
         if (baseMsg instanceof Lighting || baseMsg instanceof Automation || baseMsg instanceof EnergyManagement
-                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN) {
+                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN || baseMsg instanceof Auxiliary) {
             String ownId = ownIdFromMessage(baseMsg);
             logger.debug("ownIdFromMessage({}) --> {}", baseMsg, ownId);
             OpenWebNetThingHandler deviceHandler = registeredDevices.get(ownId);

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                          xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0" bindingId="openwebnet"
-                          xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0" bindingId="openwebnet"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-    <!-- Thing for BUS Energy Management Central Unit (BTicino F52x) -->
-    <thing-type id="bus_aux">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="bus_gateway"/>
-        </supported-bridge-type-refs>
+	<!-- Thing for BUS Energy Management Central Unit (BTicino F52x) -->
+	<thing-type id="bus_aux">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bus_gateway"/>
+		</supported-bridge-type-refs>
 
-        <label>Auxiliary</label>
-        <description>A OpenWebNet BUS/SCS Auxiliary command</description>
+		<label>Auxiliary</label>
+		<description>A OpenWebNet BUS/SCS Auxiliary command</description>
 
-        <channels>
-            <channel id="aux" typeId="aux"/>
-        </channels>
+		<channels>
+			<channel id="aux" typeId="aux"/>
+		</channels>
 
-        <properties>
-            <property name="vendor">BTicino/Legrand</property>
-            <!--<property name="model">BTI-F52x</property> -->
-            <property name="ownDeviceType">272</property>
-        </properties>
+		<properties>
+			<property name="vendor">BTicino/Legrand</property>
+			<!--<property name="model">BTI-F52x</property> -->
+			<property name="ownDeviceType">272</property>
+		</properties>
 
-        <representation-property>ownId</representation-property>
+		<representation-property>ownId</representation-property>
 
-        <config-description>
-            <parameter name="where" type="text" required="true">
-                <label>OpenWebNet Address (where)</label>
-                <description>Example: Where=1</description>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="where" type="text" required="true">
+				<label>OpenWebNet Address (where)</label>
+				<description>Example: Where=1</description>
+			</parameter>
+		</config-description>
 
-    </thing-type>
+	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
@@ -3,7 +3,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0" bindingId="openwebnet"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- Thing for BUS Energy Management Central Unit (BTicino F52x) -->
+	<!-- Thing for BUS Auxiliary commands -->
 	<thing-type id="bus_aux">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bus_gateway"/>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0" bindingId="openwebnet"
+                          xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Thing for BUS Energy Management Central Unit (BTicino F52x) -->
+    <thing-type id="bus_aux">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bus_gateway"/>
+        </supported-bridge-type-refs>
+
+        <label>Auxiliary</label>
+        <description>A OpenWebNet BUS/SCS Auxiliary command</description>
+
+        <channels>
+            <channel id="aux" typeId="aux"/>
+        </channels>
+
+        <properties>
+            <property name="vendor">BTicino/Legrand</property>
+            <!--<property name="model">BTI-F52x</property> -->
+            <property name="ownDeviceType">272</property>
+        </properties>
+
+        <representation-property>ownId</representation-property>
+
+        <config-description>
+            <parameter name="where" type="text" required="true">
+                <label>OpenWebNet Address (where)</label>
+                <description>Example: Where=1</description>
+            </parameter>
+        </config-description>
+
+    </thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAux.xml
@@ -18,7 +18,6 @@
 
 		<properties>
 			<property name="vendor">BTicino/Legrand</property>
-			<!--<property name="model">BTI-F52x</property> -->
 			<property name="ownDeviceType">272</property>
 		</properties>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -16,6 +16,19 @@
 		</tags>
 	</channel-type>
 
+	<!-- Aux channel -->
+	<channel-type id="aux">
+		<item-type>String</item-type>
+		<label>Auxiliary</label>
+		<description>Controls an Auxiliary command (read/write)</description>
+		<state>
+			<options>
+				<option value="ON">ON</option>
+				<option value="OFF">OFF</option>
+			</options>
+		</state>
+	</channel-type>
+
 	<!-- Brightness Channel -->
 	<channel-type id="brightness">
 		<item-type>Dimmer</item-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -17,14 +17,24 @@
 	</channel-type>
 
 	<!-- Aux channel -->
+	<!--Only ON and OFF options are supported -->
 	<channel-type id="aux">
 		<item-type>String</item-type>
 		<label>Auxiliary</label>
 		<description>Controls an Auxiliary command (read/write)</description>
 		<state>
 			<options>
-				<option value="ON">ON</option>
 				<option value="OFF">OFF</option>
+				<option value="ON">ON</option>
+				<option value="TOGGLE">TOGGLE</option>
+				<option value="STOP">STOP</option>
+				<option value="UP">UP</option>
+				<option value="DOWN">DOWN</option>
+				<option value="ENABLED">ENABLED</option>
+				<option value="DISABLED">DISABLED</option>
+				<option value="RESET_GEN">RESET_GEN</option>
+				<option value="RESET_BI">RESET_BI</option>
+				<option value="RESET_TRI">RESET_TRI</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -24,17 +24,17 @@
 		<description>Controls an Auxiliary command (read/write)</description>
 		<state>
 			<options>
-				<option value="OFF">OFF</option>
-				<option value="ON">ON</option>
-				<option value="TOGGLE">TOGGLE</option>
-				<option value="STOP">STOP</option>
-				<option value="UP">UP</option>
-				<option value="DOWN">DOWN</option>
-				<option value="ENABLED">ENABLED</option>
-				<option value="DISABLED">DISABLED</option>
-				<option value="RESET_GEN">RESET_GEN</option>
-				<option value="RESET_BI">RESET_BI</option>
-				<option value="RESET_TRI">RESET_TRI</option>
+				<option value="OFF">Off</option>
+				<option value="ON">On</option>
+				<option value="TOGGLE">Toggle</option>
+				<option value="STOP">Stop</option>
+				<option value="UP">Up</option>
+				<option value="DOWN">Down</option>
+				<option value="ENABLED">Enabled</option>
+				<option value="DISABLED">Disabled</option>
+				<option value="RESET_GEN">Reset_gen</option>
+				<option value="RESET_BI">Reset_bi</option>
+				<option value="RESET_TRI">Reset_tri</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -32,9 +32,9 @@
 				<option value="DOWN">Down</option>
 				<option value="ENABLED">Enabled</option>
 				<option value="DISABLED">Disabled</option>
-				<option value="RESET_GEN">Reset_gen</option>
-				<option value="RESET_BI">Reset_bi</option>
-				<option value="RESET_TRI">Reset_tri</option>
+				<option value="RESET_GEN">Reset gen</option>
+				<option value="RESET_BI">Reset bi</option>
+				<option value="RESET_TRI">Reset tri</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
+++ b/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
@@ -22,6 +22,7 @@ import org.openhab.core.thing.Bridge;
 import org.openwebnet4j.message.BaseOpenMessage;
 import org.openwebnet4j.message.FrameException;
 import org.openwebnet4j.message.Where;
+import org.openwebnet4j.message.WhereAuxiliary;
 import org.openwebnet4j.message.WhereCEN;
 import org.openwebnet4j.message.WhereEnergyManagement;
 import org.openwebnet4j.message.WhereLightAutom;
@@ -64,7 +65,7 @@ public class OwnIdTest {
      * BUS CEN              51              51                  15.51           51
      * BUS CEN+             212             212                 25.212          212
      * BUS DryContact       399             399                 25.399          399
-     *
+     * AUX                    4               4                    9.4            4
      */
 // @formatter:on
 
@@ -83,7 +84,9 @@ public class OwnIdTest {
         bus_energy(new WhereEnergyManagement("51"), Who.fromValue(18), "*#18*51*113##", "51", "18.51", "51"),
         bus_cen(new WhereCEN("51"), Who.fromValue(15), "*15*31*51##", "51", "15.51", "51"),
         bus_cen_plus(new WhereCEN("212"), Who.fromValue(25), "*25*21#31*212##", "212", "25.212", "212"),
-        bus_drycontact(new WhereCEN("399"), Who.fromValue(25), "*25*32#1*399##", "399", "25.399", "399");
+        bus_drycontact(new WhereCEN("399"), Who.fromValue(25), "*25*32#1*399##", "399", "25.399", "399"),
+        bus_aux(new WhereAuxiliary("4"), Who.fromValue(9), "*9*1*4##","4","9.4","4");
+
 
         // @formatter:on
 

--- a/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
+++ b/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Massimo Valla - Initial contribution
  * @author Andrea Conte - Energy management
+ * @author Giovanni Fabiani - AAuxiliary message support
  */
 @NonNullByDefault
 public class OwnIdTest {
@@ -65,7 +66,7 @@ public class OwnIdTest {
      * BUS CEN              51              51                  15.51           51
      * BUS CEN+             212             212                 25.212          212
      * BUS DryContact       399             399                 25.399          399
-     * AUX                    4               4                    9.4            4
+     * BUS AUX                4               4                    9.4            4
      */
 // @formatter:on
 


### PR DESCRIPTION
This PR adds initial Auxiliary (AUX) message support to the binding (WHO=9) for sending AUX messages.
This PR closes #11515.

## Description

This PR adds support for sending Auxiliary (AUX) WHO=9 messages to the Open Web Net binding.
With this addition BTicino BUS AUX (WHO=9) messages can be sent from OH3 allowing, for example, to control alarm systems of a BTicino installation.
Configuration for new things and channels has been added to the add-on README.

## Test
Tested on BTicino/Legrand bulgrar-alarm unit 3486