### PR TITLE
[mail] Fix unstable MailBuilderTest

### DIFF
--- a/bundles/org.openhab.binding.mail/src/test/java/org/openhab/binding/mail/MailBuilderTest.java
+++ b/bundles/org.openhab.binding.mail/src/test/java/org/openhab/binding/mail/MailBuilderTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import javax.mail.MessagingException;
@@ -74,7 +75,8 @@ public class MailBuilderTest {
     public void withURLAttachmentReturnsMultiPartEmail()
             throws AddressException, EmailException, MalformedURLException {
         MailBuilder builder = new MailBuilder(TEST_EMAIL);
-        Email mail = builder.withText("boo").withURLAttachment("http://www.openhab.org").build();
+        String url = Path.of("src/test/resources/attachment.txt").toUri().toURL().toString();
+        Email mail = builder.withText("boo").withURLAttachment(url).build();
         assertThat(mail, instanceOf(MultiPartEmail.class));
     }
 

--- a/bundles/org.openhab.binding.mail/src/test/resources/attachment.txt
+++ b/bundles/org.openhab.binding.mail/src/test/resources/attachment.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, ut sed dolores repudiandae, no sit inani euripidis.


### PR DESCRIPTION
When a URL attachment is used a check is done if an InputStream to the URL can be opened to see if it is valid.
Because the openHAB website was used the test would fail when the website has issues:

```
[ERROR]  org.openhab.binding.mail.MailBuilderTest.withURLAttachmentReturnsMultiPartEmail  Time elapsed: 10.391 s  <<< ERROR!
org.apache.commons.mail.EmailException: Invalid URL set:http://www.openhab.org
	at org.openhab.binding.mail.MailBuilderTest.withURLAttachmentReturnsMultiPartEmail(MailBuilderTest.java:77)
Caused by: java.io.IOException: Server returned HTTP response code: 520 for URL: http://www.openhab.org
	at org.openhab.binding.mail.MailBuilderTest.withURLAttachmentReturnsMultiPartEmail(MailBuilderTest.java:77)
```

It will now use a file URL instead so it no longer depends on a website.

--- 

See: https://github.com/openhab/openhab-addons/runs/5528459800