### PR TITLE
[mqtt] Remove MQTT system broker leftovers

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -27,7 +27,6 @@ import org.openhab.binding.mqtt.internal.action.MQTTActions;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttConnectionObserver;
 import org.openhab.core.io.transport.mqtt.MqttConnectionState;
-import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -41,8 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This base implementation handles connection changes of the {@link MqttBrokerConnection}
- * and puts the Thing on or offline. It also handles adding/removing notifications of the
- * {@link MqttService} and provides a basic dispose() implementation.
+ * and puts the Thing on or offline. It also provides a basic dispose() implementation.
  *
  * @author David Graeff - Initial contribution
  */

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -30,7 +30,6 @@ import org.openhab.binding.mqtt.internal.ssl.PinnedCallback;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttConnectionState;
-import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.io.transport.mqtt.MqttWillAndTestament;
 import org.openhab.core.io.transport.mqtt.reconnect.PeriodicReconnectStrategy;
 import org.openhab.core.thing.Bridge;
@@ -41,8 +40,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This handler provided more detailed connection information from a
  * {@link MqttBrokerConnection} via a Thing property, put the Thing
- * offline or online depending on the connection and adds the configured
- * connection to the {@link MqttService}.
+ * offline or online depending on the connection.
  *
  * @author David Graeff - Initial contribution
  * @author Jimmy Tanagra - Add birth and shutdown message

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
@@ -27,16 +27,13 @@ import org.openhab.binding.mqtt.discovery.MQTTTopicDiscoveryParticipant;
 import org.openhab.binding.mqtt.discovery.MQTTTopicDiscoveryService;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
 import org.openhab.binding.mqtt.handler.BrokerHandler;
-import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,13 +66,6 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
     protected final Set<AbstractBrokerHandler> handlers = Collections
             .synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
-    private MqttService mqttService;
-
-    @Activate
-    public MqttBrokerHandlerFactory(@Reference MqttService mqttService) {
-        this.mqttService = mqttService;
-    }
-
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -96,9 +86,6 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
 
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
-        if (mqttService == null) {
-            throw new IllegalStateException("MqttService must be bound, before ThingHandlers can be created");
-        }
         if (!(thing instanceof Bridge)) {
             throw new IllegalStateException("A bridge type is expected");
         }

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/handler/BrokerHandlerTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/handler/BrokerHandlerTest.java
@@ -34,7 +34,6 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttConnectionState;
 import org.openhab.core.io.transport.mqtt.MqttException;
-import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingStatus;
@@ -54,7 +53,6 @@ public class BrokerHandlerTest extends JavaTest {
 
     private @Mock ThingHandlerCallback callback;
     private @Mock Bridge thing;
-    private @Mock MqttService service;
 
     private MqttBrokerConnectionEx connection;
 
@@ -83,7 +81,7 @@ public class BrokerHandlerTest extends JavaTest {
     public void handlerInitWithoutUrl() throws IllegalArgumentException {
         // Assume it is a real handler and not a mock as defined above
         handler = new BrokerHandler(thing);
-        assertThrows(IllegalArgumentException.class, () -> initializeHandlerWaitForTimeout());
+        assertThrows(IllegalArgumentException.class, this::initializeHandlerWaitForTimeout);
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/MQTTTopicDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/MQTTTopicDiscoveryServiceTest.java
@@ -34,7 +34,6 @@ import org.openhab.binding.mqtt.handler.BrokerHandler;
 import org.openhab.binding.mqtt.handler.BrokerHandlerEx;
 import org.openhab.binding.mqtt.handler.MqttBrokerConnectionEx;
 import org.openhab.core.config.core.Configuration;
-import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 
@@ -49,9 +48,6 @@ public class MQTTTopicDiscoveryServiceTest {
     private ScheduledExecutorService scheduler;
 
     private MqttBrokerHandlerFactory subject;
-
-    @Mock
-    private MqttService mqttService;
 
     @Mock
     private Bridge thing;
@@ -83,7 +79,7 @@ public class MQTTTopicDiscoveryServiceTest {
         handler = spy(new BrokerHandlerEx(thing, connection));
         handler.setCallback(callback);
 
-        subject = new MqttBrokerHandlerFactory(mqttService);
+        subject = new MqttBrokerHandlerFactory();
     }
 
     @AfterEach


### PR DESCRIPTION
The MqttService was used to keep track of the system MQTT brokers.
Since there are none the dependency can be removed.

Related to: openhab/openhab-core#2842
See also: #12157