### PR TITLE
[openwebnet] handle Thermo Central Unit monitoring messages

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -188,7 +188,10 @@ The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing.
 | `batteryStatus`              | `bus_thermo_cu`                        | String             | The Central Unit Battery status: `OK`, `KO`                                                                                                                                             | R          | Y        |
 | `weeklyProgram`              | `bus_thermo_cu`                        | Number             | The program number (`1`, `2`, `3`) when Central Unit mode is `WEEKLY`                                                                                                                   | R/W        | N        |
 | `scenarioProgram`            | `bus_thermo_cu`                        | Number             | The program number (`1`, `2`, .. ,  `16`) when Central Unit mode is `SCENARIO`                                                                                                          | R/W        | N        |
-
+| `failureDiscovered`          | `bus_thermo_cu`                        | Switch             | Indicates if a Failure was discovered by the Central Unit: `ON`, `OFF`                                                                                                                  | R          | Y        |
+| `atLeastOneProbeOFF`         | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in OFF mode: `ON`, `OFF`                                                                                                                             | R          | Y        |
+| `atLeastOneProbeProtection`  | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in PROTECTION mode: `ON`, `OFF`                                                                                                                      | R          | Y        |
+| `atLeastOneProbeManual`      | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in MANUAL mode: `ON`, `OFF`                                                                                                                          | R          | Y        |
 
 ### Notes on channels
 
@@ -291,11 +294,15 @@ Number:Power        iCENTRAL_Tb           "Power [%.0f %unit%]" { channel="openw
 // 99 zones central unit 
 Group   gCentralUnit                "Central Unit"                
 Number:Temperature iCU_3550_manualset "Temperature"       (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:setpointTemperature", ga="thermostatTemperatureSetpoint" }
-String iCU_3550_remote    "Remote Control"    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:remoteControl" }
-String iCU_3550_battery   "Battery Status"    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:batteryStatus" }
-String iCU_3550_mode      "Mode"              (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:mode" }
-Number iCU_3550_wpn       "Weekly Program"    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:weeklyProgram" } 
-Number iCU_3550_spn       "Scenario Program"  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:scenarioProgram" } 
+String iCU_3550_remote    "Remote Control"                    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:remoteControl" }
+String iCU_3550_battery   "Battery Status"                    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:batteryStatus" }
+String iCU_3550_mode      "Mode"                              (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:mode" }
+Number iCU_3550_wpn       "Weekly Program"                    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:weeklyProgram" } 
+Number iCU_3550_spn       "Scenario Program"                  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:scenarioProgram" } 
+String iCU_3550_func      "Function"                          (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:function" }
+Switch iCU_3550_at1off    "At least one probe in OFF"         (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeOFF" } 
+Switch iCU_3550_at1pro    "At least one probe in Protection"  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeProtection" } 
+Switch iCU_3550_at1man    "At least one probe in Manual"      (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeManual" } 
 
 Group   gLivingRoomZone                         "Living Room Zone"   { ga="Thermostat" [ modes="auto=GENERIC,heat=HEATING,cool=COOLING", thermostatTemperatureRange="7,35", useFahrenheit=false ] }
 Number:Temperature  iLR_zone_temp               "Temperature [%.1f %unit%]"   (gLivingRoomZone) { channel="openwebnet:bus_thermo_zone:mybridge:LR_zone:temperature", ga="thermostatTemperatureAmbient" }

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -189,7 +189,7 @@ The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing.
 | `weeklyProgram`              | `bus_thermo_cu`                        | Number             | The program number (`1`, `2`, `3`) when Central Unit mode is `WEEKLY`                                                                                                                   | R/W        | N        |
 | `scenarioProgram`            | `bus_thermo_cu`                        | Number             | The program number (`1`, `2`, .. ,  `16`) when Central Unit mode is `SCENARIO`                                                                                                          | R/W        | N        |
 | `failureDiscovered`          | `bus_thermo_cu`                        | Switch             | Indicates if a Failure was discovered by the Central Unit: `ON`, `OFF`                                                                                                                  | R          | Y        |
-| `atLeastOneProbeOFF`         | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in OFF mode: `ON`, `OFF`                                                                                                                             | R          | Y        |
+| `atLeastOneProbeOff`         | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in OFF mode: `ON`, `OFF`                                                                                                                             | R          | Y        |
 | `atLeastOneProbeProtection`  | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in PROTECTION mode: `ON`, `OFF`                                                                                                                      | R          | Y        |
 | `atLeastOneProbeManual`      | `bus_thermo_cu`                        | Switch             | Indicates if at least one probe is in MANUAL mode: `ON`, `OFF`                                                                                                                          | R          | Y        |
 
@@ -300,9 +300,9 @@ String iCU_3550_mode      "Mode"                              (gCentralUnit) { c
 Number iCU_3550_wpn       "Weekly Program"                    (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:weeklyProgram" } 
 Number iCU_3550_spn       "Scenario Program"                  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:scenarioProgram" } 
 String iCU_3550_func      "Function"                          (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:function" }
-Switch iCU_3550_at1off    "At least one probe in OFF"         (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeOFF" } 
-Switch iCU_3550_at1pro    "At least one probe in Protection"  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeProtection" } 
-Switch iCU_3550_at1man    "At least one probe in Manual"      (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeManual" } 
+Switch iCU_3550_at1off    "At least one probe in OFF"         (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeOff" } 
+Switch iCU_3550_at1pro    "At least one probe in PROTECTION"  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeProtection" } 
+Switch iCU_3550_at1man    "At least one probe in MANUAL"      (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeManual" } 
 Switch iCU_3550_failure   "Failure discovered"                (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:failureDiscovered" } 
 
 Group   gLivingRoomZone                         "Living Room Zone"   { ga="Thermostat" [ modes="auto=GENERIC,heat=HEATING,cool=COOLING", thermostatTemperatureRange="7,35", useFahrenheit=false ] }

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -303,6 +303,7 @@ String iCU_3550_func      "Function"                          (gCentralUnit) { c
 Switch iCU_3550_at1off    "At least one probe in OFF"         (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeOFF" } 
 Switch iCU_3550_at1pro    "At least one probe in Protection"  (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeProtection" } 
 Switch iCU_3550_at1man    "At least one probe in Manual"      (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:atLeastOneProbeManual" } 
+Switch iCU_3550_failure   "Failure discovered"                (gCentralUnit) { channel="openwebnet:bus_thermo_cu:mybridge:CU_3550:failureDiscovered" } 
 
 Group   gLivingRoomZone                         "Living Room Zone"   { ga="Thermostat" [ modes="auto=GENERIC,heat=HEATING,cool=COOLING", thermostatTemperatureRange="7,35", useFahrenheit=false ] }
 Number:Temperature  iLR_zone_temp               "Temperature [%.1f %unit%]"   (gLivingRoomZone) { channel="openwebnet:bus_thermo_zone:mybridge:LR_zone:temperature", ga="thermostatTemperatureAmbient" }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -134,7 +134,7 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_CU_WEEKLY_PROGRAM_NUMBER = "weeklyProgram";
     public static final String CHANNEL_CU_SCENARIO_PROGRAM_NUMBER = "scenarioProgram";
     public static final String CHANNEL_CU_FAILURE_DISCOVERED = "failureDiscovered";
-    public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF = "atLeastOneProbeOFF";
+    public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF = "atLeastOneProbeOff";
     public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_PROTECTION = "atLeastOneProbeProtection";
     public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_MANUAL = "atLeastOneProbeManual";
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -133,6 +133,10 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_CU_BATTERY_STATUS = "batteryStatus";
     public static final String CHANNEL_CU_WEEKLY_PROGRAM_NUMBER = "weeklyProgram";
     public static final String CHANNEL_CU_SCENARIO_PROGRAM_NUMBER = "scenarioProgram";
+    public static final String CHANNEL_CU_FAILURE_DISCOVERED = "failureDiscovered";
+    public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF = "atLeastOneProbeOFF";
+    public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_PROTECTION = "atLeastOneProbeProtection";
+    public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_MANUAL = "atLeastOneProbeManual";
 
     // energy management
     public static final String CHANNEL_POWER = "power";

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -390,13 +390,13 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 }
             }
 
-            if (probesInOFF.size() == 0) {
+            if (probesInOFF.isEmpty()) {
                 updateCUAtLeastOneProbeOFF(OnOffType.OFF);
             }
-            if (probesInProtection.size() == 0) {
+            if (probesInProtection.isEmpty()) {
                 updateCUAtLeastOneProbeProtection(OnOffType.OFF);
             }
-            if (probesInManual.size() == 0) {
+            if (probesInManual.isEmpty()) {
                 updateCUAtLeastOneProbeManual(OnOffType.OFF);
             }
         }
@@ -485,15 +485,17 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     private void updateCUBatteryStatus(String status) {
         updateState(CHANNEL_CU_BATTERY_STATUS, new StringType(status));
 
-        if (status == CU_BATTERY_KO) // do not log default value (which is automatically setted)
+        if (status == CU_BATTERY_KO) { // do not log default value (which is automatically setted)
             logger.debug("updateCUBatteryStatus(): {}", status);
+        }
     }
 
     private void updateCUFailureDiscovered(OnOffType status) {
         updateState(CHANNEL_CU_FAILURE_DISCOVERED, status);
 
-        if (status == OnOffType.ON) // do not log default value (which is automatically setted)
+        if (status == OnOffType.ON) { // do not log default value (which is automatically setted)
             logger.debug("updateCUFailureDiscovered(): {}", status);
+        }
     }
 
     private void updateCUAtLeastOneProbeOFF(OnOffType status) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -368,34 +368,37 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
         Thermoregulation.OperationMode mode = w.getMode();
         Thermoregulation.Function function = w.getFunction();
 
-        if (mode == Thermoregulation.OperationMode.OFF) {
-            probesInManual.remove(tmsg.getWhere().value());
-            probesInProtection.remove(tmsg.getWhere().value());
-            if (probesInOFF.add(tmsg.getWhere().value())) {
-                logger.debug("atLeastOneProbeInOFF: added WHERE ---> {}", tmsg.getWhere());
+        // keep track of thermostats (zones) status
+        if (!isCentralUnit && (!((WhereThermo) deviceWhere).isProbe())) {
+            if (mode == Thermoregulation.OperationMode.OFF) {
+                probesInManual.remove(tmsg.getWhere().value());
+                probesInProtection.remove(tmsg.getWhere().value());
+                if (probesInOFF.add(tmsg.getWhere().value())) {
+                    logger.debug("atLeastOneProbeInOFF: added WHERE ---> {}", tmsg.getWhere());
+                }
+            } else if (mode == Thermoregulation.OperationMode.PROTECTION) {
+                probesInManual.remove(tmsg.getWhere().value());
+                probesInOFF.remove(tmsg.getWhere().value());
+                if (probesInProtection.add(tmsg.getWhere().value())) {
+                    logger.debug("atLeastOneProbeInProtection: added WHERE ---> {}", tmsg.getWhere());
+                }
+            } else if (mode == Thermoregulation.OperationMode.MANUAL) {
+                probesInProtection.remove(tmsg.getWhere().value());
+                probesInOFF.remove(tmsg.getWhere().value());
+                if (probesInManual.add(tmsg.getWhere().value())) {
+                    logger.debug("atLeastOneProbeInManual: added WHERE ---> {}", tmsg.getWhere());
+                }
             }
-        } else if (mode == Thermoregulation.OperationMode.PROTECTION) {
-            probesInManual.remove(tmsg.getWhere().value());
-            probesInOFF.remove(tmsg.getWhere().value());
-            if (probesInProtection.add(tmsg.getWhere().value())) {
-                logger.debug("atLeastOneProbeInProtection: added WHERE ---> {}", tmsg.getWhere());
-            }           
-        } else if (mode == Thermoregulation.OperationMode.MANUAL) {
-            probesInProtection.remove(tmsg.getWhere().value());
-            probesInOFF.remove(tmsg.getWhere().value());
-            if (probesInManual.add(tmsg.getWhere().value())) {
-                logger.debug("atLeastOneProbeInManual: added WHERE ---> {}", tmsg.getWhere());
-            }
-        }
 
-        if (probesInOFF.size() == 0) {
-            updateCUAtLeastOneProbeOFF(OnOffType.OFF);
-        }
-        if (probesInProtection.size() == 0) {
-            updateCUAtLeastOneProbeProtection(OnOffType.OFF);
-        }
-        if (probesInManual.size() == 0) {
-            updateCUAtLeastOneProbeManual(OnOffType.OFF);
+            if (probesInOFF.size() == 0) {
+                updateCUAtLeastOneProbeOFF(OnOffType.OFF);
+            }
+            if (probesInProtection.size() == 0) {
+                updateCUAtLeastOneProbeProtection(OnOffType.OFF);
+            }
+            if (probesInManual.size() == 0) {
+                updateCUAtLeastOneProbeManual(OnOffType.OFF);
+            }
         }
 
         updateState(CHANNEL_FUNCTION, new StringType(function.toString()));
@@ -482,14 +485,14 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     private void updateCUBatteryStatus(String status) {
         updateState(CHANNEL_CU_BATTERY_STATUS, new StringType(status));
 
-        if (status == CU_BATTERY_KO)  // do not log default value (which is automatically setted)
+        if (status == CU_BATTERY_KO) // do not log default value (which is automatically setted)
             logger.debug("updateCUBatteryStatus(): {}", status);
     }
 
     private void updateCUFailureDiscovered(OnOffType status) {
         updateState(CHANNEL_CU_FAILURE_DISCOVERED, status);
 
-        if (status == OnOffType.ON)  // do not log default value (which is automatically setted)
+        if (status == OnOffType.ON) // do not log default value (which is automatically setted)
             logger.debug("updateCUFailureDiscovered(): {}", status);
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -303,8 +303,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 updateCURemoteControlStatus(CU_REMOTE_CONTROL_ENABLED);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.BATTERY_KO) {
                 updateCUBatteryStatus(CU_BATTERY_KO);
-            } // must intercept all possibile WHATs (will be implemented soon)
-            else if (msg.getWhat() == Thermoregulation.WhatThermo.AT_LEAST_ONE_PROBE_OFF) {
+            } else if (msg.getWhat() == Thermoregulation.WhatThermo.AT_LEAST_ONE_PROBE_OFF) {
                 updateCUAtLeastOneProbeOFF(OnOffType.ON);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.AT_LEAST_ONE_PROBE_ANTIFREEZE) {
                 updateCUAtLeastOneProbeProtection(OnOffType.ON);
@@ -312,7 +311,8 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 updateCUAtLeastOneProbeManual(OnOffType.ON);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.FAILURE_DISCOVERED) {
                 updateCUFailureDiscovered(OnOffType.ON);
-            } else if (msg.getWhat() == Thermoregulation.WhatThermo.RELEASE_SENSOR_LOCAL_ADJUST) {
+            } // must intercept all possibile WHATs (will be implemented soon)
+            else if (msg.getWhat() == Thermoregulation.WhatThermo.RELEASE_SENSOR_LOCAL_ADJUST) {
                 logger.debug("handleMessage() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
             } else {
                 // check and eventually parse mode and function

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -304,7 +304,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.BATTERY_KO) {
                 updateCUBatteryStatus(CU_BATTERY_KO);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.AT_LEAST_ONE_PROBE_OFF) {
-                updateCUAtLeastOneProbeOFF(OnOffType.ON);
+                updateCUAtLeastOneProbeOff(OnOffType.ON);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.AT_LEAST_ONE_PROBE_ANTIFREEZE) {
                 updateCUAtLeastOneProbeProtection(OnOffType.ON);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.AT_LEAST_ONE_PROBE_MANUAL) {
@@ -391,7 +391,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             }
 
             if (probesInOFF.isEmpty()) {
-                updateCUAtLeastOneProbeOFF(OnOffType.OFF);
+                updateCUAtLeastOneProbeOff(OnOffType.OFF);
             }
             if (probesInProtection.isEmpty()) {
                 updateCUAtLeastOneProbeProtection(OnOffType.OFF);
@@ -498,9 +498,9 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
         }
     }
 
-    private void updateCUAtLeastOneProbeOFF(OnOffType status) {
+    private void updateCUAtLeastOneProbeOff(OnOffType status) {
         updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF, status);
-        logger.debug("updateCUAtLeastOneProbeOFF(): {}", status);
+        logger.debug("updateCUAtLeastOneProbeOff(): {}", status);
     }
 
     private void updateCUAtLeastOneProbeProtection(OnOffType status) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
@@ -18,6 +18,10 @@
 			<channel id="remoteControl" typeId="remoteControl"/>
 			<channel id="batteryStatus" typeId="batteryStatus"/>
 			<channel id="function" typeId="functionCentralUnit"/>
+			<channel id="failureDiscovered" typeId="failureDiscovered"/>
+			<channel id="atLeastOneProbeOFF" typeId="atLeastOneProbeOFF"/>
+			<channel id="atLeastOneProbeProtection" typeId="atLeastOneProbeProtection"/>
+			<channel id="atLeastOneProbeManual" typeId="atLeastOneProbeManual"/>
 			<!-- read/write -->
 			<channel id="setpointTemperature" typeId="setpointTemperature"/>
 			<channel id="mode" typeId="modeCentralUnit"/>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
@@ -19,7 +19,7 @@
 			<channel id="batteryStatus" typeId="batteryStatus"/>
 			<channel id="function" typeId="functionCentralUnit"/>
 			<channel id="failureDiscovered" typeId="failureDiscovered"/>
-			<channel id="atLeastOneProbeOFF" typeId="atLeastOneProbeOFF"/>
+			<channel id="atLeastOneProbeOff" typeId="atLeastOneProbeOff"/>
 			<channel id="atLeastOneProbeProtection" typeId="atLeastOneProbeProtection"/>
 			<channel id="atLeastOneProbeManual" typeId="atLeastOneProbeManual"/>
 			<!-- read/write -->

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -288,7 +288,7 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="atLeastOneProbeOFF" advanced="true">
+	<channel-type id="atLeastOneProbeOff" advanced="true">
 		<item-type>Switch</item-type>
 		<label>At least one probe OFF</label>
 		<description>At least one probe OFF indicator in Central Unit (read only)</description>
@@ -297,7 +297,7 @@
 
 	<channel-type id="atLeastOneProbeProtection" advanced="true">
 		<item-type>Switch</item-type>
-		<label>At least one probe in Protection</label>
+		<label>At least one probe in PROTECTION</label>
 		<description>At least one probe in PROTECTION (Anti Freeze/Thermal Protection) indicator in Central Unit (read only)</description>
 		<state readOnly="true"></state>
 	</channel-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -281,6 +281,34 @@
 		</state>
 	</channel-type>
 
+	<channel-type id="failureDiscovered" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Failure Discovered</label>
+		<description>Central Unit Failure Discovered (read only)</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="atLeastOneProbeOFF" advanced="true">
+		<item-type>Switch</item-type>
+		<label>At least one probe OFF</label>
+		<description>At least one probe OFF indicator in Central Unit (read only)</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="atLeastOneProbeProtection" advanced="true">
+		<item-type>Switch</item-type>
+		<label>At least one probe in Protection</label>
+		<description>At least one probe in Protection (Anti Freeze/Thermal Protection) indicator in Central Unit (read only)</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="atLeastOneProbeManual" advanced="true">
+		<item-type>Switch</item-type>
+		<label>At least one probe in MANUAL</label>
+		<description>At least one probe in MANUAL indicator in Central Unit (read only)</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
 	<!-- Energy channels -->
 	<channel-type id="power">
 		<item-type>Number:Power</item-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -298,7 +298,7 @@
 	<channel-type id="atLeastOneProbeProtection" advanced="true">
 		<item-type>Switch</item-type>
 		<label>At least one probe in Protection</label>
-		<description>At least one probe in Protection (Anti Freeze/Thermal Protection) indicator in Central Unit (read only)</description>
+		<description>At least one probe in PROTECTION (Anti Freeze/Thermal Protection) indicator in Central Unit (read only)</description>
 		<state readOnly="true"></state>
 	</channel-type>
 


### PR DESCRIPTION
Enhance OpenWebNet binding to support thermoregulation with 4/99 zone central unit, e.g. BTicino 3550 model.

The Central Unit provides some information on the on-board display:

- at least one probe in OFF mode (WHAT = AT_LEAST_ONE_PROBE_OFF)
- at least one probe in PROTECTION mode (WHAT = AT_LEAST_ONE_PROBE_ANTIFREEZE)
- at least one probe in MANUAL mode (WHAT = AT_LEAST_ONE_PROBE_MANUAL)
- a generic FAILURE was detected on the system (WHAT = FAILURE_DISCOVERED)

For each case a specific read-only channel was added.
