### PR TITLE
[renault] API key update.

### DIFF
--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/Constants.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/Constants.java
@@ -26,7 +26,7 @@ public class Constants {
 
     private static final String GIGYA_URL_EU = "https://accounts.eu1.gigya.com";
     private static final String GIGYA_URL_US = "https://accounts.us1.gigya.com";
-    private static final String KAMEREON_APIKEY = "Ae9FDWugRxZQAGm3Sxgk7uJn6Q4CGEA2";
+    private static final String KAMEREON_APIKEY = "VAX7XYKGfa92yMvXculCkEFyfZbuM7Ss";
     private static final String KAMEREON_URL_EU = "https://api-wired-prod-1-euw1.wrd-aws.com";
     private static final String KAMEREON_URL_US = "https://api-wired-prod-1-usw2.wrd-aws.com";
 


### PR DESCRIPTION
Signed-off-by: Doug Culnane <doug@culnane.net>

I and 2 other users have had connection errors. See: (https://community.openhab.org/t/betatest-renault-ze-services-binding/72226/190?u=doug_culnane)

The API key has changed which it does every year apparently... So I used the new key that the python developers have extracted:
https://github.com/hacf-fr/renault-api/commit/03f4dbd9f27dc84aa748510892fbb3f55eed0f1d

This worked on my installation.

I will submit a pull request with this as a configuration variable with the default being the current key.  This will allow easier updating of running systems in the future.



