### PR TITLE
[openwebnet] fixed generic_device thing-type, improved refresh at boot

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -231,7 +231,8 @@ See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-r
 
 There are three WEEKLY and sixteen SCENARIO programs defined for the Central Unit.
 
-In order to activate one of them you have to use two different channels: 
+In order to activate one of them you have to use two different channels:
+
 - with `mode` you can set the mode (`WEEKLY` or `SCENARIO`)
 - with `weeklyProgram` (if `WEEKLY` was setted) or with `scenarioProgram` (if `SCENARIO` was setted) you can set the program number
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/GenericDevice.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/GenericDevice.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<!-- OpenWebNet Generic Device -->
-	<thing-type id="device">
+	<thing-type id="generic_device">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bus_gateway"/>
 			<bridge-type-ref id="zb_gateway"/>


### PR DESCRIPTION
Fixed `generic_device` thing-type (used when a BTicino device cannot be recognized) and added a time limit to devices refresh at boot/reconnect.