### PR TITLE
[openthermgateway] Various improvements

### DIFF
--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/handler/OpenThermGatewayHandler.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/handler/OpenThermGatewayHandler.java
@@ -50,6 +50,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class OpenThermGatewayHandler extends BaseBridgeHandler implements OpenThermGatewayCallback {
+    private static final String PROPERTY_GATEWAY_ID_NAME = "gatewayId";
+    private static final String PROPERTY_GATEWAY_ID_TAG = "PR: A=";
 
     private final Logger logger = LoggerFactory.getLogger(OpenThermGatewayHandler.class);
 
@@ -178,6 +180,18 @@ public class OpenThermGatewayHandler extends BaseBridgeHandler implements OpenTh
                     }
                 default:
             }
+        }
+    }
+
+    @Override
+    public void receiveAcknowledgement(String message) {
+        scheduler.submit(() -> receiveAcknowledgementTask(message));
+    }
+
+    private void receiveAcknowledgementTask(String message) {
+        if (message.startsWith(PROPERTY_GATEWAY_ID_TAG)) {
+            getThing().setProperty(PROPERTY_GATEWAY_ID_NAME,
+                    message.substring(PROPERTY_GATEWAY_ID_TAG.length()).strip());
         }
     }
 

--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayCallback.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayCallback.java
@@ -17,7 +17,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 /**
  * The {@link OpenThermGatewayCallback} is used as a callback interface by a connector to signal status
  * and relay incoming messages to be processed by the binding.
- * 
+ *
  * @author Arjen Korevaar - Initial contribution
  */
 @NonNullByDefault
@@ -26,4 +26,6 @@ public interface OpenThermGatewayCallback {
     void connectionStateChanged(ConnectionState state);
 
     void receiveMessage(Message message);
+
+    void receiveAcknowledgement(String message);
 }

--- a/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/openthermgateway.xml
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/openthermgateway.xml
@@ -10,7 +10,7 @@
 			<channel id="sendcommand" typeId="sendcommand"/>
 		</channels>
 		<properties>
-			<property name="version">2.2.0</property>
+			<property name="version">2.2.1</property>
 		</properties>
 		<config-description-ref uri="thing-type:openthermgateway:openthermgateway"/>
 	</bridge-type>


### PR DESCRIPTION
This PR addresses one potential issue, and makes a few slight improvements as follows..
- As described in #12457 there was a risk of sending new commands before the gateway had finished processing prior commands. Now all commands are pipelined via a FIFO queue to prevent that.
- Added a Thing Property to display the OpenTherm Gateway identification / version string.
- Now a `logger.warn()` message is reported if the gateway watchdog timer triggers a self reset.
- Improved `logger.trace()` reporting of messages read from / written to, the OpenTherm Gateway.
- Bumped the binding version property.

Closes #12457

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
