### PR TITLE
[plugwiseha] Fix Zone thermostat not updating

### DIFF
--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Locations.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Locations.java
@@ -41,7 +41,7 @@ public class Locations extends PlugwiseHACollection<Location> {
                     if (updatedPointLogs != null) {
                         updatedPointLogs.merge(originalLocation.getPointLogs());
                     }
-                    
+
                     ActuatorFunctionalities updatedActuatorFunctionalities = location.getActuatorFunctionalities();
                     if (updatedActuatorFunctionalities != null) {
                         updatedActuatorFunctionalities.merge(originalLocation.getActuatorFunctionalities());

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Locations.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Locations.java
@@ -41,6 +41,11 @@ public class Locations extends PlugwiseHACollection<Location> {
                     if (updatedPointLogs != null) {
                         updatedPointLogs.merge(originalLocation.getPointLogs());
                     }
+                    
+                    ActuatorFunctionalities updatedActuatorFunctionalities = location.getActuatorFunctionalities();
+                    if (updatedActuatorFunctionalities != null) {
+                        updatedActuatorFunctionalities.merge(originalLocation.getActuatorFunctionalities());
+                    }
 
                     this.put(id, location);
                 }


### PR DESCRIPTION
Previous PR reduced http request rate/load by enabling incremental updates from the PlugwiseHA API. This PR fixes a situation that was overlooked in that PR. This bug made it impossible to set the thermostat for a zone.