### PR TITLE
[miele] Fix configuration validation and optimize performance

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/DeviceUtil.java
@@ -89,7 +89,7 @@ public class DeviceUtil {
      * as well as built-in/translated strings.
      */
     public static State getStateTextState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+            MieleTranslationProvider translationProvider) {
         return getTextState(s, dmd, translationProvider, STATES, MISSING_STATE_TEXT_PREFIX, "");
     }
 
@@ -106,7 +106,7 @@ public class DeviceUtil {
      * @return Text string as State
      */
     public static State getTextState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider, Map<String, String> valueMap, String propertyPrefix,
+            MieleTranslationProvider translationProvider, Map<String, String> valueMap, String propertyPrefix,
             String appliancePrefix) {
         if ("0".equals(s)) {
             return UnDefType.UNDEF;
@@ -122,7 +122,7 @@ public class DeviceUtil {
         }
 
         String value = valueMap.get(s);
-        if (value != null && translationProvider != null) {
+        if (value != null) {
             String key = TEXT_PREFIX + propertyPrefix + appliancePrefix + value;
             return new StringType(
                     translationProvider.getText(key, gatewayText != null ? gatewayText : propertyPrefix + s));

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleGatewayCommunicationController.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleGatewayCommunicationController.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.miele.internal;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.zip.GZIPInputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.miele.internal.exceptions.MieleRpcException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+
+/**
+ * The {@link MieleGatewayCommunicationController} class is used for communicating with
+ * the XGW 3000 gateway through JSON-RPC.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class MieleGatewayCommunicationController {
+
+    private final URL url;
+    private final Random rand = new Random();
+    private final Gson gson = new Gson();
+    private final Logger logger = LoggerFactory.getLogger(MieleGatewayCommunicationController.class);
+
+    public MieleGatewayCommunicationController(String host) throws MalformedURLException {
+        url = new URL("http://" + host + "/remote/json-rpc");
+    }
+
+    public JsonElement invokeOperation(FullyQualifiedApplianceIdentifier applianceIdentifier, String modelID,
+            String methodName) throws MieleRpcException {
+        Object[] args = new Object[4];
+        args[0] = applianceIdentifier.getUid();
+        args[1] = MieleBindingConstants.MIELE_CLASS + modelID;
+        args[2] = methodName;
+        args[3] = null;
+
+        return invokeRPC("HDAccess/invokeDCOOperation", args);
+    }
+
+    public JsonElement invokeRPC(String methodName, Object[] args) throws MieleRpcException {
+        JsonElement result = null;
+        JsonObject req = new JsonObject();
+        int id = rand.nextInt(Integer.MAX_VALUE);
+        req.addProperty("jsonrpc", "2.0");
+        req.addProperty("id", id);
+        req.addProperty("method", methodName);
+
+        JsonArray params = new JsonArray();
+        for (Object o : args) {
+            params.add(gson.toJsonTree(o));
+        }
+        req.add("params", params);
+
+        String requestData = req.toString();
+        String responseData = null;
+        try {
+            responseData = post(url, Collections.emptyMap(), requestData);
+        } catch (IOException e) {
+            throw new MieleRpcException("Exception occurred while posting data", e);
+        }
+
+        logger.trace("The request '{}' yields '{}'", requestData, responseData);
+        JsonObject parsedResponse = null;
+        try {
+            parsedResponse = (JsonObject) JsonParser.parseReader(new StringReader(responseData));
+        } catch (JsonParseException e) {
+            throw new MieleRpcException("Error parsing JSON response", e);
+        }
+
+        JsonElement error = parsedResponse.get("error");
+        if (error != null && !error.isJsonNull()) {
+            if (error.isJsonPrimitive()) {
+                throw new MieleRpcException("Remote exception occurred: '" + error.getAsString() + "'");
+            } else if (error.isJsonObject()) {
+                JsonObject o = error.getAsJsonObject();
+                Integer code = (o.has("code") ? o.get("code").getAsInt() : null);
+                String message = (o.has("message") ? o.get("message").getAsString() : null);
+                String data = (o.has("data")
+                        ? (o.get("data") instanceof JsonObject ? o.get("data").toString() : o.get("data").getAsString())
+                        : null);
+                throw new MieleRpcException(
+                        "Remote exception occurred: '" + code + "':'" + message + "':'" + data + "'");
+            } else {
+                throw new MieleRpcException("Unknown remote exception occurred: '" + error.toString() + "'");
+            }
+        }
+
+        result = parsedResponse.get("result");
+        if (result == null) {
+            throw new MieleRpcException("Result is missing in response");
+        }
+
+        return result;
+    }
+
+    private String post(URL url, Map<String, String> headers, String data) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            connection.addRequestProperty(entry.getKey(), entry.getValue());
+        }
+
+        connection.addRequestProperty("Accept-Encoding", "gzip");
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.connect();
+
+        OutputStream out = null;
+
+        try {
+            out = connection.getOutputStream();
+
+            out.write(data.getBytes());
+            out.flush();
+
+            int statusCode = connection.getResponseCode();
+            if (statusCode != HttpURLConnection.HTTP_OK) {
+                logger.debug("An unexpected status code was returned: '{}'", statusCode);
+            }
+        } finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+
+        String responseEncoding = connection.getHeaderField("Content-Encoding");
+        responseEncoding = (responseEncoding == null ? "" : responseEncoding.trim());
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        InputStream in = connection.getInputStream();
+        try {
+            in = connection.getInputStream();
+            if ("gzip".equalsIgnoreCase(responseEncoding)) {
+                in = new GZIPInputStream(in);
+            }
+            in = new BufferedInputStream(in);
+
+            byte[] buff = new byte[1024];
+            int n;
+            while ((n = in.read(buff)) > 0) {
+                bos.write(buff, 0, n);
+            }
+            bos.flush();
+            bos.close();
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+
+        return bos.toString();
+    }
+}

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -23,10 +23,8 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
-import org.openhab.binding.miele.internal.api.dto.DeviceClassObject;
-import org.openhab.binding.miele.internal.api.dto.DeviceProperty;
 import org.openhab.binding.miele.internal.api.dto.HomeDevice;
-import org.openhab.binding.miele.internal.handler.ApplianceStatusListener;
+import org.openhab.binding.miele.internal.handler.DiscoveryListener;
 import org.openhab.binding.miele.internal.handler.MieleApplianceHandler;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
@@ -47,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 @NonNullByDefault
-public class MieleApplianceDiscoveryService extends AbstractDiscoveryService implements ApplianceStatusListener {
+public class MieleApplianceDiscoveryService extends AbstractDiscoveryService implements DiscoveryListener {
 
     private final Logger logger = LoggerFactory.getLogger(MieleApplianceDiscoveryService.class);
 
@@ -61,13 +59,13 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
     }
 
     public void activate() {
-        mieleBridgeHandler.registerApplianceStatusListener(this);
+        mieleBridgeHandler.registerDiscoveryListener(this);
     }
 
     @Override
     public void deactivate() {
         removeOlderResults(new Date().getTime());
-        mieleBridgeHandler.unregisterApplianceStatusListener(this);
+        mieleBridgeHandler.unregisterDiscoveryListener(this);
     }
 
     @Override
@@ -144,16 +142,6 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
         if (thingUID != null) {
             thingRemoved(thingUID);
         }
-    }
-
-    @Override
-    public void onApplianceStateChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceClassObject dco) {
-        // nothing to do
-    }
-
-    @Override
-    public void onAppliancePropertyChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceProperty dp) {
-        // nothing to do
     }
 
     private @Nullable ThingUID getThingUID(HomeDevice appliance) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -75,7 +75,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
 
     @Override
     public void startScan() {
-        List<HomeDevice> appliances = mieleBridgeHandler.getHomeDevices();
+        List<HomeDevice> appliances = mieleBridgeHandler.getHomeDevicesEmptyOnFailure();
         for (HomeDevice l : appliances) {
             onApplianceAddedInternal(l);
         }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceChannelSelector.java
@@ -64,7 +64,7 @@ public interface ApplianceChannelSelector {
      * @param dmd - the device meta data
      * @param translationProvider {@link MieleTranslationProvider} instance
      */
-    State getState(String s, @Nullable DeviceMetaData dmd, @Nullable MieleTranslationProvider translationProvider);
+    State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider);
 
     /**
      * Returns a State for the given string, taking into

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
@@ -49,7 +49,7 @@ public interface ApplianceStatusListener {
     /**
      * This method is called whenever an appliance is added.
      *
-     * @param appliance The XGW homedevice definition of the appliance that was removed
+     * @param appliance The XGW homedevice definition of the appliance that was added
      */
     void onApplianceAdded(HomeDevice appliance);
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
@@ -13,15 +13,13 @@
 package org.openhab.binding.miele.internal.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.api.dto.DeviceClassObject;
 import org.openhab.binding.miele.internal.api.dto.DeviceProperty;
 import org.openhab.binding.miele.internal.api.dto.HomeDevice;
 
 /**
- *
- * The {@link ApplianceStatusListener} is notified when an appliance status has changed or
- * an appliance has been removed or added.
+ * The {@link ApplianceStatusListener} is notified when the status for the subscribed
+ * appliance has changed or it has been removed or added.
  *
  * @author Karel Goderis - Initial contribution
  * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
@@ -32,25 +30,21 @@ public interface ApplianceStatusListener {
     /**
      * This method is called whenever the state of the given appliance has changed.
      *
-     * @param applianceIdentifier the fully qualified identifier of the appliance that has changed
      * @param dco the POJO containing the new state (properties and/or operations)
      */
-    void onApplianceStateChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceClassObject dco);
+    void onApplianceStateChanged(DeviceClassObject dco);
 
     /**
      * This method is called whenever a "property" of the given appliance has changed.
      *
-     * @param applianceIdentifier the fully qualified identifier of the appliance that has changed
      * @param dco the POJO containing the new state of the property
      */
-    void onAppliancePropertyChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceProperty dp);
+    void onAppliancePropertyChanged(DeviceProperty dp);
 
     /**
      * This method is called whenever an appliance is removed.
-     *
-     * @param appliance The XGW homedevice definition of the appliance that was removed
      */
-    void onApplianceRemoved(HomeDevice appliance);
+    void onApplianceRemoved();
 
     /**
      * This method is called whenever an appliance is added.

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
@@ -45,16 +45,14 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
     STATE("", STATE_CHANNEL_ID, DecimalType.class, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PROGRAMS, MISSING_PROGRAM_TEXT_PREFIX,
                     MIELE_COFFEE_MACHINE_TEXT_PREFIX);
         }
@@ -63,8 +61,7 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
     PROGRAMTYPE("programType", "type", StringType.class, false),
     PROGRAM_PHASE_TEXT(PHASE_PROPERTY_NAME, PHASE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PHASES, MISSING_PHASE_TEXT_PREFIX,
                     MIELE_COFFEE_MACHINE_TEXT_PREFIX);
         }
@@ -73,8 +70,7 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
     // lightingStatus signalFailure signalInfo
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -133,8 +129,7 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
@@ -163,7 +163,7 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
@@ -63,7 +63,7 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
         try {
             switch (selector) {
                 case SWITCH: {
-                    MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+                    MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
                     if (bridgeHandler == null) {
                         logger.warn("Command '{}' failed, missing bridge handler", command);
                         return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_COFFEE_SYSTEM;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -52,7 +51,7 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DiscoveryListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DiscoveryListener.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.miele.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.miele.internal.api.dto.HomeDevice;
+
+/**
+ * The {@link DiscoveryListener} is notified when any appliance has been removed or added.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public interface DiscoveryListener {
+
+    /**
+     * This method is called whenever any appliance is removed.
+     *
+     * @param appliance The XGW homedevice definition of the appliance that was removed
+     */
+    void onApplianceRemoved(HomeDevice appliance);
+
+    /**
+     * This method is called whenever any appliance is added.
+     *
+     * @param appliance The XGW homedevice definition of the appliance that was removed
+     */
+    void onApplianceAdded(HomeDevice appliance);
+}

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DiscoveryListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DiscoveryListener.java
@@ -33,7 +33,7 @@ public interface DiscoveryListener {
     /**
      * This method is called whenever any appliance is added.
      *
-     * @param appliance The XGW homedevice definition of the appliance that was removed
+     * @param appliance The XGW homedevice definition of the appliance that was added
      */
     void onApplianceAdded(HomeDevice appliance);
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -74,7 +74,7 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
         try {
             switch (selector) {
                 case SWITCH: {
-                    MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+                    MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
                     if (bridgeHandler == null) {
                         logger.warn("Command '{}' failed, missing bridge handler", command);
                         return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_DISHWASHER;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
@@ -63,7 +62,7 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -238,7 +238,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -52,16 +52,14 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true, false),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
     STATE("", STATE_CHANNEL_ID, DecimalType.class, false, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PROGRAMS, MISSING_PROGRAM_TEXT_PREFIX,
                     MIELE_DISHWASHER_TEXT_PREFIX);
         }
@@ -69,8 +67,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     PROGRAM("", PROGRAM_CHANNEL_ID, DecimalType.class, false, false),
     PROGRAM_PHASE_TEXT(PHASE_PROPERTY_NAME, PHASE_TEXT_CHANNEL_ID, StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PHASES, MISSING_PHASE_TEXT_PREFIX,
                     MIELE_DISHWASHER_TEXT_PREFIX);
         }
@@ -78,8 +75,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false, false),
     START_TIME("startTime", "start", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -93,8 +89,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     },
     DURATION("duration", "duration", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -108,8 +103,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     },
     ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -123,8 +117,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     },
     FINISH_TIME("finishTime", "finish", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -138,8 +131,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -208,8 +200,7 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -45,8 +45,7 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
@@ -54,23 +53,20 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     SUPERCOOL("", SUPERCOOL_CHANNEL_ID, OnOffType.class, false),
     FRIDGECURRENTTEMP("currentTemperature", "current", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     FRIDGETARGETTEMP("targetTemperature", "target", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
         @Override
 
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -124,8 +120,7 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -154,7 +154,7 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -172,7 +172,7 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -46,8 +46,7 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
@@ -58,36 +57,31 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     SUPERFREEZE("", SUPERFREEZE_CHANNEL_ID, OnOffType.class, false),
     FREEZERCURRENTTEMP("freezerCurrentTemperature", "freezercurrent", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     FREEZERTARGETTEMP("freezerTargetTemperature", "freezertarget", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     FRIDGECURRENTTEMP("fridgeCurrentTemperature", "fridgecurrent", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     FRIDGETARGETTEMP("fridgeTargetTemperature", "fridgetarget", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -142,8 +136,7 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
@@ -62,7 +62,7 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
         JsonElement result = null;
 
         try {
-            MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+            MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
             if (bridgeHandler == null) {
                 logger.warn("Command '{}' failed, missing bridge handler", command);
                 return;
@@ -108,7 +108,7 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
     }
 
     @Override
-    protected void onAppliancePropertyChanged(DeviceProperty dp) {
+    public void onAppliancePropertyChanged(DeviceProperty dp) {
         super.onAppliancePropertyChanged(dp);
 
         if (!STATE_PROPERTY_NAME.equals(dp.Name)) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
@@ -52,7 +52,7 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -62,7 +62,7 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
         JsonElement result = null;
 
         try {
-            MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+            MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
             if (bridgeHandler == null) {
                 logger.warn("Command '{}' failed, missing bridge handler", command);
                 return;
@@ -109,7 +109,7 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
     }
 
     @Override
-    protected void onAppliancePropertyChanged(DeviceProperty dp) {
+    public void onAppliancePropertyChanged(DeviceProperty dp) {
         super.onAppliancePropertyChanged(dp);
 
         if (!STATE_PROPERTY_NAME.equals(dp.Name)) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -52,7 +52,7 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
@@ -42,8 +42,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
@@ -52,8 +51,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE1_POWER("plate1PowerStep", "plate1power", DecimalType.class, false),
     PLATE1_HEAT("plate1RemainingHeat", "plate1heat", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             // If there is remaining heat, the device metadata contains some informative string which can not be
             // converted into a DecimalType. We therefore ignore the metadata and return the device property value as a
             // State
@@ -64,8 +62,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE2_POWER("plate2PowerStep", "plate2power", DecimalType.class, false),
     PLATE2_HEAT("plate2RemainingHeat", "plate2heat", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getState(s);
         }
     },
@@ -73,8 +70,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE3_POWER("plate3PowerStep", "plate3power", DecimalType.class, false),
     PLATE3_HEAT("plate3RemainingHeat", "plate3heat", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getState(s);
         }
     },
@@ -82,8 +78,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE4_POWER("plate4PowerStep", "plate4power", DecimalType.class, false),
     PLATE4_HEAT("plate4RemainingHeat", "plate4heat", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getState(s);
         }
     },
@@ -91,8 +86,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE5_POWER("plate5PowerStep", "plate5power", DecimalType.class, false),
     PLATE5_HEAT("plate5RemainingHeat", "plate5heat", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getState(s);
         }
     },
@@ -100,8 +94,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     PLATE6_POWER("plate6PowerStep", "plate6power", DecimalType.class, false),
     PLATE6_HEAT("plate6RemainingHeat", "plate6heat", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getState(s);
         }
     },
@@ -147,8 +140,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
@@ -177,7 +177,7 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
@@ -138,7 +138,7 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
@@ -43,8 +43,7 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
@@ -53,8 +52,7 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
     LIGHT("lightingStatus", "light", OnOffType.class, false) {
         @Override
 
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("ON");
             }
@@ -108,8 +106,7 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_HOOD;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -51,7 +50,7 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
@@ -60,7 +60,7 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
         JsonElement result = null;
 
         try {
-            MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+            MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
             if (bridgeHandler == null) {
                 logger.warn("Command '{}' failed, missing bridge handler", command);
                 return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -150,7 +150,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             try {
                 locale = new Locale.Builder().setLanguageTag(language).build();
             } catch (IllformedLocaleException e) {
-                logger.error("Invalid language configured: {}", e.getMessage());
+                logger.warn("Invalid language configured: {}", e.getMessage());
             }
         }
         if (locale == null) {
@@ -288,7 +288,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
                 }
             }
         } catch (IllegalArgumentException e) {
-            logger.error("An exception occurred while processing a changed device property :'{}'", e.getMessage());
+            logger.warn("An exception occurred while processing a changed device property: '{}'", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -36,6 +36,7 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
@@ -262,20 +263,18 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             String dpValue = dp.Value.strip().trim();
 
             if (selector != null) {
-                if (!selector.isProperty()) {
-                    ChannelUID theChannelUID = new ChannelUID(getThing().getUID(), selector.getChannelID());
-
-                    State state = selector.getState(dpValue, dmd, this.translationProvider);
+                String channelId = selector.getChannelID();
+                ThingUID thingUid = getThing().getUID();
+                State state = selector.getState(dpValue, dmd, this.translationProvider);
+                if (selector.isProperty()) {
+                    String value = state.toString();
+                    logger.trace("Updating the property '{}' of '{}' to '{}'", channelId, thingUid, value);
+                    updateProperty(channelId, value);
+                } else {
+                    ChannelUID theChannelUID = new ChannelUID(thingUid, channelId);
                     logger.trace("Update state of {} with getState '{}'", theChannelUID, state);
                     updateState(theChannelUID, state);
                     updateRawChannel(dp.Name, dpValue);
-                } else {
-                    logger.debug("Updating the property '{}' of '{}' to '{}'", selector.getChannelID(),
-                            getThing().getUID(), selector.getState(dpValue, dmd, this.translationProvider).toString());
-                    Map<String, String> properties = editProperties();
-                    properties.put(selector.getChannelID(),
-                            selector.getState(dpValue, dmd, this.translationProvider).toString());
-                    updateProperties(properties);
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -78,7 +78,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     protected @Nullable MieleBridgeHandler bridgeHandler;
     protected TranslationProvider i18nProvider;
     protected LocaleProvider localeProvider;
-    protected @Nullable MieleTranslationProvider translationProvider;
+    protected MieleTranslationProvider translationProvider;
     private Class<E> selectorType;
     protected String modelID;
 
@@ -91,6 +91,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
         this.localeProvider = localeProvider;
         this.selectorType = selectorType;
         this.modelID = modelID;
+        this.translationProvider = new MieleTranslationProvider(i18nProvider, localeProvider);
     }
 
     public ApplianceChannelSelector getValueSelectorFromChannelID(String valueSelectorText)

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -35,6 +35,7 @@ import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
@@ -128,10 +129,20 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     public void initialize() {
         logger.debug("Initializing Miele appliance handler.");
         final String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        if (applianceId != null) {
-            this.applianceId = applianceId;
-            this.onBridgeConnectionResumed();
+        if (applianceId == null || applianceId.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.uid-not-set");
+            return;
         }
+        this.applianceId = applianceId;
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.bridge-missing");
+            return;
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+        onBridgeConnectionResumed();
     }
 
     public void onBridgeConnectionResumed() {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -178,7 +178,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         @Override
         public void run() {
             if (!IP_PATTERN.matcher((String) getConfig().get(HOST)).matches()) {
-                logger.debug("Invalid IP address for the Miele@Home gateway : '{}'", getConfig().get(HOST));
+                logger.debug("Invalid IP address for the Miele@home gateway: '{}'", getConfig().get(HOST));
                 return;
             }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -79,24 +79,26 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     private static final Pattern IP_PATTERN = Pattern
             .compile("^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
-    protected static final int POLLING_PERIOD = 15; // in seconds
-    protected static final int JSON_RPC_PORT = 2810;
-    protected static final String JSON_RPC_MULTICAST_IP1 = "239.255.68.139";
-    protected static final String JSON_RPC_MULTICAST_IP2 = "224.255.68.139";
+    private static final int POLLING_PERIOD = 15; // in seconds
+    private static final int JSON_RPC_PORT = 2810;
+    private static final String JSON_RPC_MULTICAST_IP1 = "239.255.68.139";
+    private static final String JSON_RPC_MULTICAST_IP2 = "224.255.68.139";
+
+    private final Logger logger = LoggerFactory.getLogger(MieleBridgeHandler.class);
+
     private boolean lastBridgeConnectionState = false;
     private boolean currentBridgeConnectionState = false;
 
     private Gson gson = new Gson();
     private @NonNullByDefault({}) MieleGatewayCommunicationController gatewayCommunication;
-    private final Logger logger = LoggerFactory.getLogger(MieleBridgeHandler.class);
 
     private Set<ApplianceStatusListener> applianceStatusListeners = ConcurrentHashMap.newKeySet();
-    protected @Nullable ScheduledFuture<?> pollingJob;
-    protected @Nullable ExecutorService executor;
-    protected @Nullable Future<?> eventListenerJob;
+    private @Nullable ScheduledFuture<?> pollingJob;
+    private @Nullable ExecutorService executor;
+    private @Nullable Future<?> eventListenerJob;
 
-    protected Map<String, HomeDevice> cachedHomeDevicesByApplianceId = new ConcurrentHashMap<String, HomeDevice>();
-    protected Map<String, HomeDevice> cachedHomeDevicesByRemoteUid = new ConcurrentHashMap<String, HomeDevice>();
+    private Map<String, HomeDevice> cachedHomeDevicesByApplianceId = new ConcurrentHashMap<String, HomeDevice>();
+    private Map<String, HomeDevice> cachedHomeDevicesByRemoteUid = new ConcurrentHashMap<String, HomeDevice>();
 
     public MieleBridgeHandler(Bridge bridge) {
         super(bridge);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -482,7 +482,9 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         if (cachedHomeDevice != null) {
             applianceStatusListener.onApplianceAdded(cachedHomeDevice);
         } else {
-            refreshHomeDevices(getHomeDevices());
+            if (isInitialized()) {
+                refreshHomeDevices(getHomeDevices());
+            }
         }
 
         return true;
@@ -494,13 +496,19 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     }
 
     public boolean registerDiscoveryListener(DiscoveryListener discoveryListener) {
-        boolean result = discoveryListeners.add(discoveryListener);
-        if (result) {
-            for (HomeDevice hd : getHomeDevices()) {
-                discoveryListener.onApplianceAdded(hd);
+        if (!discoveryListeners.add(discoveryListener)) {
+            return false;
+        }
+        if (cachedHomeDevicesByApplianceId.isEmpty()) {
+            if (isInitialized()) {
+                refreshHomeDevices(getHomeDevices());
+            }
+        } else {
+            for (Entry<String, HomeDevice> entry : cachedHomeDevicesByApplianceId.entrySet()) {
+                discoveryListener.onApplianceAdded(entry.getValue());
             }
         }
-        return result;
+        return true;
     }
 
     public boolean unregisterDiscoveryListener(DiscoveryListener discoveryListener) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -14,29 +14,20 @@ package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.StringReader;
 import java.net.DatagramPacket;
-import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.MulticastSocket;
 import java.net.SocketTimeoutException;
-import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.IllformedLocaleException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -46,11 +37,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.zip.GZIPInputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
+import org.openhab.binding.miele.internal.MieleGatewayCommunicationController;
 import org.openhab.binding.miele.internal.api.dto.DeviceClassObject;
 import org.openhab.binding.miele.internal.api.dto.DeviceProperty;
 import org.openhab.binding.miele.internal.api.dto.HomeDevice;
@@ -70,11 +61,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
 
 /**
  * The {@link MieleBridgeHandler} is responsible for handling commands, which are
@@ -100,8 +87,8 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     private boolean lastBridgeConnectionState = false;
     private boolean currentBridgeConnectionState = false;
 
-    protected Random rand = new Random();
-    protected Gson gson = new Gson();
+    private Gson gson = new Gson();
+    private @NonNullByDefault({}) MieleGatewayCommunicationController gatewayCommunication;
     private final Logger logger = LoggerFactory.getLogger(MieleBridgeHandler.class);
 
     protected List<ApplianceStatusListener> applianceStatusListeners = new CopyOnWriteArrayList<>();
@@ -111,8 +98,6 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
 
     protected Map<String, HomeDevice> cachedHomeDevicesByApplianceId = new ConcurrentHashMap<String, HomeDevice>();
     protected Map<String, HomeDevice> cachedHomeDevicesByRemoteUid = new ConcurrentHashMap<String, HomeDevice>();
-
-    protected @Nullable URL url;
 
     public MieleBridgeHandler(Bridge bridge) {
         super(bridge);
@@ -127,9 +112,8 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         }
 
         try {
-            url = new URL("http://" + (String) getConfig().get(HOST) + "/remote/json-rpc");
+            gatewayCommunication = new MieleGatewayCommunicationController((String) getConfig().get(HOST));
         } catch (MalformedURLException e) {
-            logger.debug("An exception occurred while defining an URL :'{}'", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, e.getMessage());
             return;
         }
@@ -247,7 +231,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                         Object[] args = new Object[2];
                         args[0] = applianceIdentifier.getUid();
                         args[1] = true;
-                        JsonElement result = invokeRPC("HDAccess/getDeviceClassObjects", args);
+                        JsonElement result = gatewayCommunication.invokeRPC("HDAccess/getDeviceClassObjects", args);
 
                         for (JsonElement obj : result.getAsJsonArray()) {
                             try {
@@ -286,7 +270,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                 // That's why we do an HTTP access instead
 
                 // If there is no connection, this line will fail
-                invokeRPC("system.listMethods", new Object[0]);
+                gatewayCommunication.invokeRPC("system.listMethods", new Object[0]);
             } catch (MieleRpcException e) {
                 logger.debug("{} is not reachable", ipAddress);
                 return false;
@@ -304,7 +288,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
             try {
                 String[] args = new String[1];
                 args[0] = "(type=SuperVision)";
-                JsonElement result = invokeRPC("HDAccess/getHomeDevices", args);
+                JsonElement result = gatewayCommunication.invokeRPC("HDAccess/getHomeDevices", args);
 
                 for (JsonElement obj : result.getAsJsonArray()) {
                     HomeDevice hd = gson.fromJson(obj, HomeDevice.class);
@@ -456,134 +440,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                     + " was not found in appliance list from gateway - operations can not be invoked");
         }
 
-        Object[] args = new Object[4];
-        args[0] = applianceIdentifier.getUid();
-        args[1] = MIELE_CLASS + modelID;
-        args[2] = methodName;
-        args[3] = null;
-
-        return invokeRPC("HDAccess/invokeDCOOperation", args);
-    }
-
-    protected JsonElement invokeRPC(String methodName, Object[] args) throws MieleRpcException {
-        JsonElement result = null;
-        URL url = this.url;
-        if (url == null) {
-            throw new MieleRpcException("URL is not set");
-        }
-
-        JsonObject req = new JsonObject();
-        int id = rand.nextInt(Integer.MAX_VALUE);
-        req.addProperty("jsonrpc", "2.0");
-        req.addProperty("id", id);
-        req.addProperty("method", methodName);
-
-        JsonArray params = new JsonArray();
-        for (Object o : args) {
-            params.add(gson.toJsonTree(o));
-        }
-        req.add("params", params);
-
-        String requestData = req.toString();
-        String responseData = null;
-        try {
-            responseData = post(url, Collections.emptyMap(), requestData);
-        } catch (IOException e) {
-            throw new MieleRpcException("Exception occurred while posting data", e);
-        }
-
-        logger.trace("The request '{}' yields '{}'", requestData, responseData);
-        JsonObject parsedResponse = null;
-        try {
-            parsedResponse = (JsonObject) JsonParser.parseReader(new StringReader(responseData));
-        } catch (JsonParseException e) {
-            throw new MieleRpcException("Error parsing JSON response", e);
-        }
-
-        JsonElement error = parsedResponse.get("error");
-        if (error != null && !error.isJsonNull()) {
-            if (error.isJsonPrimitive()) {
-                throw new MieleRpcException("Remote exception occurred: '" + error.getAsString() + "'");
-            } else if (error.isJsonObject()) {
-                JsonObject o = error.getAsJsonObject();
-                Integer code = (o.has("code") ? o.get("code").getAsInt() : null);
-                String message = (o.has("message") ? o.get("message").getAsString() : null);
-                String data = (o.has("data")
-                        ? (o.get("data") instanceof JsonObject ? o.get("data").toString() : o.get("data").getAsString())
-                        : null);
-                throw new MieleRpcException(
-                        "Remote exception occurred: '" + code + "':'" + message + "':'" + data + "'");
-            } else {
-                throw new MieleRpcException("Unknown remote exception occurred: '" + error.toString() + "'");
-            }
-        }
-
-        result = parsedResponse.get("result");
-        if (result == null) {
-            throw new MieleRpcException("Result is missing in response");
-        }
-
-        return result;
-    }
-
-    protected String post(URL url, Map<String, String> headers, String data) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            connection.addRequestProperty(entry.getKey(), entry.getValue());
-        }
-
-        connection.addRequestProperty("Accept-Encoding", "gzip");
-
-        connection.setRequestMethod("POST");
-        connection.setDoOutput(true);
-        connection.connect();
-
-        OutputStream out = null;
-
-        try {
-            out = connection.getOutputStream();
-
-            out.write(data.getBytes());
-            out.flush();
-
-            int statusCode = connection.getResponseCode();
-            if (statusCode != HttpURLConnection.HTTP_OK) {
-                logger.debug("An unexpected status code was returned: '{}'", statusCode);
-            }
-        } finally {
-            if (out != null) {
-                out.close();
-            }
-        }
-
-        String responseEncoding = connection.getHeaderField("Content-Encoding");
-        responseEncoding = (responseEncoding == null ? "" : responseEncoding.trim());
-
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-
-        InputStream in = connection.getInputStream();
-        try {
-            in = connection.getInputStream();
-            if ("gzip".equalsIgnoreCase(responseEncoding)) {
-                in = new GZIPInputStream(in);
-            }
-            in = new BufferedInputStream(in);
-
-            byte[] buff = new byte[1024];
-            int n;
-            while ((n = in.read(buff)) > 0) {
-                bos.write(buff, 0, n);
-            }
-            bos.flush();
-            bos.close();
-        } finally {
-            if (in != null) {
-                in.close();
-            }
-        }
-
-        return bos.toString();
+        return gatewayCommunication.invokeOperation(applianceIdentifier, modelID, methodName);
     }
 
     private synchronized void onUpdate() {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -134,9 +134,9 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
             return;
         }
 
+        updateStatus(ThingStatus.UNKNOWN);
         onUpdate();
         lastBridgeConnectionState = false;
-        updateStatus(ThingStatus.UNKNOWN);
     }
 
     private boolean validateConfig(Configuration config) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -249,7 +249,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         }
     };
 
-    private void refreshHomeDevices(List<HomeDevice> homeDevices) {
+    private synchronized void refreshHomeDevices(List<HomeDevice> homeDevices) {
         for (HomeDevice hd : homeDevices) {
             String key = hd.getApplianceIdentifier().getApplianceId();
             if (!cachedHomeDevicesByApplianceId.containsKey(key)) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -91,7 +90,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     private @NonNullByDefault({}) MieleGatewayCommunicationController gatewayCommunication;
     private final Logger logger = LoggerFactory.getLogger(MieleBridgeHandler.class);
 
-    protected List<ApplianceStatusListener> applianceStatusListeners = new CopyOnWriteArrayList<>();
+    private Set<ApplianceStatusListener> applianceStatusListeners = ConcurrentHashMap.newKeySet();
     protected @Nullable ScheduledFuture<?> pollingJob;
     protected @Nullable ExecutorService executor;
     protected @Nullable Future<?> eventListenerJob;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -52,8 +52,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
@@ -63,8 +62,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     PROGRAMTYPE("programType", "type", StringType.class, false),
     PROGRAM_PHASE_TEXT(PHASE_PROPERTY_NAME, PHASE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PHASES, MISSING_PHASE_TEXT_PREFIX,
                     MIELE_OVEN_TEXT_PREFIX);
         }
@@ -72,8 +70,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false),
     START_TIME("startTime", "start", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -87,8 +84,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     },
     DURATION("duration", "duration", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -102,8 +98,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     },
     ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -117,8 +112,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     },
     FINISH_TIME("finishTime", "finish", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -132,37 +126,32 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     },
     TARGET_TEMP("targetTemperature", "target", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     MEASURED_TEMP("measuredTemperature", "measured", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     DEVICE_TEMP_ONE("deviceTemperature1", "temp1", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     DEVICE_TEMP_TWO("deviceTemperature2", "temp2", QuantityType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
         @Override
 
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -221,8 +210,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -251,7 +251,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
@@ -61,7 +61,7 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
         JsonElement result = null;
 
         try {
-            MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+            MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
             if (bridgeHandler == null) {
                 logger.warn("Command '{}' failed, missing bridge handler", command);
                 return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_OVEN;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -52,7 +51,7 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
@@ -51,16 +51,14 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
     STATE("", STATE_CHANNEL_ID, DecimalType.class, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PROGRAMS, MISSING_PROGRAM_TEXT_PREFIX,
                     MIELE_TUMBLE_DRYER_TEXT_PREFIX);
         }
@@ -69,8 +67,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     PROGRAMTYPE("programType", "type", StringType.class, false),
     PROGRAM_PHASE_TEXT(PHASE_PROPERTY_NAME, PHASE_TEXT_CHANNEL_ID, StringType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PHASES, MISSING_PHASE_TEXT_PREFIX,
                     MIELE_TUMBLE_DRYER_TEXT_PREFIX);
         }
@@ -78,8 +75,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false),
     START_TIME("startTime", "start", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -93,8 +89,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     },
     DURATION("duration", "duration", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -108,8 +103,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     },
     ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -123,8 +117,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     },
     FINISH_TIME("finishTime", "finish", DateTimeType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -138,16 +131,14 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     },
     DRYING_STEP("dryingStep", "step", DecimalType.class, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
         @Override
 
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -217,8 +208,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
@@ -247,7 +247,7 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
@@ -63,7 +63,7 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
         try {
             switch (selector) {
                 case SWITCH: {
-                    MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+                    MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
                     if (bridgeHandler == null) {
                         logger.warn("Command '{}' failed, missing bridge handler", command);
                         return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_TUMBLE_DRYER;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -52,7 +51,7 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -52,16 +52,14 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     DEVICE_TYPE("mieleDeviceType", "deviceType", StringType.class, true, false),
     STATE_TEXT(STATE_PROPERTY_NAME, STATE_TEXT_CHANNEL_ID, StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getStateTextState(s, dmd, translationProvider);
         }
     },
     STATE("", STATE_CHANNEL_ID, DecimalType.class, false, false),
     PROGRAM_TEXT(PROGRAM_ID_PROPERTY_NAME, PROGRAM_TEXT_CHANNEL_ID, StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PROGRAMS, MISSING_PROGRAM_TEXT_PREFIX,
                     MIELE_WASHING_MACHINE_TEXT_PREFIX);
         }
@@ -70,8 +68,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     PROGRAMTYPE("programType", "type", StringType.class, false, false),
     PROGRAM_PHASE_TEXT(PHASE_PROPERTY_NAME, PHASE_TEXT_CHANNEL_ID, StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return DeviceUtil.getTextState(s, dmd, translationProvider, PHASES, MISSING_PHASE_TEXT_PREFIX,
                     MIELE_WASHING_MACHINE_TEXT_PREFIX);
         }
@@ -79,8 +76,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false, false),
     START_TIME("startTime", "start", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -94,8 +90,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     },
     DURATION("duration", "duration", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -109,8 +104,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     },
     ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -124,8 +118,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     },
     FINISH_TIME("finishTime", "finish", DateTimeType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             Date date = new Date();
             SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
@@ -139,15 +132,13 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     },
     TARGET_TEMP("targetTemperature", "target", QuantityType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             return getTemperatureState(s);
         }
     },
     SPINNING_SPEED("spinningSpeed", "spinningspeed", StringType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("0".equals(s)) {
                 return getState("Without spinning");
             }
@@ -159,8 +150,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false, false) {
         @Override
-        public State getState(String s, @Nullable DeviceMetaData dmd,
-                @Nullable MieleTranslationProvider translationProvider) {
+        public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
             if ("true".equals(s)) {
                 return getState("OPEN");
             }
@@ -234,8 +224,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public State getState(String s, @Nullable DeviceMetaData dmd,
-            @Nullable MieleTranslationProvider translationProvider) {
+    public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
         return this.getState(s, dmd);
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -264,7 +264,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
                 return state;
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
+            logger.warn("An exception occurred while converting '{}' into a State", s);
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -76,7 +76,7 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
         try {
             switch (selector) {
                 case SWITCH: {
-                    MieleBridgeHandler bridgeHandler = this.bridgeHandler;
+                    MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
                     if (bridgeHandler == null) {
                         logger.warn("Command '{}' failed, missing bridge handler", command);
                         return;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_WASHING_MACHINE;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
@@ -64,7 +63,7 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = this.applianceId;
         if (applianceId == null) {
             logger.warn("Command '{}' failed, appliance id is unknown", command);
             return;

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele.properties
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele.properties
@@ -125,11 +125,13 @@ channel-type.miele.waterConsumption.description = Water consumption by the curre
 
 # thing status descriptions
 
+offline.configuration-error.bridge-missing = Bridge is missing
 offline.configuration-error.ip-address-not-set = Cannot connect to the Miele gateway: host IP address is not set.
 offline.configuration-error.ip-multicast-interface-not-set = Cannot connect to the Miele gateway: multicast interface is not set.
 offline.configuration-error.invalid-ip-gateway = Invalid IP address for the Miele@Home gateway: {0}
 offline.configuration-error.invalid-ip-multicast-interface = Invalid IP address for the multicast interface: {0}
 offline.configuration-error.invalid-language = Invalid language: {0}
+offline.configuration-error.uid-not-set = Appliance ID is not set
 
 # Discovery result
 


### PR DESCRIPTION
This pull request contains various fixes and optimizations for the Miele@home binding. These issues were discovered by analyzing the code, backed up by manual testing as proof. See also #12504 for findings. Please read this PR commit by commit for better understanding.

### Bugfixes
- Appliance configuration is now validated: Missing or empty UID will now result in status **OFFLINE** with **CONFIGURATION_ERROR**.
- Appliances removed from bridge (i.e. non-existent appliances) are now marked as **OFFLINE** with **GONE**. Previously they were marked as **ONLINE**.

### Optimizations
- An unneeded call to the Miele gateway every 15 seconds has been removed. This call received a payload of almost 6 KB.
- Appliance handlers are no longer notified about updates for other appliances. Everything was broadcasted and each handler would filter.
- Listeners will receive immediate callback when appliances are already cached.
- Listener registrations will no longer cause all appliances to be fetched from gateway for each registration.
- Jobs are no longer checked/scheduled upon each listener registration.

### Refactoring
- JSON-RPC handling has been extracted to a separate class.
- Listener interface has been divided into a distinct interface for discovery and another one for appliance status.
- Online/offline status transitions has been simplified.
- Null annotation improvement for translation provider.
- Log levels have been adjusted for some messages.
- Access levels for some variables were reduced to prevent being exposed to subclasses for no reason.
- Many other simplifications.

# Testing

Besides general regression testing with appliances running programs, the following specific scenarios have been addressed:
- Online/offline transitions have been tested by disabling/enabling a port on the switch for the XGW 3000 gateway.
- Configuration of thing with missing/empty UID resulting in status **OFFLINE** with **CONFIGURATION_ERROR**: "Appliance ID is not set"
- Configuration of non-existent UID resulting in status **OFFLINE** with **GONE**.