### PR TITLE
[openwebnet] fixing support for central unit

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.7.1</version>
+      <version>0.8.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.8.0-SNAPSHOT</version>
+      <version>0.8.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -122,7 +122,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                         "@text/offline.conf-error-where");
             }
 
-            // reset state of signal chanells (they will be setted when specific messages are received)
+            // reset state of signal channels (they will be setted when specific messages are received)
             updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_MANUAL, OnOffType.OFF);
             updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF, OnOffType.OFF);
             updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_PROTECTION, OnOffType.OFF);
@@ -202,7 +202,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             programNumber = command.toString();
             logger.debug("handleSetProgramNumber() Program number set to {}", programNumber);
 
-            // force mode update if we are already in SCENARIO o WEEKLY mode
+            // force OperationMode update if we are already in SCENARIO o WEEKLY mode
             if (currentMode.isScenario() || currentMode.isWeekly()) {
                 try {
                     Thermoregulation.OperationMode new_mode = Thermoregulation.OperationMode
@@ -261,9 +261,9 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
 
                         // store current mode
                         currentMode = new_mode;
-                    } else
+                    } else {
                         new_mode = Thermoregulation.OperationMode.valueOf(command.toString());
-
+                    }
                     send(Thermoregulation.requestWriteMode(getWhere(w.value()), new_mode, currentFunction,
                             currentSetPointTemp));
                 } catch (OWNException e) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -202,12 +202,8 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             programNumber = command.toString();
             logger.debug("handleSetProgramNumber() Program number set to {}", programNumber);
 
-            logger.debug("handleSetProgramNumber() AC currentMode {}", currentMode);
-
             // force mode update if we are already in SCENARIO o WEEKLY mode
             if (currentMode.isScenario() || currentMode.isWeekly()) {
-                logger.debug("handleSetProgramNumber() AC 1");
-
                 try {
                     Thermoregulation.OperationMode new_mode = Thermoregulation.OperationMode
                             .valueOf(currentMode.mode() + "_" + programNumber);
@@ -215,15 +211,12 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                             currentSetPointTemp);
                     send(Thermoregulation.requestWriteMode(getWhere(""), new_mode, currentFunction,
                             currentSetPointTemp));
-                    logger.debug("handleSetProgramNumber() AC 2");
-
                 } catch (OWNException e) {
                     logger.warn("handleSetProgramNumber() {}", e.getMessage());
                 } catch (IllegalArgumentException e) {
                     logger.warn("handleSetProgramNumber() Unsupported command {} for thing {}", command,
                             getThing().getUID());
                 }
-                logger.debug("handleSetProgramNumber() AC 3");
             }
 
         } else {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -207,8 +207,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 try {
                     Thermoregulation.OperationMode new_mode = Thermoregulation.OperationMode
                             .valueOf(currentMode.mode() + "_" + programNumber);
-                    logger.debug("handleSetProgramNumber() new mode {}", new_mode, currentFunction,
-                            currentSetPointTemp);
+                    logger.debug("handleSetProgramNumber() new mode {}", new_mode);
                     send(Thermoregulation.requestWriteMode(getWhere(""), new_mode, currentFunction,
                             currentSetPointTemp));
                 } catch (OWNException e) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -77,12 +77,13 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     private double currentSetPointTemp = 11.5d; // 11.5 is the default setTemp used in MyHomeUP mobile app
 
     private Thermoregulation.Function currentFunction = Thermoregulation.Function.GENERIC;
+    private Thermoregulation.OperationMode currentMode = Thermoregulation.OperationMode.MANUAL;
 
     private boolean isStandAlone = false;
 
     private boolean isCentralUnit = false;
 
-    private String programNumber = "";
+    private String programNumber = "1";
 
     private static Set<String> probesInProtection = new HashSet<String>();
     private static Set<String> probesInOFF = new HashSet<String>();
@@ -92,6 +93,8 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     private static final String CU_REMOTE_CONTROL_DISABLED = "DISABLED";
     private static final String CU_BATTERY_OK = "OK";
     private static final String CU_BATTERY_KO = "KO";
+    private static final Integer UNDOCUMENTED_WHAT_4001 = 4001;
+    private static final Integer UNDOCUMENTED_WHAT_4002 = 4002;
 
     public OpenWebNetThermoregulationHandler(Thing thing) {
         super(thing);
@@ -118,6 +121,13 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "@text/offline.conf-error-where");
             }
+
+            // reset state of signal chanells (they will be setted when specific messages are received)
+            updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_MANUAL, OnOffType.OFF);
+            updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF, OnOffType.OFF);
+            updateState(CHANNEL_CU_AT_LEAST_ONE_PROBE_PROTECTION, OnOffType.OFF);
+            updateState(CHANNEL_CU_SCENARIO_PROGRAM_NUMBER, new DecimalType(programNumber));
+            updateState(CHANNEL_CU_WEEKLY_PROGRAM_NUMBER, new DecimalType(programNumber));
         }
     }
 
@@ -192,6 +202,30 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             programNumber = command.toString();
             logger.debug("handleSetProgramNumber() Program number set to {}", programNumber);
 
+            logger.debug("handleSetProgramNumber() AC currentMode {}", currentMode);
+
+            // force mode update if we are already in SCENARIO o WEEKLY mode
+            if (currentMode.isScenario() || currentMode.isWeekly()) {
+                logger.debug("handleSetProgramNumber() AC 1");
+
+                try {
+                    Thermoregulation.OperationMode new_mode = Thermoregulation.OperationMode
+                            .valueOf(currentMode.mode() + "_" + programNumber);
+                    logger.debug("handleSetProgramNumber() new mode {}", new_mode, currentFunction,
+                            currentSetPointTemp);
+                    send(Thermoregulation.requestWriteMode(getWhere(""), new_mode, currentFunction,
+                            currentSetPointTemp));
+                    logger.debug("handleSetProgramNumber() AC 2");
+
+                } catch (OWNException e) {
+                    logger.warn("handleSetProgramNumber() {}", e.getMessage());
+                } catch (IllegalArgumentException e) {
+                    logger.warn("handleSetProgramNumber() Unsupported command {} for thing {}", command,
+                            getThing().getUID());
+                }
+                logger.debug("handleSetProgramNumber() AC 3");
+            }
+
         } else {
             logger.warn("handleSetProgramNumber() Unsupported command {} for thing {}", command, getThing().getUID());
         }
@@ -229,9 +263,12 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 try {
                     Thermoregulation.OperationMode new_mode = Thermoregulation.OperationMode.OFF;
 
-                    if (isCentralUnit && WhatThermo.isComplex(command.toString()))
+                    if (isCentralUnit && WhatThermo.isComplex(command.toString())) {
                         new_mode = Thermoregulation.OperationMode.valueOf(command.toString() + "_" + programNumber);
-                    else
+
+                        // store current mode
+                        currentMode = new_mode;
+                    } else
                         new_mode = Thermoregulation.OperationMode.valueOf(command.toString());
 
                     send(Thermoregulation.requestWriteMode(getWhere(w.value()), new_mode, currentFunction,
@@ -279,18 +316,11 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     protected void handleMessage(BaseOpenMessage msg) {
         super.handleMessage(msg);
 
-        logger.debug("handleMessage() AC PRIMA");
-        updateCUAtLeastOneProbeProtection(OnOffType.OFF);
-        logger.debug("handleMessage() AC DOPO");
-
-        if (msg.getWhat() != null) {
-            if (msg.getWhat().value() == 4002) {
-                logger.debug("handleMessage() AC Ignoring unsupported WHAT. Frame={}", msg);
+        if (isCentralUnit) {
+            if (msg.getWhat() == null) {
                 return;
             }
-        }
 
-        if (isCentralUnit) {
             // there isn't a message used for setting OK for battery status so let's assume
             // it's OK and then change to KO if according message is received
             updateCUBatteryStatus(CU_BATTERY_OK);
@@ -312,8 +342,13 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 updateCUAtLeastOneProbeManual(OnOffType.ON);
             } else if (msg.getWhat() == Thermoregulation.WhatThermo.FAILURE_DISCOVERED) {
                 updateCUFailureDiscovered(OnOffType.ON);
-            } // must intercept all possibile WHATs (will be implemented soon)
-            else if (msg.getWhat() == Thermoregulation.WhatThermo.RELEASE_SENSOR_LOCAL_ADJUST) {
+            } // must intercept all possibile WHATs
+            else if (msg.getWhat() == Thermoregulation.WhatThermo.RELEASE_SENSOR_LOCAL_ADJUST) { // will be implemented
+                                                                                                 // soon
+                logger.debug("handleMessage() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
+            } else if (msg.getWhat().value() == UNDOCUMENTED_WHAT_4001) {
+                logger.debug("handleMessage() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
+            } else if (msg.getWhat().value() == UNDOCUMENTED_WHAT_4002) {
                 logger.debug("handleMessage() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
             } else {
                 // check and update values of other channel (mode, function, temp)
@@ -362,29 +397,30 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             logger.debug("updateModeAndFunction() Could not parse Mode from: {}", tmsg.getFrameValue());
             return;
         }
+
         if (w.getFunction() == null) {
             logger.debug("updateModeAndFunction() Could not parse Function from: {}", tmsg.getFrameValue());
             return;
         }
 
-        Thermoregulation.OperationMode mode = w.getMode();
+        Thermoregulation.OperationMode operationMode = w.getMode();
         Thermoregulation.Function function = w.getFunction();
 
         // keep track of thermostats (zones) status
         if (!isCentralUnit && (!((WhereThermo) deviceWhere).isProbe())) {
-            if (mode == Thermoregulation.OperationMode.OFF) {
+            if (operationMode == Thermoregulation.OperationMode.OFF) {
                 probesInManual.remove(tmsg.getWhere().value());
                 probesInProtection.remove(tmsg.getWhere().value());
                 if (probesInOFF.add(tmsg.getWhere().value())) {
                     logger.debug("atLeastOneProbeInOFF: added WHERE ---> {}", tmsg.getWhere());
                 }
-            } else if (mode == Thermoregulation.OperationMode.PROTECTION) {
+            } else if (operationMode == Thermoregulation.OperationMode.PROTECTION) {
                 probesInManual.remove(tmsg.getWhere().value());
                 probesInOFF.remove(tmsg.getWhere().value());
                 if (probesInProtection.add(tmsg.getWhere().value())) {
                     logger.debug("atLeastOneProbeInProtection: added WHERE ---> {}", tmsg.getWhere());
                 }
-            } else if (mode == Thermoregulation.OperationMode.MANUAL) {
+            } else if (operationMode == Thermoregulation.OperationMode.MANUAL) {
                 probesInProtection.remove(tmsg.getWhere().value());
                 probesInOFF.remove(tmsg.getWhere().value());
                 if (probesInManual.add(tmsg.getWhere().value())) {
@@ -398,23 +434,31 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             if (probesInProtection.isEmpty()) {
                 updateCUAtLeastOneProbeProtection(OnOffType.OFF);
             }
-            else {
-                logger.debug("atLeastOneProbeInProtection: {}wheres", probesInProtection.size());
-            }
             if (probesInManual.isEmpty()) {
                 updateCUAtLeastOneProbeManual(OnOffType.OFF);
             }
-            else {
-                logger.debug("atLeastOneProbeInManual: {}wheres", probesInManual.size());
-            }
-
         }
 
         updateState(CHANNEL_FUNCTION, new StringType(function.toString()));
-        updateState(CHANNEL_MODE, new StringType(mode.toString()));
+
+        // must convert from OperationMode to Mode and set ProgramNumber when necessary
+        updateState(CHANNEL_MODE, new StringType(operationMode.mode()));
+        if (operationMode.isScenario()) {
+            logger.debug("updateModeAndFunction() set SCENARIO program to: {}", operationMode.programNumber());
+            updateState(CHANNEL_CU_SCENARIO_PROGRAM_NUMBER, new DecimalType(operationMode.programNumber()));
+        }
+        if (operationMode.isWeekly()) {
+            logger.debug("updateModeAndFunction() set WEEKLY program to: {}", operationMode.programNumber());
+            updateState(CHANNEL_CU_WEEKLY_PROGRAM_NUMBER, new DecimalType(operationMode.programNumber()));
+        }
 
         // store current function
         currentFunction = function;
+
+        // in case of central unit store also current operation mode
+        if (isCentralUnit) {
+            currentMode = operationMode;
+        }
     }
 
     private void updateTemperature(Thermoregulation tmsg) {
@@ -429,7 +473,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
 
     private void updateSetpoint(Thermoregulation tmsg) {
         try {
-            double temp;
+            double temp = 11.5d;
             if (isCentralUnit) {
                 if (tmsg.getWhat() == null) {
                     // it should be like *4*WHAT#TTTT*#0##
@@ -439,19 +483,19 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                 }
 
                 String[] parameters = tmsg.getWhatParams();
-                if (parameters.length == 0) {
-                    logger.debug("updateSetpoint() parameters.lenght=0 ---> {}", tmsg.toStringVerbose());
-                    return;
-                } else {
-                    logger.debug("updateSetpoint() pre-parsed temp: {} ---> {}", tmsg.toStringVerbose(), parameters[0]);
+                if (parameters.length > 0) {
                     temp = Thermoregulation.decodeTemperature(parameters[0]);
-                    logger.debug("updateSetpoint() parsed temp: {} ---> {}", parameters[0], temp);
+                    logger.debug("updateSetpoint() parsed temperature from {}: {} ---> {}", tmsg.toStringVerbose(),
+                            parameters[0], temp);
                 }
             } else {
                 temp = Thermoregulation.parseTemperature(tmsg);
             }
             updateState(CHANNEL_TEMP_SETPOINT, getAsQuantityTypeOrNull(temp, SIUnits.CELSIUS));
             currentSetPointTemp = temp;
+        } catch (NumberFormatException e) {
+            logger.warn("updateSetpoint() NumberFormatException on frame {}: {}", tmsg, e.getMessage());
+            updateState(CHANNEL_TEMP_SETPOINT, UnDefType.UNDEF);
         } catch (FrameException e) {
             logger.warn("updateSetpoint() FrameException on frame {}: {}", tmsg, e.getMessage());
             updateState(CHANNEL_TEMP_SETPOINT, UnDefType.UNDEF);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -279,12 +279,17 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     protected void handleMessage(BaseOpenMessage msg) {
         super.handleMessage(msg);
 
-        if (msg.getWhat().value() == 4002)
-        {
-            logger.debug("handleMessage() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
-            return;
+        logger.debug("handleMessage() AC PRIMA");
+        updateCUAtLeastOneProbeProtection(OnOffType.OFF);
+        logger.debug("handleMessage() AC DOPO");
+
+        if (msg.getWhat() != null) {
+            if (msg.getWhat().value() == 4002) {
+                logger.debug("handleMessage() AC Ignoring unsupported WHAT. Frame={}", msg);
+                return;
+            }
         }
-        
+
         if (isCentralUnit) {
             // there isn't a message used for setting OK for battery status so let's assume
             // it's OK and then change to KO if according message is received
@@ -393,9 +398,16 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             if (probesInProtection.isEmpty()) {
                 updateCUAtLeastOneProbeProtection(OnOffType.OFF);
             }
+            else {
+                logger.debug("atLeastOneProbeInProtection: {}wheres", probesInProtection.size());
+            }
             if (probesInManual.isEmpty()) {
                 updateCUAtLeastOneProbeManual(OnOffType.OFF);
             }
+            else {
+                logger.debug("atLeastOneProbeInManual: {}wheres", probesInManual.size());
+            }
+
         }
 
         updateState(CHANNEL_FUNCTION, new StringType(function.toString()));
@@ -426,16 +438,14 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
                     return;
                 }
 
-                // TODO: use new getWhatParams() method when availlable
-                // https://github.com/mvalla/openwebnet4j/issues/30
                 String[] parameters = tmsg.getWhatParams();
                 if (parameters.length == 0) {
                     logger.debug("updateSetpoint() parameters.lenght=0 ---> {}", tmsg.toStringVerbose());
                     return;
                 } else {
+                    logger.debug("updateSetpoint() pre-parsed temp: {} ---> {}", tmsg.toStringVerbose(), parameters[0]);
                     temp = Thermoregulation.decodeTemperature(parameters[0]);
-                    logger.debug("updateSetpoint() parsed temp: {} ---> {}  ({})", parameters[0], temp,
-                            tmsg.toStringVerbose());
+                    logger.debug("updateSetpoint() parsed temp: {} ---> {}", parameters[0], temp);
                 }
             } else {
                 temp = Thermoregulation.parseTemperature(tmsg);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -279,6 +279,12 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     protected void handleMessage(BaseOpenMessage msg) {
         super.handleMessage(msg);
 
+        if (msg.getWhat().value() == 4002)
+        {
+            logger.debug("handleMessage() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
+            return;
+        }
+        
         if (isCentralUnit) {
             // there isn't a message used for setting OK for battery status so let's assume
             // it's OK and then change to KO if according message is received
@@ -422,12 +428,15 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
 
                 // TODO: use new getWhatParams() method when availlable
                 // https://github.com/mvalla/openwebnet4j/issues/30
-                int[] parameters = tmsg.getCommandParams();
+                String[] parameters = tmsg.getWhatParams();
                 if (parameters.length == 0) {
                     logger.debug("updateSetpoint() parameters.lenght=0 ---> {}", tmsg.toStringVerbose());
                     return;
-                } else
-                    temp = Thermoregulation.decodeTemperature(String.format("%1$4s", parameters[0]).replace(' ', '0'));
+                } else {
+                    temp = Thermoregulation.decodeTemperature(parameters[0]);
+                    logger.debug("updateSetpoint() parsed temp: {} ---> {}  ({})", parameters[0], temp,
+                            tmsg.toStringVerbose());
+                }
             } else {
                 temp = Thermoregulation.parseTemperature(tmsg);
             }


### PR DESCRIPTION
Objective:

Enhance OpenWebNet binding to support thermoregulation with 4/99 zone central unit, e.g. BTicino 3550 model.

Changelog

- fix read setTemp (MANUAL mode) at startup
- fix read mode (OFF/PROTECTION/WEEKLY/SCENARIO/MANUAL) at startup
- fix https://github.com/openhab/openhab-addons/issues/12401
- fix https://github.com/openhab/openhab-addons/issues/12417

It requires Own4j version 0.8.1