### PR TITLE
[jrubyscripting] Accept generic global variable names

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
@@ -48,9 +48,6 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
     // difficult ways to debug.
     private static final Set<String> FILTERED_PRESETS = Set.of("File", "Files", "Path", "Paths");
     private static final Set<String> INSTANCE_PRESETS = Set.of();
-    private static final Set<String> GLOBAL_PRESETS = Set.of("scriptExtension", "automationManager", "ruleRegistry",
-            "items", "voice", "rules", "things", "events", "itemRegistry", "ir", "actions", "se", "audio",
-            "lifecycleTracker");
 
     private final javax.script.ScriptEngineFactory factory = new org.jruby.embed.jsr223.JRubyEngineFactory();
 
@@ -69,7 +66,8 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     // Adds $ in front of a set of variables so that Ruby recognizes them as global variables
     private static Map.Entry<String, Object> mapGlobalPresets(Map.Entry<String, Object> entry) {
-        if (GLOBAL_PRESETS.contains(entry.getKey())) {
+        if (Character.isLowerCase(entry.getKey().charAt(0)) && !(entry.getValue() instanceof Class)
+                && !(entry.getValue() instanceof Enum)) {
             return Map.entry("$" + entry.getKey(), entry.getValue());
         } else {
             return entry;


### PR DESCRIPTION
Remove hard coded list of scoped global variables and use a more generic criteria. This will allow introduction of other / new scoped variables whose names are not already in the hard coded list.
