### PR TITLE
[pulseaudio] Fix misconfiguration example in README

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -74,7 +74,7 @@ This requires the module **module-simple-protocol-tcp** to be present on the tar
 ```
 Bridge pulseaudio:bridge:<bridgname> "<Bridge Label>" @ "<Room>" [ host="<ipAddress>", port=4712 ] {
   Things:
-	Thing sink          multiroom       "Snapcast"           @ "Room"       [name="alsa_card.pci-0000_00_1f.3", activateSimpleProtocolSink="true", simpleProtocolSinkPort=4711] // the name corresponds to `pactl list sinks` output
+	Thing sink          multiroom       "Snapcast"           @ "Room"       [name="alsa_card.pci-0000_00_1f.3", activateSimpleProtocolSink=true, simpleProtocolSinkPort=4711] // the name corresponds to `pactl list sinks` output
 	Thing source        microphone      "microphone"         @ "Room"       [name="alsa_input.pci-0000_00_14.2.analog-stereo"]
 	Thing sink-input    openhabTTS      "OH-Voice"           @ "Room"       [name="alsa_output.pci-0000_00_1f.3.hdmi-stereo-extra1"]
 	Thing source-output remotePulseSink "Other Room Speaker" @ "Other Room" [name="alsa_input.pci-0000_00_14.2.analog-stereo"]


### PR DESCRIPTION
As seen [on the community forum](https://community.openhab.org/t/pulseaudio-thing-initialization-during-startup-to-early-and-therefore-causing-an-exception/134657) by a user encountering an issue, the configuration file example in the pulseaudio README has an error with the parameter activateSimpleProtocolSink
