### PR TITLE
[homematic] Validate datapoint values before writing to config

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.Future;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.homematic.internal.HomematicBindingConstants;
 import org.openhab.binding.homematic.internal.common.HomematicConfig;
 import org.openhab.binding.homematic.internal.communicator.HomematicGateway;
@@ -419,7 +420,7 @@ public class HomematicThingHandler extends BaseThingHandler {
         }
     }
 
-    private Object getValueForConfiguration(HmDatapoint dp) {
+    private @Nullable Object getValueForConfiguration(HmDatapoint dp) {
         if (dp.getValue() == null) {
             return null;
         }
@@ -434,12 +435,12 @@ public class HomematicThingHandler extends BaseThingHandler {
             final boolean minValid, maxValid;
             if (dp.isFloatType()) {
                 Double numValue = dp.getDoubleValue();
-                minValid = dp.getMinValue() == null || numValue >= dp.getMaxValue().doubleValue();
-                maxValid = dp.getMinValue() == null || numValue <= dp.getMinValue().doubleValue();
+                minValid = dp.getMinValue() == null || numValue >= dp.getMinValue().doubleValue();
+                maxValid = dp.getMaxValue() == null || numValue <= dp.getMaxValue().doubleValue();
             } else {
                 Integer numValue = dp.getIntegerValue();
-                minValid = dp.getMinValue() == null || numValue >= dp.getMaxValue().intValue();
-                maxValid = dp.getMinValue() == null || numValue <= dp.getMinValue().intValue();
+                minValid = dp.getMinValue() == null || numValue >= dp.getMinValue().intValue();
+                maxValid = dp.getMaxValue() == null || numValue <= dp.getMaxValue().intValue();
             }
             if (minValid && maxValid) {
                 return dp.getValue();

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
@@ -140,8 +140,7 @@ public class HomematicThingHandler extends BaseThingHandler {
             loadHomematicChannelValues(channel);
             for (HmDatapoint dp : channel.getDatapoints()) {
                 if (dp.getParamsetType() == HmParamsetType.MASTER) {
-                    config.put(MetadataUtils.getParameterName(dp),
-                            dp.isEnumType() ? dp.getOptionValue() : dp.getValue());
+                    config.put(MetadataUtils.getParameterName(dp), getValueForConfiguration(dp));
                 }
             }
         }
@@ -401,7 +400,7 @@ public class HomematicThingHandler extends BaseThingHandler {
             if (dp.getParamsetType() == HmParamsetType.MASTER) {
                 // update configuration
                 Configuration config = editConfiguration();
-                config.put(MetadataUtils.getParameterName(dp), dp.isEnumType() ? dp.getOptionValue() : dp.getValue());
+                config.put(MetadataUtils.getParameterName(dp), getValueForConfiguration(dp));
                 updateConfiguration(config);
             } else if (!HomematicTypeGeneratorImpl.isIgnoredDatapoint(dp)) {
                 // update channel
@@ -418,6 +417,37 @@ public class HomematicThingHandler extends BaseThingHandler {
         } catch (Exception ex) {
             logger.error("{}", ex.getMessage(), ex);
         }
+    }
+
+    private Object getValueForConfiguration(HmDatapoint dp) {
+        if (dp.getValue() == null) {
+            return null;
+        }
+        if (dp.isEnumType()) {
+            return dp.getOptionValue();
+        }
+        if (dp.isNumberType()) {
+            // For number datapoints that are only used depending on the value of other datapoints,
+            // the CCU may return invalid (out of range) values if the datapoint currently is not in use.
+            // Make sure to not invalidate the whole configuration by returning the datapoint's default
+            // value in that case.
+            final boolean minValid, maxValid;
+            if (dp.isFloatType()) {
+                Double numValue = dp.getDoubleValue();
+                minValid = dp.getMinValue() == null || numValue >= dp.getMaxValue().doubleValue();
+                maxValid = dp.getMinValue() == null || numValue <= dp.getMinValue().doubleValue();
+            } else {
+                Integer numValue = dp.getIntegerValue();
+                minValid = dp.getMinValue() == null || numValue >= dp.getMaxValue().intValue();
+                maxValid = dp.getMinValue() == null || numValue <= dp.getMinValue().intValue();
+            }
+            if (minValid && maxValid) {
+                return dp.getValue();
+            }
+            logger.warn("Value for datapoint {} is outside of valid range, using default value for config.", dp);
+            return dp.getDefaultValue();
+        }
+        return dp.getValue();
     }
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
@@ -150,17 +150,32 @@ public class HmDatapoint implements Cloneable {
      */
     public String getOptionValue() {
         if (options != null && value != null) {
-            int idx = 0;
-            if (value instanceof Integer) {
-                idx = (int) value;
-            } else {
-                idx = Integer.parseInt(value.toString());
-            }
+            int idx = getIntegerValue();
             if (idx < options.length) {
                 return options[idx];
             }
         }
         return null;
+    }
+
+    public Integer getIntegerValue() {
+        if (value instanceof Integer) {
+            return (int) value;
+        } else if (value != null) {
+            return Integer.parseInt(value.toString());
+        } else {
+            return null;
+        }
+    }
+
+    public Double getDoubleValue() {
+        if (value instanceof Double) {
+            return (double) value;
+        } else if (value != null) {
+            return Double.parseDouble(value.toString());
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/model/HmDatapoint.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.homematic.internal.model;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.homematic.internal.misc.MiscUtils;
 
 /**
@@ -148,17 +149,15 @@ public class HmDatapoint implements Cloneable {
     /**
      * Returns the value of a option list.
      */
-    public String getOptionValue() {
-        if (options != null && value != null) {
-            int idx = getIntegerValue();
-            if (idx < options.length) {
-                return options[idx];
-            }
+    public @Nullable String getOptionValue() {
+        Integer idx = getIntegerValue();
+        if (options != null && idx != null && idx < options.length) {
+            return options[idx];
         }
         return null;
     }
 
-    public Integer getIntegerValue() {
+    public @Nullable Integer getIntegerValue() {
         if (value instanceof Integer) {
             return (int) value;
         } else if (value != null) {
@@ -168,7 +167,7 @@ public class HmDatapoint implements Cloneable {
         }
     }
 
-    public Double getDoubleValue() {
+    public @Nullable Double getDoubleValue() {
         if (value instanceof Double) {
             return (double) value;
         } else if (value != null) {


### PR DESCRIPTION
HM config datapoint values on some devices can be out of their valid
range in some cases, particularly if they are unused by the device
currently. Since openhab-core now validates attempts to update
configuration by the thing handlers, make sure we always send a valid
configuration even for those affected datapoints.

One example for such behaviour is HmIPW-DRBL4, which has multiple datapoints which depend on each other:
- POWERUP_JUMPTARGET can have values OFF, ON, OFF_DELAY, ON_DELAY
- POWERUP_ONDELAY_VALUE, POWERUP_ONDELAY_UNIT are only used if POWERUP_JUMPTARGET has value ON_DELAY
- likewise, POWERUP_OFFDELAY_VALUE and POWERUP_OFFDELAY_UNIT are only used if POWERUP_JUMPTARGET has value OFF_DELAY
- if e.g. the POWERUP_JUMPTARGET is OFF, e.g. POWERUP_ONDELAY_VALUE might stay uninitialized by CCU and/or device itself, in which case it may be reported with an invalid value

Fixes the issue reported [here](https://github.com/openhab/openhab-addons/pull/12192#issuecomment-1080436944)