### PR TITLE
[marytts] Fix incorrect WAV header for some voices

### DIFF
--- a/bundles/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
+++ b/bundles/org.openhab.voice.marytts/src/main/java/org/openhab/voice/marytts/internal/MaryTTSAudioStream.java
@@ -57,8 +57,8 @@ class MaryTTSAudioStream extends FixedLengthAudioStream {
         // The length of an AudioInputStream is expressed in sample frames, not bytes so readAllBytes() cannot be used.
         rawAudio = inputStreamToBytes(inputStream);
         this.length = rawAudio.length + 36;
-        this.inputStream = new SequenceInputStream(getWavHeaderInputStream(length), new ByteArrayInputStream(rawAudio));
         this.audioFormat = audioFormat;
+        this.inputStream = new SequenceInputStream(getWavHeaderInputStream(length), new ByteArrayInputStream(rawAudio));
     }
 
     private byte[] inputStreamToBytes(InputStream inputStream) throws IOException {


### PR DESCRIPTION
With this fix, MaryTTS creates the correct wav header for the audio inputstream (audioformat is now assigned before we use it in the method 'getWavHeaderInputStream')

This bug was detected [in a community post](https://community.openhab.org/t/pulseaudio-as-sink-is-playing-back-way-to-fast/129349/6), and the sound was playing too fast.

I made [a snapshot release](https://github.com/dalgwen/openhab-addons/releases/tag/3.3.0_SNAPSHOT-marytts_wav_header).