### PR TITLE
[openthermgateway] Log warning if trying to create a legacy Thing type

### DIFF
--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayBindingConstants.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayBindingConstants.java
@@ -35,9 +35,10 @@ public class OpenThermGatewayBindingConstants {
     public static final ThingTypeUID BOILER_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "boiler");
     public static final ThingTypeUID VENTILATION_HEATRECOVERY_THING_TYPE_UID = new ThingTypeUID(BINDING_ID,
             "ventilationheatrecovery");
+    public static final ThingTypeUID LEGACY_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "otgw");
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPE_UIDS = Set.of(OPENTHERM_GATEWAY_THING_TYPE_UID,
-            BOILER_THING_TYPE_UID, VENTILATION_HEATRECOVERY_THING_TYPE_UID);
+            BOILER_THING_TYPE_UID, VENTILATION_HEATRECOVERY_THING_TYPE_UID, LEGACY_THING_TYPE_UID);
 
     // List of id's for writeable channels
     public static final String CHANNEL_SEND_COMMAND = "sendcommand";

--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayHandlerFactory.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayHandlerFactory.java
@@ -24,6 +24,8 @@ import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link OpenThermGatewayHandlerFactory} is responsible for creating things and thing
@@ -34,6 +36,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.openthermgateway")
 @NonNullByDefault
 public class OpenThermGatewayHandlerFactory extends BaseThingHandlerFactory {
+    private final Logger logger = LoggerFactory.getLogger(OpenThermGatewayHandlerFactory.class);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -50,6 +53,10 @@ public class OpenThermGatewayHandlerFactory extends BaseThingHandlerFactory {
             return new BoilerHandler(thing);
         } else if (thingTypeUID.equals(OpenThermGatewayBindingConstants.VENTILATION_HEATRECOVERY_THING_TYPE_UID)) {
             return new VentilationHeatRecoveryHandler(thing);
+        } else if (thingTypeUID.equals(OpenThermGatewayBindingConstants.LEGACY_THING_TYPE_UID)) {
+            logger.warn(
+                    "Thing type {} is no longer supported by the OpenThermGateway binding. You need to create new Things according to the documentation.",
+                    thingTypeUID);
         }
 
         return null;


### PR DESCRIPTION
The binding now outputs a warning message in the log if trying to create a legacy `otgw` Thing type.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
