### PR TITLE
[epsonprojector] Fix discovery service to prevent erroneous inbox items

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
@@ -12,6 +12,11 @@
  */
 package org.openhab.binding.epsonprojector.internal.discovery;
 
+import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.DEFAULT_PORT;
+import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.THING_PROPERTY_HOST;
+import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.THING_PROPERTY_MAC;
+import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.THING_PROPERTY_PORT;
+
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
@@ -20,8 +25,11 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,10 +45,6 @@ public class MulticastListener {
     private final Logger logger = LoggerFactory.getLogger(MulticastListener.class);
 
     private MulticastSocket socket;
-
-    // Epson-specific properties defined in this binding
-    private String uid = "";
-    private String ipAddress = "";
 
     // Epson projector devices announce themselves on a multicast port
     private static final String EPSON_MULTICAST_GROUP = "239.255.250.250";
@@ -70,10 +74,10 @@ public class MulticastListener {
     }
 
     /*
-     * Wait on the multicast socket for an announcement beacon. Return false on socket timeout or error.
-     * Otherwise, parse the beacon for information about the device.
+     * Wait on the multicast socket for an announcement beacon. Return null on socket timeout or error.
+     * Otherwise, parse the beacon for information about the device and return the device properties.
      */
-    public boolean waitForBeacon() throws IOException {
+    public @Nullable Map<String, Object> waitForBeacon() throws IOException {
         byte[] bytes = new byte[600];
         boolean beaconFound;
 
@@ -90,11 +94,11 @@ public class MulticastListener {
         }
 
         if (beaconFound) {
-            // Get the device properties from the announcement beacon
-            parseAnnouncementBeacon(msgPacket);
+            // Return the device properties from the announcement beacon
+            return parseAnnouncementBeacon(msgPacket);
         }
 
-        return beaconFound;
+        return null;
     }
 
     /*
@@ -103,47 +107,26 @@ public class MulticastListener {
      * Example Epson beacon:
      * AMXB<-UUID=000048746B33><-SDKClass=VideoProjector><-GUID=EPSON_EMP001><-Revision=1.0.0>
      */
-    private void parseAnnouncementBeacon(DatagramPacket packet) {
+    private @Nullable Map<String, Object> parseAnnouncementBeacon(DatagramPacket packet) {
         String beacon = (new String(packet.getData(), StandardCharsets.UTF_8)).trim();
-
         logger.trace("Multicast listener parsing announcement packet: {}", beacon);
 
-        clearProperties();
+        if (beacon.contains("EPSON") && beacon.contains("VideoProjector")) {
+            String[] parameterList = beacon.replace(">", "").split("<-");
 
-        if (beacon.toUpperCase().contains("EPSON") && beacon.toUpperCase().contains("VIDEOPROJECTOR")) {
-            ipAddress = packet.getAddress().getHostAddress();
-            parseEpsonAnnouncementBeacon(beacon);
-        } else {
+            for (String parameter : parameterList) {
+                String[] keyValue = parameter.split("=");
+
+                if (keyValue.length == 2 && keyValue[0].contains("UUID") && !"".equals(keyValue[1])) {
+                    Map<String, Object> properties = new HashMap<>();
+                    properties.put(THING_PROPERTY_MAC, keyValue[1]);
+                    properties.put(THING_PROPERTY_HOST, packet.getAddress().getHostAddress());
+                    properties.put(THING_PROPERTY_PORT, DEFAULT_PORT);
+                    return properties;
+                }
+            }
             logger.debug("Multicast listener doesn't know how to parse beacon: {}", beacon);
         }
-    }
-
-    private void parseEpsonAnnouncementBeacon(String beacon) {
-        String[] parameterList = beacon.split("<-");
-
-        for (String parameter : parameterList) {
-            String[] keyValue = parameter.split("=");
-
-            if (keyValue.length != 2) {
-                continue;
-            }
-
-            if (keyValue[0].contains("UUID")) {
-                uid = keyValue[1].substring(0, keyValue[1].length() - 1);
-            }
-        }
-    }
-
-    private void clearProperties() {
-        uid = "";
-        ipAddress = "";
-    }
-
-    public String getUID() {
-        return uid;
-    }
-
-    public String getIPAddress() {
-        return ipAddress;
+        return null;
     }
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
@@ -26,6 +26,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -111,7 +112,7 @@ public class MulticastListener {
         String beacon = (new String(packet.getData(), StandardCharsets.UTF_8)).trim();
         logger.trace("Multicast listener parsing announcement packet: {}", beacon);
 
-        if (beacon.contains("EPSON") && beacon.contains("VideoProjector")) {
+        if (beacon.toUpperCase(Locale.ENGLISH).contains("EPSON") && beacon.contains("VideoProjector")) {
             String[] parameterList = beacon.replace(">", "").split("<-");
 
             for (String parameter : parameterList) {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
@@ -118,7 +118,7 @@ public class MulticastListener {
             for (String parameter : parameterList) {
                 String[] keyValue = parameter.split("=");
 
-                if (keyValue.length == 2 && keyValue[0].contains("UUID") && !"".equals(keyValue[1])) {
+                if (keyValue.length == 2 && keyValue[0].contains("UUID") && !keyValue[1].isEmpty()) {
                     Map<String, Object> properties = new HashMap<>();
                     properties.put(THING_PROPERTY_MAC, keyValue[1]);
                     properties.put(THING_PROPERTY_HOST, packet.getAddress().getHostAddress());


### PR DESCRIPTION
Fix an issue with the Epson binding creating erroneous inbox items when AMX discovery beacon packets from other devices (GlobalCache, etc) are received. The code was improved to ignore non Epson discovery beacon packets and will handle multiple Epson projectors on the network properly (thread safe).

First discovered in this post: https://community.openhab.org/t/is-the-epson-projector-binding-abandoned/107769/82