### PR TITLE
[icloud] Fix ONLINE state when device response status is 203

### DIFF
--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudDeviceHandler.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudDeviceHandler.java
@@ -67,7 +67,7 @@ public class ICloudDeviceHandler extends BaseThingHandler implements ICloudDevic
     public void deviceInformationUpdate(List<ICloudDeviceInformation> deviceInformationList) {
         ICloudDeviceInformation deviceInformationRecord = getDeviceInformationRecord(deviceInformationList);
         if (deviceInformationRecord != null) {
-            if (deviceInformationRecord.getDeviceStatus() == 200) {
+            if (deviceInformationRecord.getDeviceStatus() == 200 || deviceInformationRecord.getDeviceStatus() == 203) {
                 updateStatus(ONLINE);
             } else {
                 updateStatus(OFFLINE, COMMUNICATION_ERROR, "Reported offline by iCloud webservice");


### PR DESCRIPTION
This minor patch fixes an issue when the device response status code is 203.

This seems to work, but I don't know if this is enough/acceptable. Devices reports 203 status sometimes when they are online, sometimes when they are offline. However there seems to be another status code (201) for offline devices.

I couldn't find any info online what these status codes mean, nor any other reported value which can indicate the real status of an iCloud device.

Closes #12501