### PR TITLE
[http] Support all 2xx response codes

### DIFF
--- a/bundles/org.openhab.binding.http/src/test/java/org/openhab/binding/http/internal/http/HttpResponseListenerTest.java
+++ b/bundles/org.openhab.binding.http/src/test/java/org/openhab/binding/http/internal/http/HttpResponseListenerTest.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.http.internal.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link HttpResponseListenerTest}.
+ *
+ * @author Corubba Smith - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+public class HttpResponseListenerTest {
+
+    private Request request = mock(Request.class);
+    private Response response = mock(Response.class);
+
+    // ******** Common methods ******** //
+
+    /**
+     * Run the given listener with the given result.
+     */
+    private void run(HttpResponseListener listener, Result result) {
+        listener.onComplete(result);
+    }
+
+    /**
+     * Return a default Result using the request- and response-mocks and no failure.
+     */
+    private Result createResult() {
+        return new Result(request, response);
+    }
+
+    /**
+     * Run the given listener with a default result.
+     */
+    private void run(HttpResponseListener listener) {
+        run(listener, createResult());
+    }
+
+    /**
+     * Set the given payload as body of the response in the buffer of the given listener.
+     */
+    private void setPayload(HttpResponseListener listener, byte[] payload) {
+        listener.onContent(null, ByteBuffer.wrap(payload));
+    }
+
+    /**
+     * Run a default listener with the given result and the given payload.
+     */
+    private CompletableFuture<@Nullable Content> run(Result result, byte @Nullable [] payload) {
+        CompletableFuture<@Nullable Content> future = new CompletableFuture<>();
+        HttpResponseListener listener = new HttpResponseListener(future, null, 1024 * 1024);
+        if (null != payload) {
+            setPayload(listener, payload);
+        }
+        run(listener, result);
+        return future;
+    }
+
+    /**
+     * Run a default listener with the given result.
+     */
+    private CompletableFuture<@Nullable Content> run(Result result) {
+        return run(result, null);
+    }
+
+    /**
+     * Run a default listener with a default result and the given payload.
+     */
+    private CompletableFuture<@Nullable Content> run(byte @Nullable [] payload) {
+        return run(createResult(), payload);
+    }
+
+    /**
+     * Run a default listener with a default result.
+     */
+    private CompletableFuture<@Nullable Content> run() {
+        return run(createResult());
+    }
+
+    @BeforeEach
+    void init() {
+        // required for the request trace
+        when(response.getHeaders()).thenReturn(new HttpFields());
+    }
+
+    // ******** Tests ******** //
+
+    /**
+     * When a exception is thrown during the request phase, the future completes unexceptionally
+     * with no value.
+     */
+    @Test
+    public void requestException() {
+        RuntimeException requestFailure = new RuntimeException("The request failed!");
+        Result result = new Result(request, requestFailure, response);
+
+        CompletableFuture<@Nullable Content> future = run(result);
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+        assertNull(future.join());
+    }
+
+    /**
+     * When a exception is thrown during the response phase, the future completes unexceptionally
+     * with no value.
+     */
+    @Test
+    public void responseException() {
+        RuntimeException responseFailure = new RuntimeException("The response failed!");
+        Result result = new Result(request, response, responseFailure);
+
+        CompletableFuture<@Nullable Content> future = run(result);
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+        assertNull(future.join());
+    }
+
+    /**
+     * When the remote side does not send any payload, the future completes normally and contains a
+     * empty Content.
+     */
+    @Test
+    public void okWithNoBody() {
+        when(response.getStatus()).thenReturn(HttpStatus.OK_200);
+
+        CompletableFuture<@Nullable Content> future = run();
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+
+        Content content = future.join();
+        assertNotNull(content);
+        assertNotNull(content.getRawContent());
+        assertEquals(0, content.getRawContent().length);
+        assertNull(content.getMediaType());
+    }
+
+    /**
+     * When the remote side sends a payload, the future completes normally and contains a Content
+     * object with the payload.
+     */
+    @Test
+    public void okWithBody() {
+        when(response.getStatus()).thenReturn(HttpStatus.OK_200);
+
+        final String textPayload = "foobar";
+        CompletableFuture<@Nullable Content> future = run(textPayload.getBytes());
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+
+        Content content = future.join();
+        assertNotNull(content);
+        assertNotNull(content.getRawContent());
+        assertEquals(textPayload, new String(content.getRawContent()));
+        assertNull(content.getMediaType());
+    }
+
+    /**
+     * When the remote side sends a payload and encoding header, the future completes normally
+     * and contains a Content object with the payload. The payload gets decoded using the encoding
+     * the remote sent.
+     */
+    @Test
+    public void okWithEncodedBody() throws UnsupportedEncodingException {
+        final String encodingName = "UTF-16LE";
+        final String fallbackEncodingName = "UTF-8";
+
+        CompletableFuture<@Nullable Content> future = new CompletableFuture<>();
+        HttpResponseListener listener = new HttpResponseListener(future, fallbackEncodingName, 1024 * 1024);
+
+        response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; charset=" + encodingName);
+        when(response.getRequest()).thenReturn(request);
+        listener.onHeaders(response);
+
+        final String textPayload = "漢字編碼方法";
+        setPayload(listener, textPayload.getBytes(encodingName));
+
+        when(response.getStatus()).thenReturn(HttpStatus.OK_200);
+        run(listener);
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+
+        Content content = future.join();
+        assertNotNull(content);
+        assertNotNull(content.getRawContent());
+        assertEquals(textPayload, new String(content.getRawContent(), encodingName));
+        assertEquals(textPayload, content.getAsString());
+        assertEquals("text/plain", content.getMediaType());
+    }
+
+    /**
+     * When the remote side sends a payload but no encoding, the future completes normally and
+     * contains a Content object with the payload. The payload gets decoded using the fallback
+     * encoding of the listener.
+     */
+    @Test
+    public void okWithEncodedBodyFallback() throws UnsupportedEncodingException {
+        final String encodingName = "UTF-16BE";
+
+        CompletableFuture<@Nullable Content> future = new CompletableFuture<>();
+        HttpResponseListener listener = new HttpResponseListener(future, encodingName, 1024 * 1024);
+
+        final String textPayload = "汉字编码方法";
+        setPayload(listener, textPayload.getBytes(encodingName));
+
+        when(response.getStatus()).thenReturn(HttpStatus.OK_200);
+        run(listener);
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCompletedExceptionally());
+
+        Content content = future.join();
+        assertNotNull(content);
+        assertNotNull(content.getRawContent());
+        assertEquals(textPayload, new String(content.getRawContent(), encodingName));
+        assertEquals(textPayload, content.getAsString());
+        assertNull(content.getMediaType());
+    }
+
+    /**
+     * When the remote side response with a HTTP/204 and no payload, the future completes normally
+     * and contains a empty Content.
+     * At least that is what should happen, right now the future finishes exceptionally.
+     */
+    @Test
+    public void nocontent() {
+        when(response.getStatus()).thenReturn(HttpStatus.NO_CONTENT_204);
+
+        CompletableFuture<@Nullable Content> future = run();
+
+        assertTrue(future.isDone());
+        assertTrue(future.isCompletedExceptionally());
+
+        CompletionException exceptionWrapper = assertThrows(CompletionException.class, () -> future.join());
+        assertNotNull(exceptionWrapper);
+
+        Throwable exception = exceptionWrapper.getCause();
+        assertNotNull(exception);
+        assertTrue(exception instanceof IllegalStateException);
+        assertEquals("Response - Code204", exception.getMessage());
+    }
+
+    /**
+     * When the remote side response with a HTTP/401, the future completes exceptionally with a
+     * HttpAuthException.
+     */
+    @Test
+    public void unauthorized() {
+        when(response.getStatus()).thenReturn(HttpStatus.UNAUTHORIZED_401);
+
+        CompletableFuture<@Nullable Content> future = run();
+
+        assertTrue(future.isDone());
+        assertTrue(future.isCompletedExceptionally());
+
+        @Nullable
+        CompletionException exceptionWrapper = assertThrows(CompletionException.class, () -> future.join());
+        assertNotNull(exceptionWrapper);
+
+        Throwable exception = exceptionWrapper.getCause();
+        assertNotNull(exception);
+        assertTrue(exception instanceof HttpAuthException);
+    }
+
+    /**
+     * When the remote side responds with anything we don't expect (in this case a HTTP/500), the
+     * future completes exceptionally with a IllegalStateException.
+     */
+    @Test
+    public void unexpectedStatus() {
+        when(response.getStatus()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR_500);
+
+        CompletableFuture<@Nullable Content> future = run();
+
+        assertTrue(future.isDone());
+        assertTrue(future.isCompletedExceptionally());
+
+        @Nullable
+        CompletionException exceptionWrapper = assertThrows(CompletionException.class, () -> future.join());
+        assertNotNull(exceptionWrapper);
+
+        Throwable exception = exceptionWrapper.getCause();
+        assertNotNull(exception);
+        assertTrue(exception instanceof IllegalStateException);
+        assertEquals("Response - Code500", exception.getMessage());
+    }
+}

--- a/bundles/org.openhab.binding.http/src/test/java/org/openhab/binding/http/internal/http/HttpResponseListenerTest.java
+++ b/bundles/org.openhab.binding.http/src/test/java/org/openhab/binding/http/internal/http/HttpResponseListenerTest.java
@@ -256,7 +256,6 @@ public class HttpResponseListenerTest {
     /**
      * When the remote side response with a HTTP/204 and no payload, the future completes normally
      * and contains a empty Content.
-     * At least that is what should happen, right now the future finishes exceptionally.
      */
     @Test
     public void nocontent() {
@@ -265,15 +264,13 @@ public class HttpResponseListenerTest {
         CompletableFuture<@Nullable Content> future = run();
 
         assertTrue(future.isDone());
-        assertTrue(future.isCompletedExceptionally());
+        assertFalse(future.isCompletedExceptionally());
 
-        CompletionException exceptionWrapper = assertThrows(CompletionException.class, () -> future.join());
-        assertNotNull(exceptionWrapper);
-
-        Throwable exception = exceptionWrapper.getCause();
-        assertNotNull(exception);
-        assertTrue(exception instanceof IllegalStateException);
-        assertEquals("Response - Code204", exception.getMessage());
+        Content content = future.join();
+        assertNotNull(content);
+        assertNotNull(content.getRawContent());
+        assertEquals(0, content.getRawContent().length);
+        assertNull(content.getMediaType());
     }
 
     /**

--- a/bundles/org.openhab.binding.http/src/test/resources/simplelogger.properties
+++ b/bundles/org.openhab.binding.http/src/test/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+# to run through all code-branches
+org.slf4j.simpleLogger.log.org.openhab.binding.http=trace


### PR DESCRIPTION
Until now, the http binding did only regard the `HTTP/200 OK` response code as successful, all the other 2xx codes were treated as failed. This behaviour made it impossible to work with non-trivial REST APIs that may return "HTTP/201 Created" or "HTTP/204 No Content".

I thought about simply extending the switch-case with all to other 2xx constant from `HttpStatus`, but that felt cumbersome. I am not really happy that the switch now only has one case and a default left, but I kept it this way (instead of dissolving it into the outer `if-elseif-else`) to keep the possibility for future special-handling of specific return codes.

I also removed that content null check, because `getContent()` never returns null; it always returns a byte-array (which may has the length 0).

Fixes #11369