### PR TITLE
[tesla] Remove synchronization to avoid deadlocks

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
@@ -711,7 +711,7 @@ public class TeslaVehicleHandler extends BaseThingHandler {
         sendCommand(COMMAND_WAKE_UP, account.wakeUpTarget);
     }
 
-    protected synchronized Vehicle queryVehicle() {
+    protected Vehicle queryVehicle() {
         String authHeader = account.getAuthHeader();
 
         if (authHeader != null) {


### PR DESCRIPTION
I just experienced a deadlock situation due to this synchronization here.
The `BaseThingHandler` does a synchronize on `this` within `updateState()` - this means that handler implementations must not do the same, if they also use other kinds of locks. 

Since the method in question is only called at a define interval from a job within the binding, the synchronization is not necessary at this place. Therefore removing it should fix the deadlock situations.

Signed-off-by: Kai Kreuzer <kai@openhab.org>