### PR TITLE
[upnpcontrol] Fix null pointer exception for invalid protocolInfo

### DIFF
--- a/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/queue/UpnpEntryRes.java
+++ b/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/queue/UpnpEntryRes.java
@@ -28,9 +28,12 @@ public class UpnpEntryRes {
     private String importUri;
     private String res = "";
 
-    public UpnpEntryRes(String protocolInfo, @Nullable Long size, @Nullable String duration,
+    public UpnpEntryRes(@Nullable String protocolInfo, @Nullable Long size, @Nullable String duration,
             @Nullable String importUri) {
-        this.protocolInfo = protocolInfo.trim();
+        // According to the UPnP standard, res should always contain protocolInfo. Some devices do not respect this
+        // standard in their AVTransport implementation. To avoid null pointer exceptions, take care of this special
+        // case.
+        this.protocolInfo = (protocolInfo == null) ? "*" : protocolInfo.trim();
         this.size = size;
         this.duration = (duration == null) ? "" : duration.trim();
         this.importUri = (importUri == null) ? "" : importUri.trim();


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

According to the UPnP standard, res should always contain protocolInfo. Some devices do not respect this standard in their AVTransport implementation. To avoid null pointer exceptions, take care of this special case.