### PR TITLE
Add .gradle to .gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .project
 .DS_Store
+.gradle
 *.iml
 npm-debug.log
 .build.log


### PR DESCRIPTION
This is sometimes added by IntelliJ when importing a project.

Signed-off-by: Jan N. Klug <github@klug.nrw>
