### PR TITLE
Bump commons-io

### DIFF
--- a/bundles/org.openhab.binding.ipp/pom.xml
+++ b/bundles/org.openhab.binding.ipp/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: IPP Binding</name>
 
   <properties>
-    <bnd.importpackage>!org.simpleframework.xml.*,!org.cups4j,!net.sf.ehcache.*,!net.spy.*</bnd.importpackage>
+    <bnd.importpackage>!org.simpleframework.xml.*,!org.cups4j,!net.sf.ehcache.*,!net.spy.*,!sun.nio.ch</bnd.importpackage>
   </properties>
 
   <dependencies>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.logreader/pom.xml
+++ b/bundles/org.openhab.binding.logreader/pom.xml
@@ -14,6 +14,10 @@
 
   <name>openHAB Add-ons :: Bundles :: Log Reader Binding</name>
 
+  <properties>
+    <bnd.importpackage>!sun.nio.ch.*</bnd.importpackage>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -40,7 +44,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.voice.marytts/pom.xml
+++ b/bundles/org.openhab.voice.marytts/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: Voice :: Mary Text-to-Speech</name>
 
   <properties>
-    <bnd.importpackage>com.twmacinta.util;resolution:=optional,gnu.trove;resolution:=optional,Jampack;resolution:=optional,net.didion.jwnl*;resolution:=optional,org.apache.http*;resolution:=optional,org.apache.xerces.impl*;resolution:=optional,org.hsqldb;resolution:=optional,org.jdesktop.layout*;resolution:=optional</bnd.importpackage>
+    <bnd.importpackage>com.twmacinta.util;resolution:=optional,gnu.trove;resolution:=optional,Jampack;resolution:=optional,net.didion.jwnl*;resolution:=optional,org.apache.http*;resolution:=optional,org.apache.xerces.impl*;resolution:=optional,org.hsqldb;resolution:=optional,org.jdesktop.layout*;resolution:=optional;sun.nio.ch.*</bnd.importpackage>
   </properties>
 
   <dependencies>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This brings commons-io in-line with version in core.

Exclusion of `sun.nio.ch.*` is safe because it is only needed for classes available since 2.9.0 (which is above the version used before)

Signed-off-by: Jan N. Klug <github@klug.nrw>
