### PR TITLE
[orbitbhyve] do not update status of a disabled sprinker

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
@@ -308,11 +308,13 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
     private void updateAllStatuses() {
         List<OrbitBhyveDevice> devices = getDevices();
         for (Thing th : getThing().getThings()) {
-            String deviceId = th.getUID().getId();
-            OrbitBhyveSprinklerHandler handler = (OrbitBhyveSprinklerHandler) th.getHandler();
-            for (OrbitBhyveDevice device : devices) {
-                if (deviceId.equals(th.getUID().getId())) {
-                    updateDeviceStatus(device, handler);
+            if (th.isEnabled()) {
+                String deviceId = th.getUID().getId();
+                OrbitBhyveSprinklerHandler handler = (OrbitBhyveSprinklerHandler) th.getHandler();
+                for (OrbitBhyveDevice device : devices) {
+                    if (deviceId.equals(th.getUID().getId())) {
+                        updateDeviceStatus(device, handler);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a rare bug when the bridge sets the sprinkler's status to ONLINE/OFFLINE even if the sprinkler is disabled.

Signed-off-by: Ondrej Pecta <opecta@gmail.com>
