### PR TITLE
[goecharger] fix issue with category

### DIFF
--- a/bundles/org.openhab.binding.goecharger/README.md
+++ b/bundles/org.openhab.binding.goecharger/README.md
@@ -106,6 +106,7 @@ end
 ```
 
 Advanced example:
+
 ```
 rule "Set charging limit for go-eCharger"
 when

--- a/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
@@ -211,7 +211,7 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature circuit board</label>
 		<description>Temperature of the Go-eCharger on circuit board</description>
-		<category>Temperature</category>		
+		<category>Temperature</category>
 		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="fmw">

--- a/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
@@ -205,14 +205,12 @@
 		<label>Temperature type 2 port</label>
 		<description>Temperature of the Go-eCharger on the type 2 port</description>
 		<state pattern="%d %unit%" readOnly="true"/>
-		<category>Temperature</category>
 	</channel-type>
 	<channel-type id="tmp">
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature circuit board</label>
 		<description>Temperature of the Go-eCharger on circuit board</description>
 		<state pattern="%d %unit%" readOnly="true"/>
-		<category>Temperature</category>
 	</channel-type>
 	<channel-type id="fmw">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
@@ -204,12 +204,14 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature type 2 port</label>
 		<description>Temperature of the Go-eCharger on the type 2 port</description>
+		<category>Temperature</category>
 		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="tmp">
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature circuit board</label>
 		<description>Temperature of the Go-eCharger on circuit board</description>
+		<category>Temperature</category>		
 		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="fmw">


### PR DESCRIPTION
category before state in thing-types.xml (Fixes #12661)
remove warning within readme.md

Signed-off-by: Reinhard Plaim <reinhardplaim@gmail.com>