### PR TITLE
[openweathermap] Update README.md

### DIFF
--- a/bundles/org.openhab.binding.openweathermap/README.md
+++ b/bundles/org.openhab.binding.openweathermap/README.md
@@ -1,9 +1,3 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # OpenWeatherMap Binding
 
 This binding integrates the [OpenWeatherMap weather API](https://openweathermap.org/api).


### PR DESCRIPTION
Removed first section from README.
These are not rendered in the online documentation and make the inline documention (More...) of the binding inside OH error out and show the raw text.

Signed-off-by: Mark Herwege [mark.herwege@telenet.be](mailto:mark.herwege@telenet.be)
