### PR TITLE
Update KNX code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -151,7 +151,7 @@
 /bundles/org.openhab.binding.kaleidescape/ @mlobstein
 /bundles/org.openhab.binding.keba/ @kgoderis
 /bundles/org.openhab.binding.km200/ @Markinus
-/bundles/org.openhab.binding.knx/ @sjka
+/bundles/org.openhab.binding.knx/ @kaikreuzer
 /bundles/org.openhab.binding.kodi/ @pail23 @cweitkamp
 /bundles/org.openhab.binding.konnected/ @volfan6415
 /bundles/org.openhab.binding.kostalinverter/ @cschneider


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>