### PR TITLE
[elroconnects] Correct error for long thing names

### DIFF
--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/util/ElroConnectsUtil.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/util/ElroConnectsUtil.java
@@ -46,8 +46,10 @@ public final class ElroConnectsUtil {
      */
     public static String encode(String input, int length) {
         byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
-        String content = "@".repeat(length - bytes.length) + new String(bytes, StandardCharsets.UTF_8) + "$";
-        bytes = content.getBytes(StandardCharsets.UTF_8);
+        String content = "@".repeat((length > bytes.length) ? (length - bytes.length) : 0)
+                + new String(bytes, StandardCharsets.UTF_8);
+        bytes = Arrays.copyOf(content.getBytes(StandardCharsets.UTF_8), length);
+        bytes[length] = (byte) "$".charAt(0);
         return HexUtils.bytesToHex(bytes);
     }
 


### PR DESCRIPTION
Thing names longer than 15 characters caused a index out of bound exception when syncing the name with the name in the elro system.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>
