### PR TITLE
[nest] Fix for missing refresh token after reauthorization

### DIFF
--- a/bundles/org.openhab.binding.nest/README.md
+++ b/bundles/org.openhab.binding.nest/README.md
@@ -89,11 +89,11 @@ Finally, an SDM Account Thing can be created to access the SDM project using the
 1. Create an authorization code for the binding:
     1. Replace the **Project ID** and **Client ID** in the URL below with your SDM Project ID and SDM OAuth 2.0 Client ID and open the URL in a new browser tab:
        
-       `https://nestservices.google.com/partnerconnections/<ProjectID>/auth?scope=https://www.googleapis.com/auth/sdm.service&access_type=offline&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<ClientID>`
+       `https://nestservices.google.com/partnerconnections/<ProjectID>/auth?scope=https://www.googleapis.com/auth/sdm.service&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<ClientID>`
        
        For the example values used so far this is:
        
-       `https://nestservices.google.com/partnerconnections/585de72e-968c-435c-b16a-31d1d3f76833/auth?scope=https://www.googleapis.com/auth/sdm.service&access_type=offline&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=1046297811237-3f5sj4ccfubit0fum027ral82jgffsd1.apps.googleusercontent.com`
+       `https://nestservices.google.com/partnerconnections/585de72e-968c-435c-b16a-31d1d3f76833/auth?scope=https://www.googleapis.com/auth/sdm.service&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=1046297811237-3f5sj4ccfubit0fum027ral82jgffsd1.apps.googleusercontent.com`
     1. Enable all the permissions you want to use with the binding and click "Next" to continue
     1. Login using your Google account when prompted
     1. On the "Google hasn't verified this app" page, click on "Advanced"
@@ -153,11 +153,11 @@ Finally, the existing SDM Account Thing can be updated so it can subscribe to SD
 1. Create an authorization code for the binding:
     1. Replace the **Client ID** in the URL below with your Pub/Sub OAuth 2.0 Client ID and open the URL in a new browser tab:
        
-       `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/pubsub&access_type=offline&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<ClientID>`
+       `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/pubsub&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<ClientID>`
        
        For the example client this is:
        
-       `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/pubsub&access_type=offline&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=1046297811237-lg27h26kln6r1nbg54jpg6nfjg6h4b3n.apps.googleusercontent.com`
+       `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/pubsub&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=1046297811237-lg27h26kln6r1nbg54jpg6nfjg6h4b3n.apps.googleusercontent.com`
     1. Login using your Google account when prompted
     1. On the "Google hasn't verified this app" page, click on "Advanced"
     1. Then click on "Go to ... (advanced)"

--- a/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/sdm/api/SDMAPI.java
+++ b/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/sdm/api/SDMAPI.java
@@ -136,6 +136,10 @@ public class SDMAPI {
             if (response == null || response.getAccessToken() == null || response.getAccessToken().isEmpty()) {
                 throw new InvalidSDMAccessTokenException("No SDM access token. Client may not have been authorized.");
             }
+            if (response.getRefreshToken() == null || response.getRefreshToken().isEmpty()) {
+                throw new InvalidSDMAccessTokenException(
+                        "No SDM refresh token. Delete and readd credentials, then reauthorize.");
+            }
             return BEARER + response.getAccessToken();
         } catch (OAuthException | OAuthResponseException e) {
             throw new InvalidSDMAccessTokenException(


### PR DESCRIPTION
By default, the Google OAuth API returns the refresh token only on the first authorization. On subsequent authorizations using the same Client ID and Secret, Google does not return the refresh token in the access token response. This causes the binding to fail on the first refresh of the access token after a reauthorization.

This affects the SDM and Pub/Sub APIs. However, the failure is more spectacular with the Pub/Sub API as it causes the binding to repeatedly do a pub/sub request against the Google API every 20-40 msec.

This PR adds a new query parameter (prompt=consent) to the URL used to get the authorization code. This parameter causes Google to always return the refresh token in the authorization response (via `oAuthService.getAccessTokenResponseByAuthorizationCode`).

In addition, this PR adds checks to make sure the refresh token in present in the access token response in order to fail more quickly and gracefully if the refresh token is missing.

Further details of my analysis are here.
https://community.openhab.org/t/nest-binding-throwing-pub-sub-errors-repeatedly/135721

I know @wborn is pretty time-constrained right now, but I'm hopeful he can find a few minutes to review. 😉 

Signed-off-by: Mark Hilbush <mark@hilbush.com>
