### PR TITLE
[lutron] Fix item-type tag value for channel type buttonpress

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1378,7 +1378,7 @@
 	</channel-type>
 
 	<channel-type id="buttonpress">
-		<item-type>Text</item-type>
+		<item-type>String</item-type>
 		<label>Last Button Press</label>
 		<description>Last button pressed</description>
 		<state readOnly="true"/>


### PR DESCRIPTION
Related to #12712

Signed-off-by: Laurent Garnier <lg.hc@free.fr>