### PR TITLE
[miele] Fix logging for appliances where consumption data is not supported

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -114,7 +114,7 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
 
     public void onApplianceExtendedStateChanged(byte[] extendedDeviceState) {
         if (extendedDeviceState.length < EXTENDED_STATE_MIN_SIZE_BYTES) {
-            logger.warn("Unexpected size of extended state: {}", extendedDeviceState);
+            logger.debug("Insufficient extended state data to extract consumption values: {}", extendedDeviceState);
             return;
         }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -116,7 +116,7 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
 
     public void onApplianceExtendedStateChanged(byte[] extendedDeviceState) {
         if (extendedDeviceState.length < EXTENDED_STATE_MIN_SIZE_BYTES) {
-            logger.warn("Unexpected size of extended state: {}", extendedDeviceState);
+            logger.debug("Insufficient extended state data to extract consumption values: {}", extendedDeviceState);
             return;
         }
 


### PR DESCRIPTION
This is another iteration #11417 regarding extended device state.

A wrong assumption about the minimum amount of data being available in **ExtendedDeviceState** has been revealed after receiving data from an older appliance model.

Accordingly, logging has been fixed to more accurately describe this issue and log level has been reduced to **DEBUG**.