### PR TITLE
[goecharger] Fix missing powerAll channel

### DIFF
--- a/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
@@ -22,6 +22,7 @@
 			<channel id="powerL1" typeId="pl1"/>
 			<channel id="powerL2" typeId="pl2"/>
 			<channel id="powerL3" typeId="pl3"/>
+			<channel id="powerAll" typeId="pall"/>
 			<channel id="allowCharging" typeId="alw"/>
 			<channel id="cableCurrent" typeId="cbl"/>
 			<channel id="firmware" typeId="fmw"/>


### PR DESCRIPTION
[bug] Somehow powerAll got lost in the thing-types.xml.
This commit adds it back and fixes issue #12735 

Signed-off-by: Sascha Kloß <sascha.kloss@gmx.de>
