### PR TITLE
[hdpowerview] Add Silhouette Duolite (shade type 38) to capabilities database

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -66,6 +66,7 @@ public class ShadeCapabilitiesDatabase {
             new Type( 9).capabilities(7).text("Duette DuoLite Top Down Bottom Up"),
             new Type(18).capabilities(1).text("Silhouette"),
             new Type(23).capabilities(1).text("Silhouette"),
+            new Type(38).capabilities(9).text("Silhouette Duolite"),
             new Type(42).capabilities(0).text("M25T Roller Blind"),
             new Type(43).capabilities(1).text("Facette"),
             new Type(44).capabilities(0).text("Twist"),


### PR DESCRIPTION
Add type 38 shade to capabilities database

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
