### PR TITLE
[openwebnet] add default translations

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -1,19 +1,262 @@
 # binding
 
 binding.openwebnet.name = OpenWebNet (BTicino/Legrand) Binding
-binding.openwebnet.description = The OpenWebNet binding integrates BTicino (Legrand) MyHOME&reg; BUS and wireless systems using the OpenWebNet protocol.
+binding.openwebnet.description = The OpenWebNet Binding integrates the BTicino/Legrand 'MyHOME' connected home system using the OpenWebNet protocol. It supports BUS (SCS) and ZigBee USB gateways and devices.
+
+# thing types
+
+thing-type.openwebnet.bus_automation.label = Automation
+thing-type.openwebnet.bus_automation.description = A OpenWebNet BUS/SCS automation device to control roller shutters, blinds, etc. BTicino models: xxx/yyyy/etc.
+thing-type.openwebnet.bus_aux.label = Auxiliary
+thing-type.openwebnet.bus_aux.description = A OpenWebNet BUS/SCS Auxiliary command
+thing-type.openwebnet.bus_cen_scenario_control.label = CEN Scenario Control
+thing-type.openwebnet.bus_cen_scenario_control.description = A OpenWebNet BUS/SCS CEN Scenario Control device. BTicino models: HC/HD/HS/L/N/NT4680
+thing-type.openwebnet.bus_cenplus_scenario_control.label = CEN+ Scenario Control
+thing-type.openwebnet.bus_cenplus_scenario_control.description = A OpenWebNet BUS/SCS CEN+ Scenario Control device. BTicino models: HC/HD/HS/L/N/NT4680
+thing-type.openwebnet.bus_dimmer.label = Dimmer
+thing-type.openwebnet.bus_dimmer.description = A OpenWebNet BUS/SCS dimmer for the dimmer control of 1 light. BTicino models: yyyy/zzzz/etc.
+thing-type.openwebnet.bus_dry_contact_ir.label = Dry Contact/IR Interface
+thing-type.openwebnet.bus_dry_contact_ir.description = A OpenWebNet BUS/SCS Dry Contact Interface or IR Interface. BTicino models: 3477/F428, IR 4610-4611-4640 etc.
+thing-type.openwebnet.bus_energy_meter.label = Energy Meter
+thing-type.openwebnet.bus_energy_meter.description = A OpenWebNet BUS/SCS Energy Meter. BTicino models: F52x
+thing-type.openwebnet.bus_gateway.label = BUS Gateway
+thing-type.openwebnet.bus_gateway.description = This thing allows to connect to a IP BUS/SCS gateway that supports the OpenWebNet protocol (models: F454, MyHOMEServer1, F455, MH200N, F453, etc.)
+thing-type.openwebnet.bus_on_off_switch.label = Switch
+thing-type.openwebnet.bus_on_off_switch.description = A OpenWebNet BUS/SCS switch for the control of 1 light/load. BTicino models: xxx/yyyy/etc.
+thing-type.openwebnet.bus_thermo_cu.label = Thermo Central Unit
+thing-type.openwebnet.bus_thermo_cu.description = A OpenWebNet BUS/SCS configured thermo Central Unit.
+thing-type.openwebnet.bus_thermo_sensor.label = Thermo Sensor
+thing-type.openwebnet.bus_thermo_sensor.description = A OpenWebNet BUS/SCS thermo sensor (probe) for measuring temperature in a zone. BTicino models: L/N/NT4577 etc.
+thing-type.openwebnet.bus_thermo_zone.label = Thermo Zone
+thing-type.openwebnet.bus_thermo_zone.description = A OpenWebNet BUS/SCS configured thermo zone (managed via Central Unit or stand alone).
+thing-type.openwebnet.generic_device.label = Generic Device
+thing-type.openwebnet.generic_device.description = An OpenWebNet Generic Device.
+thing-type.openwebnet.zb_automation.label = ZigBee Automation
+thing-type.openwebnet.zb_automation.description = A OpenWebNet ZigBee automation device to control roller shutters, blinds, etc. BTicino models: xxx/yyyy/etc.
+thing-type.openwebnet.zb_dimmer.label = ZigBee Dimmer
+thing-type.openwebnet.zb_dimmer.description = A OpenWebNet ZigBee dimmer for the dimmer control of 1 light. BTicino models: 4585/4594/etc.
+thing-type.openwebnet.zb_gateway.label = ZigBee USB Gateway
+thing-type.openwebnet.zb_gateway.description = This USB gateway (BTicino/Legrand models: BTI-3578/088328) connects to a BTicino/Legrand ZigBee network and uses the OpenWebNet protocol. For more information see: https://catalogo.bticino.it/BTI-3578-IT and https://www.legrand.com/ecatalogue/088328-openweb-net-zigbee-gateway-radio-interface.html
+thing-type.openwebnet.zb_on_off_switch.label = ZigBee Switch
+thing-type.openwebnet.zb_on_off_switch.description = A OpenWebNet ZigBee switch (actuator) for the control of 1 load/light. BTicino models: 4591/3684/etc.
+thing-type.openwebnet.zb_on_off_switch2u.label = ZigBee 2-units Switch
+thing-type.openwebnet.zb_on_off_switch2u.description = A OpenWebNet ZigBee 2-units switch (actuator) for the control of 2 loads/lights. BTicino model: 4592
+
+# thing types config
+
+thing-type.config.openwebnet.bus_automation.shutterRun.label = Shutter Run
+thing-type.config.openwebnet.bus_automation.shutterRun.description = Time (in ms) to go from max position (e.g. CLOSED) to the other position (e.g. OPEN). Example: 12000 (=12sec). Use AUTO (default) to calibrate the shutter automatically (UP->DOWN->Position%) the first time a Position command (%) is sent.
+thing-type.config.openwebnet.bus_automation.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_automation.where.description = Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01
+thing-type.config.openwebnet.bus_aux.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_aux.where.description = Example: Where=1
+thing-type.config.openwebnet.bus_cen_scenario_control.buttons.label = Configured Buttons
+thing-type.config.openwebnet.bus_cen_scenario_control.buttons.description = List (comma separated) of buttons numbers [0-31] configured for this scenario device. Example: buttons=1,2,4
+thing-type.config.openwebnet.bus_cen_scenario_control.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_cen_scenario_control.where.description = Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01
+thing-type.config.openwebnet.bus_cenplus_scenario_control.buttons.label = Configured Buttons
+thing-type.config.openwebnet.bus_cenplus_scenario_control.buttons.description = List (comma separated) of buttons numbers [0-31] configured for this scenario device, example: buttons=1,2,4
+thing-type.config.openwebnet.bus_cenplus_scenario_control.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_cenplus_scenario_control.where.description = Use 2+N[0-2047]. Example: scenario control 5 --> where=25
+thing-type.config.openwebnet.bus_dimmer.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_dimmer.where.description = Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01
+thing-type.config.openwebnet.bus_dry_contact_ir.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_dry_contact_ir.where.description = Automation Dry Contacts (N=1-201): example N=60 --> where=360. Alarm Dry Contacts and IR sensors (Zone=1-9, N=1-9): example Zone=4, N=5 --> where=345
+thing-type.config.openwebnet.bus_energy_meter.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_energy_meter.where.description = Example: 5N with N=[1-255]
+thing-type.config.openwebnet.bus_gateway.discoveryByActivation.label = Discovery By Activation
+thing-type.config.openwebnet.bus_gateway.discoveryByActivation.description = Discover BUS devices when they are activated (also when a device scan is not active) (default: false)
+thing-type.config.openwebnet.bus_gateway.host.label = Host
+thing-type.config.openwebnet.bus_gateway.host.description = OpenWebNet gateway IP address / hostname (example: 192.168.1.35)
+thing-type.config.openwebnet.bus_gateway.passwd.label = Password
+thing-type.config.openwebnet.bus_gateway.passwd.description = OpenWebNet gateway password (default: 12345)
+thing-type.config.openwebnet.bus_gateway.port.label = Port
+thing-type.config.openwebnet.bus_gateway.port.description = OpenWebNet gateway port (default: 20000)
+thing-type.config.openwebnet.bus_on_off_switch.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_on_off_switch.where.description = Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01
+thing-type.config.openwebnet.bus_thermo_cu.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_thermo_cu.where.description = The Central Unit can only assume where=0.
+thing-type.config.openwebnet.bus_thermo_sensor.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_thermo_sensor.where.description = Example: sensor 3 of zone 2 --> where=302. Sensor 5 of external zone 00 --> where=500
+thing-type.config.openwebnet.bus_thermo_zone.standAlone.label = Stand-alone
+thing-type.config.openwebnet.bus_thermo_zone.standAlone.description = Distinguishes between a zone managed by a Central Unit (false) or stand-alone (true, default)
+thing-type.config.openwebnet.bus_thermo_zone.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.bus_thermo_zone.where.description = Example: zone 2 --> where=2.
+thing-type.config.openwebnet.generic_device.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.generic_device.where.description = It identifies one OpenWebNet device
+thing-type.config.openwebnet.zb_automation.shutterRun.label = Shutter Run
+thing-type.config.openwebnet.zb_automation.shutterRun.description = Time (in ms) to go from max position (e.g. CLOSED) to the other position (e.g. OPEN). Example: 12000 (=12sec). Use AUTO (default) to calibrate the shutter automatically (UP->DOWN->Position%) the first time a Position command (%) is sent.
+thing-type.config.openwebnet.zb_automation.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.zb_automation.where.description = It identifies one ZigBee device. Example: 765432101#9
+thing-type.config.openwebnet.zb_dimmer.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.zb_dimmer.where.description = It identifies one ZigBee device. Example: 765432101#9
+thing-type.config.openwebnet.zb_gateway.serialPort.label = Serial Port
+thing-type.config.openwebnet.zb_gateway.serialPort.description = Serial port where the OpenWebNet ZigBee USB Gateway is connected. Example: COM3 (Win), /dev/ttyUSB0 (Linux), etc.
+thing-type.config.openwebnet.zb_on_off_switch.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.zb_on_off_switch.where.description = It identifies one ZigBee device. Example: 765432101#9
+thing-type.config.openwebnet.zb_on_off_switch2u.where.label = OpenWebNet Address (where)
+thing-type.config.openwebnet.zb_on_off_switch2u.where.description = It identifies one ZigBee device. Example: 765432100#9 (use unit=00 at the end)
+
+# channel types
+
+channel-type.openwebnet.actuators.label = Actuators Status
+channel-type.openwebnet.actuators.description = Actuators status (read only)
+channel-type.openwebnet.actuators.state.option.OFF = OFF
+channel-type.openwebnet.actuators.state.option.ON = ON
+channel-type.openwebnet.actuators.state.option.OPENED = Opened
+channel-type.openwebnet.actuators.state.option.CLOSED = Closed
+channel-type.openwebnet.actuators.state.option.STOP = Stop
+channel-type.openwebnet.actuators.state.option.OFF_FAN_COIL = OFF Fan Coil
+channel-type.openwebnet.actuators.state.option.ON_SPEED_1 = ON speed 1
+channel-type.openwebnet.actuators.state.option.ON_SPEED_2 = ON speed 2
+channel-type.openwebnet.actuators.state.option.ON_SPEED_3 = ON speed 3
+channel-type.openwebnet.actuators.state.option.OFF_SPEED_1 = OFF speed 1
+channel-type.openwebnet.actuators.state.option.OFF_SPEED_2 = OFF speed 2
+channel-type.openwebnet.actuators.state.option.OFF_SPEED_3 = OFF speed 3
+channel-type.openwebnet.atLeastOneProbeManual.label = At least one probe in MANUAL
+channel-type.openwebnet.atLeastOneProbeManual.description = At least one probe in MANUAL indicator in Central Unit (read only)
+channel-type.openwebnet.atLeastOneProbeOff.label = At least one probe OFF
+channel-type.openwebnet.atLeastOneProbeOff.description = At least one probe OFF indicator in Central Unit (read only)
+channel-type.openwebnet.atLeastOneProbeProtection.label = At least one probe in PROTECTION
+channel-type.openwebnet.atLeastOneProbeProtection.description = At least one probe in PROTECTION (Anti Freeze/Thermal Protection) indicator in Central Unit (read only)
+channel-type.openwebnet.aux.label = Auxiliary
+channel-type.openwebnet.aux.description = Controls an Auxiliary command (read/write)
+channel-type.openwebnet.aux.state.option.OFF = Off
+channel-type.openwebnet.aux.state.option.ON = On
+channel-type.openwebnet.aux.state.option.TOGGLE = Toggle
+channel-type.openwebnet.aux.state.option.STOP = Stop
+channel-type.openwebnet.aux.state.option.UP = Up
+channel-type.openwebnet.aux.state.option.DOWN = Down
+channel-type.openwebnet.aux.state.option.ENABLED = Enabled
+channel-type.openwebnet.aux.state.option.DISABLED = Disabled
+channel-type.openwebnet.aux.state.option.RESET_GEN = Reset gen
+channel-type.openwebnet.aux.state.option.RESET_BI = Reset bi
+channel-type.openwebnet.aux.state.option.RESET_TRI = Reset tri
+channel-type.openwebnet.batteryStatus.label = Battery Status
+channel-type.openwebnet.batteryStatus.description = Central Unit Battery status (read only)
+channel-type.openwebnet.batteryStatus.state.option.OK = OK
+channel-type.openwebnet.batteryStatus.state.option.KO = KO
+channel-type.openwebnet.brightness.label = Brightness
+channel-type.openwebnet.brightness.description = Control the brightness and switch the light ON and OFF
+channel-type.openwebnet.cenButtonEvent.label = CEN Button Event
+channel-type.openwebnet.cenPlusButtonEvent.label = CEN+ Button Event
+channel-type.openwebnet.conditioningValves.label = Conditioning Valves
+channel-type.openwebnet.conditioningValves.description = Conditioning Valves status (read only)
+channel-type.openwebnet.conditioningValves.state.option.OFF = OFF
+channel-type.openwebnet.conditioningValves.state.option.ON = ON
+channel-type.openwebnet.conditioningValves.state.option.OPENED = Opened
+channel-type.openwebnet.conditioningValves.state.option.CLOSED = Closed
+channel-type.openwebnet.conditioningValves.state.option.STOP = Stop
+channel-type.openwebnet.conditioningValves.state.option.OFF_FAN_COIL = OFF Fan Coil
+channel-type.openwebnet.conditioningValves.state.option.ON_SPEED_1 = ON speed 1
+channel-type.openwebnet.conditioningValves.state.option.ON_SPEED_2 = ON speed 2
+channel-type.openwebnet.conditioningValves.state.option.ON_SPEED_3 = ON speed 3
+channel-type.openwebnet.conditioningValves.state.option.OFF_SPEED_1 = OFF speed 1
+channel-type.openwebnet.conditioningValves.state.option.OFF_SPEED_2 = OFF speed 2
+channel-type.openwebnet.conditioningValves.state.option.OFF_SPEED_3 = OFF speed 3
+channel-type.openwebnet.dryContactIR.label = Sensor
+channel-type.openwebnet.dryContactIR.description = Dry Contact Interface or IR Interface sensor movement (read only)
+channel-type.openwebnet.failureDiscovered.label = Failure Discovered
+channel-type.openwebnet.failureDiscovered.description = Central Unit Failure Discovered (read only)
+channel-type.openwebnet.function.label = Thermo Function
+channel-type.openwebnet.function.description = Thermo function of the thermostat (read/write)
+channel-type.openwebnet.function.state.option.HEATING = Heating
+channel-type.openwebnet.function.state.option.COOLING = Cooling
+channel-type.openwebnet.function.state.option.GENERIC = Generic
+channel-type.openwebnet.functionCentralUnit.label = Thermo Function
+channel-type.openwebnet.functionCentralUnit.description = Thermo function of the Central Unit
+channel-type.openwebnet.functionCentralUnit.state.option.HEATING = Heating
+channel-type.openwebnet.functionCentralUnit.state.option.COOLING = Cooling
+channel-type.openwebnet.heatingValves.label = Heating Valves
+channel-type.openwebnet.heatingValves.description = Heating Valves status (read only)
+channel-type.openwebnet.heatingValves.state.option.OFF = OFF
+channel-type.openwebnet.heatingValves.state.option.ON = ON
+channel-type.openwebnet.heatingValves.state.option.OPENED = Opened
+channel-type.openwebnet.heatingValves.state.option.CLOSED = Closed
+channel-type.openwebnet.heatingValves.state.option.STOP = Stop
+channel-type.openwebnet.heatingValves.state.option.OFF_FAN_COIL = OFF Fan Coil
+channel-type.openwebnet.heatingValves.state.option.ON_SPEED_1 = ON speed 1
+channel-type.openwebnet.heatingValves.state.option.ON_SPEED_2 = ON speed 2
+channel-type.openwebnet.heatingValves.state.option.ON_SPEED_3 = ON speed 3
+channel-type.openwebnet.heatingValves.state.option.OFF_SPEED_1 = OFF speed 1
+channel-type.openwebnet.heatingValves.state.option.OFF_SPEED_2 = OFF speed 2
+channel-type.openwebnet.heatingValves.state.option.OFF_SPEED_3 = OFF speed 3
+channel-type.openwebnet.localOffset.label = Local Offset
+channel-type.openwebnet.localOffset.description = Local knob status (read only)
+channel-type.openwebnet.localOffset.state.option.OFF = OFF
+channel-type.openwebnet.localOffset.state.option.PROTECTION = PROTECTION
+channel-type.openwebnet.localOffset.state.option.PLUS_3 = +3
+channel-type.openwebnet.localOffset.state.option.PLUS_2 = +2
+channel-type.openwebnet.localOffset.state.option.PLUS_1 = +1
+channel-type.openwebnet.localOffset.state.option.NORMAL = 0
+channel-type.openwebnet.localOffset.state.option.MINUS_1 = -1
+channel-type.openwebnet.localOffset.state.option.MINUS_2 = -2
+channel-type.openwebnet.localOffset.state.option.MINUS_3 = -3
+channel-type.openwebnet.mode.label = Mode
+channel-type.openwebnet.mode.description = Set mode of the thermostat (read/write)
+channel-type.openwebnet.mode.state.option.MANUAL = Manual
+channel-type.openwebnet.mode.state.option.PROTECTION = Protection
+channel-type.openwebnet.mode.state.option.OFF = Off
+channel-type.openwebnet.modeCentralUnit.label = Central Unit Mode
+channel-type.openwebnet.modeCentralUnit.description = Set mode of the Central Unit (read/write)
+channel-type.openwebnet.modeCentralUnit.state.option.MANUAL = Manual
+channel-type.openwebnet.modeCentralUnit.state.option.PROTECTION = Protection
+channel-type.openwebnet.modeCentralUnit.state.option.OFF = Off
+channel-type.openwebnet.modeCentralUnit.state.option.WEEKLY = Weekly
+channel-type.openwebnet.modeCentralUnit.state.option.SCENARIO = Scenario
+channel-type.openwebnet.power.label = Power
+channel-type.openwebnet.power.description = Current active power
+channel-type.openwebnet.remoteControl.label = Remote Control
+channel-type.openwebnet.remoteControl.description = Central Unit Remote Control status (read only)
+channel-type.openwebnet.remoteControl.state.option.DISABLED = DISABLED
+channel-type.openwebnet.remoteControl.state.option.ENABLED = ENABLED
+channel-type.openwebnet.scenarioProgramCentralUnit.label = Scenario Program Number
+channel-type.openwebnet.scenarioProgramCentralUnit.description = Set scenario program number for the Central Unit, valid only with Central Unit mode = "SCENARIO" (read/write)
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.1 = Program 1
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.2 = Program 2
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.3 = Program 3
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.4 = Program 4
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.5 = Program 5
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.6 = Program 6
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.7 = Program 7
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.8 = Program 8
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.9 = Program 9
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.10 = Program 10
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.11 = Program 11
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.12 = Program 12
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.13 = Program 13
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.14 = Program 14
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.15 = Program 15
+channel-type.openwebnet.scenarioProgramCentralUnit.state.option.16 = Program 16
+channel-type.openwebnet.setpointTemperature.label = Setpoint Temperature
+channel-type.openwebnet.setpointTemperature.description = Setpoint temperature (read/write)
+channel-type.openwebnet.shutter.label = Roller Shutter
+channel-type.openwebnet.shutter.description = Control the roller shutter position
+channel-type.openwebnet.speedFanCoil.label = Set Fan Speed
+channel-type.openwebnet.speedFanCoil.description = Set speed of the Fan Coil (read/write)
+channel-type.openwebnet.speedFanCoil.state.option.AUTO = Auto
+channel-type.openwebnet.speedFanCoil.state.option.SPEED_1 = Fan speed 1
+channel-type.openwebnet.speedFanCoil.state.option.SPEED_2 = Fan speed 2
+channel-type.openwebnet.speedFanCoil.state.option.SPEED_3 = Fan speed 3
+channel-type.openwebnet.switch.label = Switch
+channel-type.openwebnet.switch.description = Switch the power ON and OFF
+channel-type.openwebnet.temperature.label = Temperature
+channel-type.openwebnet.temperature.description = Current temperature (read only)
+channel-type.openwebnet.weeklyProgramCentralUnit.label = Weekly Program Number
+channel-type.openwebnet.weeklyProgramCentralUnit.description = Set weekly program number for the Central Unit, valid only with Central Unit mode = "WEEKLY" (read/write)
+channel-type.openwebnet.weeklyProgramCentralUnit.state.option.1 = Program 1
+channel-type.openwebnet.weeklyProgramCentralUnit.state.option.2 = Program 2
+channel-type.openwebnet.weeklyProgramCentralUnit.state.option.3 = Program 3
 
 # thing status descriptions
 
+offline.comm-error-disconnected = Disconnected from gateway.
+offline.comm-error-timeout = Connection to gateway timed out.
+offline.comm-error-connection = Could not connect to gateway.
+offline.comm-error-state = Could not get channel state.
 offline.conf-error-no-ip-address = Cannot connect to gateway. No host/IP address has been provided in configuration.
 offline.conf-error-no-serial-port = Cannot connect to gateway. No serial port has been provided in configuration.
 offline.conf-error-where = OpenWebNet Address (where) parameter in configuration is null or invalid.
 offline.conf-error-no-bridge = No bridge associated. Assign a bridge in configuration.
 offline.conf-error-auth = Authentication failed. Check gateway password in configuration.
-
-offline.comm-error-disconnected = Disconnected from gateway.
-offline.comm-error-timeout = Connection to gateway timed out.
-offline.comm-error-connection = Could not connect to gateway.
-offline.comm-error-state = Could not get channel state. 
-
 unknown.waiting-state = Waiting state update...


### PR DESCRIPTION
As requested [in this other PR](https://github.com/openhab/openhab-addons/pull/12483#issuecomment-1075576483), this new PR adds default translations to the openwebnet binding.
Translations to other languages will be completed using crowdin.