### PR TITLE
[insteon] ignore commands if device is not online

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
@@ -410,9 +410,14 @@ public class InsteonDeviceHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        logger.debug("channel {} was triggered with the command {}", channelUID.getAsString(), command);
+        if (ThingStatus.ONLINE.equals(getThing().getStatus())) {
+            logger.debug("channel {} was triggered with the command {}", channelUID.getAsString(), command);
 
-        getInsteonBinding().sendCommand(channelUID.getAsString(), command);
+            getInsteonBinding().sendCommand(channelUID.getAsString(), command);
+        } else {
+            logger.debug("the command {} for channel {} was ignored because the thing is not ONLINE", command,
+                    channelUID.getAsString());
+        }
     }
 
     @Override


### PR DESCRIPTION
Added as a defensive measure to ensure that commands are ignored if the device is offline.