### PR TITLE
[mqtt] Disable broken test

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/handler/BrokerHandlerTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/handler/BrokerHandlerTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -95,6 +96,7 @@ public class BrokerHandlerTest extends JavaTest {
         verify(handler).createBrokerConnection();
     }
 
+    @Disabled("Temporarily disabled as broken since May 2022")
     @Test
     public void handlerInit() throws InterruptedException, IllegalArgumentException {
         assertThat(initializeHandlerWaitForTimeout(), is(true));


### PR DESCRIPTION
Disable test that causes all full builds to fail.

Hopefully it can be brought back at some point, but so far I have not succeeded in understanding exactly how it broke, and how it's intended to work. All three `statusUpdated` invocations set `ThingStatus.OFFLINE`.

Related to: #12784