### PR TITLE
[hdpowerview] Change method names to match documentation

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/ShadePosition.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/ShadePosition.java
@@ -101,7 +101,7 @@ public class ShadePosition {
                  * Secondary, upper rail of a dual action shade: => NOT INVERTED
                  */
                 posKind1 = posKindCoords.ordinal();
-                if (shadeCapabilities.supportsSecondaryDuolite()) {
+                if (shadeCapabilities.supportsSecondaryOverlapped()) {
                     position1 = MAX_SHADE - (int) Math.round((double) percent / 100 * MAX_SHADE);
                 } else {
                     position1 = (int) Math.round((double) percent / 100 * MAX_SHADE);
@@ -142,7 +142,7 @@ public class ShadePosition {
                 if (VANE_TILT_POSITION.equals(posKind1) && shadeCapabilities.supportsTiltOnClosed()) {
                     return PercentType.HUNDRED;
                 }
-                if (SECONDARY_POSITION.equals(posKind1) && shadeCapabilities.supportsSecondaryDuolite()) {
+                if (SECONDARY_POSITION.equals(posKind1) && shadeCapabilities.supportsSecondaryOverlapped()) {
                     return PercentType.HUNDRED;
                 }
                 break;
@@ -153,12 +153,12 @@ public class ShadePosition {
                  * Secondary, upper rail of a dual action shade: => NOT INVERTED
                  */
                 if (posKindCoords.equals(posKind1)) {
-                    if (shadeCapabilities.supportsSecondaryDuolite()) {
+                    if (shadeCapabilities.supportsSecondaryOverlapped()) {
                         return new PercentType(100 - (int) Math.round((double) position1 / MAX_SHADE * 100));
                     }
                     return new PercentType((int) Math.round((double) position1 / MAX_SHADE * 100));
                 }
-                if (PRIMARY_POSITION.equals(posKind1) && shadeCapabilities.supportsSecondaryDuolite()) {
+                if (PRIMARY_POSITION.equals(posKind1) && shadeCapabilities.supportsSecondaryOverlapped()) {
                     return PercentType.ZERO;
                 }
                 break;
@@ -351,7 +351,7 @@ public class ShadePosition {
                     } else {
                         setPosition1(shadeCapabilities, posKindCoords, percent);
                     }
-                } else if (shadeCapabilities.supportsSecondaryDuolite()) {
+                } else if (shadeCapabilities.supportsSecondaryOverlapped()) {
                     setPosition1(shadeCapabilities, posKindCoords, percent);
                 }
                 break;

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/ShadePosition.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/ShadePosition.java
@@ -101,7 +101,7 @@ public class ShadePosition {
                  * Secondary, upper rail of a dual action shade: => NOT INVERTED
                  */
                 posKind1 = posKindCoords.ordinal();
-                if (shadeCapabilities.supportsBlackoutShade()) {
+                if (shadeCapabilities.supportsSecondaryDuolite()) {
                     position1 = MAX_SHADE - (int) Math.round((double) percent / 100 * MAX_SHADE);
                 } else {
                     position1 = (int) Math.round((double) percent / 100 * MAX_SHADE);
@@ -142,7 +142,7 @@ public class ShadePosition {
                 if (VANE_TILT_POSITION.equals(posKind1) && shadeCapabilities.supportsTiltOnClosed()) {
                     return PercentType.HUNDRED;
                 }
-                if (SECONDARY_POSITION.equals(posKind1) && shadeCapabilities.supportsBlackoutShade()) {
+                if (SECONDARY_POSITION.equals(posKind1) && shadeCapabilities.supportsSecondaryDuolite()) {
                     return PercentType.HUNDRED;
                 }
                 break;
@@ -153,12 +153,12 @@ public class ShadePosition {
                  * Secondary, upper rail of a dual action shade: => NOT INVERTED
                  */
                 if (posKindCoords.equals(posKind1)) {
-                    if (shadeCapabilities.supportsBlackoutShade()) {
+                    if (shadeCapabilities.supportsSecondaryDuolite()) {
                         return new PercentType(100 - (int) Math.round((double) position1 / MAX_SHADE * 100));
                     }
                     return new PercentType((int) Math.round((double) position1 / MAX_SHADE * 100));
                 }
-                if (PRIMARY_POSITION.equals(posKind1) && shadeCapabilities.supportsBlackoutShade()) {
+                if (PRIMARY_POSITION.equals(posKind1) && shadeCapabilities.supportsSecondaryDuolite()) {
                     return PercentType.ZERO;
                 }
                 break;
@@ -351,7 +351,7 @@ public class ShadePosition {
                     } else {
                         setPosition1(shadeCapabilities, posKindCoords, percent);
                     }
-                } else if (shadeCapabilities.supportsBlackoutShade()) {
+                } else if (shadeCapabilities.supportsSecondaryDuolite()) {
                     setPosition1(shadeCapabilities, posKindCoords, percent);
                 }
                 break;

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -233,7 +233,7 @@ public class ShadeCapabilitiesDatabase {
          *
          * @return true if the primary shade is inverted.
          */
-        public boolean isPrimaryStateInverted() {
+        public boolean isPrimaryInverted() {
             return primaryInverted;
         }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -40,16 +40,16 @@ public class ShadeCapabilitiesDatabase {
      */
     private static final Map<Integer, Capabilities> CAPABILITIES_DATABASE = Arrays.asList(
     // @formatter:off
-            new Capabilities(0).primary().tiltOnClosed()                      .text("Bottom Up"),
-            new Capabilities(1).primary().tiltOnClosed()                      .text("Bottom Up Tilt 90°"),
-            new Capabilities(2).primary().tiltAnywhere().tilt180()            .text("Bottom Up Tilt 180°"),
-            new Capabilities(3).primary().tiltOnClosed()                      .text("Vertical"),
-            new Capabilities(4).primary().tiltAnywhere().tilt180()            .text("Vertical Tilt 180°"),
-            new Capabilities(5)          .tiltAnywhere().tilt180()            .text("Tilt Only 180°"),
-            new Capabilities(6).primary()                                     .text("Top Down")                 .primaryStateInverted(),
-            new Capabilities(7).primary()                         .secondary().text("Top Down Bottom Up"),
-            new Capabilities(8).primary()                                     .text("Duolite Lift")             .withBlackoutShade(),
-            new Capabilities(9).primary().tiltAnywhere()                      .text("Duolite Lift and Tilt 90°").withBlackoutShade(),
+            new Capabilities(0).primary()        .tiltOnClosed()                             .text("Bottom Up"),
+            new Capabilities(1).primary()        .tiltOnClosed()                             .text("Bottom Up Tilt 90°"),
+            new Capabilities(2).primary()        .tiltAnywhere().tilt180()                   .text("Bottom Up Tilt 180°"),
+            new Capabilities(3).primary()        .tiltOnClosed()                             .text("Vertical"),
+            new Capabilities(4).primary()        .tiltAnywhere().tilt180()                   .text("Vertical Tilt 180°"),
+            new Capabilities(5)                  .tiltAnywhere().tilt180()                   .text("Tilt Only 180°"),
+            new Capabilities(6).primaryInverted()                                            .text("Top Down"),
+            new Capabilities(7).primary()                                 .secondary()       .text("Top Down Bottom Up"),
+            new Capabilities(8).primary()                                 .secondaryDuolite().text("Duolite Lift"),
+            new Capabilities(9).primary()        .tiltAnywhere()          .secondaryDuolite().text("Duolite Lift and Tilt 90°"),
     // @formatter:on
             new Capabilities()).stream().collect(Collectors.toMap(Capabilities::getValue, Function.identity()));
 
@@ -149,15 +149,15 @@ public class ShadeCapabilitiesDatabase {
         private boolean supportsSecondary;
         private boolean supportsTiltOnClosed;
         private boolean supportsTiltAnywhere;
-        private boolean supportsBlackoutShade;
-        private boolean primaryStateInverted;
+        private boolean supportsSecondaryDuolite;
+        private boolean primaryInverted;
         private boolean tilt180Degrees;
 
         public Capabilities() {
         }
 
-        protected Capabilities withBlackoutShade() {
-            supportsBlackoutShade = true;
+        protected Capabilities secondaryDuolite() {
+            supportsSecondaryDuolite = true;
             return this;
         }
 
@@ -190,8 +190,9 @@ public class ShadeCapabilitiesDatabase {
             return this;
         }
 
-        protected Capabilities primaryStateInverted() {
-            primaryStateInverted = true;
+        protected Capabilities primaryInverted() {
+            supportsPrimary = true;
+            primaryInverted = true;
             return this;
         }
 
@@ -228,21 +229,21 @@ public class ShadeCapabilitiesDatabase {
         }
 
         /**
-         * Check if the Capabilities class instance supports a secondary shade.
+         * Check if the Capabilities class instance if the primary shade is inverted.
          *
          * @return true if the primary shade is inverted.
          */
         public boolean isPrimaryStateInverted() {
-            return primaryStateInverted;
+            return primaryInverted;
         }
 
         /**
-         * Check if the Capabilities class instance supports 'tilt when closed'.
+         * Check if the Capabilities class instance supports 'tilt on closed'.
          *
          * Note: Simple bottom up or vertical shades that do not have independent vane controls, can be tilted in a
          * simple way, only when they are fully closed, by moving the shade motor a bit further.
          *
-         * @return true if the primary shade is inverted.
+         * @return true if the it supports tilt on closed.
          */
         public boolean supportsTiltOnClosed() {
             return supportsTiltOnClosed && !supportsTiltAnywhere;
@@ -251,19 +252,19 @@ public class ShadeCapabilitiesDatabase {
         /**
          * Check if the Capabilities class instance supports 180 degrees tilt.
          *
-         * @return true if the primary shade supports 180 degrees.
+         * @return true if the tilt range is 180 degrees.
          */
         public boolean supportsTilt180() {
             return tilt180Degrees;
         }
 
         /**
-         * Check if the Capabilities class instance supports a secondary 'DuoLite' blackout shade.
+         * Check if the Capabilities class instance supports a secondary 'DuoLite' (blackout) shade.
          *
-         * @return true if the primary shade supports a secondary blackout shade.
+         * @return true if the shade supports a secondary 'DuoLite' shade.
          */
-        public boolean supportsBlackoutShade() {
-            return supportsBlackoutShade;
+        public boolean supportsSecondaryDuolite() {
+            return supportsSecondaryDuolite;
         }
     }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -40,16 +40,16 @@ public class ShadeCapabilitiesDatabase {
      */
     private static final Map<Integer, Capabilities> CAPABILITIES_DATABASE = Arrays.asList(
     // @formatter:off
-            new Capabilities(0).primary()        .tiltOnClosed()                             .text("Bottom Up"),
-            new Capabilities(1).primary()        .tiltOnClosed()                             .text("Bottom Up Tilt 90°"),
-            new Capabilities(2).primary()        .tiltAnywhere().tilt180()                   .text("Bottom Up Tilt 180°"),
-            new Capabilities(3).primary()        .tiltOnClosed()                             .text("Vertical"),
-            new Capabilities(4).primary()        .tiltAnywhere().tilt180()                   .text("Vertical Tilt 180°"),
-            new Capabilities(5)                  .tiltAnywhere().tilt180()                   .text("Tilt Only 180°"),
-            new Capabilities(6).primaryInverted()                                            .text("Top Down"),
-            new Capabilities(7).primary()                                 .secondary()       .text("Top Down Bottom Up"),
-            new Capabilities(8).primary()                                 .secondaryDuolite().text("Duolite Lift"),
-            new Capabilities(9).primary()        .tiltAnywhere()          .secondaryDuolite().text("Duolite Lift and Tilt 90°"),
+            new Capabilities(0).primary()        .tiltOnClosed()                                .text("Bottom Up"),
+            new Capabilities(1).primary()        .tiltOnClosed()                                .text("Bottom Up Tilt 90°"),
+            new Capabilities(2).primary()        .tiltAnywhere().tilt180()                      .text("Bottom Up Tilt 180°"),
+            new Capabilities(3).primary()        .tiltOnClosed()                                .text("Vertical"),
+            new Capabilities(4).primary()        .tiltAnywhere().tilt180()                      .text("Vertical Tilt 180°"),
+            new Capabilities(5)                  .tiltAnywhere().tilt180()                      .text("Tilt Only 180°"),
+            new Capabilities(6).primaryInverted()                                               .text("Top Down"),
+            new Capabilities(7).primary()                                 .secondary()          .text("Top Down Bottom Up"),
+            new Capabilities(8).primary()                                 .secondaryOverlapped().text("Duolite Lift"),
+            new Capabilities(9).primary()        .tiltAnywhere()          .secondaryOverlapped().text("Duolite Lift and Tilt 90°"),
     // @formatter:on
             new Capabilities()).stream().collect(Collectors.toMap(Capabilities::getValue, Function.identity()));
 
@@ -149,15 +149,15 @@ public class ShadeCapabilitiesDatabase {
         private boolean supportsSecondary;
         private boolean supportsTiltOnClosed;
         private boolean supportsTiltAnywhere;
-        private boolean supportsSecondaryDuolite;
+        private boolean supportsSecondaryOverlapped;
         private boolean primaryInverted;
         private boolean tilt180Degrees;
 
         public Capabilities() {
         }
 
-        protected Capabilities secondaryDuolite() {
-            supportsSecondaryDuolite = true;
+        protected Capabilities secondaryOverlapped() {
+            supportsSecondaryOverlapped = true;
             return this;
         }
 
@@ -259,12 +259,13 @@ public class ShadeCapabilitiesDatabase {
         }
 
         /**
-         * Check if the Capabilities class instance supports a secondary 'DuoLite' (blackout) shade.
+         * Check if the Capabilities class instance supports an overlapped secondary shade.
+         * e.g. a 'DuoLite' or blackout shade.
          *
-         * @return true if the shade supports a secondary 'DuoLite' shade.
+         * @return true if the shade supports a secondary overlapped shade.
          */
-        public boolean supportsSecondaryDuolite() {
-            return supportsSecondaryDuolite;
+        public boolean supportsSecondaryOverlapped() {
+            return supportsSecondaryOverlapped;
         }
     }
 

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
@@ -50,7 +50,7 @@ public class ShadePositionTest {
         assertTrue(db.getCapabilities(4).supportsTilt180());
         assertTrue(db.getCapabilities(5).supportsTilt180());
         assertFalse(db.getCapabilities(5).supportsPrimary());
-        assertTrue(db.getCapabilities(6).isPrimaryStateInverted());
+        assertTrue(db.getCapabilities(6).isPrimaryInverted());
         assertTrue(db.getCapabilities(7).supportsSecondary());
         assertTrue(db.getCapabilities(8).supportsSecondaryDuolite());
         assertTrue(db.getCapabilities(9).supportsSecondaryDuolite());
@@ -61,9 +61,9 @@ public class ShadePositionTest {
         assertFalse(db.isTypeInDatabase(99));
         assertFalse(db.isCapabilitiesInDatabase(99));
 
-        assertFalse(db.getCapabilities(0).isPrimaryStateInverted());
-        assertFalse(db.getCapabilities(-1).isPrimaryStateInverted());
-        assertFalse(db.getCapabilities(99).isPrimaryStateInverted());
+        assertFalse(db.getCapabilities(0).isPrimaryInverted());
+        assertFalse(db.getCapabilities(-1).isPrimaryInverted());
+        assertFalse(db.getCapabilities(99).isPrimaryInverted());
 
         assertFalse(db.getCapabilities(0).supportsSecondary());
         assertFalse(db.getCapabilities(-1).supportsSecondary());

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
@@ -52,8 +52,8 @@ public class ShadePositionTest {
         assertFalse(db.getCapabilities(5).supportsPrimary());
         assertTrue(db.getCapabilities(6).isPrimaryInverted());
         assertTrue(db.getCapabilities(7).supportsSecondary());
-        assertTrue(db.getCapabilities(8).supportsSecondaryDuolite());
-        assertTrue(db.getCapabilities(9).supportsSecondaryDuolite());
+        assertTrue(db.getCapabilities(8).supportsSecondaryOverlapped());
+        assertTrue(db.getCapabilities(9).supportsSecondaryOverlapped());
 
         assertEquals(db.getType(4).getCapabilities(), 0);
         assertEquals(db.getType(-1).getCapabilities(), -1);

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
@@ -52,8 +52,8 @@ public class ShadePositionTest {
         assertFalse(db.getCapabilities(5).supportsPrimary());
         assertTrue(db.getCapabilities(6).isPrimaryStateInverted());
         assertTrue(db.getCapabilities(7).supportsSecondary());
-        assertTrue(db.getCapabilities(8).supportsBlackoutShade());
-        assertTrue(db.getCapabilities(9).supportsBlackoutShade());
+        assertTrue(db.getCapabilities(8).supportsSecondaryDuolite());
+        assertTrue(db.getCapabilities(9).supportsSecondaryDuolite());
 
         assertEquals(db.getType(4).getCapabilities(), 0);
         assertEquals(db.getType(-1).getCapabilities(), -1);


### PR DESCRIPTION
In this [post](https://github.com/jlaur/hdpowerview-doc/issues/1#issuecomment-1133774105) @jlaur pointed out a naming inconsistency concerning the two types of secondary shade -- namely regular secondary shades vs. Duolite blackout secondary shades.

In this PR the method names have been refactored so that methods and fields for both types of secondary shades include the word 'secondary' in them. No functionality has been changed; this is only done to improve clarity of the code.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
