### PR TITLE
[mqtt.homie] Disable unstable test

### DIFF
--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/homie/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/homie/HomieImplementationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -228,6 +229,7 @@ public class HomieImplementationTest extends MqttOSGiTest {
     }
 
     @SuppressWarnings("null")
+    @Disabled("Temporarily disabled: unstable")
     @Test
     public void parseHomieTree() throws Exception {
         // Create a Homie Device object. Because spied Nodes are required for call verification,


### PR DESCRIPTION
CI builds are often (but not always) failing because of test `parseHomieTree`.

```
TEST org.openhab.binding.mqtt.homie.HomieImplementationTest#parseHomieTree() <<< ERROR: 
Expected: is "false"
     but: was null
java.lang.AssertionError: 
Expected: is "false"
     but: was null
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.openhab.binding.mqtt.homie.HomieImplementationTest.parseHomieTree(HomieImplementationTest.java:303)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at aQute.tester.bundle.engine.BundleDescriptor.executeChild(BundleDescriptor.java:49)
	at aQute.tester.bundle.engine.BundleEngine.lambda$executeBundle$7(BundleEngine.java:120)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aQute.tester.bundle.engine.BundleEngine.executeBundle(BundleEngine.java:120)
	at aQute.tester.bundle.engine.BundleEngine.lambda$executeBundle$8(BundleEngine.java:133)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aQute.tester.bundle.engine.BundleEngine.executeBundle(BundleEngine.java:133)
	at aQute.tester.bundle.engine.BundleEngine.lambda$execute$5(BundleEngine.java:100)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aQute.tester.bundle.engine.BundleEngine.execute(BundleEngine.java:100)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at aQute.tester.junit.platform.Activator.test(Activator.java:439)
	at aQute.tester.junit.platform.Activator.automatic(Activator.java:344)
	at aQute.tester.junit.platform.Activator.run(Activator.java:216)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at aQute.launcher.Launcher.launch(Launcher.java:450)
	at aQute.launcher.Launcher.run(Launcher.java:184)
	at aQute.launcher.Launcher.main(Launcher.java:160)
	at aQute.launcher.pre.EmbeddedLauncher.executeWithRunPath(EmbeddedLauncher.java:170)
	at aQute.launcher.pre.EmbeddedLauncher.findAndExecute(EmbeddedLauncher.java:135)
	at aQute.launcher.pre.EmbeddedLauncher.main(EmbeddedLauncher.java:52)
org.openhab.binding.mqtt.homie [io.moquette.broker.DefaultMoquetteSslContextCreator] WARN : The key manager password is null or empty. The SSL context won't be initialized.
org.openhab.binding.mqtt.homie [io.moquette.broker.NewNettyAcceptor] ERROR : Can't initialize SSLHandler layer! Exiting, check your configuration of jks
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.DefaultMoquetteSslContextCreator] WARN : The key manager password is null or empty. The SSL context won't be initialized.
org.openhab.binding.mqtt.homie [io.moquette.broker.NewNettyAcceptor] ERROR : Can't initialize SSLHandler layer! Exiting, check your configuration of jks
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
org.openhab.binding.mqtt.homie [io.moquette.broker.Session] WARN : Received a PUBACK with not matching packetId
[INFO] 1 Error(s)
Error:  Error   : Exit code remote process 1: /opt/hostedtoolcache/Java_Zulu_jdk/11.0.15-10/x64/bin/java -cp /home/runner/work/openhab-addons/openhab-addons/itests/org.openhab.binding.mqtt.homie.tests/target/test/tmp/testing/itest/cnf/cache/6.2.0/bnd-cache/biz.aQute.launcher/biz.aQute.launcher.pre.jar -Dlauncher.properties=/home/runner/work/openhab-addons/openhab-addons/itests/org.openhab.binding.mqtt.homie.tests/target/test/tmp/testing/itest/generated/launch4064546675254492319.properties -Dorg.osgi.service.http.port=41541 --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED -Dio.netty.noUnsafe=true -Dmqttbroker.port=45479 -ea -Dlauncher.runpath=/home/runner/work/openhab-addons/openhab-addons/itests/org.openhab.binding.mqtt.homie.tests/target/test/tmp/testing/itest/cnf/cache/6.2.0/org.openhab.core.bom.runtime-index/org.eclipse.osgi-3.17.200.v20220215-2237.jar,/home/runner/work/openhab-addons/openhab-addons/itests/org.openhab.binding.mqtt.homie.tests/target/test/tmp/testing/itest/cnf/cache/6.2.0/bnd-cache/biz.aQute.launcher/biz.aQute.launcher-6.2.0.jar aQute.launcher.pre.EmbeddedLauncher
```

There are some timing dependencies in this test that might cause this, but it could also be concurrency related.

Related to #12811