### PR TITLE
[ipcamera] Doorbird online/offline bug fix

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1354,7 +1354,8 @@ public class IpCameraHandler extends BaseThingHandler {
 
     void pollingCameraConnection() {
         keepMjpegRunning();
-        if (thing.getThingTypeUID().getId().equals(GENERIC_THING)) {
+        if (thing.getThingTypeUID().getId().equals(GENERIC_THING)
+                || thing.getThingTypeUID().getId().equals(DOORBIRD_THING)) {
             if (rtspUri.isEmpty()) {
                 logger.warn("Binding has not been supplied with a FFmpeg Input URL, so some features will not work.");
             }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/StreamOutput.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/StreamOutput.java
@@ -36,7 +36,7 @@ public class StreamOutput {
     private final String boundary;
     private String contentType;
     private final ServletOutputStream output;
-    private BlockingQueue<byte[]> fifo = new ArrayBlockingQueue<byte[]>(30);
+    private BlockingQueue<byte[]> fifo = new ArrayBlockingQueue<byte[]>(50);
     private boolean connected = false;
     public boolean isSnapshotBased = false;
 


### PR DESCRIPTION
This PR fixes a bug only effecting Doorbird cameras. Reported in the forum and also confirmed by the user that it fixes the issue. See here:

https://community.openhab.org/t/ipcamera-doorbird-camera-things-going-offline-not-getting-back-online/134207/12

Signed-off-by: Matthew Skinner <matt@pcmus.com>