### PR TITLE
[tado] Remove strict version dependencies for Gson/Jetty and upgrade

### DIFF
--- a/bundles/org.openhab.binding.tado/pom.xml
+++ b/bundles/org.openhab.binding.tado/pom.xml
@@ -54,17 +54,4 @@
     </plugins>
   </build>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-      <version>9.4.12.v20180830</version>
-    </dependency>
-  </dependencies>
-
 </project>


### PR DESCRIPTION
The POM listed two dependencies for libraries, Gson and Jetty, which are included from core already. Therefore they didn't track core versions, and had to be upgraded manually:
- **gson:** 2.8.3 -> 2.8.9 (in core)
- **jetty-client:** 9.4.12 -> 9.4.46 (in core)

Running `mvn dependency:tree` before removal (relevant parts extracted):

```
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ org.openhab.binding.tado ---
[INFO] org.openhab.addons.bundles:org.openhab.binding.tado:jar:3.3.0-SNAPSHOT
[INFO] +- com.google.code.gson:gson:jar:2.8.3:compile
[INFO] +- org.eclipse.jetty:jetty-client:jar:9.4.12.v20180830:compile
[INFO] |  +- org.eclipse.jetty:jetty-http:jar:9.4.12.v20180830:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.12.v20180830:compile
[INFO] |  \- org.eclipse.jetty:jetty-io:jar:9.4.12.v20180830:compile
```

After changes:

```
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ org.openhab.binding.tado ---
[INFO] org.openhab.addons.bundles:org.openhab.binding.tado:jar:3.3.0-SNAPSHOT
[INFO] +- org.openhab.core.bom:org.openhab.core.bom.compile:pom:3.3.0-SNAPSHOT:provided
[INFO] |  +- com.google.code.gson:gson:jar:2.8.9:provided
[INFO] |  +- org.eclipse.jetty:jetty-client:jar:9.4.46.v20220331:provided
[INFO] |  |  +- org.eclipse.jetty:jetty-http:jar:9.4.46.v20220331:provided
```

