### PR TITLE
[netatmo] Fix getActiveChildren

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/CommonInterface.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/CommonInterface.java
@@ -126,8 +126,10 @@ public interface CommonInterface {
     default List<CommonInterface> getActiveChildren() {
         Thing thing = getThing();
         if (thing instanceof Bridge) {
-            return ((Bridge) thing).getThings().stream().filter(Thing::isEnabled).map(Thing::getHandler)
-                    .filter(Objects::nonNull).map(CommonInterface.class::cast).collect(Collectors.toList());
+            return ((Bridge) thing).getThings().stream().filter(Thing::isEnabled)
+                    .filter(th -> th.getStatusInfo().getStatusDetail() != ThingStatusDetail.BRIDGE_OFFLINE)
+                    .map(Thing::getHandler).filter(Objects::nonNull).map(CommonInterface.class::cast)
+                    .collect(Collectors.toList());
         }
         return List.of();
     }


### PR DESCRIPTION
Wait for the thing being initialized properly by the thing manager
before considering it as an active children for the bridge.

Fix #12809

Signed-off-by: Laurent Garnier <lg.hc@free.fr>