### PR TITLE
[shelly] Fix CoAP message parsing for Plug-S and Bulb

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/coap/ShellyCoapJSonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/coap/ShellyCoapJSonDTO.java
@@ -224,8 +224,13 @@ public class ShellyCoapJSonDTO {
 
                 in.endArray();
             }
-            in.endObject();
 
+            if (name.equalsIgnoreCase(COIOT_TAG_ACT)) {
+                // skip record
+                in.skipValue();
+            }
+
+            in.endObject();
             return descr;
         }
 


### PR DESCRIPTION
This fixes #12831, a problem on CoAP messages for Plug-S and Bulb. This missing handling caused an exception preventing channel updates.

