### PR TITLE
[roku] Add PowerOn option to Remote Button channel

### DIFF
--- a/bundles/org.openhab.binding.roku/README.md
+++ b/bundles/org.openhab.binding.roku/README.md
@@ -83,6 +83,7 @@ InputHDMI3
 InputHDMI4  
 InputAV1  
 PowerOff  
+PowerOn  
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.roku/src/main/resources/OH-INF/i18n/roku.properties
+++ b/bundles/org.openhab.binding.roku/src/main/resources/OH-INF/i18n/roku.properties
@@ -73,6 +73,7 @@ channel-type.roku.buttonTv.state.option.InputHDMI3 = Input HDMI3
 channel-type.roku.buttonTv.state.option.InputHDMI4 = Input HDMI4
 channel-type.roku.buttonTv.state.option.InputAV1 = Input AV1
 channel-type.roku.buttonTv.state.option.PowerOff = Power Off
+channel-type.roku.buttonTv.state.option.PowerOn = Power On
 channel-type.roku.channelName.label = Channel Name
 channel-type.roku.channelName.description = The Name of the Channel Currently Selected
 channel-type.roku.playMode.label = Play Mode

--- a/bundles/org.openhab.binding.roku/src/main/resources/OH-INF/thing/roku.xml
+++ b/bundles/org.openhab.binding.roku/src/main/resources/OH-INF/thing/roku.xml
@@ -129,6 +129,7 @@
 				<option value="InputHDMI4">Input HDMI4</option>
 				<option value="InputAV1">Input AV1</option>
 				<option value="PowerOff">Power Off</option>
+				<option value="PowerOn">Power On</option>
 			</options>
 		</state>
 	</channel-type>


### PR DESCRIPTION
Add missing Power On option to Remote Button drop down for Roku TV.

Discussed in the community here: https://community.openhab.org/t/roku-binding-power-for-tvs/136223