### PR TITLE
[openwebnet] add support for Basic Scenarios (WHO=0)

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -44,8 +44,8 @@ The following Things and OpenWebNet `WHOs` are supported:
 | Lighting                      |     `1`     |             `bus_on_off_switch`, `bus_dimmer`              | BUS switches and dimmers                                         | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers)                                                                                           |
 | Automation                    |     `2`     |                      `bus_automation`                      | BUS roller shutters, with position feedback and auto-calibration | Successfully tested: LN4672M2                                                                                                                                                                              |
 | Temperature Control           |     `4`     |  `bus_thermo_zone`, `bus_thermo_sensor`, `bus_thermo_cu`   | Thermo zones management and temperature sensors (probes).        | Successfully tested: H/LN4691, HS4692, KG4691; thermo sensors: L/N/NT4577 + 3455; Central Units (4 or 99 zones) are not fully supported yet. See [Channels - Thermo](#configuring-thermo) for more details |
-| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                     | Successfully tested: AUX configured for bulgrar-alarm unit 3486. Only sending AUX commands is supported                                                                                                    |
-| CEN & CEN+ Scenarios          | `15` & `25` | `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: scenario buttons: HC/HD/HS/L/N/NT4680                                                                                                                                                 |
+| Auxiliary (AUX)               |     `9`     |                         `bus_aux`                          | AUX commands                                                     | Successfully tested: AUX configured for bulgrar-alarm unit 3486. **Only sending AUX commands is supported**                                                                                                    |
+| Basic, CEN & CEN+ Scenarios          | `0`, `15`, `25` | `bus_scenario_panel`, `bus_cen_scenario_control`, `bus_cenplus_scenario_control` | Basic and CEN/CEN+ scenarios events and virtual activation                 | Successfully tested: CEN/CEN+ scenario buttons: HC/HD/HS/L/N/NT4680. Currently testing WHO=0 scenarios F420/IR 3456                                                                                                                                                                 |
 | Dry Contact and IR Interfaces |    `25`     |                    `bus_dry_contact_ir`                    | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610                                                                                                                     |
 | Energy Management             |    `18`     |                     `bus_energy_meter`                     | Energy Management                                                | Successfully tested: F520, F521                                                                                                                                                                            |
 
@@ -69,7 +69,7 @@ For other gateways you can add them manually, see [Thing Configuration](#thing-c
 - Once the gateway is online, a second Inbox Scan will discover BUS devices
 - BUS/SCS Dimmers must be ON and dimmed (30%-100%) during a Scan, otherwise they will be discovered as simple On/Off switches
     - *KNOWN ISSUE*: In some cases dimmers connected to a F429 Dali-interface are not automatically discovered
-- CEN/CEN+ Scenario Control devices will be discovered by activation only. See [discovery by activation](#discovery-by-activation) for details. After confirming a discovered CEN/CEN+ device from Inbox, activate again its scenario buttons to add button channels automatically
+- Basic Scenario Panels and CEN/CEN+ Scenario Control devices will be discovered by activation only. See [discovery by activation](#discovery-by-activation) for details. After confirming a discovered CEN/CEN+ scenario device from Inbox, activate again its buttons to add button channels automatically
 
 #### Discovery by Activation
 
@@ -129,6 +129,7 @@ For any manually added device, you must configure:
     - example for BUS/SCS system, address Point-to-point with Area (A) and Light-point (PL):
         - light device A=`2` (Area 2), PL=`4` (Light-point 4) --> `where="24"`
         - light device A=`03`, PL=`11` on local bus --> `where="0311#4#01"`
+        - scenario Control Panel `02` --> `where="02"`    
         - CEN scenario A=`05`, PL=`12` --> `where="0512"`
         - CEN+ scenario `5`: add a `2` before --> `where="25"`
         - Dry Contact or IR Interface `99`: add a `3` before --> `where="399"`
@@ -161,14 +162,13 @@ To control a BTicino alarm system the alarm unit should be configured for exampl
 
 Antitheft -> Automations -> then toggle the Event option -> then select OPEN code
 
-- Type in the AUX command you want to set, e.g.\*9\*1\*4\## (where=4)
-- Type in the associated Open Web Net code you want to execute, e.g.\*5\*8*#1234## (engage alarm on zones 1,2,3,4).
+- Type in the AUX command you want to set, e.g `*9*1*4##` (where=4)
+- Type in the associated Open Web Net code you want to execute, e.g. `*5*8*#1234##` (engage alarm on zones 1, 2, 3, 4).
 
-Please note that receiving AUX messages originating from the bus is not supported yet, only sending messages to the bus is supported.
+**NOTE** receiving AUX messages originating from the BUS is not supported yet, only sending messages to the BUS is supported.
 
 
-
-### Central Unit integration missing points 
+### Thermo Central Unit integration missing points 
 
 - Read setPoint temperature and current mode
 - Holiday activation command (all zones)
@@ -176,17 +176,18 @@ Please note that receiving AUX messages originating from the bus is not supporte
 
 ## Channels 
 
-### Lighting, Automation, Power meter, CEN/CEN+ Scenario Events and Dry Contact / IR Interfaces channels
+### Lighting, Automation, Power meter, Basic/CEN/CEN+ Scenario Events and Dry Contact / IR Interfaces channels
 
 | Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                                                     | Read/Write  |
 |-----------------------------------------|---------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|:-----------:|
 | `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                                             |     R/W     |
 | `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                                                           |     R/W     |
 | `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))                                         |     R/W     |
-| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#cen-cen-channels)                                                           | R (TRIGGER) |
+| `scenario`                              | `bus_scenario_panel`    | String        | Trigger channel for basic scenario events [see possible values](#scenario-channels)                                                           | R (TRIGGER) |
+| `button#X`                              | `bus_cen_scenario_control`, `bus_cenplus_scenario_control`    | String        | Trigger channel for CEN/CEN+ scenario events [see possible values](#scenario-channels)                                                           | R (TRIGGER) |
 | `sensor`                                | `bus_dry_contact_ir`                                          | Switch        | Indicates if a Dry Contact Interface is `ON`/`OFF`, or if a IR Sensor is detecting movement (`ON`), or not  (`OFF`)                             |      R      |
 | `power`                                 | `bus_energy_meter`                                            | Number:Power  | The current active power usage from Energy Meter                                                                                                |      R      |
-| `aux`                                   | `bus_aux`                                                     | String        | Possible commands: ON,OFF,TOGGLE, STOP, UP,DOWN,ENABLED, DISABLED, RESET_GEN, RESET_BI, RESET_TRI. Only   'ON' and `OFF'  are supported for now |     R/W     |
+| `aux`                                   | `bus_aux`                                                     | String        | To send commands to auxiliary devices. Possible commands: `ON`, `OFF`, `TOGGLE`, `STOP`, `UP`, `DOWN`, `ENABLED`, `DISABLED`, `RESET_GEN`, `RESET_BI`, `RESET_TRI`. Only `ON` and `OFF`  are supported for now |     R/W     |
 
 ### Thermo channels
 
@@ -223,40 +224,41 @@ It's possible to enter a value manually or set `shutterRun=AUTO` (default) to ca
 - if OH is restarted the binding does not know if a shutter position has changed in the meantime, so its position will be `UNDEF`. Move the shutter all `UP`/`DOWN` to synchronize again its position with the binding
 - the shutter position is estimated based on UP/DOWN timing: an error of ±2% is normal
 
-#### CEN/CEN+ channels
+#### Scenario channels
 
-CEN/CEN+ are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
+Basic Scenarios and CEN/CEN+ channels are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
 
-A powerful feature is to be able to assign CEN or CEN+ commands to your physical wall switches and use the events they generate to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by physical BTicino switches.
-See [openwebnet.rules](#openwebnet-rules) for an example on how to define rules that trigger on CEN/CEN+ buttons events.
+A powerful feature is to detect scenario activations and CEN/CEN+ buttons pressure events to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by BTicino scenario panels or by CEN/CEN+ physical buttons.
+See [openwebnet.rules](#openwebnet-rules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ buttons events.
 
-It's also possible to send *virtual press* events on the BUS, for example to enable the activation of MH202 scenarios from openHAB.
-See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for an example on how to use the `virtualPress` action connected to a pushbutton on a sitemap.
+It's also possible to send *virtual scenario activation* and *virtual press* events on the BUS, for example to enable the activation of MH202 scenarios from openHAB.
+See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
 
-- channels are named `button#X` where `X` is the button number on the Scenario Control device
-- in the .thing file configuration you can specify the `buttons` parameter to define a comma-separated list of buttons numbers [0-31] configured for the scenario device, example: `buttons=1,2,4`
-- possible events are:
-    - for CEN:
-        - `START_PRESS` - sent when you start pressing the button
-        - `SHORT_PRESS` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
-        - `EXTENDED_PRESS` - sent if you keep the button pressed longer than 0,5sec; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
-        - `RELEASE_EXTENDED_PRESS` - sent once when you finally release the button after having it pressed longer than 0,5sec
-    - for CEN+:
-        - `SHORT_PRESS` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
-        - `START_EXTENDED_PRESS` - sent once as soon as you keep the button pressed longer than 0,5sec
-        - `EXTENDED_PRESS` - sent after `START_EXTENDED_PRESS` if you keep the button pressed longer; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
-        - `RELEASE_EXTENDED_PRESS` - sent once when you finally release the button after having it pressed longer than 0,5sec
+- basic scenario channels are named `scenario` and possible events are: `SCENARIO_01` ... `SCENARIO_20` when a new scenario is activated
+- CEN/CEN+ channels are named `button#X` where `X` is the button number on the CEN/CEN+ Scenario Control device
+    - in the .thing file configuration you can specify the `buttons` parameter to define a comma-separated list of buttons numbers [0-31] configured for the scenario device, example: `buttons=1,2,4`
+    - possible events are:
+        - for CEN:
+            - `START_PRESS` - sent when you start pressing the button
+            - `SHORT_PRESS` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
+            - `EXTENDED_PRESS` - sent if you keep the button pressed longer than 0,5sec; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
+            - `RELEASE_EXTENDED_PRESS` - sent once when you finally release the button after having it pressed longer than 0,5sec
+        - for CEN+:
+            - `SHORT_PRESS` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
+            - `START_EXTENDED_PRESS` - sent once as soon as you keep the button pressed longer than 0,5sec
+            - `EXTENDED_PRESS` - sent after `START_EXTENDED_PRESS` if you keep the button pressed longer; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
+            - `RELEASE_EXTENDED_PRESS` - sent once when you finally release the button after having it pressed longer than 0,5sec
 
-####  `mode` for values WEEKLY and SCENARIO (Central Unit)
+####  `mode` for values WEEKLY and SCENARIO (thermo Central Unit)
 
-There are three WEEKLY and sixteen SCENARIO programs defined for the Central Unit.
+There are three WEEKLY and sixteen SCENARIO programs defined for the thermo Central Unit.
 
 In order to activate one of them you have to use two different channels:
 
 - with `mode` you can set the mode (`WEEKLY` or `SCENARIO`)
-- with `weeklyProgram` (if `WEEKLY` was setted) or with `scenarioProgram` (if `SCENARIO` was setted) you can set the program number
+- with `weeklyProgram` (if `WEEKLY` was set) or with `scenarioProgram` (if `SCENARIO` was set) you can set the program number
 
-Example: if you want to activate SCENARIO #9 you have to set `mode` = `SCENARIO` and `scenarioProgram` = `9`.
+Example: if you want to activate SCENARIO #9 on the thermo Central Unit you have to set `mode` = `SCENARIO` and `scenarioProgram` = `9`.
 
 ## Full Example
 
@@ -277,9 +279,12 @@ Bridge openwebnet:bus_gateway:mybridge "MyHOMEServer1" [ host="192.168.1.35", pa
       bus_thermo_zone               LR_zone              "Living Room Zone"         [ where="2"]
       bus_thermo_sensor             EXT_tempsensor       "External Temperature"     [ where="500"]
 
+      bus_scenario_panel            BR_scenario_panel    "Bedroom Scenario Panel"   [ where="95" ]
+            
       bus_cen_scenario_control      LR_CEN_scenario      "Living Room CEN"          [ where="51", buttons="4,3,8"]
       bus_cenplus_scenario_control  LR_CENplus_scenario  "Living Room CEN+"         [ where="212", buttons="1,5,18" ]
       bus_dry_contact_ir            LR_IR_sensor         "Living Room IR Sensor"    [ where="399" ]
+      
       bus_aux		                Alarm_activation	 "Alarm activation"         [ where="4"   ]
 }
 ```
@@ -401,6 +406,15 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
 ### openwebnet.rules
 
 ```xtend
+rule "Basic scenario who=0"
+// A "SCENARIO_02" event started from Scenario Panel where=95 will switch ON iLR_switch %
+when
+    Channel "openwebnet:bus_scenario_panel:mybridge:BR_scenario_panel:scenario" triggered SCENARIO_02
+then
+    sendCommand(iLR_switch, ON)  
+end
+
+
 rule "CEN+ virtual press from OH button"
 /* This rule triggers when the proxy item iCENPlusProxyItem is activated, for example from a button on WebUI/sitemap.
 When activated it sends a "virtual short press" event (where=212, button=5) on the BUS 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.8.1</version>
+      <version>0.9.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -70,7 +70,8 @@ public class OpenWebNetBindingConstants {
     public static final ThingTypeUID THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL = new ThingTypeUID(BINDING_ID,
             "bus_cenplus_scenario_control");
     public static final String THING_LABEL_BUS_CENPLUS_SCENARIO_CONTROL = "CEN+ Control";
-
+    public static final ThingTypeUID THING_TYPE_BUS_SCENARIO_PANEL = new ThingTypeUID(BINDING_ID, "bus_scenario_panel");
+    public static final String THING_LABEL_BUS_SCENARIO_PANEL = "Scenario Control Panel";
     public static final ThingTypeUID THING_TYPE_BUS_AUX = new ThingTypeUID(BINDING_ID, "bus_aux");
     public static final String THING_LABEL_BUS_AUX = "Auxiliary";
     // ZIGBEE
@@ -102,14 +103,16 @@ public class OpenWebNetBindingConstants {
     // ## CEN/CEN+ Scenario
     public static final Set<ThingTypeUID> SCENARIO_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_CEN_SCENARIO_CONTROL,
             THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL, THING_TYPE_BUS_DRY_CONTACT_IR);
-
+    // ## Basic Scenario
+    public static final Set<ThingTypeUID> SCENARIO_BASIC_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_SCENARIO_PANEL);
     // ## Aux
     public static final Set<ThingTypeUID> AUX_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_AUX);
     // ## Groups
     public static final Set<ThingTypeUID> DEVICE_SUPPORTED_THING_TYPES = Stream
             .of(LIGHTING_SUPPORTED_THING_TYPES, AUTOMATION_SUPPORTED_THING_TYPES,
                     THERMOREGULATION_SUPPORTED_THING_TYPES, ENERGY_MANAGEMENT_SUPPORTED_THING_TYPES,
-                    SCENARIO_SUPPORTED_THING_TYPES, GENERIC_SUPPORTED_THING_TYPES, AUX_SUPPORTED_THING_TYPES)
+                    SCENARIO_SUPPORTED_THING_TYPES, SCENARIO_BASIC_SUPPORTED_THING_TYPES, AUX_SUPPORTED_THING_TYPES,
+                    GENERIC_SUPPORTED_THING_TYPES)
             .flatMap(Collection::stream).collect(Collectors.toCollection(HashSet::new));
     public static final Set<ThingTypeUID> BRIDGE_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_ZB_GATEWAY,
             THING_TYPE_BUS_GATEWAY);
@@ -143,7 +146,6 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_OFF = "atLeastOneProbeOff";
     public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_PROTECTION = "atLeastOneProbeProtection";
     public static final String CHANNEL_CU_AT_LEAST_ONE_PROBE_MANUAL = "atLeastOneProbeManual";
-
     // energy management
     public static final String CHANNEL_POWER = "power";
     // scenario button channels
@@ -151,8 +153,9 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_TYPE_CEN_BUTTON_EVENT = "cenButtonEvent";
     public static final String CHANNEL_TYPE_CEN_PLUS_BUTTON_EVENT = "cenPlusButtonEvent";
     public static final String CHANNEL_DRY_CONTACT_IR = "sensor";
-
-    // Aux
+    // basic scenario
+    public static final String CHANNEL_SCENARIO = "scenario";
+    // aux
     public static final String CHANNEL_AUX = "aux";
 
     // devices config properties
@@ -170,4 +173,5 @@ public class OpenWebNetBindingConstants {
     public static final String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
     public static final String PROPERTY_MODEL = "model";
     public static final String PROPERTY_SERIAL_NO = "serialNumber";
+
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
@@ -22,6 +22,7 @@ import org.openhab.binding.openwebnet.internal.handler.OpenWebNetBridgeHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetEnergyHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetGenericHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetLightingHandler;
+import org.openhab.binding.openwebnet.internal.handler.OpenWebNetScenarioBasicHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetScenarioHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetThermoregulationHandler;
 import org.openhab.core.thing.Bridge;
@@ -79,6 +80,9 @@ public class OpenWebNetHandlerFactory extends BaseThingHandlerFactory {
         } else if (OpenWebNetAuxiliaryHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
             logger.debug("Creating NEW AUXILIARY Handler");
             return new OpenWebNetAuxiliaryHandler(thing);
+        } else if (OpenWebNetScenarioBasicHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            logger.debug("Creating NEW SCENARIO BASIC Handler");
+            return new OpenWebNetScenarioBasicHandler(thing);
         }
         logger.warn("ThingType {} is not supported by this binding", thing.getThingTypeUID());
         return null;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -156,6 +156,12 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
                 deviceWho = Who.ENERGY_MANAGEMENT;
                 break;
             }
+            case BASIC_SCENARIO: {
+                thingTypeUID = OpenWebNetBindingConstants.THING_TYPE_BUS_SCENARIO_PANEL;
+                thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_SCENARIO_PANEL;
+                deviceWho = Who.SCENARIO;
+                break;
+            }
             case SCENARIO_CONTROL: {
                 thingTypeUID = OpenWebNetBindingConstants.THING_TYPE_BUS_CEN_SCENARIO_CONTROL;
                 thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_CEN_SCENARIO_CONTROL;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -57,6 +57,7 @@ import org.openwebnet4j.message.FrameException;
 import org.openwebnet4j.message.GatewayMgmt;
 import org.openwebnet4j.message.Lighting;
 import org.openwebnet4j.message.OpenMessage;
+import org.openwebnet4j.message.Scenario;
 import org.openwebnet4j.message.Thermoregulation;
 import org.openwebnet4j.message.What;
 import org.openwebnet4j.message.Where;
@@ -68,9 +69,10 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link OpenWebNetBridgeHandler} is responsible for handling communication with gateways and handling events.
  *
- * @author Massimo Valla - Initial contribution
+ * @author Massimo Valla - Initial contribution, Lighting, Automation, Scenario
  * @author Andrea Conte - Energy management, Thermoregulation
  * @author Gilberto Cocchi - Thermoregulation
+ * @author Giovanni Fabiani - Aux
  */
 @NonNullByDefault
 public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implements GatewayListener {
@@ -326,7 +328,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         }
         // we support these types only
         if (baseMsg instanceof Lighting || baseMsg instanceof Automation || baseMsg instanceof EnergyManagement
-                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN) {
+                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN || baseMsg instanceof Scenario) {
             BaseOpenMessage bmsg = baseMsg;
             if (baseMsg instanceof Lighting) {
                 What what = baseMsg.getWhat();
@@ -498,7 +500,8 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         BaseOpenMessage baseMsg = (BaseOpenMessage) msg;
         // let's try to get the Thing associated with this message...
         if (baseMsg instanceof Lighting || baseMsg instanceof Automation || baseMsg instanceof EnergyManagement
-                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN || baseMsg instanceof Auxiliary) {
+                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN || baseMsg instanceof Auxiliary
+                || baseMsg instanceof Scenario) {
             String ownId = ownIdFromMessage(baseMsg);
             logger.debug("ownIdFromMessage({}) --> {}", baseMsg, ownId);
             OpenWebNetThingHandler deviceHandler = registeredDevices.get(ownId);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioBasicHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioBasicHandler.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.openwebnet.internal.handler;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.types.Command;
+import org.openwebnet4j.message.BaseOpenMessage;
+import org.openwebnet4j.message.Scenario.WhatScenario;
+import org.openwebnet4j.message.Where;
+import org.openwebnet4j.message.WhereLightAutom;
+import org.openwebnet4j.message.Who;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OpenWebNetScenarioBasicHandler} is responsible for handling Basic Scenario (WHO=0) messages.
+ * It extends the abstract {@link OpenWebNetThingHandler}.
+ *
+ * @author Massimo Valla - Initial contribution
+ */
+@NonNullByDefault
+public class OpenWebNetScenarioBasicHandler extends OpenWebNetThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OpenWebNetScenarioBasicHandler.class);
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.SCENARIO_BASIC_SUPPORTED_THING_TYPES;
+
+    public OpenWebNetScenarioBasicHandler(Thing thing) {
+        super(thing);
+        logger.debug("created Scenario Panel device for thing: {}", getThing().getUID());
+    }
+
+    @Override
+    protected String ownIdPrefix() {
+        return Who.SCENARIO.value().toString();
+    }
+
+    @Override
+    protected void handleMessage(BaseOpenMessage msg) {
+        super.handleMessage(msg);
+        if (msg.isCommand()) {
+            WhatScenario scenario = (WhatScenario) msg.getWhat();
+            if (scenario == null) {
+                logger.warn("Invalid Basic Scenario: {}. Ignoring message {}", scenario, msg);
+                return;
+            }
+            logger.info("Basic Scenario {} has been activated", scenario);
+            triggerChannel(OpenWebNetBindingConstants.CHANNEL_SCENARIO, scenario.toString());
+        } else {
+            logger.debug("handleMessage() Ignoring unsupported DIM for thing {}. Frame={}", getThing().getUID(), msg);
+        }
+    }
+
+    @Override
+    protected void handleChannelCommand(ChannelUID channel, Command command) {
+        // TODO not supported yet
+        logger.info("Activation of Basic Scenario (WHO=0) is not supported yet. Ignoring command {} for channel {}",
+                command, channel);
+    }
+
+    @Override
+    protected void requestChannelState(ChannelUID channel) {
+        logger.debug("requestChannelState() Basic Scenario channels are trigger channels and do not have state.");
+    }
+
+    @Override
+    protected void refreshDevice(boolean refreshAll) {
+        logger.debug("Basic Scenario channels are trigger channels and do not have state.");
+    }
+
+    @Override
+    protected Where buildBusWhere(String wStr) throws IllegalArgumentException {
+        return new WhereLightAutom(wStr);
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusScenario.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusScenario.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0" bindingId="openwebnet"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Thing for BUS Basic Scenario Panels -->
+	<thing-type id="bus_scenario_panel">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bus_gateway"/>
+		</supported-bridge-type-refs>
+
+		<label>Basic Scenario Panel</label>
+		<description>A OpenWebNet BUS/SCS Basic Scenario Panel</description>
+
+		<channels>
+			<channel id="scenario" typeId="scenarioEvent"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">BTicino/Legrand</property>
+			<property name="ownDeviceType">3</property>
+		</properties>
+
+		<representation-property>ownId</representation-property>
+
+		<config-description>
+			<parameter name="where" type="text" required="true">
+				<label>OpenWebNet Address (where)</label>
+				<description>Example: Control Panel 02 --> where=02. On local bus: where=02#4#01</description>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -341,6 +341,37 @@
 		<state readOnly="true" pattern="%.0f %unit%"></state>
 	</channel-type>
 
+    <!-- Basic Scenario trigger channels -->
+    <channel-type id="scenarioEvent">
+        <kind>trigger</kind>
+        <label>Basic Scenario Event</label>
+        <event>
+            <options>
+                <option value="SCENARIO_01">Scenario 1</option>
+                <option value="SCENARIO_02">Scenario 2</option>
+                                <option value="SCENARIO_03">Scenario 3</option>
+                                <option value="SCENARIO_04">Scenario 4</option>
+                                <option value="SCENARIO_05">Scenario 5</option>
+                                <option value="SCENARIO_06">Scenario 6</option>
+                                <option value="SCENARIO_07">Scenario 7</option>
+                                <option value="SCENARIO_08">Scenario 8</option>
+                                <option value="SCENARIO_09">Scenario 9</option>
+                                <option value="SCENARIO_10">Scenario 10</option>
+                                <option value="SCENARIO_11">Scenario 11</option>
+                                <option value="SCENARIO_12">Scenario 12</option>
+                                <option value="SCENARIO_13">Scenario 13</option>
+                                <option value="SCENARIO_14">Scenario 14</option>
+                                <option value="SCENARIO_15">Scenario 15</option>
+                                <option value="SCENARIO_16">Scenario 16</option>
+                                <option value="SCENARIO_17">Scenario 17</option>
+                                <option value="SCENARIO_18">Scenario 18</option>
+                                <option value="SCENARIO_19">Scenario 19</option>
+                
+                <option value="SCENARIO_20">Scenario 20</option>
+            </options>
+        </event>
+    </channel-type>
+    
 	<!-- CEN/CEN+ trigger channels -->
 	<channel-type id="cenButtonEvent">
 		<kind>trigger</kind>
@@ -368,6 +399,7 @@
 		</event>
 	</channel-type>
 
+    <!-- Dry Contact / IR channel -->
 	<channel-type id="dryContactIR">
 		<item-type>Switch</item-type>
 		<label>Sensor</label>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -349,24 +349,23 @@
             <options>
                 <option value="SCENARIO_01">Scenario 1</option>
                 <option value="SCENARIO_02">Scenario 2</option>
-                                <option value="SCENARIO_03">Scenario 3</option>
-                                <option value="SCENARIO_04">Scenario 4</option>
-                                <option value="SCENARIO_05">Scenario 5</option>
-                                <option value="SCENARIO_06">Scenario 6</option>
-                                <option value="SCENARIO_07">Scenario 7</option>
-                                <option value="SCENARIO_08">Scenario 8</option>
-                                <option value="SCENARIO_09">Scenario 9</option>
-                                <option value="SCENARIO_10">Scenario 10</option>
-                                <option value="SCENARIO_11">Scenario 11</option>
-                                <option value="SCENARIO_12">Scenario 12</option>
-                                <option value="SCENARIO_13">Scenario 13</option>
-                                <option value="SCENARIO_14">Scenario 14</option>
-                                <option value="SCENARIO_15">Scenario 15</option>
-                                <option value="SCENARIO_16">Scenario 16</option>
-                                <option value="SCENARIO_17">Scenario 17</option>
-                                <option value="SCENARIO_18">Scenario 18</option>
-                                <option value="SCENARIO_19">Scenario 19</option>
-                
+                <option value="SCENARIO_03">Scenario 3</option>
+                <option value="SCENARIO_04">Scenario 4</option>
+                <option value="SCENARIO_05">Scenario 5</option>
+                <option value="SCENARIO_06">Scenario 6</option>
+                <option value="SCENARIO_07">Scenario 7</option>
+                <option value="SCENARIO_08">Scenario 8</option>
+                <option value="SCENARIO_09">Scenario 9</option>
+                <option value="SCENARIO_10">Scenario 10</option>
+                <option value="SCENARIO_11">Scenario 11</option>
+                <option value="SCENARIO_12">Scenario 12</option>
+                <option value="SCENARIO_13">Scenario 13</option>
+                <option value="SCENARIO_14">Scenario 14</option>
+                <option value="SCENARIO_15">Scenario 15</option>
+                <option value="SCENARIO_16">Scenario 16</option>
+                <option value="SCENARIO_17">Scenario 17</option>
+                <option value="SCENARIO_18">Scenario 18</option>
+                <option value="SCENARIO_19">Scenario 19</option>
                 <option value="SCENARIO_20">Scenario 20</option>
             </options>
         </event>

--- a/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
+++ b/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Massimo Valla - Initial contribution
  * @author Andrea Conte - Energy management
- * @author Giovanni Fabiani - AAuxiliary message support
+ * @author Giovanni Fabiani - Auxiliary message support
  */
 @NonNullByDefault
 public class OwnIdTest {
@@ -66,7 +66,8 @@ public class OwnIdTest {
      * BUS CEN              51              51                  15.51           51
      * BUS CEN+             212             212                 25.212          212
      * BUS DryContact       399             399                 25.399          399
-     * BUS AUX                4               4                    9.4            4
+     * BUS AUX              4               4                   9.4             4
+     * BUS Scenario         05              05                  0.05            05
      */
 // @formatter:on
 
@@ -86,7 +87,9 @@ public class OwnIdTest {
         bus_cen(new WhereCEN("51"), Who.fromValue(15), "*15*31*51##", "51", "15.51", "51"),
         bus_cen_plus(new WhereCEN("212"), Who.fromValue(25), "*25*21#31*212##", "212", "25.212", "212"),
         bus_drycontact(new WhereCEN("399"), Who.fromValue(25), "*25*32#1*399##", "399", "25.399", "399"),
-        bus_aux(new WhereAuxiliary("4"), Who.fromValue(9), "*9*1*4##","4","9.4","4");
+        bus_aux(new WhereAuxiliary("4"), Who.fromValue(9), "*9*1*4##","4","9.4","4"),
+        bus_scenario(new WhereLightAutom("05"), Who.fromValue(0), "*0*2*05##","05","0.05","05");
+
 
 
         // @formatter:on


### PR DESCRIPTION
This PR adds support for Basic Scenarios (WHO=0) to the OpenWebNet binding.
With this enhancement it will be possible to detect scenario activation events to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by physical BTicino scenario panels. 
This will solve #11378.
