### PR TITLE
[androiddebugbridge] Fix GetCurrentPackage for Android 11

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -201,7 +201,14 @@ public class AndroidDebugBridgeDevice {
 
     public String getCurrentPackage() throws AndroidDebugBridgeDeviceException, InterruptedException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
-        var out = runAdbShell("dumpsys", "window", "windows", "|", "grep", "mFocusedApp");
+        int version = Integer.parseInt(getAndroidVersion());
+        String out;
+        if (version >= 11) {
+            out = runAdbShell("dumpsys", "window", "displays", "|", "grep", "mFocusedApp");
+            logger.debug("detected android version: {} ", getAndroidVersion());
+        } else {
+            out = runAdbShell("dumpsys", "window", "windows", "|", "grep", "mFocusedApp");
+        }
         var targetLine = Arrays.stream(out.split("\n")).findFirst().orElse("");
         var lineParts = targetLine.split(" ");
         if (lineParts.length >= 2) {


### PR DESCRIPTION
* In Android 11 google updated the dympsys service and
  changed the naming of some of the command options which
  causes the binding to not parse the current package
  name correctly.

* Added a check for the current android version and if it
  returns "11" use the new command, otherwise use original

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>
