### PR TITLE
[radiothermostat] Increase timeout for thermostat status requests

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -2,7 +2,8 @@
 
 ![RadioThermostat logo](doc/index.jpg)
 
-This binding connects RadioThermostat/3M Filtrete models CT30, CT50/3M50, CT80, etc. with built-in Wi-Fi module to openHAB.
+This binding connects RadioThermostat/3M Filtrete models CT30, CT50/3M50, CT80, etc. with built-in Wi-Fi module to openHAB. 
+Thermostats using a Z-Wave module are not supported but can be used via the openHAB ZWave binding.
 
 The binding retrieves and periodically updates all basic system information from the thermostat.
 The main thermostat functions such as thermostat mode, fan mode, temperature set point and hold mode can be controlled.

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/communication/RadioThermostatConnector.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/communication/RadioThermostatConnector.java
@@ -86,7 +86,7 @@ public class RadioThermostatConnector {
     public void getAsyncThermostatData(String resource) {
         String urlStr = buildRequestURL(resource);
 
-        httpClient.newRequest(urlStr).method(GET).timeout(20, TimeUnit.SECONDS).send(new BufferingResponseListener() {
+        httpClient.newRequest(urlStr).method(GET).timeout(30, TimeUnit.SECONDS).send(new BufferingResponseListener() {
             @Override
             public void onComplete(@Nullable Result result) {
                 if (result != null && !result.isFailed()) {


### PR DESCRIPTION
When using the CT-80 thermostat, I have noticed that the thing frequently switches between offline and online status. This change increases the timeout of the status info requests to help alleviate the problem.