### PR TITLE
[homekit] update configuration revision on start

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -130,6 +130,7 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         metadataRegistry.addRegistryChangeListener(metadataChangeListener);
         itemRegistry.getItems().forEach(this::createRootAccessories);
         initialiseRevision();
+        makeNewConfigurationRevision();
         logger.info("Created {} HomeKit items.", accessoryRegistry.getAllAccessories().size());
     }
 


### PR DESCRIPTION
update configuration revision on openHAB restart. this will force all paired ios devices to request a new list of homekit accessories provided via openHAB.

this solves following issues:
- item config was change while openHAB was down.
- the orders and ids of homekit accessories has changed, as described here 
https://community.openhab.org/t/how-to-configure-homekit-light-with-colour/136137

Signed-off-by: Eugen Freiter <freiter@gmx.de>
