### PR TITLE
[nikohomecontrol] Nhc fixes

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageBase1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageBase1.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Class {@link NhcMessageBase1} used as base class for output from gson for cmd or event feedback from Niko Home
@@ -26,11 +27,12 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 abstract class NhcMessageBase1 {
 
-    private String cmd = "";
-    private String event = "";
+    private @Nullable String cmd;
+    private @Nullable String event;
 
     String getCmd() {
-        return cmd;
+        String cmd = this.cmd;
+        return ((cmd != null) ? cmd : "");
     }
 
     void setCmd(String cmd) {
@@ -38,7 +40,8 @@ abstract class NhcMessageBase1 {
     }
 
     String getEvent() {
-        return event;
+        String event = this.event;
+        return ((event != null) ? event : "");
     }
 
     void setEvent(String event) {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageCmd1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageCmd1.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Class {@link NhcMessageCmd1} used as input to gson to send commands to Niko Home Control. Extends
@@ -26,13 +27,13 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 class NhcMessageCmd1 extends NhcMessageBase1 {
 
-    private int id;
-    private int value1;
-    private int value2;
-    private int value3;
-    private int mode;
-    private int overrule;
-    private String overruletime = "";
+    private @Nullable Integer id;
+    private @Nullable Integer value1;
+    private @Nullable Integer value2;
+    private @Nullable Integer value3;
+    private @Nullable Integer mode;
+    private @Nullable Integer overrule;
+    private @Nullable String overruletime;
 
     NhcMessageCmd1(String cmd) {
         super.setCmd(cmd);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
@@ -169,8 +169,11 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         nhcEventsRunning = true;
 
         try {
-            while (!listenerStopped & (nhcIn != null) & ((nhcMessage = nhcIn.readLine()) != null)) {
-                readMessage(nhcMessage);
+            BufferedReader in = nhcIn;
+            if (in != null) {
+                while (!listenerStopped && ((nhcMessage = in.readLine()) != null)) {
+                    readMessage(nhcMessage);
+                }
             }
         } catch (IOException e) {
             if (!listenerStopped) {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -39,6 +39,7 @@ import org.openhab.binding.nikohomecontrol.internal.protocol.NhcEnergyMeter;
 import org.openhab.binding.nikohomecontrol.internal.protocol.NhcThermostat;
 import org.openhab.binding.nikohomecontrol.internal.protocol.NikoHomeControlCommunication;
 import org.openhab.binding.nikohomecontrol.internal.protocol.NikoHomeControlConstants.ActionType;
+import org.openhab.binding.nikohomecontrol.internal.protocol.nhc2.NhcDevice2.NhcParameter;
 import org.openhab.binding.nikohomecontrol.internal.protocol.nhc2.NhcDevice2.NhcProperty;
 import org.openhab.binding.nikohomecontrol.internal.protocol.nhc2.NhcMessage2.NhcMessageParam;
 import org.openhab.core.io.transport.mqtt.MqttConnectionObserver;
@@ -357,9 +358,9 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
 
     private void addDevice(NhcDevice2 device) {
         String location = null;
-        if (device.parameters != null) {
-            location = device.parameters.stream().map(p -> p.locationName).filter(Objects::nonNull).findFirst()
-                    .orElse(null);
+        List<NhcParameter> parameters = device.parameters;
+        if (parameters != null) {
+            location = parameters.stream().map(p -> p.locationName).filter(Objects::nonNull).findFirst().orElse(null);
         }
 
         if ("action".equals(device.type) || "virtual".equals(device.type)) {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -620,10 +620,6 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         switch (action.getType()) {
             case GENERIC:
             case TRIGGER:
-                if (!NHCON.equals(value)) {
-                    // Only trigger for ON
-                    return;
-                }
                 property.basicState = NHCTRIGGERED;
                 break;
             case RELAY:


### PR DESCRIPTION
These are a few small fixes extracted from [PR #11963]( https://github.com/openhab/openhab-addons/pull/11963):

- Make trigger type items act on off in the NHC system
- Fix gson serialization for empty values
- Fix some null pointer warnings
