### PR TITLE
Exclude embedded module-info.class recursively

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -580,7 +580,7 @@
             <configuration>
               <includeScope>runtime</includeScope>
               <includeTypes>jar</includeTypes>
-              <excludes>module-info.class</excludes>
+              <excludes>**/module-info.class</excludes>
               <excludeGroupIds>javax.activation,org.apache.karaf.features,org.lastnpe.eea</excludeGroupIds>
               <excludeArtifactIds>${dep.noembedding}</excludeArtifactIds>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>


### PR DESCRIPTION
See: https://github.com/openhab/openhab-addons/pull/12772#issuecomment-1145179643