### PR TITLE
[orbitbhyve] Eliminate JsonSyntaxException when restricted_frequency is null in json response

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/model/OrbitBhyveDevice.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/model/OrbitBhyveDevice.java
@@ -54,9 +54,6 @@ public class OrbitBhyveDevice {
 
     JsonObject location = new JsonObject();
 
-    @SerializedName("restricted_frequency")
-    JsonObject restrictedFrequency = new JsonObject();
-
     @SerializedName("suggested_start_time")
     String suggestedStartTime = "";
 


### PR DESCRIPTION
Fixes #12871 

Removes `restrictedFrequency`, as the binding doesn't use it.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
