### PR TITLE
[elroconnects] Set thingStatus earlier in initialize

### DIFF
--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceCxsmAlarm.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceCxsmAlarm.java
@@ -123,14 +123,15 @@ public class ElroConnectsDeviceCxsmAlarm extends ElroConnectsDevice {
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Device " + deviceId + " is not syncing with K1 hub");
+                String msg = String.format("@text/offline.device-not-syncing [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, msg);
                 break;
             case FAULT:
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
+                msg = String.format("@text/offline.device-fault [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, msg);
                 break;
             default:
                 handler.updateState(SIGNAL_STRENGTH, new DecimalType(signalStrength));

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceEntrySensor.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceEntrySensor.java
@@ -88,15 +88,16 @@ public class ElroConnectsDeviceEntrySensor extends ElroConnectsDevice {
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Device " + deviceId + " is not syncing with K1 hub");
+                String msg = String.format("@text/offline.device-not-syncing [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, msg);
                 break;
             case FAULT:
                 handler.updateState(ENTRY, UnDefType.UNDEF);
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
+                msg = String.format("@text/offline.device-fault [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, msg);
                 break;
             default:
                 handler.updateState(ENTRY,

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceGenericAlarm.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceGenericAlarm.java
@@ -116,14 +116,15 @@ public class ElroConnectsDeviceGenericAlarm extends ElroConnectsDevice {
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Device " + deviceId + " is not syncing with K1 hub");
+                String msg = String.format("@text/offline.device-not-syncing [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, msg);
                 break;
             case FAULT:
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
+                msg = String.format("@text/offline.device-fault [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, msg);
                 break;
             default:
                 handler.updateState(SIGNAL_STRENGTH, new DecimalType(signalStrength));

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceMotionSensor.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceMotionSensor.java
@@ -87,15 +87,16 @@ public class ElroConnectsDeviceMotionSensor extends ElroConnectsDevice {
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Device " + deviceId + " is not syncing with K1 hub");
+                String msg = String.format("@text/offline.device-not-syncing [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, msg);
                 break;
             case FAULT:
                 handler.updateState(MOTION, UnDefType.UNDEF);
                 handler.updateState(SIGNAL_STRENGTH, UnDefType.UNDEF);
                 handler.updateState(BATTERY_LEVEL, UnDefType.UNDEF);
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
+                msg = String.format("@text/offline.device-fault [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, msg);
                 break;
             default:
                 handler.updateState(MOTION,

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDevicePowerSocket.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDevicePowerSocket.java
@@ -69,6 +69,7 @@ public class ElroConnectsDevicePowerSocket extends ElroConnectsDevice {
         String deviceStatus = this.deviceStatus;
         if (deviceStatus.length() < 6) {
             logger.debug("Could not decode device status: {}", deviceStatus);
+            handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
             return;
         }
 

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDevicePowerSocket.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDevicePowerSocket.java
@@ -69,7 +69,8 @@ public class ElroConnectsDevicePowerSocket extends ElroConnectsDevice {
         String deviceStatus = this.deviceStatus;
         if (deviceStatus.length() < 6) {
             logger.debug("Could not decode device status: {}", deviceStatus);
-            handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
+            String msg = String.format("@text/offline.device-fault [ \"%d\" ]", deviceId);
+            handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, msg);
             return;
         }
 
@@ -82,8 +83,8 @@ public class ElroConnectsDevicePowerSocket extends ElroConnectsDevice {
                 : (STAT_OFF.equals(status) ? OnOffType.OFF : UnDefType.UNDEF);
         handler.updateState(POWER_STATE, state);
         if (UnDefType.UNDEF.equals(state)) {
-            handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Device " + deviceId + " is not syncing with K1 hub");
+            String msg = String.format("@text/offline.device-not-syncing [ \"%d\" ]", deviceId);
+            handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, msg);
         } else {
             handler.updateStatus(ThingStatus.ONLINE);
         }

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceTemperatureSensor.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/devices/ElroConnectsDeviceTemperatureSensor.java
@@ -75,7 +75,8 @@ public class ElroConnectsDeviceTemperatureSensor extends ElroConnectsDevice {
                 handler.updateState(LOW_BATTERY, UnDefType.UNDEF);
                 handler.updateState(TEMPERATURE, UnDefType.UNDEF);
                 handler.updateState(HUMIDITY, UnDefType.UNDEF);
-                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "Device " + deviceId + " has a fault");
+                String msg = String.format("@text/offline.device-fault [ \"%d\" ]", deviceId);
+                handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, msg);
                 break;
             default:
                 handler.updateState(SIGNAL_STRENGTH, new DecimalType(signalStrength));

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsAccountHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsAccountHandler.java
@@ -121,6 +121,8 @@ public class ElroConnectsAccountHandler extends BaseBridgeHandler {
         login.put("password", password);
         loginJson = gson.toJson(login);
 
+        updateStatus(ThingStatus.UNKNOWN);
+
         // If background discovery is enabled, start polling (will do login first), else only login to take the thing
         // online if successful
         if (enableBackgroundDiscovery) {

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsBridgeHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsBridgeHandler.java
@@ -172,6 +172,8 @@ public class ElroConnectsBridgeHandler extends BaseBridgeHandler {
 
         queryString = QUERY_BASE_STRING + connectorId;
 
+        updateStatus(ThingStatus.UNKNOWN);
+
         scheduler.submit(this::startCommunication);
     }
 

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsBridgeHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsBridgeHandler.java
@@ -162,10 +162,10 @@ public class ElroConnectsBridgeHandler extends BaseBridgeHandler {
         legacyFirmware = config.legacyFirmware;
 
         if (connectorId.isEmpty()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "@text/offline.no-device-id");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "@text/offline.no-connector-id");
             return;
         } else if (!CONNECTOR_ID_PATTERN.matcher(connectorId).matches()) {
-            String msg = String.format("@text/offline.invalid-device-id [ \"%s\" ]", connectorId);
+            String msg = String.format("@text/offline.invalid-connector-id [ \"%s\" ]", connectorId);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, msg);
             return;
         }

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -66,8 +66,6 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
                     String msg = String.format("@text/offline.invalid-device-type [ \"%s\" ]", deviceType);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, msg);
                 } else {
-                    updateStatus(ThingStatus.UNKNOWN);
-
                     bridgeHandler.setDeviceHandler(deviceId, this);
                     updateProperties(bridgeHandler);
                     updateDeviceName(bridgeHandler);

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -49,16 +49,19 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
         ElroConnectsDeviceConfiguration config = getConfigAs(ElroConnectsDeviceConfiguration.class);
         deviceId = config.deviceId;
 
-        Bridge bridge = getBridge();
         ElroConnectsBridgeHandler bridgeHandler = getBridgeHandler();
+        if (bridgeHandler == null) {
+            // Thing status has already been updated in getBridgeHandler()
+            return;
+        }
 
-        if ((bridge != null) && (bridgeHandler != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+        if (bridgeHandler.getThing().getStatus() == ThingStatus.ONLINE) {
             bridgeHandler.setDeviceHandler(deviceId, this);
             updateProperties(bridgeHandler);
             updateDeviceName(bridgeHandler);
             refreshChannels(bridgeHandler);
         } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
     }
 

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -63,7 +63,7 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
             if (device != null) {
                 ElroDeviceType deviceType = TYPE_MAP.get(device.getDeviceType());
                 if ((deviceType == null) || !thing.getThingTypeUID().equals(THING_TYPE_MAP.get(deviceType))) {
-                    String msg = String.format("@text/offline.invalid-device-type [ \"%s\" ]", device.getDeviceType());
+                    String msg = String.format("@text/offline.invalid-device-type [ \"%s\" ]", deviceType);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, msg);
                 } else {
                     updateStatus(ThingStatus.UNKNOWN);

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -63,7 +63,7 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
             if (device != null) {
                 ElroDeviceType deviceType = TYPE_MAP.get(device.getDeviceType());
                 if ((deviceType == null) || !thing.getThingTypeUID().equals(THING_TYPE_MAP.get(deviceType))) {
-                    String msg = String.format("@text/offline.invalid-device-type [ \"%s\" ]", deviceType);
+                    String msg = String.format("@text/offline.invalid-device-type [ \"%s\" ]", device.getDeviceType());
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, msg);
                 } else {
                     updateStatus(ThingStatus.UNKNOWN);

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -24,6 +24,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
@@ -48,13 +49,16 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
         ElroConnectsDeviceConfiguration config = getConfigAs(ElroConnectsDeviceConfiguration.class);
         deviceId = config.deviceId;
 
+        Bridge bridge = getBridge();
         ElroConnectsBridgeHandler bridgeHandler = getBridgeHandler();
 
-        if (bridgeHandler != null) {
+        if ((bridge != null) && (bridgeHandler != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
             bridgeHandler.setDeviceHandler(deviceId, this);
             updateProperties(bridgeHandler);
             updateDeviceName(bridgeHandler);
             refreshChannels(bridgeHandler);
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -88,6 +92,15 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
         }
 
         return bridgeHandler;
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            initialize();
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -63,7 +63,7 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
             if (device != null) {
                 ElroDeviceType deviceType = TYPE_MAP.get(device.getDeviceType());
                 if ((deviceType == null) || !thing.getThingTypeUID().equals(THING_TYPE_MAP.get(deviceType))) {
-                    String msg = String.format("@text/offline.invalid-device-type [ \"%d\" ]", deviceType);
+                    String msg = String.format("@text/offline.invalid-device-type [ \"%s\" ]", deviceType);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, msg);
                 } else {
                     updateStatus(ThingStatus.UNKNOWN);

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/handler/ElroConnectsDeviceHandler.java
@@ -66,6 +66,8 @@ public class ElroConnectsDeviceHandler extends BaseThingHandler {
                     String msg = String.format("@text/offline.invalid-device-type [ \"%d\" ]", deviceType);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, msg);
                 } else {
+                    updateStatus(ThingStatus.UNKNOWN);
+
                     bridgeHandler.setDeviceHandler(deviceId, this);
                     updateProperties(bridgeHandler);
                     updateDeviceName(bridgeHandler);

--- a/bundles/org.openhab.binding.elroconnects/src/main/resources/OH-INF/i18n/elroconnects.properties
+++ b/bundles/org.openhab.binding.elroconnects/src/main/resources/OH-INF/i18n/elroconnects.properties
@@ -106,3 +106,6 @@ offline.no-bridge = No bridge defined for device: {0}
 offline.no-bridge-handler = No bridge handler defined for device: {0}
 offline.invalid-device-id = Device ID {0} not defined in the connector
 offline.invalid-device-type = Thing type does not match device type {0}
+offline.device-not-syncing = Device {0} not syncing with K1 hub
+offline.device-fault = Device {0} has a fault
+

--- a/bundles/org.openhab.binding.elroconnects/src/main/resources/OH-INF/i18n/elroconnects.properties
+++ b/bundles/org.openhab.binding.elroconnects/src/main/resources/OH-INF/i18n/elroconnects.properties
@@ -93,8 +93,8 @@ offline.credentials-error = Invalid username or password
 offline.request-timeout = Request timeout
 offline.request-failed = Request failed
 
-offline.no-device-id = Device ID not set
-offline.invalid-device-id = Device ID {0} not of format ST_xxxxxxxxxxxx with xxxxxxxxxxxx the lowercase MAC address of the connector
+offline.no-connector-id = Connector ID not set
+offline.invalid-connector-id = Connector ID {0} not of format ST_xxxxxxxxxxxx with xxxxxxxxxxxx the lowercase MAC address of the connector
 offline.find-ip-fail = Error trying to find IP address for connector with ID {0}
 offline.communication-data-error = Communication data error while starting communication
 offline.communication-error = Error in communication: {0}
@@ -104,3 +104,5 @@ offline.no-hub-address = Error in communication, hub address was not set
 
 offline.no-bridge = No bridge defined for device: {0}
 offline.no-bridge-handler = No bridge handler defined for device: {0}
+offline.invalid-device-id = Device ID {0} not defined in the connector
+offline.invalid-device-type = Thing type does not match device type {0}


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

- Set thing status UNKNOWN in initialize before launching long running init
- Implement bridgeStatusChanged
