### PR TITLE
[roku] Fix reporting of Roku Home app

### DIFF
--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/RokuBindingConstants.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/RokuBindingConstants.java
@@ -70,6 +70,7 @@ public class RokuBindingConstants {
     public static final String EMPTY = "";
     public static final String ROKU_HOME = "Roku Home";
     public static final String ROKU_HOME_ID = "-1";
+    public static final String ROKU_HOME_ID_562859 = "562859";
     public static final String ROKU_HOME_BUTTON = "Home";
     public static final String NON_DIGIT_PATTERN = "[^\\d]";
     public static final String TV_APP = "tvinput.dtv";

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -135,6 +135,12 @@ public class RokuHandler extends BaseThingHandler {
             String activeAppId = ROKU_HOME_ID;
             try {
                 activeAppId = communicator.getActiveApp().getApp().getId();
+
+                // 562859 is now reported when on the home screen, reset to -1
+                if (ROKU_HOME_ID_562859.equals(activeAppId)) {
+                    activeAppId = ROKU_HOME_ID;
+                }
+
                 updateState(ACTIVE_APP, new StringType(activeAppId));
                 if (TV_APP.equals(activeAppId)) {
                     tvActive = true;


### PR DESCRIPTION
The '/query/active-app' endpoint now reports an id of 562859 instead of -1 when on the Roku Home screen. This change will revert the id back to -1 so that the Active App channel's drop down can correctly report when the Roku is on the home screen.