### PR TITLE
[ecobee] Add support for the Smart Thermostat Premium

### DIFF
--- a/bundles/org.openhab.binding.ecobee/README.md
+++ b/bundles/org.openhab.binding.ecobee/README.md
@@ -407,14 +407,20 @@ The following channels are available on the Ecobee Remote Sensor.
 
 Some or all of the following Remote Sensor channels will be added dynamically depending on the capabilities of the sensor.
 
-| Channel      | Type                  | ReadWrite | Description  |
-|--------------|-----------------------|-----------|--------------|
-| temperature  | Number:Temperature    |           | Temperature reported by the sensor  |
-| humidity     | Number:Dimensionless  |           | Humidity reported by the sensor  |
-| occupancy    | Switch                |           | Occupancy status reported by the sensor  |
-| co2          | String                |           | CO2 reported by the sensor  |
-| dryContact   | String                |           | Dry contact status reported by the sensor  |
-| adc          | String                |           | ADC reported by the sensor  |
+| Channel            | Type                  | ReadWrite | Description  |
+|--------------------|-----------------------|-----------|--------------|
+| temperature        | Number:Temperature    |           | Temperature reported by the sensor  |
+| humidity           | Number:Dimensionless  |           | Humidity reported by the sensor  |
+| occupancy          | Switch                |           | Occupancy status reported by the sensor  |
+| adc                | String                |           | ADC reported by the sensor  |
+| airPressure        | String                |           | Air Pressure reported by the sensor  |
+| airQuality         | String                |           | Air Quality reported by the sensor (clean-poor)  |
+| airQualityAccuracy | String                |           | Air Quality Accuracy reported by the sensor  |
+| co2                | String                |           | CO2 reported by the sensor  |
+| co2PPM             | String                |           | CO2 level reported by the sensor (low-high)  |
+| dryContact         | String                |           | Dry contact status reported by the sensor  |
+| vocPPM             | String                |           | Volatile organic compounds (VOC) reported by the sensor (low-high)  |
+
 
 ## Thing Actions
 

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeSensorThingHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeSensorThingHandler.java
@@ -50,11 +50,16 @@ import org.slf4j.LoggerFactory;
 public class EcobeeSensorThingHandler extends BaseThingHandler {
 
     public static final String CAPABILITY_ADC = "adc";
+    public static final String CAPABILITY_AIR_PRESSURE = "airPressure";
+    public static final String CAPABILITY_AIR_QUALITY = "airQuality";
+    public static final String CAPABILITY_AIR_QUALITY_ACCURACY = "airQualityAccuracy";
     public static final String CAPABILITY_CO2 = "co2";
+    public static final String CAPABILITY_CO2_PPM = "co2PPM";
     public static final String CAPABILITY_DRY_CONTACT = "dryContact";
     public static final String CAPABILITY_HUMIDITY = "humidity";
     public static final String CAPABILITY_OCCUPANCY = "occupancy";
     public static final String CAPABILITY_TEMPERATURE = "temperature";
+    public static final String CAPABILITY_VOC_PPM = "vocPPM";
     public static final String CAPABILITY_UNKNOWN = "unknown";
 
     private final Logger logger = LoggerFactory.getLogger(EcobeeSensorThingHandler.class);
@@ -144,9 +149,14 @@ public class EcobeeSensorThingHandler extends BaseThingHandler {
                 acceptedItemType = "Switch";
                 break;
             case CAPABILITY_ADC:
+            case CAPABILITY_AIR_PRESSURE:
+            case CAPABILITY_AIR_QUALITY:
+            case CAPABILITY_AIR_QUALITY_ACCURACY:
             case CAPABILITY_CO2:
+            case CAPABILITY_CO2_PPM:
             case CAPABILITY_DRY_CONTACT:
             case CAPABILITY_UNKNOWN:
+            case CAPABILITY_VOC_PPM:
             default:
                 acceptedItemType = "String";
                 break;
@@ -167,9 +177,14 @@ public class EcobeeSensorThingHandler extends BaseThingHandler {
                 channelTypeUID = CHANNELTYPEUID_OCCUPANCY;
                 break;
             case CAPABILITY_ADC:
+            case CAPABILITY_AIR_PRESSURE:
+            case CAPABILITY_AIR_QUALITY:
+            case CAPABILITY_AIR_QUALITY_ACCURACY:
             case CAPABILITY_CO2:
+            case CAPABILITY_CO2_PPM:
             case CAPABILITY_DRY_CONTACT:
             case CAPABILITY_UNKNOWN:
+            case CAPABILITY_VOC_PPM:
             default:
                 channelTypeUID = CHANNELTYPEUID_GENERIC;
                 break;
@@ -198,9 +213,14 @@ public class EcobeeSensorThingHandler extends BaseThingHandler {
                 state = EcobeeUtils.undefOrOnOff("true".equals(value));
                 break;
             case CAPABILITY_ADC:
+            case CAPABILITY_AIR_PRESSURE:
+            case CAPABILITY_AIR_QUALITY:
+            case CAPABILITY_AIR_QUALITY_ACCURACY:
             case CAPABILITY_CO2:
+            case CAPABILITY_CO2_PPM:
             case CAPABILITY_DRY_CONTACT:
             case CAPABILITY_UNKNOWN:
+            case CAPABILITY_VOC_PPM:
             default:
                 state = EcobeeUtils.undefOrString(value);
                 break;


### PR DESCRIPTION
The new Smart Thermostat Premium provides the following capabilities:

```
{
  "id": "ei:0",
  "name": "Dining Room",
  "type": "thermostat",
  "inUse": true,
  "capability": [
    {
      "id": "1",
      "type": "temperature",
      "value": "705"
    },
    {
      "id": "2",
      "type": "humidity",
      "value": "50"
    },
    {
      "id": "3",
      "type": "occupancy",
      "value": "false"
    },
    {
      "id": "4",
      "type": "airQualityAccuracy",
      "value": "unknown"
    },
    {
      "id": "5",
      "type": "airQuality",
      "value": "unknown"
    },
    {
      "id": "6",
      "type": "vocPPM",
      "value": "unknown"
    },
    {
      "id": "7",
      "type": "co2PPM",
      "value": "unknown"
    },
    {
      "id": "8",
      "type": "airPressure",
      "value": "unknown"
    }
  ]
}

```