### PR TITLE
[neohub] Workaround for 'Legacy API Disabled' problem

### DIFF
--- a/bundles/org.openhab.binding.neohub/README.md
+++ b/bundles/org.openhab.binding.neohub/README.md
@@ -39,7 +39,15 @@ Before the binding can communicate with the hub, the following Configuration Par
 | portNumber              | Port number of the NeoHub (Default=4242)                                                    |
 | pollingInterval         | Time (seconds) between polling requests to the NeoHub (Min=4, Max=60, Default=60)           |
 | socketTimeout           | Time (seconds) to allow for TCP socket connections to the hub to succeed (Min=4, Max=20, Default=5) |
-| preferLegacyApi         | Prefer if the binding should use the legacy API; this only works so long as the legacy API is still supported; otherwise the binding will switch to the new API anyway (Default=false) |
+| preferLegacyApi         | ADVANCED: Prefer the binding to use older API calls; if these are not supported, it switches to the new calls (Default=false) |
+
+## Connection Refused Errors
+
+From early 2022 Heatmiser introduced NeoHub firmware that has the ability to enable / disable the NeoHub `portNumber` 4242.
+If this port is disabled the OpenHAB binding cannot connect and the binding will report a *"Connection Refused"* warning in the log.
+In prior firmware versions the port was always enabled.
+But in the new firmware the port is initially enabled on power up but if no communication occurs for 48 hours it is automatically disabled.
+Alternatively the Heatmiser mobile App has a setting (Settings | System | API Access | Legacy API Enable | On) whereby the port can be permanently enabled.
 
 ## Thing Configuration for "NeoStat" and "NeoPlug"
 

--- a/bundles/org.openhab.binding.neohub/src/main/java/org/openhab/binding/neohub/internal/NeoHubBindingConstants.java
+++ b/bundles/org.openhab.binding.neohub/src/main/java/org/openhab/binding/neohub/internal/NeoHubBindingConstants.java
@@ -157,6 +157,7 @@ public class NeoHubBindingConstants {
     public static final String CMD_CODE_TIMER = "{\"TIMER_%s\":\"%s\"}";
     public static final String CMD_CODE_MANUAL = "{\"MANUAL_%s\":\"%s\"}";
     public static final String CMD_CODE_READ_DCB = "{\"READ_DCB\":100}";
+    public static final String CMD_CODE_FIRMWARE = "{\"FIRMWARE\":0}";
 
     /*
      * note: from NeoHub rev2.6 onwards the INFO command is "deprecated" and it


### PR DESCRIPTION
### Background
From early 2022 Heatmiser introduced NeoHub firmware that has the ability to enable / disable the NeoHub `portNumber` 4242. If this port is disabled the OpenHAB binding cannot connect and the binding will report a *"Connection Refused"* warning in the log. In prior firmware versions the port was always enabled. But in the new firmware the port is initially enabled on power up but if no communication occurs for 48 hours it is automatically disabled. Alternatively the Heatmiser mobile App has a setting (Settings | System | API Access | Legacy API Enable | On) whereby the port can be permanently enabled.

### Solution
In this PR when the handler `initialize()` method is called, we try to 'ping' the NeoHub. And if the ping fails with *"Connection Refused"* it sets the Bridge status as offline / configuration error, with a message to consult the readme, and also writes a warning message in the log to say the same. And a chapter has been added to the readme to explain how to resolve the issue.
 
Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
