### PR TITLE
[pulseaudio] Fix source format options

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -482,7 +482,7 @@ public class PulseaudioHandler extends BaseThingHandler {
         }
         switch (simpleFormat) {
             case "u8":
-                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, null, 8, 1,
+                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, null, 8, 1,
                         simpleRate.longValue(), simpleChannels.intValue());
             case "s16le":
                 return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 16, 1,
@@ -491,16 +491,16 @@ public class PulseaudioHandler extends BaseThingHandler {
                 return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, true, 16, 1,
                         simpleRate.longValue(), simpleChannels.intValue());
             case "s24le":
-                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 24, 1,
+                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 24, 1,
                         simpleRate.longValue(), simpleChannels.intValue());
             case "s24be":
-                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, true, 24, 1,
+                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, true, 24, 1,
                         simpleRate.longValue(), simpleChannels.intValue());
             case "s32le":
-                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, false, 32, 1,
+                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, false, 32, 1,
                         simpleRate.longValue(), simpleChannels.intValue());
             case "s32be":
-                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_UNSIGNED, true, 32, 1,
+                return new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, true, 32, 1,
                         simpleRate.longValue(), simpleChannels.intValue());
             default:
                 logger.warn("unsupported format {}", simpleFormat);

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/source.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/source.xml
@@ -54,11 +54,11 @@
 				<default>s16le</default>
 				<advanced>true</advanced>
 				<options>
-					<option value="u8">PCM signed 8-bit</option>
+					<option value="u8">PCM unsigned 8-bit</option>
 					<option value="s16le">PCM signed 16-bit little-endian</option>
 					<option value="s16be">PCM signed 16-bit big-endian</option>
-					<option value="s24le">PCM unsigned 24-bit little-endian</option>
-					<option value="s24be">PCM unsigned 24-bit big-endian</option>
+					<option value="s24le">PCM signed 24-bit little-endian</option>
+					<option value="s24be">PCM signed 24-bit big-endian</option>
 					<option value="s32le">PCM signed 32-bit little-endian</option>
 					<option value="s32be">PCM signed 32-bit big-endian</option>
 				</options>


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>

I made some mistakes when implementing the AudioSource describing the supported formats, I just realize it while testing a new keyword spotter with different bit depths and endianness.
This pr fixes it.
Reference here: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SupportedAudioFormats/