### PR TITLE
[hdpowerview] Fix signalStrength channel update after REFRESH command

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewWebTargets.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.hdpowerview.internal.api.Color;
 import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
+import org.openhab.binding.hdpowerview.internal.api.SurveyData;
 import org.openhab.binding.hdpowerview.internal.api.requests.RepeaterBlinking;
 import org.openhab.binding.hdpowerview.internal.api.requests.RepeaterColor;
 import org.openhab.binding.hdpowerview.internal.api.requests.ShadeCalibrate;
@@ -637,12 +638,12 @@ public class HDPowerViewWebTargets {
      * class instance
      *
      * @param shadeId id of the shade to be surveyed
-     * @return Survey class instance
+     * @return List of SurveyData class instances
      * @throws HubInvalidResponseException if response is invalid
      * @throws HubProcessingException if there is any processing error
      * @throws HubMaintenanceException if the hub is down for maintenance
      */
-    public Survey getShadeSurvey(int shadeId)
+    public List<SurveyData> getShadeSurvey(int shadeId)
             throws HubInvalidResponseException, HubProcessingException, HubMaintenanceException {
         String jsonResponse = invoke(HttpMethod.GET, shades + Integer.toString(shadeId),
                 Query.of("survey", Boolean.toString(true)), null);
@@ -651,7 +652,11 @@ public class HDPowerViewWebTargets {
             if (survey == null) {
                 throw new HubInvalidResponseException("Missing survey response");
             }
-            return survey;
+            List<SurveyData> surveyData = survey.surveyData;
+            if (surveyData == null) {
+                throw new HubInvalidResponseException("Missing 'survey.surveyData' element");
+            }
+            return surveyData;
         } catch (JsonParseException e) {
             throw new HubInvalidResponseException("Error parsing survey response", e);
         }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Survey.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Survey.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.hdpowerview.internal.api.responses;
 
 import java.util.List;
-import java.util.StringJoiner;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -30,18 +29,6 @@ import com.google.gson.annotations.SerializedName;
 public class Survey {
     @SerializedName("shade_id")
     public int shadeId;
-    @Nullable
     @SerializedName("survey")
-    public List<SurveyData> surveyData;
-
-    @Override
-    public String toString() {
-        List<SurveyData> surveyData = this.surveyData;
-        if (surveyData == null) {
-            return "{}";
-        }
-        StringJoiner joiner = new StringJoiner(", ");
-        surveyData.forEach(data -> joiner.add(data.toString()));
-        return joiner.toString();
-    }
+    public @Nullable List<SurveyData> surveyData;
 }


### PR DESCRIPTION
While preparing for #12928 I encountered an issue with refreshing signal strength (introduced in #11944). Signal strength is refreshed in the Hub by this request:

```
http://<hub>/api/shades/<shadeId>?survey=true
```

However, the response is a survey which does not include **signalStrength** itself. Therefore an additional request must be made to fetch the new value:

```
http://<hub>/api/shades/<shadeId>
```

This pull request fixes this issue so that new value is obtained immediately instead of waiting for next poll (up to one minute).