### PR TITLE
[homekit] fix issue with some hue lights, e.g. xiaomi

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -128,12 +128,12 @@ public class HomekitOHItemProxy {
             @Nullable PercentType brightness) {
         final HSBType currentState = item.getState() instanceof UnDefType ? HSBType.BLACK : (HSBType) item.getState();
         // logic for ColorItem = combine hue, saturation and brightness update to one command
-        final DecimalType target_hue = hue != null ? hue : currentState.getHue();
-        final PercentType target_saturation = saturation != null ? saturation : currentState.getSaturation();
-        final PercentType target_brightness = brightness != null ? brightness : currentState.getBrightness();
-        item.send(new HSBType(target_hue, target_saturation, target_brightness));
+        final DecimalType targetHue = hue != null ? hue : currentState.getHue();
+        final PercentType targetSaturation = saturation != null ? saturation : currentState.getSaturation();
+        final PercentType targetBrightness = brightness != null ? brightness : currentState.getBrightness();
+        item.send(new HSBType(targetHue, targetSaturation, targetBrightness));
         logger.trace("send HSB command for item {} with following values hue={} saturation={} brightness={}", item,
-                target_hue, target_saturation, target_brightness);
+                targetHue, targetSaturation, targetBrightness);
     }
 
     public synchronized void sendCommandProxy(HomekitCommandType commandType, State state) {


### PR DESCRIPTION
As reported here, some hue light expect all 3 value (hue, saturation and brightness) even if only one value got update
see investigation here
https://community.openhab.org/t/how-to-configure-homekit-light-with-colour/136137/33?u=yfre
this was already the case for hue and saturation changes but not for brightness. 

this fix ensure that all 3 values are always sent for item of type color. 


Signed-off-by: Eugen Freiter <freiter@gmx.de>
