### PR TITLE
[influxdb] Partial ModifiablePersistenceService support

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.influxdb/src/main/feature/feature.xml
@@ -4,8 +4,9 @@
 
 	<feature name="openhab-persistence-influxdb" description="InfluxDB Persistence" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.influxdb/${project.version}</bundle>
-		<configfile finalname="${openhab.conf}/services/influxdb.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/influxdb</configfile>
+		<bundle start-level="79">mvn:org.openhab.addons.bundles/org.openhab.persistence.influxdb/${project.version}</bundle>
+		<configfile finalname="${openhab.conf}/services/influxdb.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/influxdb
+		</configfile>
 	</feature>
 
 </features>

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreator.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreator.java
@@ -56,6 +56,7 @@ public class ItemToStorePointCreator {
         String measurementName = calculateMeasurementName(item, storeAlias);
         String itemName = item.getName();
         State state = getItemState(item);
+
         Object value = InfluxDBStateConvertUtils.stateToObject(state);
 
         InfluxPoint.Builder point = InfluxPoint.newBuilder(measurementName).withTime(Instant.now()).withValue(value)

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreatorTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreatorTest.java
@@ -13,11 +13,7 @@
 package org.openhab.persistence.influxdb.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreatorTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreatorTest.java
@@ -13,7 +13,11 @@
 package org.openhab.persistence.influxdb.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;


### PR DESCRIPTION
Signed-off-by: Arne Seime <arne.seime@gmail.com>

Partial support for persisting values with a specific timestamp by implementing `ModifiablePersistenceService` instead of `QueryablePersistenceService`.

By also changing the startlevel to 79 (before bindings), it allows the persistence service to be called from bindings to persist previous (ie offline sensor time series being reported when sensor is offline) or future time series data such as electricity prices or weather forecasts. 

A better approach would be to build this into the framework, but this seems to be a larger and quite more complex job unfortunately. See https://github.com/openhab/openhab-core/issues/844

EDIT: Someone just created a PR to handle this properly in core; https://github.com/openhab/openhab-core/pull/3000
