### PR TITLE
[orbitbhyve] Handle WebSocketException to prevent scheduled ping job failure

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketException;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.openhab.binding.orbitbhyve.internal.OrbitBhyveConfiguration;
 import org.openhab.binding.orbitbhyve.internal.discovery.OrbitBhyveDiscoveryService;
@@ -183,7 +184,10 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                     updateAllStatuses();
                 } catch (IOException e) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                            "Error sending ping to a web socket");
+                            "Error sending ping (IOException on web socket)");
+                } catch (WebSocketException e) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            String.format("Error sending ping (WebSocketException: %s)", e.getMessage()));
                 }
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Web socket creation error");
@@ -426,7 +430,10 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                 localSession.getRemote().sendString(msg);
             } catch (IOException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Cannot send hello string to web socket!");
+                        "Error sending hello string (IOException on web socket)");
+            } catch (WebSocketException e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        String.format("Error sending hello string (WebSocketException: %s)", e.getMessage()));
             }
         }
     }
@@ -466,7 +473,10 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
             }
         } catch (IOException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Error during program watering execution");
+                    "Error sending program watering execution (IOException on web socket)");
+        } catch (WebSocketException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    String.format("Error sending program watering execution (WebSocketException: %s)", e.getMessage()));
         }
     }
 
@@ -505,7 +515,11 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                         + "\",\"delay\":" + delay + ",\"timestamp\":\"" + dateTime + "\"}");
             }
         } catch (IOException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error during rain delay setting");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Error setting rain delay (IOException on web socket)");
+        } catch (WebSocketException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    String.format("Error setting rain delay (WebSocketException: %s)", e.getMessage()));
         }
     }
 
@@ -519,7 +533,11 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                         + "\",\"timestamp\":\"" + dateTime + "\",\"mode\":\"manual\",\"stations\":[]}");
             }
         } catch (IOException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error during watering stopping");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Error sending stop watering (IOException on web socket)");
+        } catch (WebSocketException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    String.format("Error sending stop watering (WebSocketException: %s)", e.getMessage()));
         }
     }
 
@@ -555,7 +573,11 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                         + "\",\"device_id\":\"" + deviceId + "\",\"timestamp\":\"" + dateTime + "\"}");
             }
         } catch (IOException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error during setting run mode");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Error setting run mode (IOException on web socket)");
+        } catch (WebSocketException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    String.format("Error setting run mode (WebSocketException: %s)", e.getMessage()));
         }
     }
 


### PR DESCRIPTION
This WebSocketException during the scheduled job execution causes the scheduled ping job to fail. This PR catches WebSocketException during the scheduled ping job execution (and at other points in the binding where it's thrown).
```
2022-06-07 21:12:35.605 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception:
org.eclipse.jetty.websocket.api.WebSocketException: Session closed
        at org.eclipse.jetty.websocket.common.WebSocketSession.outgoingFrame(WebSocketSession.java:350) ~[?:?]
        at org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint.uncheckedSendFrame(WebSocketRemoteEndpoint.java:322) ~[?:?]
        at org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint.blockingWrite(WebSocketRemoteEndpoint.java:109) ~[?:?]
        at org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint.sendString(WebSocketRemoteEndpoint.java:400) ~[?:?]
        at org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveBridgeHandler.ping(OrbitBhyveBridgeHandler.java:182) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```

Signed-off-by: Mark Hilbush <mark@hilbush.com>
