### PR TITLE
[transform.javascript] Update examples in README

### DIFF
--- a/bundles/org.openhab.transform.javascript/README.md
+++ b/bundles/org.openhab.transform.javascript/README.md
@@ -43,8 +43,8 @@ Following example will return value `23.54` when `input` data is `214`.
 
 ### Inline script example:
 
-Normally JavaScript transformation is given by filename, e.g. `JS(transform/getValue.js)`.
-Inline script can be given by `|` character following the JavaScript, e.g. `JS(| input / 10)`.
+Normally JavaScript transformation is given by filename, e.g. `JS:getValue.js`.
+Inline script can be given by `|` character following the JavaScript, e.g. `JS:| input / 10`.
    
 ## Test JavaScript
 


### PR DESCRIPTION
According to my experience, after JS there must be a colon, not a parenthesis.  The `transform/` path must be skipped.