### PR TITLE
Append the public holiday plugin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -257,6 +257,7 @@
 /bundles/org.openhab.binding.powermax/ @lolodomo
 /bundles/org.openhab.binding.proteusecometer/ @2chilled
 /bundles/org.openhab.binding.prowl/ @octa22
+/bundles/org.openhab.binding.publicholiday/ @Hinterwaeldlers
 /bundles/org.openhab.binding.publictransportswitzerland/ @jeremystucki
 /bundles/org.openhab.binding.pulseaudio/ @peuter
 /bundles/org.openhab.binding.pushbullet/ @hakan42

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1283,6 +1283,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.publicholiday</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.publictransportswitzerland</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.publicholiday/NOTICE
+++ b/bundles/org.openhab.binding.publicholiday/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.publicholiday/README.md
+++ b/bundles/org.openhab.binding.publicholiday/README.md
@@ -1,0 +1,99 @@
+# PublicHoliday Binding
+
+This binding is used to provide a public holiday channel.
+
+Using this binding, it is possible to influence rules to handle differently,
+if the current day is a public holiday
+
+## Supported Things
+
+A public holiday thing
+
+## Discovery
+
+None
+
+## Thing Configuration
+
+Using the configuration specifies, when the update of the value should be done and which public holidays should be taken
+into account.
+
+
+| Name            | Type    | Description                                                      |     Default    | Required |
+|-----------------|---------|------------------------------------------------------------------|----------------|----------|
+| updateValueCron | text    | Specifies the update time. Should be called once a day           | "05 0 * * * *" | true     |
+| $PUBLIC_HOLIDAY | boolean | True to take this value into account. Unused days can be omitted | false          | false    |
+
+Replace `$PUBLIC_HOLIDAY` with the wanted public holidays. Check the supported list of public holidays for the actual values.
+
+`updateValueCron` should run shortly after midnight
+
+## Channels
+
+| Channel                  | Type   | Read/Write | Description                              |
+|--------------------------|--------|------------|------------------------------------------|
+| isPublicHoliday          | Switch | R          | The current day is a public holiday      |
+| isDayBeforePublicHoliday | Switch | R          | The next day will be a public holiday    |
+| holidayName              | Text   | R          | The name of the public holiday or "none" |
+
+The value of the channels is updated at 0:05 AM per default.
+
+To ensure the value is valid on startup, the values are set within the startup process, too.
+
+## Full Example
+
+A short example, how to use the binding.
+
+publicHoliday.thing:
+
+```xtend
+publicholiday:publicHoliday:pubicHoliday "Public Holiday" [
+	updateValueCron="05 0 * * * *",
+	
+	newYear="true",
+	christmasEve="false",
+	christmasDay="true",
+	secondChristmasDay="true",
+	newYearsEve="true",
+]
+```
+
+publicHoliday.items:
+
+```xtend
+Switch isPublicHoliday "Holiday - Public" { channel = "publicholiday:publicHoliday:pubicHoliday:isPublicHoliday" }
+```
+
+## Supported list of public holidays
+
+Currently the following public holidays are supported.
+Use their names as written within the configuration to activate them.
+
+### General
+* newYear (01/01)
+* threeKingsDay (01/06)
+* reformationDay (10/31)
+* allSaintsDay (11/01)
+* christmasEve (12/24)
+* christmasDay (12/25)
+* secondChristmasDay (12/26)
+* newYearsEve (12/31)
+
+### Eastern related
+* goodFriday
+* easterSunday
+* easterMonday
+* ascensionDay
+* whitSunday
+* whitMonday
+* corpusChristi
+
+### Country specific
+#### Germany
+* tagDerArbeit (05/01)
+* tagDerDeutschenEinheit (10/03)
+
+## Missing public holiday values
+
+Likely many public holidays are missing. Feel free to add them via a pull
+request or leave the required information to add it accordingly

--- a/bundles/org.openhab.binding.publicholiday/pom.xml
+++ b/bundles/org.openhab.binding.publicholiday/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.publicholiday</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: PublicHoliday Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.publicholiday/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.publicholiday/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.publicholiday-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-publicholiday" description="PublicHoliday Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.publicholiday/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayBindingConstants.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayBindingConstants.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link PublicHolidayBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Martin Güthle - Initial contribution
+ */
+@NonNullByDefault
+public class PublicHolidayBindingConstants {
+
+    private static final String BINDING_ID = "publicholiday";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE = new ThingTypeUID(BINDING_ID, "publicHoliday");
+
+    // List of all Channel ids
+    public static final String CHANNEL_IS_PUBLIC_HOLIDAY = "isPublicHoliday";
+    public static final String CHANNEL_IS_DAY_BEFORE_PUBLIC_HOLIDAY = "isDayBeforePublicHoliday";
+    public static final String CHANNEL_HOLIDAY_NAME = "holidayName";
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayConfiguration.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayConfiguration.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link PublicHolidayConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Martin Güthle - Initial contribution
+ */
+@NonNullByDefault
+public class PublicHolidayConfiguration {
+
+    public String updateValueCron = "";
+    public boolean newYear = false;
+    public boolean threeKingsDay = false;
+    public boolean reformationDay = false;
+    public boolean allSaintsDay = false;
+    public boolean christmasEve = false;
+    public boolean christmasDay = false;
+    public boolean secondChristmasDay = false;
+    public boolean newYearsEve = false;
+
+    public boolean goodFriday = false;
+    public boolean easterSunday = false;
+    public boolean easterMonday = false;
+    public boolean ascensionDay = false;
+    public boolean whitSunday = false;
+    public boolean whitMonday = false;
+    public boolean corpusChristi = false;
+
+    public boolean tagDerArbeit = false;
+    public boolean tagDerDeutschenEinheit = false;
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayHandler.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayHandler.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal;
+
+import static org.openhab.binding.publicholiday.internal.PublicHolidayBindingConstants.CHANNEL_HOLIDAY_NAME;
+import static org.openhab.binding.publicholiday.internal.PublicHolidayBindingConstants.CHANNEL_IS_DAY_BEFORE_PUBLIC_HOLIDAY;
+import static org.openhab.binding.publicholiday.internal.PublicHolidayBindingConstants.CHANNEL_IS_PUBLIC_HOLIDAY;
+import static org.openhab.core.thing.ThingStatus.ONLINE;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.publicholiday.internal.publicholiday.HolidayFactory;
+import org.openhab.binding.publicholiday.internal.publicholiday.HolidayJob;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.scheduler.CronScheduler;
+import org.openhab.core.scheduler.ScheduledCompletableFuture;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PublicHolidayHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Martin Güthle - Initial contribution
+ */
+@NonNullByDefault
+public class PublicHolidayHandler extends BaseThingHandler {
+    private static final Logger logger = LoggerFactory.getLogger(PublicHolidayHandler.class);
+
+    private final CronScheduler scheduler;
+
+    private @Nullable ScheduledCompletableFuture<Void> updateJob;
+
+    private @Nullable PublicHolidayConfiguration config;
+
+    private HolidayJob jobExecutor;
+
+    public PublicHolidayHandler(Thing thing, CronScheduler scheduler) {
+        super(thing);
+        this.scheduler = scheduler;
+        jobExecutor = new HolidayJob(this, List.of());
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            if (CHANNEL_IS_PUBLIC_HOLIDAY.equals(channelUID.getId())) {
+                jobExecutor.refreshValues(true, false);
+            } else if (CHANNEL_IS_DAY_BEFORE_PUBLIC_HOLIDAY.equals(channelUID.getId())) {
+                jobExecutor.refreshValues(false, true);
+            } else if (CHANNEL_HOLIDAY_NAME.equals(channelUID.getId())) {
+                jobExecutor.refreshValues(true, false);
+            }
+        }
+    }
+
+    @Override
+    public void initialize() {
+        synchronized (this) {
+            config = getConfigAs(PublicHolidayConfiguration.class);
+            jobExecutor = new HolidayJob(this, HolidayFactory.generateHolidayList(config));
+        }
+        restartJobs();
+        updateStatus(ONLINE);
+    }
+
+    @Override
+    public void dispose() {
+        stopJobs();
+    }
+
+    public void updateValue(boolean isHoliday, boolean isNextDayHoliday, String holidayName) {
+        Channel isHolidayChannel = this.thing.getChannel(PublicHolidayBindingConstants.CHANNEL_IS_PUBLIC_HOLIDAY);
+        Channel isNextDayHolidayChannel = this.thing
+                .getChannel(PublicHolidayBindingConstants.CHANNEL_IS_DAY_BEFORE_PUBLIC_HOLIDAY);
+
+        if (isNextDayHolidayChannel != null) {
+            updateState(isHolidayChannel.getUID(), OnOffType.from(isHoliday));
+        }
+        if (isNextDayHolidayChannel != null) {
+            updateState(isNextDayHolidayChannel.getUID(), OnOffType.from(isNextDayHoliday));
+        }
+    }
+
+    private void restartJobs() {
+        stopJobs();
+        startJobs();
+    }
+
+    private void startJobs() {
+        if (config != null) {
+            jobExecutor.refreshValues(true, true);
+            synchronized (this) {
+                updateJob = scheduler.schedule(jobExecutor, config.updateValueCron);
+            }
+        } else {
+            // The initialization has not worked accordingly. Scheduling will be useless, too
+            logger.warn("Initial refreshing of the values was not possible."
+                    + "Further handling might not work as expected, too.");
+        }
+    }
+
+    private synchronized void stopJobs() {
+        synchronized (this) {
+            if (updateJob != null) {
+                updateJob.cancel(true);
+                updateJob = null;
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayHandlerFactory.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/PublicHolidayHandlerFactory.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal;
+
+import static org.openhab.binding.publicholiday.internal.PublicHolidayBindingConstants.THING_TYPE;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.scheduler.CronScheduler;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link PublicHolidayHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Martin Güthle - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.publicholiday", service = ThingHandlerFactory.class)
+public class PublicHolidayHandlerFactory extends BaseThingHandlerFactory {
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE);
+    private final CronScheduler scheduler;
+
+    @Activate
+    public PublicHolidayHandlerFactory(final @Reference CronScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE.equals(thingTypeUID)) {
+            return new PublicHolidayHandler(thing, scheduler);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/EasternRelatedHoliday.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/EasternRelatedHoliday.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import java.time.LocalDate;
+
+import org.openhab.binding.publicholiday.internal.publicholiday.definitions.EasternRelatedHolidayDef;
+
+/**
+ * Eastern related holiday representation
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public class EasternRelatedHoliday extends Holiday {
+
+    private final int offset;
+
+    public EasternRelatedHoliday(EasternRelatedHolidayDef day) {
+        super(day.name);
+        this.offset = day.offset;
+    }
+
+    private LocalDate easterDate() {
+        int year = getCurrentYear();
+        int i = year % 19;
+        int j = year / 100;
+        int k = year % 100;
+
+        int l = (19 * i + j - (j / 4) - ((j - ((j + 8) / 25) + 1) / 3) + 15) % 30;
+        int m = (32 + 2 * (j % 4) + 2 * (k / 4) - l - (k % 4)) % 7;
+        int n = l + m - 7 * ((i + 11 * l + 22 * m) / 451) + 114;
+
+        int month = n / 31;
+        int dayOfMonth = (n % 31) + 1;
+        return LocalDate.of(year, month, dayOfMonth);
+    }
+
+    @Override
+    public boolean isHoliday(LocalDate date) {
+        return easterDate().plusDays(offset).equals(date);
+    }
+
+    /**
+     * Needed for testing purpose
+     *
+     * @return The current year value
+     */
+    protected int getCurrentYear() {
+        return LocalDate.now().getYear();
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/FixedHoliday.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/FixedHoliday.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import java.time.LocalDate;
+
+import org.openhab.binding.publicholiday.internal.publicholiday.definitions.FixedDayDef;
+
+/**
+ * Fixed date holiday representation
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public class FixedHoliday extends Holiday {
+
+    private final int month;
+    private final int day;
+
+    public FixedHoliday(FixedDayDef fixedDay) {
+        super(fixedDay.getName());
+        this.month = fixedDay.getMonth();
+        this.day = fixedDay.getDay();
+    }
+
+    @Override
+    public boolean isHoliday(LocalDate date) {
+        return this.month == date.getMonthValue() && this.day == date.getDayOfMonth();
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/Holiday.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/Holiday.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import java.time.LocalDate;
+
+/**
+ * Basic holiday related handling
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public abstract class Holiday {
+
+    private final String name;
+
+    public Holiday(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Determine if the given day is a holiday
+     *
+     * @param date The current day
+     * @return True if the given day is a holiday
+     */
+    public abstract boolean isHoliday(LocalDate date);
+
+    /**
+     * Determine if the day after the given day is a holiday
+     *
+     * @param date The current day
+     * @return True if the day after the given day is a holiday
+     */
+    public final boolean isDayBeforeHoliday(LocalDate date) {
+        return isHoliday(date.plusDays(1));
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/HolidayFactory.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/HolidayFactory.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openhab.binding.publicholiday.internal.PublicHolidayConfiguration;
+import org.openhab.binding.publicholiday.internal.publicholiday.definitions.EasternRelatedHolidayDef;
+import org.openhab.binding.publicholiday.internal.publicholiday.definitions.GeneralFixedHolidayDef;
+import org.openhab.binding.publicholiday.internal.publicholiday.definitions.GermanHolidayDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generate the list of relevant holidays, based on the configuration
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public class HolidayFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(HolidayFactory.class);
+
+    public static List<Holiday> generateHolidayList(PublicHolidayConfiguration config) {
+        ArrayList<Holiday> result = new ArrayList<>();
+
+        if (config.newYear) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.NEW_YEAR));
+        }
+        if (config.threeKingsDay) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.THREE_KINGS_DAY));
+        }
+        if (config.reformationDay) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.REFORMATION_DAY));
+        }
+        if (config.allSaintsDay) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.ALL_SAINTS_DAY));
+        }
+        if (config.christmasEve) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.CHRISTMAS_EVE));
+        }
+        if (config.christmasDay) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.ALL_SAINTS_DAY));
+        }
+        if (config.secondChristmasDay) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.SECOND_CHRISTMAS_DAY));
+        }
+        if (config.newYearsEve) {
+            result.add(new FixedHoliday(GeneralFixedHolidayDef.NEW_YEARS_EVE));
+        }
+
+        if (config.goodFriday) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.GOOD_FRIDAY));
+        }
+        if (config.easterSunday) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.EASTER_SUNDAY));
+        }
+        if (config.easterMonday) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.EASTER_MONDAY));
+        }
+        if (config.ascensionDay) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.ASCENSION_DAY));
+        }
+        if (config.whitSunday) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.WHIT_SUNDAY));
+        }
+        if (config.whitMonday) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.WHIT_MONDAY));
+        }
+        if (config.corpusChristi) {
+            result.add(new EasternRelatedHoliday(EasternRelatedHolidayDef.CORPUS_CHRISTI));
+        }
+
+        if (config.tagDerArbeit) {
+            result.add(new FixedHoliday(GermanHolidayDef.TAG_DER_ARBEIT));
+        }
+        if (config.tagDerDeutschenEinheit) {
+            result.add(new FixedHoliday(GermanHolidayDef.TAG_DER_DEUTSCHEN_EINHEIT));
+        }
+
+        StringBuilder sb = new StringBuilder();
+        result.forEach(holiday -> sb.append("\n\t" + holiday.getName()));
+        logger.info("Configured public holidays: {}", sb.toString());
+
+        return result;
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/HolidayJob.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/HolidayJob.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.openhab.binding.publicholiday.internal.PublicHolidayHandler;
+import org.openhab.core.scheduler.SchedulerRunnable;
+
+/**
+ * Holiday calculation handling
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public class HolidayJob implements SchedulerRunnable {
+
+    private final PublicHolidayHandler handler;
+    private final List<Holiday> holidays;
+
+    public HolidayJob(PublicHolidayHandler handler, List<Holiday> holidays) {
+        this.handler = handler;
+        this.holidays = holidays;
+    }
+
+    @Override
+    public void run() throws Exception {
+        runImpl(LocalDate.now(), true, true);
+    }
+
+    private void runImpl(LocalDate today, boolean updCurDay, boolean updNextDay) {
+        boolean isHoliday = false;
+        boolean isNextDayHoliday = false;
+        String holidayName = "none";
+        for (var curHoliday : holidays) {
+            if (updCurDay) {
+                if (curHoliday.isHoliday(today)) {
+                    isHoliday = true;
+                    holidayName = curHoliday.getName();
+                }
+            }
+            if (updNextDay) {
+                isNextDayHoliday |= curHoliday.isDayBeforeHoliday(today);
+            }
+        }
+        handler.updateValue(isHoliday, isNextDayHoliday, holidayName);
+    }
+
+    /**
+     * Trigger the value update
+     *
+     * Meant to be called during the system startup and refresh command call
+     * 
+     * @param currentDay If set, the isPublicHoliday channel will be updated
+     * @param nextDay If set, the istDayBeforePublicHoliday channel will be updated
+     */
+    public void refreshValues(boolean currentDay, boolean nextDay) {
+        runImpl(LocalDate.now(), currentDay, nextDay);
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/EasternRelatedHolidayDef.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/EasternRelatedHolidayDef.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday.definitions;
+
+/**
+ * Eastern related holiday definitions
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public enum EasternRelatedHolidayDef {
+    GOOD_FRIDAY(-2, "Good Friday"),
+    EASTER_SUNDAY(0, "Easter Sunday"),
+    EASTER_MONDAY(1, "Easter Monday"),
+    ASCENSION_DAY(39, "Acension Day"),
+    WHIT_SUNDAY(49, "Whit Sunday"),
+    WHIT_MONDAY(50, "Whit Monday"),
+    CORPUS_CHRISTI(60, "Corpus Christi");
+
+    public final int offset;
+    public final String name;
+
+    private EasternRelatedHolidayDef(int offset, String name) {
+        this.offset = offset;
+        this.name = name;
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/FixedDayDef.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/FixedDayDef.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday.definitions;
+
+import org.openhab.binding.publicholiday.internal.publicholiday.HolidayJob;
+
+/**
+ * Definition of a fixed holiday
+ *
+ * Based on the month and the day, the {@link HolidayJob} decides whether the current and the next day is a public
+ * holiday or not.
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public interface FixedDayDef {
+
+    String getName();
+
+    int getMonth();
+
+    int getDay();
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/GeneralFixedHolidayDef.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/GeneralFixedHolidayDef.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday.definitions;
+
+/**
+ * Some general fixed holiday definitions
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public enum GeneralFixedHolidayDef implements FixedDayDef {
+    NEW_YEAR("New year", 1, 1),
+    THREE_KINGS_DAY("Three Kings day", 1, 6),
+    REFORMATION_DAY("Reformation Day", 10, 31),
+    ALL_SAINTS_DAY("All Saints Day", 11, 1),
+    CHRISTMAS_EVE("Christmas Eve", 12, 24),
+    CHRISTMAS_DAY("Christmas Day", 12, 25),
+    SECOND_CHRISTMAS_DAY("2nd Christmas Day", 12, 26),
+    NEW_YEARS_EVE("New Years Eve", 12, 31);
+
+    private final String name;
+    private final int month;
+    private final int day;
+
+    private GeneralFixedHolidayDef(String name, int month, int day) {
+        this.name = name;
+        this.month = month;
+        this.day = day;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getMonth() {
+        return month;
+    }
+
+    @Override
+    public int getDay() {
+        return day;
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/GermanHolidayDef.java
+++ b/bundles/org.openhab.binding.publicholiday/src/main/java/org/openhab/binding/publicholiday/internal/publicholiday/definitions/GermanHolidayDef.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.publicholiday.internal.publicholiday.definitions;
+
+/**
+ * German specific holiday definitions
+ * 
+ * @author Martin Güthle - Initial contribution
+ */
+public enum GermanHolidayDef implements FixedDayDef {
+    TAG_DER_ARBEIT("Tag der Arbeit", 5, 1),
+    TAG_DER_DEUTSCHEN_EINHEIT("Tag der deutschen Einheit", 10, 3);
+
+    private final String name;
+    private final int month;
+    private final int day;
+
+    private GermanHolidayDef(String name, int month, int day) {
+        this.name = name;
+        this.month = month;
+        this.day = day;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getMonth() {
+        return month;
+    }
+
+    @Override
+    public int getDay() {
+        return day;
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="publicholiday" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>PublicHoliday Binding</name>
+	<description>Determine if the current day is a public holiday</description>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+	https://openhab.org/schemas/config-description-1.0.0.xsd">
+	<config-description uri="thing-type:publicholiday:publicHolidayConfig">
+		<parameter name="updateValueCron" type="text" required="true">
+			<label>Update value time</label>
+			<description>Cron expression, when the values should be updated</description>
+			<default>05 0 * * * *</default>
+		</parameter>
+		<!-- Fixed dates -->
+		<parameter name="newYear" type="boolean" required="false">
+			<label>New Year</label>
+			<description>1st January</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="threeKingsDay" type="boolean" required="false">
+			<label>Three Kings Day</label>
+			<description>6th January</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="reformationDay" type="boolean" required="false">
+			<label>Reformation day</label>
+			<description>31th October</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="allSaintsDay" type="boolean" required="false">
+			<label>All Saints Day</label>
+			<description>1st November</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="christmasEve" type="boolean" required="false">
+			<label>Christmas Eve</label>
+			<description>24th December</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="christmasDay" type="boolean" required="false">
+			<label>Christmas Day</label>
+			<description>25th December</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="secondChristmasDay" type="boolean" required="false">
+			<label>Second Christmas Day</label>
+			<description>26th December</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="newYearsEve" type="boolean" required="false">
+			<label>New Year's Eve</label>
+			<description>31th December</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+
+		<!-- Eastern related -->
+		<parameter name="goodFriday" type="boolean" required="false">
+			<label>Good Friday</label>
+			<description>Friday before eastern</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="easterSunday" type="boolean" required="false">
+			<label>Easter Sunday</label>
+			<description>Easter Sunday</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="easterMonday" type="boolean" required="false">
+			<label>Easter Monday</label>
+			<description>Easter Monday</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="ascensionDay" type="boolean" required="false">
+			<label>Ascension Day</label>
+			<description>Ascension Day is 39 days after eastern; aka Father's Day</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="whitSunday" type="boolean" required="false">
+			<label>Whit Sunday</label>
+			<description>Whit Sunday is 49 days after eastern</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="whitMonday" type="boolean" required="false">
+			<label>Whit Monday</label>
+			<description>Whit Monday is 50 days after eastern</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="corpusChristi" type="boolean" required="false">
+			<label>Corpus Christi</label>
+			<description>Corpus Christi is 60 days after eastern</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+
+		<!-- Country specific -->
+		<!-- Germany specific -->
+		<parameter name="tagDerArbeit" type="boolean" required="false">
+			<label>Tag der Arbeit</label>
+			<description>German public holiday on 1st May</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+		<parameter name="tagDerDeutschenEinheit" type="boolean" required="false">
+			<label>Tag der deutschen Einheit</label>
+			<description>German public holiday on 3rd October</description>
+			<advanced>true</advanced>
+			<default>false</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/i18n/publicholiday_xx.properties
+++ b/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/i18n/publicholiday_xx.properties
@@ -1,0 +1,21 @@
+# FIXME: please substitute the xx with a proper locale, ie. de
+# FIXME: please do not add the file to the repo if you add or change no content
+# binding
+binding.publicholiday.name = <Your localized Binding name>
+binding.publicholiday.description = <Your localized Binding description>
+
+# thing types
+thing-type.publicholiday.sample.label = <Your localized Thing label>
+thing-type.publicholiday.sample.description = <Your localized Thing description>
+
+# thing type config description
+thing-type.config.publicholiday.sample.hostname.label = <Your localized config parameter label>
+thing-type.config.publicholiday.sample.hostname.description = <Your localized config parameter description>
+thing-type.config.publicholiday.sample.password.label = <Your localized config parameter label>
+thing-type.config.publicholiday.sample.password.description = <Your localized config parameter description>
+thing-type.config.publicholiday.sample.refreshInterval.label = <Your localized config parameter label>
+thing-type.config.publicholiday.sample.refreshInterval.description = <Your localized config parameter description>
+
+# channel types
+channel-type.publicholiday.sample-channel.label = <Your localized Channel label>
+channel-type.publicholiday.sample-channel.description = <Your localized Channel description>

--- a/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.publicholiday/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="publicholiday"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="publicHoliday">
+		<label>PublicHoliday Binding Thing</label>
+		<description>The public holiday thing</description>
+
+		<channels>
+			<channel id="isPublicHoliday" typeId="publicHolidayChannel"/>
+			<channel id="isDayBeforePublicHoliday" typeId="dayBeforePublicHolidayChannel"/>
+			<channel id="holidayName" typeId="holidayNameChannel"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:publicholiday:publicHolidayConfig"/>
+	</thing-type>
+
+	<channel-type id="publicHolidayChannel">
+		<item-type>Switch</item-type>
+		<label>isPublicHoliday</label>
+		<description>Is the current day a public holiday</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="dayBeforePublicHolidayChannel">
+		<item-type>Switch</item-type>
+		<label>isDayBeforePublicHoliday</label>
+		<description>Is the next day a public holiday</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="holidayNameChannel">
+		<item-type>Text</item-type>
+		<label>holiday name</label>
+		<description>The name of the current public holiday or none</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.publicholiday/src/test/java/org/openhab/binding/publicholiday/internal/publicholiday/EasternRelatedHolidayTest.java
+++ b/bundles/org.openhab.binding.publicholiday/src/test/java/org/openhab/binding/publicholiday/internal/publicholiday/EasternRelatedHolidayTest.java
@@ -1,0 +1,65 @@
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openhab.binding.publicholiday.internal.publicholiday.definitions.EasternRelatedHolidayDef;
+
+class EasternRelatedHolidayTest {
+
+    private EasternRelatedHoliday easternRelatedInYear(int year, EasternRelatedHolidayDef def) {
+        return new EasternRelatedHoliday(def) {
+            @Override
+            protected int getCurrentYear() {
+                return year;
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testEasterCalculation(LocalDate eastern) {
+        EasternRelatedHoliday testUnit = easternRelatedInYear(eastern.getYear(),
+                EasternRelatedHolidayDef.EASTER_SUNDAY);
+        assertTrue(testUnit.isHoliday(eastern));
+    }
+
+    static Stream<Arguments> testEasterCalculation() {
+        return List.of(Arguments.of(LocalDate.of(2022, 4, 17)), Arguments.of(LocalDate.of(2008, 3, 23)),
+                Arguments.of(LocalDate.of(2031, 4, 13))).stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testHolidayCalculation(EasternRelatedHolidayDef holiday, int year, int month, int day) {
+        LocalDate expHoliday = LocalDate.of(year, month, day);
+        EasternRelatedHoliday testUnit = easternRelatedInYear(year, holiday);
+
+        assertTrue(testUnit.isHoliday(expHoliday));
+        assertFalse(testUnit.isDayBeforeHoliday(expHoliday));
+
+        assertFalse(testUnit.isHoliday(expHoliday.minusDays(1)));
+        assertTrue(testUnit.isDayBeforeHoliday(expHoliday.minusDays(1)));
+
+        // Used test values ensure that eastern is not on the same day
+        assertFalse(testUnit.isHoliday(expHoliday.minusYears(1)));
+        assertFalse(testUnit.isDayBeforeHoliday(expHoliday.minusYears(1)));
+    }
+
+    static Stream<Arguments> testHolidayCalculation() {
+        return List.of(Arguments.of(EasternRelatedHolidayDef.GOOD_FRIDAY, 2022, 4, 15),
+                Arguments.of(EasternRelatedHolidayDef.EASTER_SUNDAY, 2021, 4, 4),
+                Arguments.of(EasternRelatedHolidayDef.EASTER_MONDAY, 2008, 3, 24),
+                Arguments.of(EasternRelatedHolidayDef.ASCENSION_DAY, 2040, 5, 10),
+                Arguments.of(EasternRelatedHolidayDef.WHIT_SUNDAY, 2037, 5, 24),
+                Arguments.of(EasternRelatedHolidayDef.WHIT_MONDAY, 2011, 6, 13),
+                Arguments.of(EasternRelatedHolidayDef.CORPUS_CHRISTI, 2019, 6, 20)).stream();
+    }
+}

--- a/bundles/org.openhab.binding.publicholiday/src/test/java/org/openhab/binding/publicholiday/internal/publicholiday/HolidayJobTest.java
+++ b/bundles/org.openhab.binding.publicholiday/src/test/java/org/openhab/binding/publicholiday/internal/publicholiday/HolidayJobTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Note to tests:
+ * There is a chance, that one test will fail, if started right before midnight,
+ * as {@code LocalDate.now} will return two different days between the calls.
+ */
+
+package org.openhab.binding.publicholiday.internal.publicholiday;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.openhab.binding.publicholiday.internal.PublicHolidayHandler;
+
+class HolidayJobTest {
+    @ParameterizedTest
+    @MethodSource
+    void run(List<Holiday> holidays, boolean expCurDay, boolean expNextDay, String expName) throws Exception {
+        PublicHolidayHandler handlerMock = mock(PublicHolidayHandler.class);
+
+        HolidayJob testUnit = new HolidayJob(handlerMock, holidays);
+        testUnit.run();
+        Mockito.verify(handlerMock).updateValue(eq(expCurDay), eq(expNextDay), eq(expName));
+    }
+
+    static Stream<Arguments> run() {
+        return List.of(
+                // no holidays configured
+                Arguments.of(List.of(), false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.NO_HOLIDAY, "h1")), false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY, "h1")), true, false, "h1"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.DAY_BEFORE, "h1")), false, true, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY_BEFORE, "h1")), true, true, "h1")).stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void refreshValues(List<Holiday> holidays, boolean updCurDay, boolean updNextDay, boolean expCurDay,
+            boolean expNextDay, String expName) throws Exception {
+        PublicHolidayHandler handlerMock = mock(PublicHolidayHandler.class);
+
+        HolidayJob testUnit = new HolidayJob(handlerMock, holidays);
+        testUnit.refreshValues(updCurDay, updNextDay);
+        Mockito.verify(handlerMock).updateValue(eq(expCurDay), eq(expNextDay), eq(expName));
+    }
+
+    static Stream<Arguments> refreshValues() {
+        return List.of(Arguments.of(List.of(), true, true, false, false, "none"),
+                Arguments.of(List.of(), true, false, false, false, "none"),
+                Arguments.of(List.of(), false, true, false, false, "none"),
+                Arguments.of(List.of(), false, false, false, false, "none"),
+
+                Arguments.of(List.of(genHoliday(HolidaySpec.NO_HOLIDAY, "h1")), true, true, false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.NO_HOLIDAY, "h1")), false, true, false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.NO_HOLIDAY, "h1")), true, false, false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.NO_HOLIDAY, "h1")), false, false, false, false, "none"),
+
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY, "h1")), true, true, true, false, "h1"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY, "h1")), false, true, false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY, "h1")), true, false, true, false, "h1"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY, "h1")), false, false, false, false, "none"),
+
+                Arguments.of(List.of(genHoliday(HolidaySpec.DAY_BEFORE, "h1")), true, true, false, true, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.DAY_BEFORE, "h1")), false, true, false, true, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.DAY_BEFORE, "h1")), true, false, false, false, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.DAY_BEFORE, "h1")), false, false, false, false, "none"),
+
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY_BEFORE, "h1")), true, true, true, true, "h1"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY_BEFORE, "h1")), false, true, false, true, "none"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY_BEFORE, "h1")), true, false, true, false, "h1"),
+                Arguments.of(List.of(genHoliday(HolidaySpec.HOLIDAY_BEFORE, "h1")), false, false, false, false, "none"))
+                .stream();
+    }
+
+    private enum HolidaySpec {
+        NO_HOLIDAY,
+        HOLIDAY,
+        DAY_BEFORE,
+        HOLIDAY_BEFORE
+    }
+
+    private static Holiday genHoliday(HolidaySpec holidaySpec, String name) {
+        return new Holiday(name) {
+            @Override
+            public boolean isHoliday(LocalDate cmpDate) {
+                int delta = LocalDate.now().until(cmpDate).getDays();
+                switch (holidaySpec) {
+                    case HOLIDAY:
+                        return delta == 0;
+                    case DAY_BEFORE:
+                        return delta == 1;
+                    case HOLIDAY_BEFORE:
+                        return delta == 0 || delta == 1;
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -290,6 +290,7 @@
     <module>org.openhab.binding.powermax</module>
     <module>org.openhab.binding.proteusecometer</module>
     <module>org.openhab.binding.prowl</module>
+    <module>org.openhab.binding.publicholiday</module>
     <module>org.openhab.binding.publictransportswitzerland</module>
     <module>org.openhab.binding.pulseaudio</module>
     <module>org.openhab.binding.pushbullet</module>


### PR DESCRIPTION
Instead of doing the calculation, if the current day (or the day after) is a public holiday, within a rule, this addon will do this and provide the result as channels.

As result, related rules can be simplified and the need to execute the calculation, if the current day is a public holiday is removed.

The user can specify which of the holidays are relevant by name and assign the channels to an item.

Draw back: Missing public holidays have to be added within the code, but only requires a few lines to be supported.

Further information of the usage are given within the readme file: https://github.com/Hinterwaeldlers/openhab-addons/blob/publicHoliday/bundles/org.openhab.binding.publicholiday/README.md