### PR TITLE
[orbitbhyve] Avoid ClassCastExceptions when accessing thing handler

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
@@ -55,6 +55,7 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.ConfigStatusBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.types.Command;
 import org.slf4j.Logger;
@@ -310,10 +311,12 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
         for (Thing th : getThing().getThings()) {
             if (th.isEnabled()) {
                 String deviceId = th.getUID().getId();
-                OrbitBhyveSprinklerHandler handler = (OrbitBhyveSprinklerHandler) th.getHandler();
-                for (OrbitBhyveDevice device : devices) {
-                    if (deviceId.equals(th.getUID().getId())) {
-                        updateDeviceStatus(device, handler);
+                ThingHandler handler = th.getHandler();
+                if (handler instanceof OrbitBhyveSprinklerHandler) {
+                    for (OrbitBhyveDevice device : devices) {
+                        if (deviceId.equals(th.getUID().getId())) {
+                            updateDeviceStatus(device, (OrbitBhyveSprinklerHandler) handler);
+                        }
                     }
                 }
             }
@@ -332,9 +335,11 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
     private void updateDeviceStatus(String deviceId) {
         for (Thing th : getThing().getThings()) {
             if (deviceId.equals(th.getUID().getId())) {
-                OrbitBhyveSprinklerHandler handler = (OrbitBhyveSprinklerHandler) th.getHandler();
-                OrbitBhyveDevice device = getDevice(deviceId);
-                updateDeviceStatus(device, handler);
+                ThingHandler handler = th.getHandler();
+                if (handler instanceof OrbitBhyveSprinklerHandler) {
+                    OrbitBhyveDevice device = getDevice(deviceId);
+                    updateDeviceStatus(device, (OrbitBhyveSprinklerHandler) handler);
+                }
             }
         }
     }
@@ -342,9 +347,9 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
     private void updateDeviceProgramStatus(OrbitBhyveProgram program) {
         for (Thing th : getThing().getThings()) {
             if (program.getDeviceId().equals(th.getUID().getId())) {
-                OrbitBhyveSprinklerHandler handler = (OrbitBhyveSprinklerHandler) th.getHandler();
-                if (handler != null) {
-                    handler.updateProgram(program);
+                ThingHandler handler = th.getHandler();
+                if (handler instanceof OrbitBhyveSprinklerHandler) {
+                    ((OrbitBhyveSprinklerHandler) handler).updateProgram(program);
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Mark Hilbush <mark@hilbush.com>

Prevent ClassCastExceptions, such as this one.

```
2022-06-14 18:08:11.322 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception:
java.lang.ClassCastException: class org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveSprinklerHandler cannot be cast to class org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveSprinklerHandler (org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveSprinklerHandler is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @518e9bf9; org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveSprinklerHandler is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @70909aa8)
        at org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveBridgeHandler.updateAllStatuses(OrbitBhyveBridgeHandler.java:313) ~[?:?]
        at org.openhab.binding.orbitbhyve.internal.handler.OrbitBhyveBridgeHandler.ping(OrbitBhyveBridgeHandler.java:183) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```
