### PR TITLE
[ahawastecollection] Disable AhaCollectionScheduleTest

### DIFF
--- a/bundles/org.openhab.binding.ahawastecollection/src/test/java/org/openhab/binding/ahawastecollection/internal/AhaCollectionScheduleTest.java
+++ b/bundles/org.openhab.binding.ahawastecollection/src/test/java/org/openhab/binding/ahawastecollection/internal/AhaCollectionScheduleTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.ahawastecollection.internal.CollectionDate.WasteType;
 
@@ -24,6 +25,7 @@ import org.openhab.binding.ahawastecollection.internal.CollectionDate.WasteType;
  * @author Sönke Küper - Initial contribution
  */
 @NonNullByDefault
+@Disabled("These tests use the real website which may not always be available")
 public class AhaCollectionScheduleTest {
 
     @Test


### PR DESCRIPTION
These tests use the real website which causes unwanted load, network connections and test failures.

See: https://github.com/openhab/openhab-addons/actions/runs/2529936944

```
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 4.109 s <<< FAILURE! - in org.openhab.binding.ahawastecollection.internal.AhaCollectionScheduleTest
[ERROR] org.openhab.binding.ahawastecollection.internal.AhaCollectionScheduleTest.testGetValuesForRegion  Time elapsed: 3.294 s  <<< ERROR!
org.jsoup.UnsupportedMimeTypeException: Unhandled content type. Must be text/*, application/xml, or application/*+xml
	at org.openhab.binding.ahawastecollection.internal.AhaCollectionScheduleTest.testGetValuesForRegion(AhaCollectionScheduleTest.java:42)

[ERROR] org.openhab.binding.ahawastecollection.internal.AhaCollectionScheduleTest.testGetValuesForHannoverCity  Time elapsed: 0.726 s  <<< ERROR!
org.jsoup.UnsupportedMimeTypeException: Unhandled content type. Must be text/*, application/xml, or application/*+xml
	at org.openhab.binding.ahawastecollection.internal.AhaCollectionScheduleTest.testGetValuesForHannoverCity(AhaCollectionScheduleTest.java:33)
```