### PR TITLE
[danfossairunit] Update default translations

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/i18n/danfossairunit.properties
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/i18n/danfossairunit.properties
@@ -19,6 +19,7 @@ thing-type.config.danfossairunit.airunit.updateUnchangedValuesEveryMillis.descri
 
 # channel group types
 
+channel-group-type.danfossairunit.humidity.label = Humidity
 channel-group-type.danfossairunit.humidity.channel.humidity.label = Humidity
 channel-group-type.danfossairunit.humidity.channel.humidity.description = Current relative humidity measured by the air unit
 channel-group-type.danfossairunit.main.label = Mode and Fan Speeds
@@ -61,7 +62,6 @@ channel-type.danfossairunit.extractFanStep.label = Extract Fan Step
 channel-type.danfossairunit.extractFanStep.description = Current step setting of the fan extracting air from the rooms
 channel-type.danfossairunit.filterPeriod.label = Filter Period
 channel-type.danfossairunit.filterPeriod.description = Number of months between filter replacements
-channel-type.danfossairunit.humidity.label = Humidity
 channel-type.danfossairunit.manualFanStep.label = Manual Fan Step
 channel-type.danfossairunit.manualFanStep.description = Controls 10-step setting of the fan when operation mode is manual
 channel-type.danfossairunit.mode.label = Mode


### PR DESCRIPTION
One string missing and one string no longer referenced. By coincidence the texts are the same.