### PR TITLE
[boschindego] Fix communication error description on failed HTTP call

### DIFF
--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
@@ -216,7 +216,7 @@ public class IndegoController {
                 throw new IndegoAuthenticationException("Context rejected");
             }
             if (!HttpStatus.isSuccess(status)) {
-                throw new IndegoAuthenticationException("The request failed with HTTP error: " + status);
+                throw new IndegoException("The request failed with error: " + status);
             }
             String jsonResponse = response.getContentAsString();
             if (jsonResponse.isEmpty()) {


### PR DESCRIPTION
Offline/communication error description should include HTTP code, but actually was set to "The login credentials are wrong or another client is connected to your Indego account".