### PR TITLE
[wundergroundupdatereceiver] Bugfix: Check whether the thing is managed before adding newly discovered parameters as channels.

### DIFF
--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandler.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandler.java
@@ -33,6 +33,7 @@ import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
@@ -63,6 +64,7 @@ public class WundergroundUpdateReceiverHandler extends BaseThingHandler {
     private final WundergroundUpdateReceiverDiscoveryService discoveryService;
     private final WundergroundUpdateReceiverUnknownChannelTypeProvider channelTypeProvider;
     private final ChannelTypeRegistry channelTypeRegistry;
+    private final ManagedThingProvider managedThingProvider;
 
     private final ChannelUID dateutcDatetimeChannel;
     private final ChannelUID lastReceivedChannel;
@@ -75,11 +77,12 @@ public class WundergroundUpdateReceiverHandler extends BaseThingHandler {
             WundergroundUpdateReceiverServlet wunderGroundUpdateReceiverServlet,
             WundergroundUpdateReceiverDiscoveryService discoveryService,
             WundergroundUpdateReceiverUnknownChannelTypeProvider channelTypeProvider,
-            ChannelTypeRegistry channelTypeRegistry) {
+            ChannelTypeRegistry channelTypeRegistry, ManagedThingProvider managedThingProvider) {
         super(thing);
         this.discoveryService = discoveryService;
         this.channelTypeProvider = channelTypeProvider;
         this.channelTypeRegistry = channelTypeRegistry;
+        this.managedThingProvider = managedThingProvider;
 
         final ChannelGroupUID metadatGroupUID = new ChannelGroupUID(getThing().getUID(), METADATA_GROUP);
 
@@ -205,7 +208,8 @@ public class WundergroundUpdateReceiverHandler extends BaseThingHandler {
                 updateState(channelUID, new DecimalType(numberValue));
             }
         } else if (this.discoveryService.isDiscovering()
-                && !WundergroundUpdateReceiverParameterMapping.isExcluded(parameterName)) {
+                && !WundergroundUpdateReceiverParameterMapping.isExcluded(parameterName)
+                && this.managedThingProvider.get(this.thing.getUID()) != null) {
             ThingBuilder thingBuilder = editThing();
             buildChannel(thingBuilder, parameterName, state);
             updateThing(thingBuilder.build());

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandlerFactory.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandlerFactory.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.wundergroundupdatereceiver.internal.Wundergrou
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -42,15 +43,17 @@ public class WundergroundUpdateReceiverHandlerFactory extends BaseThingHandlerFa
     private final ChannelTypeRegistry channelTypeRegistry;
     private final WundergroundUpdateReceiverUnknownChannelTypeProvider channelTypeProvider;
     private final WundergroundUpdateReceiverServlet wunderGroundUpdateReceiverServlet;
+    private final ManagedThingProvider managedThingProvider;
 
     @Activate
     public WundergroundUpdateReceiverHandlerFactory(@Reference HttpService httpService,
             @Reference WundergroundUpdateReceiverDiscoveryService discoveryService,
             @Reference WundergroundUpdateReceiverUnknownChannelTypeProvider channelTypeProvider,
-            @Reference ChannelTypeRegistry channelTypeRegistry) {
+            @Reference ChannelTypeRegistry channelTypeRegistry, @Reference ManagedThingProvider managedThingProvider) {
         this.discoveryService = discoveryService;
         this.channelTypeRegistry = channelTypeRegistry;
         this.channelTypeProvider = channelTypeProvider;
+        this.managedThingProvider = managedThingProvider;
         this.wunderGroundUpdateReceiverServlet = new WundergroundUpdateReceiverServlet(httpService,
                 this.discoveryService);
         this.discoveryService.servletControls = this.wunderGroundUpdateReceiverServlet;
@@ -70,7 +73,8 @@ public class WundergroundUpdateReceiverHandlerFactory extends BaseThingHandlerFa
 
         if (THING_TYPE_UPDATE_RECEIVER.equals(thingTypeUID)) {
             return new WundergroundUpdateReceiverHandler(thing, this.wunderGroundUpdateReceiverServlet,
-                    this.discoveryService, this.channelTypeProvider, this.channelTypeRegistry);
+                    this.discoveryService, this.channelTypeProvider, this.channelTypeRegistry,
+                    this.managedThingProvider);
         }
 
         return null;

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/test/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverServletTest.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/test/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverServletTest.java
@@ -65,6 +65,7 @@ import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingUID;
@@ -92,6 +93,7 @@ class WundergroundUpdateReceiverServletTest {
     private @Mock HttpService httpService;
     private @Mock ChannelTypeRegistry channelTypeRegistry;
     private @Mock WundergroundUpdateReceiverDiscoveryService discoveryService;
+    private @Mock ManagedThingProvider managedThingProvider;
 
     @BeforeEach
     public void setUp() {
@@ -231,7 +233,7 @@ class WundergroundUpdateReceiverServletTest {
                 .thenReturn(ChannelTypeBuilder.trigger(LAST_QUERY_TRIGGER_CHANNELTYPEUID, "Label").build());
         WundergroundUpdateReceiverServlet sut = new WundergroundUpdateReceiverServlet(httpService, discoveryService);
         WundergroundUpdateReceiverHandler handler = new WundergroundUpdateReceiverHandler(thing, sut, discoveryService,
-                new WundergroundUpdateReceiverUnknownChannelTypeProvider(), channelTypeRegistry);
+                new WundergroundUpdateReceiverUnknownChannelTypeProvider(), channelTypeRegistry, managedThingProvider);
         ThingHandlerCallback mockCallback = mock(ThingHandlerCallback.class);
         handler.setCallback(mockCallback);
 
@@ -330,7 +332,8 @@ class WundergroundUpdateReceiverServletTest {
                 .withChannels(channels).withConfiguration(config).build();
         ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
         WundergroundUpdateReceiverHandler handler = new WundergroundUpdateReceiverHandler(testThing, sut,
-                discoveryService, new WundergroundUpdateReceiverUnknownChannelTypeProvider(), channelTypeRegistry);
+                discoveryService, new WundergroundUpdateReceiverUnknownChannelTypeProvider(), channelTypeRegistry,
+                managedThingProvider);
         handler.setCallback(callback);
         handler.initialize();
 
@@ -443,7 +446,8 @@ class WundergroundUpdateReceiverServletTest {
                 .withChannels(channels).withConfiguration(config).build();
         ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
         WundergroundUpdateReceiverHandler handler = new WundergroundUpdateReceiverHandler(testThing, sut,
-                discoveryService, new WundergroundUpdateReceiverUnknownChannelTypeProvider(), channelTypeRegistry);
+                discoveryService, new WundergroundUpdateReceiverUnknownChannelTypeProvider(), channelTypeRegistry,
+                managedThingProvider);
         handler.setCallback(callback);
         handler.initialize();
 


### PR DESCRIPTION
# Description
Fix for bug #12997
