### PR TITLE
[hdpowerview] Return capabilities if capabilitiesOverride is not defined

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -155,7 +155,7 @@ public class ShadeCapabilitiesDatabase {
          * @return 'typeCapabilities'.
          */
         public int getCapabilitiesOverride() {
-            return capabilitiesOverride;
+            return capabilitiesOverride < 0 ? capabilities : capabilitiesOverride;
         }
     }
 


### PR DESCRIPTION
Fixes #13029 

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
