### PR TITLE
[boschindego] Add battery and garden channels (including map)

### DIFF
--- a/bundles/org.openhab.binding.boschindego/README.md
+++ b/bundles/org.openhab.binding.boschindego/README.md
@@ -8,25 +8,31 @@ His [Java Library](https://github.com/zazaz-de/iot-device-bosch-indego-controlle
 
 Currently the binding supports  ***indego***  mowers as a thing type with these configuration parameters:
 
-| Parameter          | Description                                                     | Default |
-|--------------------|-----------------------------------------------------------------|---------|
-| username           | Username for the Bosch Indego account                           |         |
-| password           | Password for the Bosch Indego account                           |         |
-| refresh            | The number of seconds between refreshing device state           | 180     |
-| cuttingTimeRefresh | The number of minutes between refreshing last/next cutting time | 60      |
+| Parameter             | Description                                                             | Default |
+|-----------------------|-------------------------------------------------------------------------|---------|
+| username              | Username for the Bosch Indego account                                   |         |
+| password              | Password for the Bosch Indego account                                   |         |
+| refresh               | The number of seconds between refreshing device state                   | 180     |
+| cuttingTimeMapRefresh | The number of minutes between refreshing last/next cutting time and map | 60      |
 
 ## Channels
 
-| Channel      | Item Type   | Description                                                                                                                         |
-|--------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| state        | Number      | You can send commands to this channel to control the mower and read the simplified state from it (1=mow, 2=return to dock, 3=pause) |
-| errorcode    | Number      | Error code of the mower (0=no error, readonly)                                                                                      |
-| statecode    | Number      | Detailed state of the mower (readonly)                                                                                              |
-| textualstate | String      | State as a text. (readonly)                                                                                                         |
-| ready        | Number      | Shows if the mower is ready to mow (1=ready, 0=not ready, readonly)                                                                 |
-| mowed        | Dimmer      | Cut grass in percent (readonly)                                                                                                     |
-| lastCutting  | DateTime    | Last cutting time (readonly)                                                                                                        |
-| nextCutting  | DateTime    | Next scheduled cutting time (readonly)                                                                                              |
+| Channel            | Item Type                | Description                                                                                                                         | Writeable |
+|--------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| state              | Number                   | You can send commands to this channel to control the mower and read the simplified state from it (1=mow, 2=return to dock, 3=pause) | Yes       |
+| errorcode          | Number                   | Error code of the mower (0=no error)                                                                                                |           |
+| statecode          | Number                   | Detailed state of the mower                                                                                                         |           |
+| textualstate       | String                   | State as a text.                                                                                                                    |           |
+| ready              | Number                   | Shows if the mower is ready to mow (1=ready, 0=not ready)                                                                           |           |
+| mowed              | Dimmer                   | Cut grass in percent                                                                                                                |           |
+| lastCutting        | DateTime                 | Last cutting time                                                                                                                   |           |
+| nextCutting        | DateTime                 | Next scheduled cutting time                                                                                                         |           |
+| batteryVoltage     | Number:ElectricPotential | Battery voltage reported by the device                                                                                              |           |
+| batteryLevel       | Number                   | Battery level as a percentage (0-100%)                                                                                              |           |
+| lowBattery         | Switch                   | Low battery warning with possible values on (low battery) and off (battery ok)                                                      |           |
+| batteryTemperature | Number:Temperature       | Battery temperature reported by the device                                                                                          |           |
+| gardenSize         | Number:Area              | Garden size mapped by the device                                                                                                    |           |
+| gardenMap          | Image                    | Garden map mapped by the device                                                                                                     |           |
 
 ### State Codes
 
@@ -81,6 +87,12 @@ Number Indego_Ready { channel="boschindego:indego:lawnmower:ready" }
 Dimmer Indego_Mowed { channel="boschindego:indego:lawnmower:mowed" }
 DateTime Indego_LastCutting { channel="boschindego:indego:lawnmower:lastCutting" }
 DateTime Indego_NextCutting { channel="boschindego:indego:lawnmower:nextCutting" }
+Number:ElectricPotential Indego_BatteryVoltage { channel="boschindego:indego:lawnmower:batteryVoltage" }
+Number Indego_BatteryLevel { channel="boschindego:indego:lawnmower:batteryLevel" }
+Switch Indego_LowBattery { channel="boschindego:indego:lawnmower:lowBattery" }
+Number:Temperature Indego_BatteryTemperature { channel="boschindego:indego:lawnmower:batteryTemperature" }
+Number:Area Indego_GardenSize { channel="boschindego:indego:lawnmower:gardenSize" }
+Image Indego_GardenMap { channel="boschindego:indego:lawnmower:gardenMap" }
 ```
 
 ### `indego.sitemap` File

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/BoschIndegoBindingConstants.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/BoschIndegoBindingConstants.java
@@ -40,6 +40,12 @@ public class BoschIndegoBindingConstants {
     public static final String READY = "ready";
     public static final String LAST_CUTTING = "lastCutting";
     public static final String NEXT_CUTTING = "nextCutting";
+    public static final String BATTERY_VOLTAGE = "batteryVoltage";
+    public static final String BATTERY_LEVEL = "batteryLevel";
+    public static final String LOW_BATTERY = "lowBattery";
+    public static final String BATTERY_TEMPERATURE = "batteryTemperature";
+    public static final String GARDEN_SIZE = "gardenSize";
+    public static final String GARDEN_MAP = "gardenMap";
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_INDEGO);
 }

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/Battery.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/Battery.java
@@ -10,20 +10,27 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.boschindego.internal.config;
+package org.openhab.binding.boschindego.internal.dto;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
+import com.google.gson.annotations.SerializedName;
 
 /**
- * Configuration for the Bosch Indego thing.
- *
+ * Battery data.
+ * 
  * @author Jacob Laursen - Initial contribution
  */
-@NonNullByDefault
-public class BoschIndegoConfiguration {
-    public @Nullable String username;
-    public @Nullable String password;
-    public long refresh = 180;
-    public long cuttingTimeMapRefresh = 60;
+public class Battery {
+    public double voltage;
+
+    public int cycles;
+
+    public double discharge;
+
+    @SerializedName("ambient_temp")
+    public int ambientTemperature;
+
+    @SerializedName("battery_temp")
+    public int batteryTemperature;
+
+    public int percent;
 }

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/Garden.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/Garden.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Garden data.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+public class Garden {
+    public long id;
+
+    public String name;
+
+    @SerializedName("signal_id")
+    public byte signalId;
+
+    public int size;
+
+    @SerializedName("inner_bounds")
+    public int innerBounds;
+
+    public int cuts;
+
+    public int runtime;
+
+    public int charge;
+
+    public int bumps;
+
+    public int stops;
+
+    @SerializedName("last_mow")
+    public int lastMow;
+
+    @SerializedName("map_cell_size")
+    public int mapCellSize;
+}

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/response/OperatingDataResponse.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/response/OperatingDataResponse.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal.dto.response;
+
+import org.openhab.binding.boschindego.internal.dto.Battery;
+import org.openhab.binding.boschindego.internal.dto.Garden;
+import org.openhab.binding.boschindego.internal.dto.response.runtime.DeviceStateRuntimes;
+
+/**
+ * Response for operating data.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+public class OperatingDataResponse {
+    public DeviceStateRuntimes runtime;
+
+    public Battery battery;
+
+    public Garden garden;
+}

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/exceptions/IndegoUnreachableException.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/exceptions/IndegoUnreachableException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal.exceptions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * {@link IndegoUnreachableException} is thrown on gateway timeout, which
+ * means that Bosch services cannot connect to the device.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class IndegoUnreachableException extends IndegoException {
+
+    private static final long serialVersionUID = -7952585411438042139L;
+
+    public IndegoUnreachableException(String message) {
+        super(message);
+    }
+
+    public IndegoUnreachableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/i18n/boschindego.properties
+++ b/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/i18n/boschindego.properties
@@ -10,8 +10,8 @@ thing-type.boschindego.indego.description = Indego which supports the connect fe
 
 # thing types config
 
-thing-type.config.boschindego.indego.cuttingTimeRefresh.label = Cutting Time Refresh Interval
-thing-type.config.boschindego.indego.cuttingTimeRefresh.description = The number of minutes between refreshing last/next cutting time.
+thing-type.config.boschindego.indego.cuttingTimeMapRefresh.label = Cutting Time/Map Refresh Interval
+thing-type.config.boschindego.indego.cuttingTimeMapRefresh.description = The number of minutes between refreshing last/next cutting time and map.
 thing-type.config.boschindego.indego.password.label = Password
 thing-type.config.boschindego.indego.password.description = Password for the Bosch Indego account.
 thing-type.config.boschindego.indego.refresh.label = Refresh Interval
@@ -21,8 +21,16 @@ thing-type.config.boschindego.indego.username.description = Username for the Bos
 
 # channel types
 
+channel-type.boschindego.batteryTemperature.label = Battery Temperature
+channel-type.boschindego.batteryTemperature.description = Battery temperature reported by the device
+channel-type.boschindego.batteryVoltage.label = Battery Voltage
+channel-type.boschindego.batteryVoltage.description = Battery voltage reported by the device
 channel-type.boschindego.errorcode.label = Error Code
 channel-type.boschindego.errorcode.description = 0 = no error
+channel-type.boschindego.gardenMap.label = Garden Map
+channel-type.boschindego.gardenMap.description = Garden map mapped by the device
+channel-type.boschindego.gardenSize.label = Garden Size
+channel-type.boschindego.gardenSize.description = Garden size mapped by the device
 channel-type.boschindego.lastCutting.label = Last Cutting
 channel-type.boschindego.lastCutting.description = Last cutting time
 channel-type.boschindego.mowed.label = Cut Grass
@@ -44,6 +52,7 @@ channel-type.boschindego.textualstate.label = Textual State
 # thing status descriptions
 
 offline.comm-error.authentication-failure = The login credentials are wrong or another client is connected to your Indego account
+offline.comm-error.unreachable = Device is unreachable
 offline.conf-error.missing-password = Password missing
 offline.conf-error.missing-username = Username missing
 

--- a/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/thing/thing-types.xml
@@ -16,6 +16,12 @@
 			<channel id="ready" typeId="ready"/>
 			<channel id="lastCutting" typeId="lastCutting"/>
 			<channel id="nextCutting" typeId="nextCutting"/>
+			<channel id="batteryVoltage" typeId="batteryVoltage"/>
+			<channel id="batteryLevel" typeId="system.battery-level"/>
+			<channel id="lowBattery" typeId="system.low-battery"/>
+			<channel id="batteryTemperature" typeId="batteryTemperature"/>
+			<channel id="gardenSize" typeId="gardenSize"/>
+			<channel id="gardenMap" typeId="gardenMap"/>
 		</channels>
 		<config-description>
 			<parameter name="username" type="text" required="true">
@@ -32,9 +38,9 @@
 				<description>The number of seconds between refreshing device state.</description>
 				<default>180</default>
 			</parameter>
-			<parameter name="cuttingTimeRefresh" type="integer" min="1">
-				<label>Cutting Time Refresh Interval</label>
-				<description>The number of minutes between refreshing last/next cutting time.</description>
+			<parameter name="cuttingTimeMapRefresh" type="integer" min="1">
+				<label>Cutting Time/Map Refresh Interval</label>
+				<description>The number of minutes between refreshing last/next cutting time and map.</description>
 				<advanced>true</advanced>
 				<default>60</default>
 			</parameter>
@@ -130,6 +136,35 @@
 		<label>Next Cutting</label>
 		<description>Next scheduled cutting time</description>
 		<category>Time</category>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="batteryVoltage" advanced="true">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>Battery Voltage</label>
+		<description>Battery voltage reported by the device</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="batteryTemperature" advanced="true">
+		<item-type>Number:Temperature</item-type>
+		<label>Battery Temperature</label>
+		<description>Battery temperature reported by the device</description>
+		<category>Temperature</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
+		</tags>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="gardenSize">
+		<item-type>Number:Area</item-type>
+		<label>Garden Size</label>
+		<description>Garden size mapped by the device</description>
+		<state pattern="%d %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="gardenMap">
+		<item-type>Image</item-type>
+		<label>Garden Map</label>
+		<description>Garden map mapped by the device</description>
 		<state readOnly="true"/>
 	</channel-type>
 


### PR DESCRIPTION
Introduce new channels:
- batteryVoltage
- batteryLevel
- lowBattery
- batteryTemperature
- gardenSize
- gardenMap

Binding is now also able to detect whether device is online, so it will be marked as offline when unreachable. This is based on **/operatingData** which will directly communicate with the device, whereas **/state** returns data even when device has been turned off for several days.

Fixes #12938
Fixes #13017

JAR: https://drive.google.com/file/d/1pWVrOl-QcKf3zeHuqizhV1VDpXecxizC/view?usp=sharing