### PR TITLE
[enigma2] Remove FIXMEs from translations

### DIFF
--- a/bundles/org.openhab.binding.enigma2/src/main/resources/OH-INF/i18n/enigma2.properties
+++ b/bundles/org.openhab.binding.enigma2/src/main/resources/OH-INF/i18n/enigma2.properties
@@ -1,5 +1,3 @@
-# FIXME: please substitute the xx_XX with a proper locale, ie. de_DE
-# FIXME: please do not add the file to the repo if you add or change no content
 # binding
 binding.enigma2.name = Enigma2 Binding
 binding.enigma2.description = This is the binding for Enigma2


### PR DESCRIPTION
They would also get added by Crowdin, see https://github.com/openhab/openhab-addons/pull/13074.