### PR TITLE
[dsmr] Fix incorrect deriving of sub channel names when updating channels

### DIFF
--- a/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/handler/DSMRMeterHandler.java
+++ b/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/handler/DSMRMeterHandler.java
@@ -136,15 +136,13 @@ public class DSMRMeterHandler extends BaseThingHandler implements P1TelegramList
     private synchronized void updateState() {
         logger.trace("Update state for device: {}", getThing().getThingTypeUID().getId());
         if (!lastReceivedValues.isEmpty()) {
-            for (CosemObject cosemObject : lastReceivedValues) {
-                String channel = cosemObject.getType().name().toLowerCase();
+            for (final CosemObject cosemObject : lastReceivedValues) {
+                for (final Entry<String, ? extends State> entry : cosemObject.getCosemValues().entrySet()) {
+                    final String channel = cosemObject.getType().name().toLowerCase()
+                            /* CosemObject has a specific sub channel if key not empty */
+                            + (entry.getKey().isEmpty() ? "" : "_" + entry.getKey());
 
-                for (Entry<String, ? extends State> entry : cosemObject.getCosemValues().entrySet()) {
-                    if (!entry.getKey().isEmpty()) {
-                        /* CosemObject has a specific sub channel */
-                        channel += "_" + entry.getKey();
-                    }
-                    State newState = entry.getValue();
+                    final State newState = entry.getValue();
                     logger.debug("Updating state for channel {} to value {}", channel, newState);
                     updateState(channel, newState);
                 }


### PR DESCRIPTION
Subchannels were created by appending the key. However this was done inside a loop and if multiple updates were needed they would be appended to the channel name, instead of taking the channel name each time.

Reported on https://community.openhab.org/t/no-power-failure-logs-in-dsmr/137116