### PR TITLE
[groupepsa] Handle 'JsonSyntaxException' when parsing error messages

### DIFF
--- a/bundles/org.openhab.binding.groupepsa/src/main/java/org/openhab/binding/groupepsa/internal/rest/api/GroupePSAConnectApi.java
+++ b/bundles/org.openhab.binding.groupepsa/src/main/java/org/openhab/binding/groupepsa/internal/rest/api/GroupePSAConnectApi.java
@@ -151,12 +151,15 @@ public class GroupePSAConnectApi {
 
         switch (statusCode) {
             case HttpStatus.NOT_FOUND_404:
-                ErrorObject error = gson.fromJson(response.getContentAsString(), ErrorObject.class);
-                String message = (error != null) ? error.getMessage() : null;
-                if (message == null) {
-                    message = "Unknown";
+                ErrorObject error = null;
+                try {
+                    error = gson.fromJson(response.getContentAsString(), ErrorObject.class);
+                } catch (JsonSyntaxException e) {
+                    throw new GroupePSACommunicationException("Error in received JSON: " + getRootCause(e).getMessage(),
+                            e);
                 }
-                throw new GroupePSACommunicationException(statusCode, message);
+                String message = (error == null) ? null : error.getMessage();
+                throw new GroupePSACommunicationException(statusCode, message == null ? "Unknown" : message);
 
             case HttpStatus.FORBIDDEN_403:
             case HttpStatus.UNAUTHORIZED_401:


### PR DESCRIPTION
- Handle `JsonSyntaxException` when parsing error messages

```
2022-07-04 17:58:42.363 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:226) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:963) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:928) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:877) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:848) ~[?:?]
        at org.openhab.binding.groupepsa.internal.rest.api.GroupePSAConnectApi.checkForError(GroupePSAConnectApi.java:154) ~[?:?]
        at org.openhab.binding.groupepsa.internal.rest.api.GroupePSAConnectApi.parseResponse(GroupePSAConnectApi.java:174) ~[?:?]
        at org.openhab.binding.groupepsa.internal.rest.api.GroupePSAConnectApi.getVehicleStatus(GroupePSAConnectApi.java:196) ~[?:?]
        at org.openhab.binding.groupepsa.internal.bridge.GroupePSABridgeHandler.getVehicleStatus(GroupePSABridgeHandler.java:218) ~[?:?]
        at org.openhab.binding.groupepsa.internal.things.GroupePSAHandler.updateGroupePSAState(GroupePSAHandler.java:226) ~[?:?]
        at org.openhab.binding.groupepsa.internal.things.GroupePSAHandler.pollStatus(GroupePSAHandler.java:114) ~[?:?]
        at org.openhab.binding.groupepsa.internal.things.GroupePSAHandler.lambda$0(GroupePSAHandler.java:180) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(Unknown Source) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
        at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
        at com.google.gson.stream.JsonReader.beginObject(JsonReader.java:384) ~[?:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:215) ~[?:?]
        ... 17 more
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unuseable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
