### PR TITLE
[tradfri] Update jmdns bundle in itest

### DIFF
--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -18,7 +18,7 @@ Fragment-Host: org.openhab.binding.tradfri
 -runbundles: \
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	javax.jmdns;version='[3.5.7,3.5.8)',\
+	javax.jmdns;version='[3.5.8,3.5.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.californium.core;version='[2.0.0,2.0.1)',\
 	org.eclipse.californium.element-connector;version='[2.0.0,2.0.1)',\


### PR DESCRIPTION
This fixes the build as jmdns got updated in openhab/openhab-core#3029.