### PR TITLE
[boschindego] Fix duplicated calls during initialization

### DIFF
--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
@@ -497,7 +497,7 @@ public class IndegoController {
      * @throws IndegoAuthenticationException if request was rejected as unauthorized
      * @throws IndegoException if any communication or parsing error occurred
      */
-    public String getSerialNumber() throws IndegoAuthenticationException, IndegoException {
+    public synchronized String getSerialNumber() throws IndegoAuthenticationException, IndegoException {
         if (!session.isInitialized()) {
             logger.debug("Session not yet initialized when serial number was requested; authenticating...");
             authenticate();


### PR DESCRIPTION
Fixes #13085:
- **First issue:** Double authentication because two jobs are started at the same time, and each of them need to authenticate. Solved by mutual exclusion of calls to `getSerialNumber()` which is used to verify session and construct URL's.
- **Second issue**: Cutting times fetched twice because of a concurrency issue within `refreshState()`, where cutting times are fetched when state changes. This will always happen on startup, and at the same time another job is scheduled for fetching cutting times immediately and then hourly. Solved by skipping call when not having a previous state. In this situation the scheduled job will fetch cutting times regularly.