### PR TITLE
Hide compiler warnings for generated code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@ Import-Package: \\
             <compilerArgs>
               <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot,+nullAnnotConflict,-nullUncheckedConversion</arg>
               <arg>-warn:+null,+inheritNullAnnot,-nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
+              <arg>-nowarn:[${project.build.directory}/generated-sources]</arg>
             </compilerArgs>
             <showWarnings>true</showWarnings>
             <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Generated Swagger/OpenAPI code can be messy resulting in a lot of compiler warnings obscuring more important compiler warnings.

Fixes #12498