### PR TITLE
Update OH version in skeleton scripts

### DIFF
--- a/bundles/create_openhab_binding_skeleton.cmd
+++ b/bundles/create_openhab_binding_skeleton.cmd
@@ -10,7 +10,7 @@ IF %ARGC% NEQ 3 (
 	exit /B 1
 )
 
-SET OpenhabVersion="3.3.0-SNAPSHOT"
+SET OpenhabVersion="3.4.0-SNAPSHOT"
 
 SET BindingIdInCamelCase=%~1
 SET BindingIdInLowerCase=%BindingIdInCamelCase%

--- a/bundles/create_openhab_binding_skeleton.sh
+++ b/bundles/create_openhab_binding_skeleton.sh
@@ -2,7 +2,7 @@
 
 [ $# -lt 3 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author> <GitHub Username>"; exit 1; }
 
-openHABVersion=3.3.0-SNAPSHOT
+openHABVersion=3.4.0-SNAPSHOT
 
 camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`


### PR DESCRIPTION
Hi. I tried to start working on a new binding on the weekend, and it wouldn't build in Eclipse, because it couldn't find the 3.3.0 SNAPSHOTS. I have never run a `mvn install` against 3.3.0-SNAPSHOT, so it make sense that the base is not in my m2 repo.

After a little bit of digging, I found that all the bundles had moved to 3.4.0-SNAPSHOT, but my binding was still on 3.3.0-SNAPSHOT because it was created by this skeleton shell script.

This PR should solve that in future for anyone else that encounters this issue.
