### PR TITLE
[dali] Use correct command argument to query current color temperature

### DIFF
--- a/bundles/org.openhab.binding.dali/src/main/java/org/openhab/binding/dali/internal/handler/DaliDt8DeviceHandler.java
+++ b/bundles/org.openhab.binding.dali/src/main/java/org/openhab/binding/dali/internal/handler/DaliDt8DeviceHandler.java
@@ -86,8 +86,8 @@ public class DaliDt8DeviceHandler extends DaliDeviceHandler {
                 if (readDeviceTargetId != null) {
                     readAddress = DaliAddress.createShortAddress(readDeviceTargetId);
                 }
-                // Write argument 0x02 (query color temperature) to DTR0 and set DT8
-                daliHandler.sendCommand(DaliStandardCommand.createSetDTR0Command(2));
+                // Write argument 0xc2 (query temporary color temperature) to DTR0 and set DT8
+                daliHandler.sendCommand(DaliStandardCommand.createSetDTR0Command(0xc2));
                 daliHandler.sendCommand(DaliStandardCommand.createSetDeviceTypeCommand(8));
                 // Mirek MSB is returned as result
                 CompletableFuture<@Nullable NumericMask> responseMsb = daliHandler.sendCommandWithResponse(


### PR DESCRIPTION
# [dali] Use correct command argument to query current color temperature

# Description

This PR fixes a small bug in the recently introduced DALI DT8 support:

When querying the current color temperature from a DALI DT8 device (e.g. after changing it or due to a refresh command), the OpenHAB DALI binding would currently query the actual current color temperature. If this happens while the device is still fading between two temperatures, a value somewhere between the start and target values is returned. This makes OpenHAB behave somewhat erratic (sliders jumping to unexpected positions), and we've even experienced some cases (with up/down buttons instead of sliders) where the color temperature could not be changed apart from a very limited range.

This PR changes the behavior to query the target color temperature (for some reason referred to as "temporary color temperature" in DALI instead of only "color temperature") instead of the current color temperature. This fix leads to the behavior a user would expect when chaning the color temperature: OpenHAB showing the value the DALI device is fading to.