### PR TITLE
[homekit] fix potential null pointer exceptions

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -148,6 +148,8 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
         try {
             HomekitSettings oldSettings = settings;
             settings = processConfig(config);
+            if ((oldSettings == null) || (settings == null))
+                return;
             changeListener.updateSettings(settings);
             if (!oldSettings.networkInterface.equals(settings.networkInterface) || oldSettings.port != settings.port
                     || oldSettings.useOHmDNS != settings.useOHmDNS) {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -142,16 +142,17 @@ public class HomekitAccessoryFactory {
     };
 
     private static List<HomekitCharacteristicType> getRequiredCharacteristics(HomekitTaggedItem taggedItem) {
+        final List<HomekitCharacteristicType> characteristics = new ArrayList<>();
+        if (MANDATORY_CHARACTERISTICS.get(taggedItem.getAccessoryType()) != null) {
+            characteristics.addAll(Arrays.asList(MANDATORY_CHARACTERISTICS.get(taggedItem.getAccessoryType())));
+        }
         if (taggedItem.getAccessoryType() == BATTERY) {
             final String isChargeable = taggedItem.getConfiguration(HomekitBatteryImpl.BATTERY_TYPE, "false");
             if ("true".equalsIgnoreCase(isChargeable) || "yes".equalsIgnoreCase(isChargeable)) {
-                final List<HomekitCharacteristicType> characteristics = new ArrayList<>();
-                characteristics.addAll(Arrays.asList(MANDATORY_CHARACTERISTICS.get(taggedItem.getAccessoryType())));
                 characteristics.add(BATTERY_CHARGING_STATE);
-                return characteristics;
             }
         }
-        return Arrays.asList(MANDATORY_CHARACTERISTICS.get(taggedItem.getAccessoryType()));
+        return characteristics;
     }
 
     /**

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -143,7 +143,7 @@ public class HomekitAccessoryFactory {
 
     private static List<HomekitCharacteristicType> getRequiredCharacteristics(HomekitTaggedItem taggedItem) {
         final List<HomekitCharacteristicType> characteristics = new ArrayList<>();
-        if (MANDATORY_CHARACTERISTICS.get(taggedItem.getAccessoryType()) != null) {
+        if (MANDATORY_CHARACTERISTICS.containsKey(taggedItem.getAccessoryType())) {
             characteristics.addAll(Arrays.asList(MANDATORY_CHARACTERISTICS.get(taggedItem.getAccessoryType())));
         }
         if (taggedItem.getAccessoryType() == BATTERY) {


### PR DESCRIPTION
fix 2 potentail NPE

- first one happens if addon is deployed on new and not configured openhab installation. in this case "settings" can be null
- second one can happen if homekit accessory type is missing, wrong or incomplete. reported here
https://community.openhab.org/t/homekit-binding-stops-working-after-upgrading-to-oh-3-3-0/137302

Signed-off-by: Eugen Freiter <freiter@gmx.de>
