### PR TITLE
Switch to fork of gatt parser library in order to fix incompatibility with xstream

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/pom.xml
@@ -22,9 +22,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sputnikdev</groupId>
+      <groupId>org.openhab</groupId>
       <artifactId>bluetooth-gatt-parser</artifactId>
-      <version>1.9.4</version>
+      <version>2.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtils.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothChannelUtils.java
@@ -22,6 +22,13 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.bluetooth.gattparser.BluetoothGattParser;
+import org.openhab.bluetooth.gattparser.FieldHolder;
+import org.openhab.bluetooth.gattparser.GattRequest;
+import org.openhab.bluetooth.gattparser.spec.Enumeration;
+import org.openhab.bluetooth.gattparser.spec.Field;
+import org.openhab.bluetooth.gattparser.spec.FieldFormat;
+import org.openhab.bluetooth.gattparser.spec.FieldType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -29,13 +36,6 @@ import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sputnikdev.bluetooth.gattparser.BluetoothGattParser;
-import org.sputnikdev.bluetooth.gattparser.FieldHolder;
-import org.sputnikdev.bluetooth.gattparser.GattRequest;
-import org.sputnikdev.bluetooth.gattparser.spec.Enumeration;
-import org.sputnikdev.bluetooth.gattparser.spec.Field;
-import org.sputnikdev.bluetooth.gattparser.spec.FieldFormat;
-import org.sputnikdev.bluetooth.gattparser.spec.FieldType;
 
 /**
  * The {@link BluetoothChannelUtils} contains utility functions used by the GattChannelHandler

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/CharacteristicChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/CharacteristicChannelTypeProvider.java
@@ -25,6 +25,10 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.bluetooth.BluetoothBindingConstants;
+import org.openhab.bluetooth.gattparser.BluetoothGattParser;
+import org.openhab.bluetooth.gattparser.BluetoothGattParserFactory;
+import org.openhab.bluetooth.gattparser.spec.Enumerations;
+import org.openhab.bluetooth.gattparser.spec.Field;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeProvider;
@@ -34,10 +38,6 @@ import org.openhab.core.types.StateOption;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sputnikdev.bluetooth.gattparser.BluetoothGattParser;
-import org.sputnikdev.bluetooth.gattparser.BluetoothGattParserFactory;
-import org.sputnikdev.bluetooth.gattparser.spec.Enumerations;
-import org.sputnikdev.bluetooth.gattparser.spec.Field;
 
 /**
  * {@link CharacteristicChannelTypeProvider} that provides channel types for dynamically discovered characteristics.

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -29,6 +29,13 @@ import org.openhab.binding.bluetooth.BluetoothBindingConstants;
 import org.openhab.binding.bluetooth.BluetoothCharacteristic;
 import org.openhab.binding.bluetooth.BluetoothDevice.ConnectionState;
 import org.openhab.binding.bluetooth.ConnectedBluetoothHandler;
+import org.openhab.bluetooth.gattparser.BluetoothGattParser;
+import org.openhab.bluetooth.gattparser.BluetoothGattParserFactory;
+import org.openhab.bluetooth.gattparser.FieldHolder;
+import org.openhab.bluetooth.gattparser.GattRequest;
+import org.openhab.bluetooth.gattparser.GattResponse;
+import org.openhab.bluetooth.gattparser.spec.Characteristic;
+import org.openhab.bluetooth.gattparser.spec.Field;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -44,13 +51,6 @@ import org.openhab.core.types.State;
 import org.openhab.core.util.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sputnikdev.bluetooth.gattparser.BluetoothGattParser;
-import org.sputnikdev.bluetooth.gattparser.BluetoothGattParserFactory;
-import org.sputnikdev.bluetooth.gattparser.FieldHolder;
-import org.sputnikdev.bluetooth.gattparser.GattRequest;
-import org.sputnikdev.bluetooth.gattparser.GattResponse;
-import org.sputnikdev.bluetooth.gattparser.spec.Characteristic;
-import org.sputnikdev.bluetooth.gattparser.spec.Field;
 
 /**
  * This is a handler for generic connected bluetooth devices that dynamically generates


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/10278#issuecomment-1171727057

Signed-off-by: Kai Kreuzer <kai@openhab.org>
