### PR TITLE
[boschindego] Refresh cutting times right after next planned cutting

### DIFF
--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
@@ -278,6 +278,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
             }
         }
 
+        cancelCuttingTimeRefresh();
         if (isLinked(NEXT_CUTTING)) {
             Instant nextCutting = controller.getPredictiveNextCutting();
             if (nextCutting != null) {
@@ -290,14 +291,16 @@ public class BoschIndegoHandler extends BaseThingHandler {
         }
     }
 
-    private void scheduleCuttingTimesRefresh(Instant nextCutting) {
+    private void cancelCuttingTimeRefresh() {
         ScheduledFuture<?> cuttingTimeFuture = this.cuttingTimeFuture;
         if (cuttingTimeFuture != null) {
             // Do not interrupt as we might be running within that job.
             cuttingTimeFuture.cancel(false);
             this.cuttingTimeFuture = null;
         }
+    }
 
+    private void scheduleCuttingTimesRefresh(Instant nextCutting) {
         // Schedule additional update right after next planned cutting. This ensures a faster update
         // in case the next cutting will be postponed (for example due to weather conditions).
         long secondsUntilNextCutting = Instant.now().until(nextCutting, ChronoUnit.SECONDS) + 2;

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.boschindego.internal.BoschIndegoBindingConstan
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -71,6 +72,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
     private @NonNullByDefault({}) IndegoController controller;
     private @Nullable ScheduledFuture<?> statePollFuture;
     private @Nullable ScheduledFuture<?> cuttingTimeMapPollFuture;
+    private @Nullable ScheduledFuture<?> cuttingTimeFuture;
     private boolean propertiesInitialized;
     private Optional<Integer> previousStateCode = Optional.empty();
 
@@ -124,6 +126,11 @@ public class BoschIndegoHandler extends BaseThingHandler {
             pollFuture.cancel(true);
         }
         this.cuttingTimeMapPollFuture = null;
+        pollFuture = this.cuttingTimeFuture;
+        if (pollFuture != null) {
+            pollFuture.cancel(true);
+        }
+        this.cuttingTimeFuture = null;
 
         scheduler.execute(() -> {
             try {
@@ -249,6 +256,17 @@ public class BoschIndegoHandler extends BaseThingHandler {
         updateStatus(ThingStatus.ONLINE);
     }
 
+    private void refreshCuttingTimesWithExceptionHandling() {
+        try {
+            refreshCuttingTimes();
+        } catch (IndegoAuthenticationException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.comm-error.authentication-failure");
+        } catch (IndegoException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
     private void refreshCuttingTimes() throws IndegoAuthenticationException, IndegoException {
         if (isLinked(LAST_CUTTING)) {
             Instant lastCutting = controller.getPredictiveLastCutting();
@@ -265,9 +283,28 @@ public class BoschIndegoHandler extends BaseThingHandler {
             if (nextCutting != null) {
                 updateState(NEXT_CUTTING,
                         new DateTimeType(ZonedDateTime.ofInstant(nextCutting, timeZoneProvider.getTimeZone())));
+                scheduleCuttingTimesRefresh(nextCutting);
             } else {
                 updateState(NEXT_CUTTING, UnDefType.UNDEF);
             }
+        }
+    }
+
+    private void scheduleCuttingTimesRefresh(Instant nextCutting) {
+        ScheduledFuture<?> cuttingTimeFuture = this.cuttingTimeFuture;
+        if (cuttingTimeFuture != null) {
+            // Do not interrupt as we might be running within that job.
+            cuttingTimeFuture.cancel(false);
+            this.cuttingTimeFuture = null;
+        }
+
+        // Schedule additional update right after next planned cutting. This ensures a faster update
+        // in case the next cutting will be postponed (for example due to weather conditions).
+        long secondsUntilNextCutting = Instant.now().until(nextCutting, ChronoUnit.SECONDS) + 2;
+        if (secondsUntilNextCutting > 0) {
+            logger.debug("Scheduling fetching of cutting times in {} seconds", secondsUntilNextCutting);
+            this.cuttingTimeFuture = scheduler.schedule(this::refreshCuttingTimesWithExceptionHandling,
+                    secondsUntilNextCutting, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Schedule additional update right after next planned cutting. This ensures a faster/immediate update in case the next cutting will be postponed (for example due to weather conditions). Previously this update could take up to one hour.

Tested and finally confirmed to work correctly after four days of waiting time - it was scheduled to mow at 10:00, and immediately hereafter the next scheduled time was updated:

```
2022-07-26 10:00:01.797 [TRACE] [oschindego.internal.IndegoController] - GET request for https://api.indego.iot.bosch-si.com/api/v1/alms/xxxxxxxx/predictive/nextcutting
2022-07-26 10:00:01.841 [TRACE] [oschindego.internal.IndegoController] - JSON response: '{
  "mow_next" : "2022-07-29T10:00:00+02:00"
}'
2022-07-26 10:00:01.844 [DEBUG] [.internal.handler.BoschIndegoHandler] - Scheduling fetching of cutting times in 259200 seconds
2022-07-26 10:00:01.897 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Indego_NextCutting' changed from 2022-07-26T10:00:00.000+0200 to 2022-07-29T10:00:00.000+0200
```

Related to #12986