### PR TITLE
[homematic] Allow default value that is less than allowed minimum

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -374,12 +374,18 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                     if (dp.isNumberType()) {
                         Number defaultValue = (Number) dp.getDefaultValue();
                         Number maxValue = dp.getMaxValue();
-                        // some datapoints can have a default value that is greater than the maximum value
-                        if (defaultValue != null && maxValue != null
-                                && defaultValue.doubleValue() > maxValue.doubleValue()) {
-                            maxValue = defaultValue;
+                        Number minValue = dp.getMinValue();
+                        if (defaultValue != null) {
+                            // some datapoints can have a default value that is greater than the maximum value
+                            if (maxValue != null && defaultValue.doubleValue() > maxValue.doubleValue()) {
+                                maxValue = defaultValue;
+                            }
+                            // ... and there are also default values less than the minimum value
+                            if (minValue != null && defaultValue.doubleValue() < minValue.doubleValue()) {
+                                minValue = defaultValue;
+                            }
                         }
-                        builder.withMinimum(MetadataUtils.createBigDecimal(dp.getMinValue()));
+                        builder.withMinimum(MetadataUtils.createBigDecimal(minValue));
                         builder.withMaximum(MetadataUtils.createBigDecimal(maxValue));
                         builder.withUnitLabel(MetadataUtils.getUnit(dp));
                     }


### PR DESCRIPTION
For some Homematic devices the default values can be higher than the allowed maximum value or less than the allowed minimum value (e.g. 0 for "not set"). 

Default values that are higher than the maximum value were alreaday allowed. With this fix also default values that are less than  the minimum value are allowed.

Unfortunately, this means that the range of allowed values has to be increased.

Resolves #13097

Signed-off-by: Martin Herbst <develop@mherbst.de>

