### PR TITLE
[hdpowerview] Add additional hub properties

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
@@ -65,6 +65,7 @@ public class HDPowerViewBindingConstants {
     // Hub properties
     public static final String PROPERTY_FIRMWARE_NAME = "firmwareName";
     public static final String PROPERTY_RADIO_FIRMWARE_VERSION = "radioFirmwareVersion";
+    public static final String PROPERTY_HUB_NAME = "hubName";
 
     // Shade properties
     public static final String PROPERTY_SHADE_TYPE = "type";

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/HubFirmware.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/HubFirmware.java
@@ -10,11 +10,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.hdpowerview.internal.api.responses;
+package org.openhab.binding.hdpowerview.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.hdpowerview.internal.api.Firmware;
 
 /**
  * Firmware information for an HD PowerView hub
@@ -22,7 +21,7 @@ import org.openhab.binding.hdpowerview.internal.api.Firmware;
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-public class FirmwareVersions {
+public class HubFirmware {
     @Nullable
     public Firmware mainProcessor;
     @Nullable

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Times.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/Times.java
@@ -10,19 +10,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.hdpowerview.internal.api.responses;
+package org.openhab.binding.hdpowerview.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.hdpowerview.internal.api.HubFirmware;
 
 /**
- * Firmware information for an HD PowerView hub
+ * Times as part of {@link UserData} for an HD PowerView hub
  *
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-public class FirmwareVersion {
-    @Nullable
-    public HubFirmware firmware;
+public class Times {
+    public @Nullable String timezone;
+    public int localSunriseTimeInMinutes;
+    public int localSunsetTimeInMinutes;
+    public int currentOffset;
+    public double longitude;
+    public double latitude;
 }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/UserData.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/UserData.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.api;
+
+import java.util.Base64;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * User data for an HD PowerView hub
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class UserData {
+    public @Nullable String hubName;
+    public boolean localTimeDataSet;
+    public boolean enableScheduledEvents;
+    public boolean editingEnabled;
+    public boolean setupCompleted;
+    public @Nullable String gateway;
+    public @Nullable String dns;
+    public boolean staticIp;
+    @SerializedName("_id")
+    public @Nullable String id;
+    public @Nullable Color color;
+    public boolean autoBackup;
+    public @Nullable String ip;
+    public @Nullable String macAddress;
+    public @Nullable String mask;
+    public boolean wireless;
+    public @Nullable HubFirmware firmware;
+    public @Nullable String serialNumber;
+    public @Nullable String rfIDInt;
+    public @Nullable String rfID;
+    public int rfStatus;
+    public @Nullable Times times;
+    public @Nullable String brand;
+    public boolean rcUp;
+    public boolean remoteConnectEnabled;
+
+    public String getHubName() {
+        return hubName != null ? new String(Base64.getDecoder().decode(hubName)) : "";
+    }
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/UserDataResponse.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/UserDataResponse.java
@@ -14,15 +14,14 @@ package org.openhab.binding.hdpowerview.internal.api.responses;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.hdpowerview.internal.api.HubFirmware;
+import org.openhab.binding.hdpowerview.internal.api.UserData;
 
 /**
- * Firmware information for an HD PowerView hub
+ * Response with {@link UserData} for an HD PowerView hub
  *
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-public class FirmwareVersion {
-    @Nullable
-    public HubFirmware firmware;
+public class UserDataResponse {
+    public @Nullable UserData userData;
 }


### PR DESCRIPTION
Resolves #13173 by adding the following hub properties:
- Serial number
- MAC address
- Hub name

In the future serial number or MAC address can potentially replace host as representation property.

Example:
![image](https://user-images.githubusercontent.com/19519842/180777288-9447438e-3da1-4e91-a265-4fccd64eb8ed.png)
