### PR TITLE
[boschindego] Provide faster channel updates

### DIFF
--- a/bundles/org.openhab.binding.boschindego/README.md
+++ b/bundles/org.openhab.binding.boschindego/README.md
@@ -8,12 +8,13 @@ His [Java Library](https://github.com/zazaz-de/iot-device-bosch-indego-controlle
 
 Currently the binding supports  ***indego***  mowers as a thing type with these configuration parameters:
 
-| Parameter          | Description                                                     | Default |
-|--------------------|-----------------------------------------------------------------|---------|
-| username           | Username for the Bosch Indego account                           |         |
-| password           | Password for the Bosch Indego account                           |         |
-| refresh            | The number of seconds between refreshing device state           | 180     |
-| cuttingTimeRefresh | The number of minutes between refreshing last/next cutting time | 60      |
+| Parameter          | Description                                                       | Default |
+|--------------------|-------------------------------------------------------------------|---------|
+| username           | Username for the Bosch Indego account                             |         |
+| password           | Password for the Bosch Indego account                             |         |
+| refresh            | The number of seconds between refreshing device state when idle   | 180     |
+| stateActiveRefresh | The number of seconds between refreshing device state when active | 30      |
+| cuttingTimeRefresh | The number of minutes between refreshing last/next cutting time   | 60      |
 
 ## Channels
 
@@ -27,12 +28,15 @@ Currently the binding supports  ***indego***  mowers as a thing type with these 
 | mowed              | Dimmer                   | Cut grass in percent                                                                                                                |           |
 | lastCutting        | DateTime                 | Last cutting time                                                                                                                   |           |
 | nextCutting        | DateTime                 | Next scheduled cutting time                                                                                                         |           |
-| batteryVoltage     | Number:ElectricPotential | Battery voltage reported by the device                                                                                              |           |
-| batteryLevel       | Number                   | Battery level as a percentage (0-100%)                                                                                              |           |
-| lowBattery         | Switch                   | Low battery warning with possible values on (low battery) and off (battery ok)                                                      |           |
-| batteryTemperature | Number:Temperature       | Battery temperature reported by the device                                                                                          |           |
+| batteryVoltage     | Number:ElectricPotential | Battery voltage reported by the device [^1]                                                                                         |           |
+| batteryLevel       | Number                   | Battery level as a percentage (0-100%) [^1]                                                                                         |           |
+| lowBattery         | Switch                   | Low battery warning with possible values on (low battery) and off (battery ok) [^1]                                                 |           |
+| batteryTemperature | Number:Temperature       | Battery temperature reported by the device [^1]                                                                                     |           |
 | gardenSize         | Number:Area              | Garden size mapped by the device                                                                                                    |           |
-| gardenMap          | Image                    | Garden map mapped by the device                                                                                                     |           |
+| gardenMap          | Image                    | Garden map created by the device [^2]                                                                                               |           |
+
+[^1]: This will be updated every six hours when the device is idle. It will wake up the device, which can include turning on its display. When the device is active or charging, this will be updated every two minutes.
+[^2]: This will be updated as often as specified by the `stateActiveRefresh` thing parameter.
 
 ### State Codes
 

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/DeviceStateAttribute.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/DeviceStateAttribute.java
@@ -10,21 +10,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.boschindego.internal.config;
+package org.openhab.binding.boschindego.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Configuration for the Bosch Indego thing.
- *
+ * {@link DeviceStateAttribute} describes a characteristic for a device state.
+ * 
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-public class BoschIndegoConfiguration {
-    public @Nullable String username;
-    public @Nullable String password;
-    public long refresh = 180;
-    public long stateActiveRefresh = 30;
-    public long cuttingTimeRefresh = 60;
+public enum DeviceStateAttribute {
+    READY_TO_MOW,
+    DOCKED,
+    CHARGING,
+    ACTIVE,
+    COMPLETED
 }

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/DeviceStatus.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/DeviceStatus.java
@@ -30,8 +30,8 @@ import org.openhab.binding.boschindego.internal.dto.DeviceCommand;
 @NonNullByDefault
 public class DeviceStatus {
 
-    private final static String STATE_PREFIX = "indego.state.";
-    private final static String STATE_UNKNOWN = "unknown";
+    private static final String STATE_PREFIX = "indego.state.";
+    private static final String STATE_UNKNOWN = "unknown";
 
     private static final Map<Integer, DeviceStatus> STATUS_MAP = Map.ofEntries(
             entry(0, new DeviceStatus("reading-status", EnumSet.noneOf(DeviceStateAttribute.class),

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/DeviceStatus.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/DeviceStatus.java
@@ -14,6 +14,7 @@ package org.openhab.binding.boschindego.internal;
 
 import static java.util.Map.entry;
 
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,59 +23,90 @@ import org.openhab.binding.boschindego.internal.dto.DeviceCommand;
 
 /**
  * {@link DeviceStatus} describes status codes from the device with corresponding
- * ready state and associated command.
+ * characteristics and associated command.
  * 
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
 public class DeviceStatus {
 
-    public static final int STATE_LEARNING_LAWN = 516;
-
     private final static String STATE_PREFIX = "indego.state.";
     private final static String STATE_UNKNOWN = "unknown";
 
     private static final Map<Integer, DeviceStatus> STATUS_MAP = Map.ofEntries(
-            entry(0, new DeviceStatus("reading-status", false, DeviceCommand.RETURN)),
-            entry(257, new DeviceStatus("charging", false, DeviceCommand.RETURN)),
-            entry(258, new DeviceStatus("docked", true, DeviceCommand.RETURN)),
-            entry(259, new DeviceStatus("docked-software-update", false, DeviceCommand.RETURN)),
-            entry(260, new DeviceStatus("docked", true, DeviceCommand.RETURN)),
-            entry(261, new DeviceStatus("docked", true, DeviceCommand.RETURN)),
-            entry(262, new DeviceStatus("docked-loading-map", false, DeviceCommand.MOW)),
-            entry(263, new DeviceStatus("docked-saving-map", false, DeviceCommand.RETURN)),
-            entry(266, new DeviceStatus("leaving-dock", false, DeviceCommand.MOW)),
-            entry(513, new DeviceStatus("mowing", false, DeviceCommand.MOW)),
-            entry(514, new DeviceStatus("relocalising", false, DeviceCommand.MOW)),
-            entry(515, new DeviceStatus("loading-map", false, DeviceCommand.MOW)),
-            entry(STATE_LEARNING_LAWN, new DeviceStatus("learning-lawn", false, DeviceCommand.MOW)),
-            entry(517, new DeviceStatus("paused", true, DeviceCommand.PAUSE)),
-            entry(518, new DeviceStatus("border-cut", false, DeviceCommand.MOW)),
-            entry(519, new DeviceStatus("idle-in-lawn", true, DeviceCommand.MOW)),
-            entry(523, new DeviceStatus("spotmow", false, DeviceCommand.MOW)),
-            entry(769, new DeviceStatus("returning-to-dock", false, DeviceCommand.RETURN)),
-            entry(770, new DeviceStatus("returning-to-dock", false, DeviceCommand.RETURN)),
-            entry(771, new DeviceStatus("returning-to-dock-battery-low", false, DeviceCommand.RETURN)),
-            entry(772, new DeviceStatus("returning-to-dock-calendar-timeslot-ended", false, DeviceCommand.RETURN)),
-            entry(773, new DeviceStatus("returning-to-dock-battery-temp-range", false, DeviceCommand.RETURN)),
-            entry(774, new DeviceStatus("returning-to-dock", false, DeviceCommand.RETURN)),
-            entry(775, new DeviceStatus("returning-to-dock-lawn-complete", false, DeviceCommand.RETURN)),
-            entry(776, new DeviceStatus("returning-to-dock-relocalising", false, DeviceCommand.RETURN)),
-            entry(1025, new DeviceStatus("diagnostic-mode", false, null)),
-            entry(1026, new DeviceStatus("end-of-life", false, null)),
-            entry(1281, new DeviceStatus("software-update", false, null)),
-            entry(1537, new DeviceStatus("energy-save-mode", true, DeviceCommand.RETURN)),
-            entry(64513, new DeviceStatus("docked", true, DeviceCommand.RETURN)));
+            entry(0, new DeviceStatus("reading-status", EnumSet.noneOf(DeviceStateAttribute.class),
+                    DeviceCommand.RETURN)),
+            entry(257,
+                    new DeviceStatus("charging", EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.CHARGING),
+                            DeviceCommand.RETURN)),
+            entry(258, new DeviceStatus("docked",
+                    EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.READY_TO_MOW), DeviceCommand.RETURN)),
+            entry(259,
+                    new DeviceStatus("docked-software-update", EnumSet.of(DeviceStateAttribute.DOCKED),
+                            DeviceCommand.RETURN)),
+            entry(260, new DeviceStatus("docked",
+                    EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.READY_TO_MOW), DeviceCommand.RETURN)),
+            entry(261, new DeviceStatus("docked",
+                    EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.READY_TO_MOW), DeviceCommand.RETURN)),
+            entry(262,
+                    new DeviceStatus("docked-loading-map",
+                            EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(263, new DeviceStatus("docked-saving-map",
+                    EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.ACTIVE), DeviceCommand.RETURN)),
+            entry(266,
+                    new DeviceStatus("leaving-dock",
+                            EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(513, new DeviceStatus("mowing", EnumSet.of(DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(514, new DeviceStatus("relocalising", EnumSet.of(DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(515, new DeviceStatus("loading-map", EnumSet.noneOf(DeviceStateAttribute.class), DeviceCommand.MOW)),
+            entry(516, new DeviceStatus("learning-lawn", EnumSet.of(DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(517, new DeviceStatus("paused", EnumSet.of(DeviceStateAttribute.READY_TO_MOW), DeviceCommand.PAUSE)),
+            entry(518, new DeviceStatus("border-cut", EnumSet.of(DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(519,
+                    new DeviceStatus("idle-in-lawn", EnumSet.of(DeviceStateAttribute.READY_TO_MOW), DeviceCommand.MOW)),
+            entry(523, new DeviceStatus("spotmow", EnumSet.of(DeviceStateAttribute.ACTIVE), DeviceCommand.MOW)),
+            entry(769,
+                    new DeviceStatus("returning-to-dock", EnumSet.of(DeviceStateAttribute.ACTIVE),
+                            DeviceCommand.RETURN)),
+            entry(770,
+                    new DeviceStatus("returning-to-dock", EnumSet.of(DeviceStateAttribute.ACTIVE),
+                            DeviceCommand.RETURN)),
+            entry(771,
+                    new DeviceStatus("returning-to-dock-battery-low", EnumSet.of(DeviceStateAttribute.ACTIVE),
+                            DeviceCommand.RETURN)),
+            entry(772,
+                    new DeviceStatus("returning-to-dock-calendar-timeslot-ended",
+                            EnumSet.of(DeviceStateAttribute.ACTIVE), DeviceCommand.RETURN)),
+            entry(773,
+                    new DeviceStatus("returning-to-dock-battery-temp-range", EnumSet.of(DeviceStateAttribute.ACTIVE),
+                            DeviceCommand.RETURN)),
+            entry(774,
+                    new DeviceStatus("returning-to-dock", EnumSet.of(DeviceStateAttribute.ACTIVE),
+                            DeviceCommand.RETURN)),
+            entry(775, new DeviceStatus("returning-to-dock-lawn-complete",
+                    EnumSet.of(DeviceStateAttribute.ACTIVE, DeviceStateAttribute.COMPLETED), DeviceCommand.RETURN)),
+            entry(776,
+                    new DeviceStatus("returning-to-dock-relocalising", EnumSet.of(DeviceStateAttribute.ACTIVE),
+                            DeviceCommand.RETURN)),
+            entry(1025, new DeviceStatus("diagnostic-mode", EnumSet.noneOf(DeviceStateAttribute.class), null)),
+            entry(1026, new DeviceStatus("end-of-life", EnumSet.noneOf(DeviceStateAttribute.class), null)),
+            entry(1281, new DeviceStatus("software-update", EnumSet.noneOf(DeviceStateAttribute.class), null)),
+            entry(1537,
+                    new DeviceStatus("energy-save-mode", EnumSet.of(DeviceStateAttribute.READY_TO_MOW),
+                            DeviceCommand.RETURN)),
+            entry(64513, new DeviceStatus("docked",
+                    EnumSet.of(DeviceStateAttribute.DOCKED, DeviceStateAttribute.READY_TO_MOW), DeviceCommand.RETURN)));
 
     private String textKey;
 
-    private boolean isReadyToMow;
+    private EnumSet<DeviceStateAttribute> attributes;
 
     private @Nullable DeviceCommand associatedCommand;
 
-    private DeviceStatus(String textKey, boolean isReadyToMow, @Nullable DeviceCommand associatedCommand) {
+    private DeviceStatus(String textKey, EnumSet<DeviceStateAttribute> attributes,
+            @Nullable DeviceCommand associatedCommand) {
         this.textKey = textKey;
-        this.isReadyToMow = isReadyToMow;
+        this.attributes = attributes;
         this.associatedCommand = associatedCommand;
     }
 
@@ -91,19 +123,22 @@ public class DeviceStatus {
         }
 
         DeviceCommand command = null;
+        EnumSet<DeviceStateAttribute> attributes = EnumSet.noneOf(DeviceStateAttribute.class);
         switch (code & 0xff00) {
             case 0x100:
                 command = DeviceCommand.RETURN;
                 break;
             case 0x200:
                 command = DeviceCommand.MOW;
+                attributes.add(DeviceStateAttribute.ACTIVE);
                 break;
             case 0x300:
                 command = DeviceCommand.RETURN;
+                attributes.add(DeviceStateAttribute.ACTIVE);
                 break;
         }
 
-        return new DeviceStatus(String.valueOf(code), false, command);
+        return new DeviceStatus(String.valueOf(code), attributes, command);
     }
 
     /**
@@ -121,7 +156,23 @@ public class DeviceStatus {
     }
 
     public boolean isReadyToMow() {
-        return isReadyToMow;
+        return attributes.contains(DeviceStateAttribute.READY_TO_MOW);
+    }
+
+    public boolean isActive() {
+        return attributes.contains(DeviceStateAttribute.ACTIVE);
+    }
+
+    public boolean isCharging() {
+        return attributes.contains(DeviceStateAttribute.CHARGING);
+    }
+
+    public boolean isDocked() {
+        return attributes.contains(DeviceStateAttribute.DOCKED);
+    }
+
+    public boolean isCompleted() {
+        return attributes.contains(DeviceStateAttribute.COMPLETED);
     }
 
     public @Nullable DeviceCommand getAssociatedCommand() {

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.boschindego.internal;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.ExecutionException;
@@ -550,6 +551,21 @@ public class IndegoController {
      */
     public DeviceStateResponse getState() throws IndegoAuthenticationException, IndegoException {
         return getRequestWithAuthentication(SERIAL_NUMBER_SUBPATH + this.getSerialNumber() + "/state",
+                DeviceStateResponse.class);
+    }
+
+    /**
+     * Queries the device state from the server. This overload will return when the state
+     * has changed, or the timeout has been reached.
+     * 
+     * @param timeout Maximum time to wait for response
+     * @return the device state
+     * @throws IndegoAuthenticationException if request was rejected as unauthorized
+     * @throws IndegoException if any communication or parsing error occurred
+     */
+    public DeviceStateResponse getState(Duration timeout) throws IndegoAuthenticationException, IndegoException {
+        return getRequestWithAuthentication(
+                SERIAL_NUMBER_SUBPATH + this.getSerialNumber() + "/state?longpoll=true&timeout=" + timeout.getSeconds(),
                 DeviceStateResponse.class);
     }
 

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoController.java
@@ -371,7 +371,7 @@ public class IndegoController {
     }
 
     /**
-     * Wraps {@link #putRequest(String, Object)} into an authenticated session.
+     * Wraps {@link #putPostRequest(HttpMethod, String, Object)} into an authenticated session.
      * 
      * @param path the relative path to which the request should be sent
      * @param requestDto the DTO which should be sent to the server as JSON
@@ -385,7 +385,7 @@ public class IndegoController {
         }
         try {
             logger.debug("Session {} valid, skipping authentication", session);
-            putRequest(path, requestDto);
+            putPostRequest(HttpMethod.PUT, path, requestDto);
         } catch (IndegoAuthenticationException e) {
             if (logger.isTraceEnabled()) {
                 logger.trace("Context rejected", e);
@@ -394,27 +394,59 @@ public class IndegoController {
             }
             session.invalidate();
             authenticate();
-            putRequest(path, requestDto);
+            putPostRequest(HttpMethod.PUT, path, requestDto);
         }
     }
 
     /**
-     * Sends a PUT request to the server.
+     * Wraps {@link #putPostRequest(HttpMethod, String, Object)} into an authenticated session.
      * 
+     * @param path the relative path to which the request should be sent
+     * @throws IndegoAuthenticationException if request was rejected as unauthorized
+     * @throws IndegoException if any communication or parsing error occurred
+     */
+    private void postRequestWithAuthentication(String path) throws IndegoAuthenticationException, IndegoException {
+        if (!session.isValid()) {
+            authenticate();
+        }
+        try {
+            logger.debug("Session {} valid, skipping authentication", session);
+            putPostRequest(HttpMethod.POST, path, null);
+        } catch (IndegoAuthenticationException e) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Context rejected", e);
+            } else {
+                logger.debug("Context rejected: {}", e.getMessage());
+            }
+            session.invalidate();
+            authenticate();
+            putPostRequest(HttpMethod.POST, path, null);
+        }
+    }
+
+    /**
+     * Sends a PUT/POST request to the server.
+     * 
+     * @param method the type of request ({@link HttpMethod.PUT} or {@link HttpMethod.POST})
      * @param path the relative path to which the request should be sent
      * @param requestDto the DTO which should be sent to the server as JSON
      * @throws IndegoAuthenticationException if request was rejected as unauthorized
      * @throws IndegoException if any communication or parsing error occurred
      */
-    private void putRequest(String path, Object requestDto) throws IndegoAuthenticationException, IndegoException {
+    private void putPostRequest(HttpMethod method, String path, @Nullable Object requestDto)
+            throws IndegoAuthenticationException, IndegoException {
         try {
-            Request request = httpClient.newRequest(BASE_URL + path).method(HttpMethod.PUT)
+            Request request = httpClient.newRequest(BASE_URL + path).method(method)
                     .header(CONTEXT_HEADER_NAME, session.getContextId())
                     .header(HttpHeader.CONTENT_TYPE, CONTENT_TYPE_HEADER);
-            String payload = gson.toJson(requestDto);
-            request.content(new StringContentProvider(payload));
-            if (logger.isTraceEnabled()) {
-                logger.trace("PUT request for {} with payload '{}'", BASE_URL + path, payload);
+            if (requestDto != null) {
+                String payload = gson.toJson(requestDto);
+                request.content(new StringContentProvider(payload));
+                if (logger.isTraceEnabled()) {
+                    logger.trace("{} request for {} with payload '{}'", method, BASE_URL + path, payload);
+                }
+            } else {
+                logger.trace("{} request for {} with no payload", method, BASE_URL + path);
             }
             ContentResponse response = sendRequest(request);
             int status = response.getStatus();
@@ -701,5 +733,18 @@ public class IndegoController {
     public void setPredictiveExclusionTime(final DeviceCalendarResponse calendar)
             throws IndegoAuthenticationException, IndegoException {
         putRequestWithAuthentication(SERIAL_NUMBER_SUBPATH + this.getSerialNumber() + "/predictive/calendar", calendar);
+    }
+
+    /**
+     * Request map position updates for the next ({@link count} * {@link interval}) number of seconds.
+     * 
+     * @param count Number of updates
+     * @param interval Number of seconds between updates
+     * @throws IndegoAuthenticationException if request was rejected as unauthorized
+     * @throws IndegoException if any communication or parsing error occurred
+     */
+    public void requestPosition(int count, int interval) throws IndegoAuthenticationException, IndegoException {
+        postRequestWithAuthentication(SERIAL_NUMBER_SUBPATH + this.getSerialNumber() + "/requestPosition?count=" + count
+                + "&interval=" + interval);
     }
 }

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/response/DeviceStateResponse.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/dto/response/DeviceStateResponse.java
@@ -41,7 +41,20 @@ public class DeviceStateResponse {
 
     public int yPos;
 
+    /**
+     * This is returned only for non-longpoll requests.
+     */
     public DeviceStateRuntimes runtime;
+
+    /**
+     * This is returned only for longpoll requests.
+     */
+    public long charge;
+
+    /**
+     * This is returned only for longpoll requests.
+     */
+    public long operate;
 
     @SerializedName("mowed_ts")
     public long mowedTimestamp;

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
@@ -70,9 +70,10 @@ public class BoschIndegoHandler extends BaseThingHandler {
     private static final String MAP_POSITION_STROKE_COLOR = "#8c8b6d";
     private static final String MAP_POSITION_FILL_COLOR = "#fff701";
     private static final int MAP_POSITION_RADIUS = 10;
-    private static final int MAP_REFRESH_INTERVAL_DAYS = 1;
-    private static final Duration OPERATING_DATA_INACTIVE_REFRESH_INTERVAL_DURATION = Duration.ofHours(6);
-    private static final Duration OPERATING_DATA_ACTIVE_REFRESH_INTERVAL_DURATION = Duration.ofMinutes(2);
+
+    private static final Duration MAP_REFRESH_INTERVAL = Duration.ofDays(1);
+    private static final Duration OPERATING_DATA_INACTIVE_REFRESH_INTERVAL = Duration.ofHours(6);
+    private static final Duration OPERATING_DATA_ACTIVE_REFRESH_INTERVAL = Duration.ofMinutes(2);
     private static final Duration MAP_REFRESH_SESSION_DURATION = Duration.ofMinutes(5);
     private static final Duration COMMAND_STATE_REFRESH_TIMEOUT = Duration.ofSeconds(10);
 
@@ -329,7 +330,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
         if (deviceStatus.isActive()) {
             refreshIntervalSeconds = stateActiveRefreshIntervalSeconds;
         } else if (deviceStatus.isCharging()) {
-            refreshIntervalSeconds = (int) OPERATING_DATA_ACTIVE_REFRESH_INTERVAL_DURATION.getSeconds();
+            refreshIntervalSeconds = (int) OPERATING_DATA_ACTIVE_REFRESH_INTERVAL.getSeconds();
         } else {
             refreshIntervalSeconds = stateInactiveRefreshIntervalSeconds;
         }
@@ -345,10 +346,8 @@ public class BoschIndegoHandler extends BaseThingHandler {
         // Refresh operating data only occationally or when robot is active/charging.
         // This will contact the robot directly through cellular network and wake it up
         // when sleeping.
-        if ((isActive && operatingDataTimestamp
-                .isBefore(Instant.now().minus(OPERATING_DATA_ACTIVE_REFRESH_INTERVAL_DURATION)))
-                || operatingDataTimestamp
-                        .isBefore(Instant.now().minus(OPERATING_DATA_INACTIVE_REFRESH_INTERVAL_DURATION))) {
+        if ((isActive && operatingDataTimestamp.isBefore(Instant.now().minus(OPERATING_DATA_ACTIVE_REFRESH_INTERVAL)))
+                || operatingDataTimestamp.isBefore(Instant.now().minus(OPERATING_DATA_INACTIVE_REFRESH_INTERVAL))) {
             refreshOperatingData();
         }
     }
@@ -434,8 +433,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
         }
         RawType cachedMap = this.cachedMap;
         boolean mapRefreshed;
-        if (cachedMap == null
-                || cachedMapTimestamp.isBefore(Instant.now().minus(Duration.ofDays(MAP_REFRESH_INTERVAL_DAYS)))) {
+        if (cachedMap == null || cachedMapTimestamp.isBefore(Instant.now().minus(MAP_REFRESH_INTERVAL))) {
             this.cachedMap = cachedMap = controller.getMap();
             cachedMapTimestamp = Instant.now();
             mapRefreshed = true;

--- a/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/i18n/boschindego.properties
+++ b/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/i18n/boschindego.properties
@@ -14,8 +14,10 @@ thing-type.config.boschindego.indego.cuttingTimeRefresh.label = Cutting Time Ref
 thing-type.config.boschindego.indego.cuttingTimeRefresh.description = The number of minutes between refreshing last/next cutting time.
 thing-type.config.boschindego.indego.password.label = Password
 thing-type.config.boschindego.indego.password.description = Password for the Bosch Indego account.
-thing-type.config.boschindego.indego.refresh.label = Refresh Interval
-thing-type.config.boschindego.indego.refresh.description = The number of seconds between refreshing device state.
+thing-type.config.boschindego.indego.refresh.label = Idle Refresh Interval
+thing-type.config.boschindego.indego.refresh.description = The number of seconds between refreshing device state when idle.
+thing-type.config.boschindego.indego.stateActiveRefresh.label = Active Refresh Interval
+thing-type.config.boschindego.indego.stateActiveRefresh.description = The number of seconds between refreshing device state when active.
 thing-type.config.boschindego.indego.username.label = Username
 thing-type.config.boschindego.indego.username.description = Username for the Bosch Indego account.
 
@@ -28,7 +30,7 @@ channel-type.boschindego.batteryVoltage.description = Battery voltage reported b
 channel-type.boschindego.errorcode.label = Error Code
 channel-type.boschindego.errorcode.description = 0 = no error
 channel-type.boschindego.gardenMap.label = Garden Map
-channel-type.boschindego.gardenMap.description = Garden map mapped by the device
+channel-type.boschindego.gardenMap.description = Garden map created by the device
 channel-type.boschindego.gardenSize.label = Garden Size
 channel-type.boschindego.gardenSize.description = Garden size mapped by the device
 channel-type.boschindego.lastCutting.label = Last Cutting

--- a/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/thing/thing-types.xml
@@ -34,9 +34,15 @@
 				<description>Password for the Bosch Indego account.</description>
 			</parameter>
 			<parameter name="refresh" type="integer" min="60">
-				<label>Refresh Interval</label>
-				<description>The number of seconds between refreshing device state.</description>
+				<label>Idle Refresh Interval</label>
+				<description>The number of seconds between refreshing device state when idle.</description>
 				<default>180</default>
+			</parameter>
+			<parameter name="stateActiveRefresh" type="integer" min="6">
+				<label>Active Refresh Interval</label>
+				<description>The number of seconds between refreshing device state when active.</description>
+				<advanced>true</advanced>
+				<default>30</default>
 			</parameter>
 			<parameter name="cuttingTimeRefresh" type="integer" min="1">
 				<label>Cutting Time Refresh Interval</label>
@@ -165,7 +171,7 @@
 	<channel-type id="gardenMap">
 		<item-type>Image</item-type>
 		<label>Garden Map</label>
-		<description>Garden map mapped by the device</description>
+		<description>Garden map created by the device</description>
 		<state readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.boschindego/src/test/java/org/openhab/binding/boschindego/internal/DeviceStatusTest.java
+++ b/bundles/org.openhab.binding.boschindego/src/test/java/org/openhab/binding/boschindego/internal/DeviceStatusTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.boschindego.internal.dto.DeviceCommand;
+
+/**
+ * Unit tests for {@link DeviceStatus}.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class DeviceStatusTest {
+    @Test
+    public void unknownIdleStateHasReturnCommand() {
+        assertThat(DeviceStatus.fromCode(256).getAssociatedCommand(), is(DeviceCommand.RETURN));
+    }
+
+    @Test
+    public void unknownMowStateHasReturnCommand() {
+        assertThat(DeviceStatus.fromCode(520).getAssociatedCommand(), is(DeviceCommand.MOW));
+    }
+
+    @Test
+    public void unknownReturnStateHasReturnCommand() {
+        assertThat(DeviceStatus.fromCode(777).getAssociatedCommand(), is(DeviceCommand.RETURN));
+    }
+
+    @Test
+    public void chargingIsCharging() {
+        assertThat(DeviceStatus.fromCode(257).isCharging(), is(true));
+    }
+
+    @Test
+    public void dockedLoadingMapIsActive() {
+        assertThat(DeviceStatus.fromCode(262).isActive(), is(true));
+    }
+
+    @Test
+    public void lawnCompleteIsCompleted() {
+        assertThat(DeviceStatus.fromCode(775).isCompleted(), is(true));
+    }
+}


### PR DESCRIPTION
This pull request implements a balanced way of using the API in order to provide faster updates and reduced load when fast updates are not needed. In addition, position tracking is now automatically requested when mower is active. This allows for updating the map with a frequency as high as six seconds between refreshes.

Some details:
- The most expensive call, `/operatingData` (contacting the robot), was previously called every three minutes (with default configuration). This has now been changed to every six hours when idle and every two minutes when active or charging. For a mower running one hour every day and charging 30 minutes, this **reduces** the number of calls per day from 480 to 49 while at the same time providing faster updates. It also fixes an issue with the display being always on, since this call wakes up the device.
- The most common call, `/state`, was previously called every three minutes (with default configuration). This has now been changed to every three minutes when idle, every two minutes when charging and every 30 seconds when active (in which case the result now includes updated map positions). For the same mower example, this **increases** the number of calls from 480 to 585 if the map channel is linked.
- The last/next cutting times are still updated once per hour, but additional updates have been **reduced** and at the same time been made more accurate. For example, the last cutting time will now be updated before the mower even returns to the dock.
- State update after triggering commands has been fixed to wait for new state and then start receiving updates with a frequency according to the need. Previously state would be refreshed before actually changed, so when starting a mowing session it could take up to three minutes to update state accordingly.

Related to:
- #13182
- #12938
- #12986
- #13017