### PR TITLE
Update Ffmpeg for accept special URL

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
@@ -69,9 +69,9 @@ public class Ffmpeg {
             altInput = input.substring(0, 7) + credentials + input.substring(7);
         }
         if (inputArguments.isEmpty()) {
-            ffmpegCommand = "-i " + altInput + " " + outArguments + " " + output;
+            ffmpegCommand = "-i " + "'" + altInput + "'" + " " + outArguments + " " + output;
         } else {
-            ffmpegCommand = inputArguments + " -i " + altInput + " " + outArguments + " " + output;
+            ffmpegCommand = inputArguments + " -i " + "'" + altInput + "'" + " " + outArguments + " " + output;
         }
         Collections.addAll(commandArrayList, ffmpegCommand.trim().split("\\s+"));
         // ffmpegLocation may have a space in its folder


### PR DESCRIPTION
# Update Ffmpeg command
Ffmpeg command  should accept special URL (with parameters)

# Descripton

Proposal for fixing bug.

Some cameras use in rtps parameters (ex. rtsp://user:password@ipadress:554/cam/realmonitor?channel=1&amp;subtype=0). But ffmpeg will not run if whole input is not in quotes or double quotes.

Note: This example is from Amcrest Doorbell, it must be set manully as Generic IP camera, because URL in Dahua and Amcrest is not ok for this camera.

# Testing

On my own doorbell camera :-) (https://www.amazon.com/Amcrest-Doorbell-Weatherproof-Wide-Angle-AD110/dp/B07ZJS3L5Y)
