### PR TITLE
[tapocontrol] included P115 smart-socket

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -12,7 +12,7 @@ The following Tapo-Devices are supported
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### P110 EnergyMonitoring SmartPlug (WiFi)
+### P110/P115 EnergyMonitoring SmartPlug (WiFi)
 
 * Power On/Off
 * Wi-Fi signal (SignalStrength)
@@ -91,17 +91,17 @@ The thing has the following configuration parameters:
 
 All devices support some of the following channels:
 
-| group     | channel          |type                    | description                  | things supporting this channel              |
-|-----------|----------------- |------------------------|------------------------------|---------------------------------------------|
-| actuator  | output           | Switch                 | Power device on or off       | P100, P105, P110, L510, L530, L900, L920    |
-|           | brightness       | Dimmer                 | Brightness 0-100%            | L510, L530, L900                            |
-|           | colorTemperature | Number                 | White-Color-Temp 2500-6500K  | L510, L530, L900                            |
-|           | color            | Color                  | Color                        | L530, L900                                  |
-| device    | wifiSignal       | system.signal-strength | WiFi-quality-level           | P100, P105, P110, L510, L530, L900, L920    |
-|           | onTime           | Number:Time            | seconds output is on         | P100, P105, P110, L510, L530, L900, L920    |
-| energy    | actualPower      | Number:Power           | actual Power (Watt)          | P110                                        |
-|           | todayEnergyUsage | Number:Energy          | used energy today (Wh)       | P110                                        |
-|           | todayRuntime      | Number:Time            | seconds output was on today  | P110                                        |
+| group     | channel          |type                    | description                  | things supporting this channel                 |
+|-----------|----------------- |------------------------|------------------------------|------------------------------------------------|
+| actuator  | output           | Switch                 | Power device on or off       | P100, P105, P110, P115, L510, L530, L900, L920 |
+|           | brightness       | Dimmer                 | Brightness 0-100%            | L510, L530, L900                               |
+|           | colorTemperature | Number                 | White-Color-Temp 2500-6500K  | L510, L530, L900                               |
+|           | color            | Color                  | Color                        | L530, L900                                     |
+| device    | wifiSignal       | system.signal-strength | WiFi-quality-level           | P100, P105, P110, P115, L510, L530, L900, L920 |
+|           | onTime           | Number:Time            | seconds output is on         | P100, P105, P110, P115, L510, L530, L900, L920 |
+| energy    | actualPower      | Number:Power           | actual Power (Watt)          | P110, P115                                     |
+|           | todayEnergyUsage | Number:Energy          | used energy today (Wh)       | P110, P115                                     |
+|           | todayRuntime     | Number:Time            | seconds output was on today  | P110, P115                                     |
 
 
 ## Channel Refresh

--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -6,13 +6,13 @@ This binding adds support to control Tapo (Copyright © TP-Link Corporation Limi
 
 The following Tapo-Devices are supported
 
-### P100/P105 SmartPlug (WiFi)
+### P100/P105 SmartPlug (Wi-Fi)
 
 * Power On/Off
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### P110/P115 EnergyMonitoring SmartPlug (WiFi)
+### P110/P115 EnergyMonitoring SmartPlug (Wi-Fi)
 
 * Power On/Off
 * Wi-Fi signal (SignalStrength)
@@ -21,7 +21,7 @@ The following Tapo-Devices are supported
 * today EnergyUsage (Wh)
 * today Runtime (Time in seconds device was on today)
 
-### L510(Series) dimmable SmartBulb (WiFi)
+### L510(Series) dimmable SmartBulb (Wi-Fi)
 
 * Light On/Off
 * Brightnes (Dimmer)  0-100 %
@@ -29,7 +29,7 @@ The following Tapo-Devices are supported
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### L530(Series) MultiColor SmartBulb (WiFi)
+### L530(Series) MultiColor SmartBulb (Wi-Fi)
 
 * Light On/Off
 * Brightnes (Dimmer)  0-100 %
@@ -38,7 +38,7 @@ The following Tapo-Devices are supported
 * Wi-Fi signal (SignalStrength)
 * On-Time (Time in seconds device is switched on)
 
-### L900/L920 LED-LightStrip (WiFi)
+### L900/L920 LED-LightStrip (Wi-Fi)
 
 * Light On/Off
 * Brightnes (Dimmer)  0-100 %

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
@@ -76,7 +76,7 @@ public class TapoThingConstants {
                             SUPPORTED_COLOR_BULB_UIDS, SUPPORTED_LIGHT_STRIP_UIDS)
                     .flatMap(Set::stream).collect(Collectors.toSet()));
     /*** THINGS WITH ENERGY DATA ***/
-    public static final Set<ThingTypeUID> SUPPORTED_ENERGY_DATA_UIDS = Set.of(P110_THING_TYPE);
+    public static final Set<ThingTypeUID> SUPPORTED_ENERGY_DATA_UIDS = Set.of(P110_THING_TYPE, P115_THING_TYPE);
 
     /*** THINGS WITH CHANNEL GROUPS ***/
     public static final Set<ThingTypeUID> CHANNEL_GROUP_THING_SET = Collections

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
@@ -37,6 +37,7 @@ public class TapoThingConstants {
     public static final String DEVICE_P100 = "P100";
     public static final String DEVICE_P105 = "P105";
     public static final String DEVICE_P110 = "P110";
+    public static final String DEVICE_P115 = "P115";
     public static final String DEVICE_L510 = "L510";
     public static final String DEVICE_L530 = "L530";
     public static final String DEVICE_L900 = "L900";
@@ -55,6 +56,7 @@ public class TapoThingConstants {
     public static final ThingTypeUID P100_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P100);
     public static final ThingTypeUID P105_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P105);
     public static final ThingTypeUID P110_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P110);
+    public static final ThingTypeUID P115_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_P115);
     public static final ThingTypeUID L510_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L510);
     public static final ThingTypeUID L530_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L530);
     public static final ThingTypeUID L900_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_L900);
@@ -64,7 +66,7 @@ public class TapoThingConstants {
     /*** SET OF SUPPORTED UIDS ***/
     public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_UIDS = Set.of(BRIDGE_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_SMART_PLUG_UIDS = Set.of(P100_THING_TYPE, P105_THING_TYPE,
-            P110_THING_TYPE);
+            P110_THING_TYPE, P115_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_WHITE_BULB_UIDS = Set.of(L510_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_COLOR_BULB_UIDS = Set.of(L530_THING_TYPE);
     public static final Set<ThingTypeUID> SUPPORTED_LIGHT_STRIP_UIDS = Set.of(L900_THING_TYPE, L920_THING_TYPE);

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/i18n/tapocontrol.properties
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/i18n/tapocontrol.properties
@@ -19,6 +19,8 @@ thing-type.tapocontrol.P105.label = P105 SmartPlug
 thing-type.tapocontrol.P105.description = Tapo Mini Smart Wifi Plug
 thing-type.tapocontrol.P110.label = P110 SmartPlug
 thing-type.tapocontrol.P110.description = Tapo Smart Monitoring Wifi Plug
+thing-type.tapocontrol.P115.label = P115 SmartPlug
+thing-type.tapocontrol.P115.description = Tapo Smart Monitoring Wifi Plug
 thing-type.tapocontrol.bridge.label = Cloud-Login
 thing-type.tapocontrol.bridge.description = Cloud Connector. Acts as device-bridge
 
@@ -85,5 +87,3 @@ channel-type.tapocontrol.todayEnergyUsageChannel.label = Today Usage
 channel-type.tapocontrol.todayEnergyUsageChannel.description = Today energy usage
 channel-type.tapocontrol.todayRuntimeChannel.label = Today Runtime
 channel-type.tapocontrol.todayRuntimeChannel.description = Today runtime (On-Time)
-
-

--- a/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/P115.xml
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/resources/OH-INF/thing/P115.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tapocontrol"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- P115 THING-TYPE (SOCKET) -->
+	<thing-type id="P115">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>P115 SmartPlug</label>
+		<description>Tapo Smart Monitoring Wifi Plug</description>
+		<channel-groups>
+			<channel-group id="actuator" typeId="smartPlug"/>
+			<channel-group id="device" typeId="deviceState"/>
+			<channel-group id="energy" typeId="energyMonitor"/>
+		</channel-groups>
+		<representation-property>macAddress</representation-property>
+
+		<config-description-ref uri="thing-type:tapo:device"/>
+	</thing-type>
+</thing:thing-descriptions>


### PR DESCRIPTION
This PR now added the Tapo P115 smart-socket to tapocontrol.
Also fixed thing configuration warning occured since OH3.3