### PR TITLE
[daikin] Fix changing specialmode from ECO to NORMAL

### DIFF
--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinWebTargets.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinWebTargets.java
@@ -137,14 +137,18 @@ public class DaikinWebTargets {
         return EnergyInfoDayAndWeek.parse(response);
     }
 
-    public void setSpecialMode(SpecialMode specialMode) throws DaikinCommunicationException {
+    public void setSpecialMode(SpecialMode newMode) throws DaikinCommunicationException {
         Map<String, String> queryParams = new HashMap<>();
-        if (specialMode == SpecialMode.NORMAL) {
+        if (newMode == SpecialMode.NORMAL) {
             queryParams.put("set_spmode", "0");
-            queryParams.put("spmode_kind", "1");
+
+            ControlInfo controlInfo = getControlInfo();
+            if (!controlInfo.advancedMode.isUndefined()) {
+                queryParams.put("spmode_kind", controlInfo.getSpecialMode().getValue());
+            }
         } else {
             queryParams.put("set_spmode", "1");
-            queryParams.put("spmode_kind", Integer.toString(specialMode.getValue()));
+            queryParams.put("spmode_kind", newMode.getValue());
         }
         String response = invoke(setSpecialModeUri, queryParams);
         if (!response.contains("ret=OK")) {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -181,17 +181,17 @@ public class Enums {
     }
 
     public enum SpecialMode {
-        NORMAL(0),
-        POWERFUL(1),
-        ECO(2);
+        NORMAL("0"),
+        POWERFUL("1"),
+        ECO("2");
 
-        private final int value;
+        private final String value;
 
-        SpecialMode(int value) {
+        SpecialMode(String value) {
             this.value = value;
         }
 
-        public int getValue() {
+        public String getValue() {
             return value;
         }
 


### PR DESCRIPTION
This supersedes #13206 and fix the transition from ECO to NORMAL, as reported in https://community.openhab.org/t/daikin-the-channel-specialmode-can-be-read-but-not-modified-from-oh-both-2-5-12-and-3-1/125561/16

