### PR TITLE
[homekit] fix window coverings based on groups of  rollershutters

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
@@ -164,7 +164,15 @@ abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAcces
         final Optional<HomekitTaggedItem> taggedItem = getCharacteristic(type);
         if (taggedItem.isPresent()) {
             final Item item = taggedItem.get().getItem();
-            if ((item instanceof RollershutterItem) || ((item instanceof DimmerItem))) {
+            Item baseItem = item;
+            // Check the type of the base item for a group item
+            if (item instanceof GroupItem) {
+                baseItem = ((GroupItem) item).getBaseItem();
+                if (baseItem == null) {
+                    baseItem = item;
+                }
+            }
+            if (baseItem instanceof RollershutterItem || baseItem instanceof DimmerItem) {
                 value = item.getStateAs(PercentType.class);
             } else {
                 value = item.getStateAs(DecimalType.class);


### PR DESCRIPTION
it was getting the state as a decimal type, not a percent type, so
it was getting 1 instead of 100.