### PR TITLE
[homekit] fix collecting characteristics that don't belong to a complex accessory

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -272,7 +272,7 @@ public class HomekitAccessoryFactory {
             MetadataRegistry metadataRegistry) {
         List<HomekitTaggedItem> collectedCharacteristics = new ArrayList<>();
         if (taggedItem.isGroup()) {
-            for (Item item : ((GroupItem) taggedItem.getItem()).getAllMembers()) {
+            for (Item item : ((GroupItem) taggedItem.getItem()).getMembers()) {
                 addMandatoryCharacteristics(taggedItem, collectedCharacteristics, item, metadataRegistry);
             }
         } else {
@@ -312,7 +312,9 @@ public class HomekitAccessoryFactory {
             // if the item has only accessory tag, e.g. TemperatureSensor,
             // then we will link all mandatory characteristic to this item,
             // e.g. we will link CurrentTemperature in case of TemperatureSensor.
-            if (isRootAccessory(accessory)) {
+            // Note that accessories that are members of other accessories do _not_
+            // count - we're already constructing another root accessory.
+            if (isRootAccessory(accessory) && mainItem.getItem().equals(item)) {
                 mandatoryCharacteristics.forEach(c -> characteristics.add(new HomekitTaggedItem(itemProxy,
                         accessory.getKey(), c, mainItem.isGroup() ? (GroupItem) mainItem.getItem() : null,
                         HomekitAccessoryFactory.getItemConfiguration(item, metadataRegistry))));


### PR DESCRIPTION
given:

```
Group eThermostat { homekit="Thermostat" }
Number:Temperature Thermostat_AmbTemp (eThermostat) { homekit="CurrentTemperature" }
Number:Temperature Thermostat_SetTemp (eThermostat) { homekit="TargetTemperature" }

Group gThermostatZoneContacts
// in reality there are multiple thermostats and multiple of these groups,
// so that a rule on members of gThermostatZoneContacts can find the related
// thermostat to turn it off when a window is open
Group:Contact:OR(OPEN,CLOSED) gWindows (eThermostat, gThermostatZoneContacts)

Contact Window_Contact (gWindows) { homekit="ContactSensor" }
```

When constructing the Thermostat accessory for eThermostat, detects the
Window_Contact as a mandatory characteristic, because it's a base accessory
in a nested group. This leads to lots of warnings about the temperature
value of a contact item being out of range.

The fix is two-fold - first of all, there's no reason to search nested
groups for characteristics of a complex accessory. Second of all,
even if for some reason you were to nest an accessory in an accessory,
the nested accessory does not actually belong to the outer accessory,
so don't add it as a mandatory characteristic of the outer.

I suspect there's still one more bug, because AbstractHomekitAccessoryImpl.
getCharacteristic(HomekitCharacteristicType.CURRENT_TEMPERATURE) was
returning Window_Contact, which is only tagged as a ContactSensor. But
after fixing the above two bugs, it was no longer reproducible, and I
didn't continue digging.
