### PR TITLE
[homekit] allow group items of the correct type anywhere that type is needed

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.DimmerItem;
@@ -49,6 +50,7 @@ public class HomekitOHItemProxy {
     private final Logger logger = LoggerFactory.getLogger(HomekitOHItemProxy.class);
     private static final int DEFAULT_DELAY = 50; // in ms
     private final Item item;
+    private final Item baseItem;
     private final Map<HomekitCommandType, State> commandCache = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
@@ -57,8 +59,20 @@ public class HomekitOHItemProxy {
     // delay, how long wait for further commands. in ms.
     private int delay = DEFAULT_DELAY;
 
+    public static Item getBaseItem(Item item) {
+        if (item instanceof GroupItem) {
+            final GroupItem groupItem = (GroupItem) item;
+            final Item baseItem = groupItem.getBaseItem();
+            if (baseItem != null) {
+                return baseItem;
+            }
+        }
+        return item;
+    }
+
     public HomekitOHItemProxy(Item item) {
         this.item = item;
+        this.baseItem = getBaseItem(item);
     }
 
     public Item getItem() {
@@ -75,9 +89,9 @@ public class HomekitOHItemProxy {
 
     @SuppressWarnings("null")
     private void sendCommand() {
-        if (!(item instanceof DimmerItem)) {
+        if (!(baseItem instanceof DimmerItem)) {
             // currently supports only DimmerItem and ColorItem (which extends DimmerItem)
-            logger.debug("unexpected item type {}. Only DimmerItem and ColorItem are supported.", item);
+            logger.debug("unexpected item type {}. Only DimmerItem and ColorItem are supported.", baseItem);
             return;
         }
         final OnOffType on = (OnOffType) commandCache.remove(ON_COMMAND);
@@ -96,16 +110,20 @@ public class HomekitOHItemProxy {
                     || ((dimmerMode == DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100) && (currentOnState != OnOffType.ON)
                             && ((brightness == null) || (brightness.intValue() == 100)))) {
                 logger.trace("send OnOff command for item {} with value {}", item, on);
-                ((DimmerItem) item).send(on);
+                if (item instanceof GroupItem) {
+                    ((GroupItem) item).send(on);
+                } else {
+                    ((DimmerItem) item).send(on);
+                }
             }
         }
 
         // if hue or saturation present, send an HSBType state update. no filter applied for HUE & Saturation
         if ((hue != null) || (saturation != null)) {
-            if (item instanceof ColorItem) {
+            if (baseItem instanceof ColorItem) {
                 sendHSBCommand((ColorItem) item, hue, saturation, brightness);
             }
-        } else if ((brightness != null) && (item instanceof DimmerItem)) {
+        } else if ((brightness != null) && (baseItem instanceof DimmerItem)) {
             // sends brightness:
             // - DIMMER_MODE_NORMAL
             // - DIMMER_MODE_FILTER_ON
@@ -116,6 +134,8 @@ public class HomekitOHItemProxy {
                 logger.trace("send Brightness command for item {} with value {}", item, brightness);
                 if (item instanceof ColorItem) {
                     sendHSBCommand((ColorItem) item, hue, saturation, brightness);
+                } else if (item instanceof GroupItem) {
+                    ((GroupItem) item).send(brightness);
                 } else {
                     ((DimmerItem) item).send(brightness);
                 }
@@ -124,14 +144,19 @@ public class HomekitOHItemProxy {
         commandCache.clear();
     }
 
-    private void sendHSBCommand(ColorItem item, @Nullable DecimalType hue, @Nullable PercentType saturation,
+    private void sendHSBCommand(Item item, @Nullable DecimalType hue, @Nullable PercentType saturation,
             @Nullable PercentType brightness) {
         final HSBType currentState = item.getState() instanceof UnDefType ? HSBType.BLACK : (HSBType) item.getState();
         // logic for ColorItem = combine hue, saturation and brightness update to one command
         final DecimalType targetHue = hue != null ? hue : currentState.getHue();
         final PercentType targetSaturation = saturation != null ? saturation : currentState.getSaturation();
         final PercentType targetBrightness = brightness != null ? brightness : currentState.getBrightness();
-        item.send(new HSBType(targetHue, targetSaturation, targetBrightness));
+        final HSBType command = new HSBType(targetHue, targetSaturation, targetBrightness);
+        if (item instanceof GroupItem) {
+            ((GroupItem) item).send(command);
+        } else {
+            ((ColorItem) item).send(command);
+        }
         logger.trace("send HSB command for item {} with following values hue={} saturation={} brightness={}", item,
                 targetHue, targetSaturation, targetBrightness);
     }
@@ -141,7 +166,7 @@ public class HomekitOHItemProxy {
         logger.trace("add command to command cache: item {}, command type {}, command state {}. cache state after: {}",
                 this, commandType, state, commandCache);
         // if cache has already HUE+SATURATION or BRIGHTNESS+ON then we don't expect any further relevant command
-        if (((item instanceof ColorItem) && commandCache.containsKey(HUE_COMMAND)
+        if (((baseItem instanceof ColorItem) && commandCache.containsKey(HUE_COMMAND)
                 && commandCache.containsKey(SATURATION_COMMAND))
                 || (commandCache.containsKey(BRIGHTNESS_COMMAND) && commandCache.containsKey(ON_COMMAND))) {
             if (future != null) {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -22,6 +22,15 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
+import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.RollershutterItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,12 +147,91 @@ public class HomekitTaggedItem {
     }
 
     /**
+     * return the base item for a group, or the item itself, in order to do type checks
+     */
+    public Item getBaseItem() {
+        return HomekitOHItemProxy.getBaseItem(proxyItem.getItem());
+    }
+
+    /**
      * return proxy item which is used to group commands.
      * 
      * @return proxy item
      */
     public HomekitOHItemProxy getProxyItem() {
         return proxyItem;
+    }
+
+    /**
+     * Send DecimalType command to a NumberItem (or a Group:Number)
+     * 
+     * @param command
+     */
+    public void send(DecimalType command) {
+        if (getItem() instanceof GroupItem && getBaseItem() instanceof NumberItem) {
+            ((GroupItem) getItem()).send(command);
+            return;
+        } else if (getItem() instanceof NumberItem) {
+            ((NumberItem) getItem()).send(command);
+            return;
+        }
+        logger.warn("Received DecimalType command for item {} that doesn't support it. This is probably a bug.",
+                getName());
+    }
+
+    /**
+     * Send OnOffType command to a SwitchItem (or a Group:Switch)
+     * 
+     * @param command
+     */
+    public void send(OnOffType command) {
+        if (getItem() instanceof GroupItem && getBaseItem() instanceof SwitchItem) {
+            ((GroupItem) getItem()).send(command);
+            return;
+        } else if (getItem() instanceof SwitchItem) {
+            ((SwitchItem) getItem()).send(command);
+            return;
+        }
+        logger.warn("Received OnOffType command for item {} that doesn't support it. This is probably a bug.",
+                getName());
+    }
+
+    /**
+     * Send PercentType command to a DimmerItem or RollershutterItem (or a Group:Dimmer/Group:Rollershutter)
+     * 
+     * @param command
+     */
+    public void send(PercentType command) {
+        if (getItem() instanceof GroupItem
+                && (getBaseItem() instanceof DimmerItem || getBaseItem() instanceof RollershutterItem)) {
+            ((GroupItem) getItem()).send(command);
+            return;
+        } else if (getItem() instanceof DimmerItem) {
+            ((DimmerItem) getItem()).send(command);
+            return;
+        } else if (getItem() instanceof RollershutterItem) {
+            ((RollershutterItem) getItem()).send(command);
+            return;
+        }
+        logger.warn("Received PercentType command for item {} that doesn't support it. This is probably a bug.",
+                getName());
+    }
+
+    /**
+     * Send StringType command to a StringItem (or a Group:String)
+     * 
+     * @param command
+     */
+    public void send(StringType command) {
+        if (getItem() instanceof GroupItem && getBaseItem() instanceof StringItem) {
+            ((GroupItem) getItem()).send(command);
+            return;
+        } else if (getItem() instanceof StringItem) {
+            ((StringItem) getItem()).send(command);
+            return;
+        }
+        logger.warn("Received StringType command for item {} that doesn't support it. This is probably a bug.",
+                getName());
     }
 
     /**

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
@@ -163,14 +163,7 @@ abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAcces
         final Optional<HomekitTaggedItem> taggedItem = getCharacteristic(type);
         if (taggedItem.isPresent()) {
             final Item item = taggedItem.get().getItem();
-            Item baseItem = item;
-            // Check the type of the base item for a group item
-            if (item instanceof GroupItem) {
-                baseItem = ((GroupItem) item).getBaseItem();
-                if (baseItem == null) {
-                    baseItem = item;
-                }
-            }
+            final Item baseItem = taggedItem.get().getBaseItem();
             if (baseItem instanceof RollershutterItem || baseItem instanceof DimmerItem) {
                 value = item.getStateAs(PercentType.class);
             } else {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/BooleanItemReader.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/BooleanItemReader.java
@@ -22,6 +22,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
+import org.openhab.io.homekit.internal.HomekitOHItemProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,9 @@ public class BooleanItemReader {
         this.item = item;
         this.trueOnOffValue = trueOnOffValue;
         this.trueOpenClosedValue = trueOpenClosedValue;
-        if (!(item instanceof SwitchItem) && !(item instanceof ContactItem) && !(item instanceof StringItem)) {
+        final Item baseItem = HomekitOHItemProxy.getBaseItem(item);
+        if (!(baseItem instanceof SwitchItem) && !(baseItem instanceof ContactItem)
+                && !(baseItem instanceof StringItem)) {
             logger.warn("Item {} is a {} instead of the expected SwitchItem, ContactItem or StringItem", item.getName(),
                     item.getClass().getName());
         }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitGarageDoorOpenerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitGarageDoorOpenerImpl.java
@@ -26,6 +26,7 @@ import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
+import org.openhab.io.homekit.internal.HomekitOHItemProxy;
 import org.openhab.io.homekit.internal.HomekitSettings;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 import org.slf4j.Logger;
@@ -100,9 +101,10 @@ public class HomekitGarageDoorOpenerImpl extends AbstractHomekitAccessoryImpl im
         }
         TargetDoorStateEnum mode;
 
-        if (item instanceof SwitchItem) {
+        final Item baseItem = HomekitOHItemProxy.getBaseItem(item);
+        if (baseItem instanceof SwitchItem) {
             mode = item.getState() == OnOffType.ON ? TargetDoorStateEnum.OPEN : TargetDoorStateEnum.CLOSED;
-        } else if (item instanceof StringItem) {
+        } else if (baseItem instanceof StringItem) {
             final HomekitSettings settings = getSettings();
             final String stringValue = item.getState().toString();
             if (stringValue.equalsIgnoreCase(settings.doorTargetStateClosed)) {
@@ -116,7 +118,7 @@ public class HomekitGarageDoorOpenerImpl extends AbstractHomekitAccessoryImpl im
                 mode = TargetDoorStateEnum.CLOSED;
             }
         } else {
-            logger.warn("Unsupported item type {} for {}. Only Switch and String are supported", item.getType(),
+            logger.warn("Unsupported item type {} for {}. Only Switch and String are supported", baseItem.getType(),
                     item.getName());
             mode = TargetDoorStateEnum.CLOSED;
         }
@@ -131,24 +133,24 @@ public class HomekitGarageDoorOpenerImpl extends AbstractHomekitAccessoryImpl im
     @Override
     public CompletableFuture<Void> setTargetDoorState(TargetDoorStateEnum targetDoorStateEnum) {
         final Optional<HomekitTaggedItem> characteristic = getCharacteristic(TARGET_DOOR_STATE);
-        Item item;
+        final HomekitTaggedItem taggedItem;
         if (characteristic.isPresent()) {
-            item = characteristic.get().getItem();
+            taggedItem = characteristic.get();
         } else {
             logger.warn("Missing mandatory characteristic {}", TARGET_DOOR_STATE);
             return CompletableFuture.completedFuture(null);
         }
 
-        if (item instanceof SwitchItem) {
-            ((SwitchItem) item).send(OnOffType.from(targetDoorStateEnum == TargetDoorStateEnum.OPEN));
-        } else if (item instanceof StringItem) {
+        if (taggedItem.getBaseItem() instanceof SwitchItem) {
+            taggedItem.send(OnOffType.from(targetDoorStateEnum == TargetDoorStateEnum.OPEN));
+        } else if (taggedItem.getBaseItem() instanceof StringItem) {
             final HomekitSettings settings = getSettings();
-            ((StringItem) item)
+            taggedItem
                     .send(new StringType(targetDoorStateEnum == TargetDoorStateEnum.OPEN ? settings.doorTargetStateOpen
                             : settings.doorTargetStateClosed));
         } else {
-            logger.warn("Unsupported item type {} for {}. Only Switch and String are supported", item.getType(),
-                    item.getName());
+            logger.warn("Unsupported item type {} for {}. Only Switch and String are supported",
+                    taggedItem.getBaseItem().getType(), taggedItem.getName());
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
@@ -15,8 +15,6 @@ package org.openhab.io.homekit.internal.accessories;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.openhab.core.items.GenericItem;
-import org.openhab.core.items.GroupItem;
 import org.openhab.core.library.items.DimmerItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
@@ -53,13 +51,10 @@ class HomekitLightbulbImpl extends AbstractHomekitAccessoryImpl implements Light
     public CompletableFuture<Void> setLightbulbPowerState(boolean value) {
         getCharacteristic(HomekitCharacteristicType.ON_STATE).ifPresent(tItem -> {
             final OnOffType onOffState = OnOffType.from(value);
-            final GenericItem item = (GenericItem) tItem.getItem();
-            if (item instanceof DimmerItem) {
+            if (tItem.getBaseItem() instanceof DimmerItem) {
                 tItem.sendCommandProxy(HomekitCommandType.ON_COMMAND, onOffState);
-            } else if (item instanceof SwitchItem) {
-                ((SwitchItem) item).send(onOffState);
-            } else if (item instanceof GroupItem) {
-                ((GroupItem) item).send(onOffState);
+            } else if (tItem.getBaseItem() instanceof SwitchItem) {
+                tItem.send(onOffState);
             }
         });
         return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
this is a theme, and I've extracted a helper method and applied it to several
other locations as well

example, I have a double-sliding door, with two contact sensors
in the alarm system, defined as:

```
Group:Contact:AND(CLOSED,OPEN) DeckDoor_Contact "Deck Door [%s]" <door> (gExteriorDoors, gWarningVisibility_Contact, gDoor, lMainFloor, gInflux) { homekit="ContactSensor" [instance=2] }
Contact DeckNDoor_Contact "Deck Door North" <door> (gInflux, DeckDoor_Contact, gGreatContacts) { channel="dscalarm:zone:46c52f35:zone11:zone_status" }
Switch DeckNDoor_Tamper "Deck Door North Tamper [%s]" <warning> (gTamper, gWarningVisibility_Switch) { channel="dscalarm:zone:46c52f35:zone11:zone_tamper" }
Contact DeckSDoor_Contact "Deck Door South" <door> (gInflux, DeckDoor_Contact, gGreatContacts) { channel="dscalarm:zone:46c52f35:zone12:zone_status" }
Switch DeckSDoor_Tamper "Deck Door South Tamper [%s]" <warning> (gTamper, gWarningVisibility_Switch) { channel="dscalarm:zone:46c52f35:zone12:zone_tamper" }
```

This allows the Group:Contact to be used for the ContactSensor.
