### PR TITLE
[gardena] Fixed connection tracker

### DIFF
--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
@@ -215,7 +215,6 @@ public class GardenaSmartImpl implements GardenaSmart, GardenaSmartWebSocketList
                 final PostOAuth2Response token = this.token;
                 if (token != null) {
                     request.header("Authorization", token.tokenType + " " + token.accessToken);
-                    request.header("Authorization-provider", token.provider);
                 }
                 request.header("X-Api-Key", config.getApiKey());
             }

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartWebSocket.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartWebSocket.java
@@ -87,7 +87,6 @@ public class GardenaSmartWebSocket {
         final ScheduledFuture<?> connectionTracker = this.connectionTracker;
         if (connectionTracker != null) {
             connectionTracker.cancel(true);
-            this.connectionTracker = null;
         }
 
         logger.debug("Closing Gardena Webservice ({})", socketId);
@@ -123,7 +122,6 @@ public class GardenaSmartWebSocket {
         ScheduledFuture<?> connectionTracker = this.connectionTracker;
         if (connectionTracker != null && !connectionTracker.isCancelled()) {
             connectionTracker.cancel(true);
-            this.connectionTracker = null;
         }
 
         // start sending PING every two minutes

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartWebSocket.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartWebSocket.java
@@ -87,6 +87,7 @@ public class GardenaSmartWebSocket {
         final ScheduledFuture<?> connectionTracker = this.connectionTracker;
         if (connectionTracker != null) {
             connectionTracker.cancel(true);
+            this.connectionTracker = null;
         }
 
         logger.debug("Closing Gardena Webservice ({})", socketId);
@@ -121,11 +122,12 @@ public class GardenaSmartWebSocket {
 
         ScheduledFuture<?> connectionTracker = this.connectionTracker;
         if (connectionTracker != null && !connectionTracker.isCancelled()) {
-            connectionTracker.cancel(false);
+            connectionTracker.cancel(true);
+            this.connectionTracker = null;
         }
 
         // start sending PING every two minutes
-        this.connectionTracker = scheduler.scheduleWithFixedDelay(this::sendKeepAlivePing, 2, 2, TimeUnit.MINUTES);
+        this.connectionTracker = scheduler.scheduleWithFixedDelay(this::sendKeepAlivePing, 1, 2, TimeUnit.MINUTES);
     }
 
     @OnWebSocketFrame


### PR DESCRIPTION
The connection tracker does not start after some websocket connections are disconnected. Therefore, every 2 minutes some API requests are sent to Gardena. This can lead to the message 429 limit exceeded after a few days/weeks.
