### PR TITLE
[mimictts] Use http method POST instead of GET

### DIFF
--- a/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/InputStreamAudioStream.java
+++ b/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/InputStreamAudioStream.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.voice.mimic.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.audio.AudioFormat;
+import org.openhab.core.audio.AudioStream;
+
+/**
+ * An AudioStream with an {@link InputStream} inside
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ */
+@NonNullByDefault
+public class InputStreamAudioStream extends AudioStream {
+
+    public InputStream innerInputStream;
+    public AudioFormat audioFormat;
+
+    public InputStreamAudioStream(InputStream innerInputStream, AudioFormat audioFormat) {
+        super();
+        this.innerInputStream = innerInputStream;
+        this.audioFormat = audioFormat;
+    }
+
+    @Override
+    public AudioFormat getFormat() {
+        return audioFormat;
+    }
+
+    @Override
+    public int read() throws IOException {
+        return innerInputStream.read();
+    }
+
+    @Override
+    public int read(byte @Nullable [] b) throws IOException {
+        return innerInputStream.read(b);
+    }
+
+    @Override
+    public int read(byte @Nullable [] b, int off, int len) throws IOException {
+        return innerInputStream.read(b, off, len);
+    }
+
+    @Override
+    public byte[] readAllBytes() throws IOException {
+        return innerInputStream.readAllBytes();
+    }
+
+    @Override
+    public byte[] readNBytes(int len) throws IOException {
+        return innerInputStream.readNBytes(len);
+    }
+
+    @Override
+    public int readNBytes(byte @Nullable [] b, int off, int len) throws IOException {
+        return innerInputStream.readNBytes(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return innerInputStream.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return innerInputStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        innerInputStream.close();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        innerInputStream.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        innerInputStream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return innerInputStream.markSupported();
+    }
+
+    @Override
+    public long transferTo(@Nullable OutputStream out) throws IOException {
+        return innerInputStream.transferTo(out);
+    }
+}

--- a/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/InputStreamAudioStream.java
+++ b/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/InputStreamAudioStream.java
@@ -18,8 +18,9 @@ import java.io.OutputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.audio.AudioException;
 import org.openhab.core.audio.AudioFormat;
-import org.openhab.core.audio.AudioStream;
+import org.openhab.core.audio.FixedLengthAudioStream;
 
 /**
  * An AudioStream with an {@link InputStream} inside
@@ -27,15 +28,17 @@ import org.openhab.core.audio.AudioStream;
  * @author Gwendal Roulleau - Initial contribution
  */
 @NonNullByDefault
-public class InputStreamAudioStream extends AudioStream {
+public class InputStreamAudioStream extends FixedLengthAudioStream {
 
     public InputStream innerInputStream;
     public AudioFormat audioFormat;
+    public long length;
 
-    public InputStreamAudioStream(InputStream innerInputStream, AudioFormat audioFormat) {
+    public InputStreamAudioStream(InputStream innerInputStream, AudioFormat audioFormat, long length) {
         super();
         this.innerInputStream = innerInputStream;
         this.audioFormat = audioFormat;
+        this.length = length;
     }
 
     @Override
@@ -106,5 +109,15 @@ public class InputStreamAudioStream extends AudioStream {
     @Override
     public long transferTo(@Nullable OutputStream out) throws IOException {
         return innerInputStream.transferTo(out);
+    }
+
+    @Override
+    public long length() {
+        return length;
+    }
+
+    @Override
+    public InputStream getClonedStream() throws AudioException {
+        throw new AudioException("Operation not supported");
     }
 }

--- a/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/MimicTTSService.java
+++ b/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/MimicTTSService.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.util.InputStreamResponseListener;
 import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.config.core.ConfigurableService;
@@ -258,7 +259,9 @@ public class MimicTTSService implements TTSService {
         try {
             response = inputStreamResponseListener.get(timeout, TimeUnit.SECONDS);
             if (response.getStatus() == 200) {
-                return new InputStreamAudioStream(inputStreamResponseListener.getInputStream(), AUDIO_FORMAT);
+                String lengthHeader = response.getHeaders().get(HttpHeader.CONTENT_LENGTH);
+                long length = Long.parseLong(lengthHeader);
+                return new InputStreamAudioStream(inputStreamResponseListener.getInputStream(), AUDIO_FORMAT, length);
             } else {
                 String errorMessage = "Cannot get wav from mimic url " + urlTTS + " with HTTP response code "
                         + response.getStatus();

--- a/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/dto/VoiceDto.java
+++ b/bundles/org.openhab.voice.mimictts/src/main/java/org/openhab/voice/mimic/internal/dto/VoiceDto.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Mimic Voice DTO.
@@ -28,5 +29,6 @@ public class VoiceDto {
     public String key = "UNDEFINED";
     public String language = "UNDEFINED";
     public String name = "UNDEFINED";
+    @Nullable
     public List<String> speakers = new ArrayList<>();
 }


### PR DESCRIPTION
Using POST method instead of GET allows longer request size.
(with get method, the request fails when the text is too long)
Also, using InputStreamResponseListener avoid keeping the response in-memory before sending it to the audiosink

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>