### PR TITLE
[sonos] Ignore TRANSITIONING device state when updating channels

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -100,6 +100,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     private static final String STATE_PLAYING = "PLAYING";
     private static final String STATE_PAUSED_PLAYBACK = "PAUSED_PLAYBACK";
     private static final String STATE_STOPPED = "STOPPED";
+    private static final String STATE_TRANSITIONING = "TRANSITIONING";
 
     private static final String LINEINCONNECTED = "LineInConnected";
     private static final String TOSLINEINCONNECTED = "TOSLinkConnected";
@@ -763,7 +764,8 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
             case STATE:
                 value = getTransportState();
                 if (value != null) {
-                    newState = new StringType(value);
+                    // Ignoring state TRANSITIONING
+                    newState = STATE_TRANSITIONING.equals(value) ? null : new StringType(value);
                 }
                 break;
             case CONTROL:
@@ -774,12 +776,15 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                     newState = PlayPauseType.PAUSE;
                 } else if (STATE_PAUSED_PLAYBACK.equals(value)) {
                     newState = PlayPauseType.PAUSE;
+                } else if (STATE_TRANSITIONING.equals(value)) {
+                    // Ignoring state TRANSITIONING
+                    newState = null;
                 }
                 break;
             case STOP:
                 value = getTransportState();
                 if (value != null) {
-                    newState = OnOffType.from(STATE_STOPPED.equals(value));
+                    newState = STATE_TRANSITIONING.equals(value) ? null : OnOffType.from(STATE_STOPPED.equals(value));
                 }
                 break;
             case SHUFFLE:

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/i18n/sonos.properties
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/i18n/sonos.properties
@@ -167,7 +167,6 @@ channel-type.sonos.state.description = The State channel contains state of the S
 channel-type.sonos.state.state.option.STOPPED = Stopped
 channel-type.sonos.state.state.option.PLAYING = Playing
 channel-type.sonos.state.state.option.PAUSED_PLAYBACK = Paused
-channel-type.sonos.state.state.option.TRANSITIONING = Transitioning
 channel-type.sonos.stop.label = Stop
 channel-type.sonos.stop.description = Stop the Sonos device. ON if the player is stopped.
 channel-type.sonos.subwoofer.label = Subwoofer

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/channels.xml
@@ -279,7 +279,6 @@
 				<option value="STOPPED">Stopped</option>
 				<option value="PLAYING">Playing</option>
 				<option value="PAUSED_PLAYBACK">Paused</option>
-				<option value="TRANSITIONING">Transitioning</option>
 			</options>
 		</state>
 	</channel-type>


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>