### PR TITLE
[jdbc] Upgrade MySQL JDBC driver to 8.0.30

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -13,7 +13,7 @@ The following databases are currently supported and tested:
 | [H2](https://www.h2database.com/)            | [h2-1.4.191.jar](https://mvnrepository.com/artifact/com.h2database/h2) |
 | [HSQLDB](http://hsqldb.org/)                 | [hsqldb-2.3.3.jar](https://mvnrepository.com/artifact/org.hsqldb/hsqldb) |
 | [MariaDB](https://mariadb.org/)              | [mariadb-java-client-1.4.6.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client) |
-| [MySQL](https://www.mysql.com/)              | [mysql-connector-java-5.1.39.jar](https://mvnrepository.com/artifact/mysql/mysql-connector-java) |
+| [MySQL](https://www.mysql.com/)              | [mysql-connector-java-8.0.30.jar](https://mvnrepository.com/artifact/mysql/mysql-connector-java) |
 | [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.4.1.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
 | [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.16.1.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
 | [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.4.1.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -29,7 +29,7 @@
     <h2.version>1.4.191</h2.version>
     <hsqldb.version>2.3.3</hsqldb.version>
     <mariadb.version>1.4.6</mariadb.version>
-    <mysql.version>8.0.28</mysql.version>
+    <mysql.version>8.0.30</mysql.version>
     <postgresql.version>42.4.1</postgresql.version>
     <sqlite.version>3.16.1</sqlite.version>
   </properties>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -34,7 +34,7 @@
 	<feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:mysql/mysql-connector-java/8.0.22</bundle>
+		<bundle start-level="80">mvn:mysql/mysql-connector-java/8.0.30</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 


### PR DESCRIPTION
See
- https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/
- https://mvnrepository.com/artifact/mysql/mysql-connector-java/8.0.30

Tested by installing compiled bundle as well as mysql-connector into addons directory:
```
openhabian@openhabian:/usr/share/openhab/addons $ ll *mysql* *jdbc*
-rw-r--r-- 1 openhabian openhab 2.4M Jul  1 05:18 mysql-connector-java.jar
-rw-r--r-- 1 openhabian openhab 296K Aug 10 22:26 org.openhab.persistence.jdbc-3.4.0-SNAPSHOT.jar
```

Then checking in database that items are persisted after the upgrade.