### PR TITLE
[Konnected] Adding base URL to config to allow for manually adding thing

### DIFF
--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
@@ -36,11 +36,11 @@ public class KonnectedBindingConstants {
     public static final ThingTypeUID THING_TYPE_PROMODULE = new ThingTypeUID(BINDING_ID, PRO_MODULE);
 
     // Thing config properties
-    public static final String BASE_URL = "base_url";
+    public static final String BASE_URL = "baseUrl";
     public static final String MAC_ADDR = "macAddress";
-    public static final String REQUEST_TIMEOUT = "request_timeout";
-    public static final String RETRY_COUNT = "retry_count";
-    public static final String CALLBACK_URI = "callback_uri";
+    public static final String REQUEST_TIMEOUT = "requestTimeout";
+    public static final String RETRY_COUNT = "retryCount";
+    public static final String CALLBACK_URL = "callbackUrl";
 
     // ESP8266_ZONE_TO_PIN map, this maps a zone to a pin for ESP8266 based devices
     // Source: https://help.konnected.io/support/solutions/articles/32000026808-zone-to-gpio-pin-mapping

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
@@ -36,7 +36,7 @@ public class KonnectedBindingConstants {
     public static final ThingTypeUID THING_TYPE_PROMODULE = new ThingTypeUID(BINDING_ID, PRO_MODULE);
 
     // Thing config properties
-    public static final String HOST = "ipAddress";
+    public static final String BASE_URL = "base_url";
     public static final String MAC_ADDR = "macAddress";
     public static final String REQUEST_TIMEOUT = "request_timeout";
     public static final String RETRY_COUNT = "retry_count";

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/discovery/KonnectedUPnPServer.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/discovery/KonnectedUPnPServer.java
@@ -60,7 +60,7 @@ public class KonnectedUPnPServer implements UpnpDiscoveryParticipant {
         ThingUID uid = getThingUID(device);
         if (uid != null) {
             Map<String, Object> properties = new HashMap<>();
-            properties.put(HOST, device.getDetails().getBaseURL());
+            properties.put(BASE_URL, device.getDetails().getBaseURL());
             properties.put(MAC_ADDR, device.getDetails().getSerialNumber());
             DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
                     .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(MAC_ADDR).build();

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -321,7 +321,7 @@ public class KonnectedHandler extends BaseThingHandler {
      * @return a json settings payload which can be sent to the Konnected Module based on the Thing
      */
     private String constructSettingsPayload() {
-        String apiUrl = (String) getThing().getConfiguration().get(CALLBACK_URI);
+        String apiUrl = (String) getThing().getConfiguration().get(CALLBACK_URL);
         if (apiUrl == null) {
             apiUrl = "http://" + callbackIpAddress + this.konnectedServletPath;
         }

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/config/config.xml
@@ -9,7 +9,7 @@
 			<label>Actions</label>
 			<description/>
 		</parameter-group>
-		<parameter name="base_url" type="text" required="true">
+		<parameter name="baseUrl" type="text" required="true">
 			<label>Base URL</label>
 			<description>The base URL of the Konnected Alarm Panel.</description>
 		</parameter>
@@ -27,7 +27,7 @@
 			<default>true</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="retry_count" type="integer">
+		<parameter name="retryCount" type="integer">
 			<label>Retry Count</label>
 			<description>The number of times the binding attempts to send http requests to the Konnected Alarm Panel. Increase
 				this setting if you are experiencing situations where the module is reporting as offline but you can access the
@@ -36,7 +36,7 @@
 			<default>2</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="request_timeout" type="integer">
+		<parameter name="requestTimeout" type="integer">
 			<label>Request Timeout</label>
 			<description>The timeout period in seconds for HTTP requests to the Konnected Alarm Panel. The default is 30.
 				Adjusting this setting can help in networks situations with high latency where the binding is erroneously reporting
@@ -45,7 +45,7 @@
 			<advanced>true</advanced>
 		</parameter>
 
-		<parameter name="callback_uri" type="text">
+		<parameter name="callbackUrl" type="text">
 			<label>Callback URI</label>
 			<description>The URI where the Konnected panel will make callbacks. The default is to auto detect the port and IP
 				address of openHAB. This may not work in case you use a reverse proxy or openHAB

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/config/config.xml
@@ -9,6 +9,10 @@
 			<label>Actions</label>
 			<description/>
 		</parameter-group>
+		<parameter name="base_url" type="text" required="true">
+			<label>Base URL</label>
+			<description>The base URL of the Konnected Alarm Panel.</description>
+		</parameter>
 		<parameter name="blink" type="boolean">
 			<label>Blink</label>
 			<description> When set to false the Led on the device won't blink during transmission.</description>

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/i18n/konnected.properties
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/i18n/konnected.properties
@@ -12,6 +12,8 @@ thing-type.konnected.wifi-module.description = The Konnected Wi-Fi Alarm Panel
 
 # thing types config
 
+thing-type.config.konnected.module.base_url.label = Base URL
+thing-type.config.konnected.module.base_url.description = The base URL of the Konnected Alarm Panel.
 thing-type.config.konnected.module.blink.label = Blink
 thing-type.config.konnected.module.blink.description = When set to false the Led on the device won't blink during transmission.
 thing-type.config.konnected.module.callback_uri.label = Callback URI

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/i18n/konnected.properties
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/i18n/konnected.properties
@@ -12,12 +12,12 @@ thing-type.konnected.wifi-module.description = The Konnected Wi-Fi Alarm Panel
 
 # thing types config
 
-thing-type.config.konnected.module.base_url.label = Base URL
-thing-type.config.konnected.module.base_url.description = The base URL of the Konnected Alarm Panel.
+thing-type.config.konnected.module.baseUrl.label = Base URL
+thing-type.config.konnected.module.baseUrl.description = The base URL of the Konnected Alarm Panel.
 thing-type.config.konnected.module.blink.label = Blink
 thing-type.config.konnected.module.blink.description = When set to false the Led on the device won't blink during transmission.
-thing-type.config.konnected.module.callback_uri.label = Callback URI
-thing-type.config.konnected.module.callback_uri.description = The URI where the Konnected panel will make callbacks. The default is to auto detect the port and IP address of openHAB. This may not work in case you use a reverse proxy or openHAB is running in Docker. Then the plugin is bound to the /konnected http context.
+thing-type.config.konnected.module.callbackUrl.label = Callback URI
+thing-type.config.konnected.module.callbackUrl.description = The URI where the Konnected panel will make callbacks. The default is to auto detect the port and IP address of openHAB. This may not work in case you use a reverse proxy or openHAB is running in Docker. Then the plugin is bound to the /konnected http context.
 thing-type.config.konnected.module.controller_removewifi.label = Factory Reset
 thing-type.config.konnected.module.controller_removewifi.description = Resets the module to Factory Conditions.
 thing-type.config.konnected.module.controller_sendConfig.label = Update Settings
@@ -27,10 +27,10 @@ thing-type.config.konnected.module.controller_softreset.description = Send A Res
 thing-type.config.konnected.module.discovery.label = Discovery
 thing-type.config.konnected.module.discovery.description = If set to false the device will not respond to discovery requests via UPnP. Make sure you have statically assigned an IP address to the module before turning this setting off. See https://help.konnected.io/support/solutions/articles/32000023968-disabling-device-discovery
 thing-type.config.konnected.module.group.actions.label = Actions
-thing-type.config.konnected.module.request_timeout.label = Request Timeout
-thing-type.config.konnected.module.request_timeout.description = The timeout period in seconds for HTTP requests to the Konnected Alarm Panel. The default is 30. Adjusting this setting can help in networks situations with high latency where the binding is erroneously reporting the thing as offline.
-thing-type.config.konnected.module.retry_count.label = Retry Count
-thing-type.config.konnected.module.retry_count.description = The number of times the binding attempts to send http requests to the Konnected Alarm Panel. Increase this setting if you are experiencing situations where the module is reporting as offline but you can access the website of the Alarm Panel to confirm that the Alarm Panel is Konnected to the Network. This will allow the binding to attempt more retries before it considers the connection a failure and marks the thing as offline.
+thing-type.config.konnected.module.requestTimeout.label = Request Timeout
+thing-type.config.konnected.module.requestTimeout.description = The timeout period in seconds for HTTP requests to the Konnected Alarm Panel. The default is 30. Adjusting this setting can help in networks situations with high latency where the binding is erroneously reporting the thing as offline.
+thing-type.config.konnected.module.retryCount.label = Retry Count
+thing-type.config.konnected.module.retryCount.description = The number of times the binding attempts to send http requests to the Konnected Alarm Panel. Increase this setting if you are experiencing situations where the module is reporting as offline but you can access the website of the Alarm Panel to confirm that the Alarm Panel is Konnected to the Network. This will allow the binding to attempt more retries before it considers the connection a failure and marks the thing as offline.
 
 # channel types
 


### PR DESCRIPTION
This PR will allow for things to be manually added, and for the address of the konnected panel to be updated.

Before this change there is no configuration for the address of the konnected panel. If a panel is manually added the thing is not functional, and there is a null pointer exception on initialization.

I renamed the fields `ipAddress` and `host` to `baseUrl` for clarity. The field contains a URL, and not an IP address. I'm not sure if this breaks backwards compatibility, but recreation of the konnected things is anyway needed for openhab version 3.4.0. 