### PR TITLE
[rollershutterposition] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -399,8 +399,8 @@
 /bundles/org.openhab.transform.jsonpath/ @clinique
 /bundles/org.openhab.transform.map/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.regex/ @openhab/add-ons-maintainers
-/bundles/org.openhab.transform.scale/ @clinique
 /bundles/org.openhab.transform.rollershutterposition/ @jsjames
+/bundles/org.openhab.transform.scale/ @clinique
 /bundles/org.openhab.transform.xpath/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.xslt/ @openhab/add-ons-maintainers
 /bundles/org.openhab.voice.googlestt/ @GiviMAD

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -400,6 +400,7 @@
 /bundles/org.openhab.transform.map/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.regex/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.scale/ @clinique
+/bundles/org.openhab.transform.rollershutterposition/ @jsjames
 /bundles/org.openhab.transform.xpath/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.xslt/ @openhab/add-ons-maintainers
 /bundles/org.openhab.voice.googlestt/ @GiviMAD

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1988,6 +1988,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.transform.rollershutterposition</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.transform.scale</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.transform.rollershutterposition/NOTICE
+++ b/bundles/org.openhab.transform.rollershutterposition/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.rollershutterposition/README.md
+++ b/bundles/org.openhab.transform.rollershutterposition/README.md
@@ -1,10 +1,12 @@
 # Rollershutter Position Emulation Profile Service
 
 The Rollershutter Position emulates absolute position setting for Rollershutter devices which only support basic UP/DOWN/STOP commands.
-This allows a Rollershutter to be set to an absolution position from 0..100 even if the controller does not support.
+This allows a Rollershutter to be set to an absolution position from 0..100 even if the controller does not support this feature (i.e. Somfy controllers).
 
 The logic code used for this profile service was adapted from Tarag Gautier's javascript implementation VASRollershutter.js.
 By implementing as a profile, it eliminates the need for setting up a jsr233 js environment and simplifies the configuration.
+
+## Configuration
 
 To use this profile, simply include the profile on the Rollershutter item which is assigned to the Rollershutter channel.
 The parameters <uptime> and <downtime> are the time it takes for the Rollershutter to fully extend or close in seconds.

--- a/bundles/org.openhab.transform.rollershutterposition/README.md
+++ b/bundles/org.openhab.transform.rollershutterposition/README.md
@@ -1,12 +1,17 @@
 # Rollershutter Position Emulation Profile Service
 
-The Rollershutter Position emulates absolute position setting for Rollershutter devices which only support basic UP/DOWN/STOP commands.  This allows Rollershutter to be set to an absolution position from 0..100.
+The Rollershutter Position emulates absolute position setting for Rollershutter devices which only support basic UP/DOWN/STOP commands.
+This allows a Rollershutter to be set to an absolution position from 0..100 even if the controller does not support.
 
-The logic code used for this profile service was adapted from Tarag Gautier's javascript implementation VASRollershutter.js.  By implementing as a profile, it eliminates the need for setting up a jsr233 js environment and simplifies the configuration.
+The logic code used for this profile service was adapted from Tarag Gautier's javascript implementation VASRollershutter.js.
+By implementing as a profile, it eliminates the need for setting up a jsr233 js environment and simplifies the configuration.
 
-To use this profile, simply include the profile on the Rollershutter item which is assigned to the Rollershutter channel.  The parameters <uptime> and <downtime> are the time it takes for the Rollershutter to fully extend or close in seconds. The precision parameter can be used to specify the minimum movement that can be made.  This is useful when latencies in the system limit prevent very small movements and will reduce the accuracy of the position estimation.
+To use this profile, simply include the profile on the Rollershutter item which is assigned to the Rollershutter channel.
+The parameters <uptime> and <downtime> are the time it takes for the Rollershutter to fully extend or close in seconds.
+The precision parameter can be used to specify the minimum movement that can be made.
+This is useful when latencies in the system limit prevent very small movements and will reduce the accuracy of the position estimation.
 
 ```java
-Rollershutter <itemName> { channel="<channelUID>"[profile="rollershutter:rollershutter-position", uptime=<uptime>, downtime=<downtime>, precision=<minimun percent movement>]]}
+Rollershutter <itemName> { channel="<channelUID>"[profile="rollershutter:position", uptime=<uptime>, downtime=<downtime>, precision=<minimun percent movement>]]}
 ```
 

--- a/bundles/org.openhab.transform.rollershutterposition/README.md
+++ b/bundles/org.openhab.transform.rollershutterposition/README.md
@@ -3,7 +3,7 @@
 The Rollershutter Position emulates absolute position setting for Rollershutter devices which only support basic UP/DOWN/STOP commands.
 This allows a Rollershutter to be set to an absolution position from 0..100 even if the controller does not support this feature (i.e. Somfy controllers).
 
-The logic code used for this profile service was adapted from Tarag Gautier's javascript implementation VASRollershutter.js.
+The logic code used for this profile service was adapted from Tarag Gautier's JavaScript implementation VASRollershutter.js.
 By implementing as a profile, it eliminates the need for setting up a jsr233 js environment and simplifies the configuration.
 
 ## Configuration

--- a/bundles/org.openhab.transform.rollershutterposition/README.md
+++ b/bundles/org.openhab.transform.rollershutterposition/README.md
@@ -1,0 +1,12 @@
+# Rollershutter Position Emulation Profile Service
+
+The Rollershutter Position emulates absolute position setting for Rollershutter devices which only support basic UP/DOWN/STOP commands.  This allows Rollershutter to be set to an absolution position from 0..100.
+
+The logic code used for this profile service was adapted from Tarag Gautier's javascript implementation VASRollershutter.js.  By implementing as a profile, it eliminates the need for setting up a jsr233 js environment and simplifies the configuration.
+
+To use this profile, simply include the profile on the Rollershutter item which is assigned to the Rollershutter channel.  The parameters <uptime> and <downtime> are the time it takes for the Rollershutter to fully extend or close in seconds. The precision parameter can be used to specify the minimum movement that can be made.  This is useful when latencies in the system limit prevent very small movements and will reduce the accuracy of the position estimation.
+
+```java
+Rollershutter <itemName> { channel="<channelUID>"[profile="rollershutter:rollershutter-position", uptime=<uptime>, downtime=<downtime>, precision=<minimun percent movement>]]}
+```
+

--- a/bundles/org.openhab.transform.rollershutterposition/pom.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.transform.rollershutterposition</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Transformation Service :: Roller Shutter Position</name>
+
+</project>

--- a/bundles/org.openhab.transform.rollershutterposition/pom.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.transform.rollershutterposition</artifactId>

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.transform.rollershutterposition-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-transformation-rollershutterposition" description="Roller Shutter Position Emulation" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.rollershutterposition/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionConstants.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionConstants.java
@@ -27,10 +27,11 @@ public class RollerShutterPositionConstants {
     // Profile Type UID
     public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID("rollershutter", "position");
 
-    // Paramaters
+    // Parameters
     public static final String UPTIME_PARAM = "uptime";
     public static final String DOWNTIME_PARAM = "downtime";
     public static final String PRECISION_PARAM = "precision";
 
     public static final int POSITION_UPDATE_PERIOD = 800; // fixed delay in milliseconds
+    public static final int DEFAULT_PRECISION = 5;
 }

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionConstants.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionConstants.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.rollershutterposition.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+
+/**
+ * The {@link RollerShutterPositionConstants } class to define transform constants
+ * used across the whole binding.
+ *
+ * @author Jeff James - Initial contribution
+ */
+@NonNullByDefault
+public class RollerShutterPositionConstants {
+
+    // Profile Type UID
+    public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID("rollershutter", "position");
+
+    // Paramaters
+    public static final String UPTIME_PARAM = "uptime";
+    public static final String DOWNTIME_PARAM = "downtime";
+    public static final String PRECISION_PARAM = "precision";
+
+    public static final int POSITION_UPDATE_PERIOD = 800; // fixed delay in milliseconds
+}

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionConstants.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -14,9 +14,10 @@ package org.openhab.transform.rollershutterposition.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.transform.TransformationService;
 
 /**
- * The {@link RollerShutterPositionConstants } class to define transform constants
+ * The {@link RollerShutterPositionConstants} class to define transform constants
  * used across the whole binding.
  *
  * @author Jeff James - Initial contribution
@@ -25,13 +26,14 @@ import org.openhab.core.thing.profiles.ProfileTypeUID;
 public class RollerShutterPositionConstants {
 
     // Profile Type UID
-    public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID("rollershutter", "position");
+    public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID(
+            TransformationService.TRANSFORM_PROFILE_SCOPE, "ROLLERSHUTTERPOSITION");
 
     // Parameters
     public static final String UPTIME_PARAM = "uptime";
     public static final String DOWNTIME_PARAM = "downtime";
     public static final String PRECISION_PARAM = "precision";
 
-    public static final int POSITION_UPDATE_PERIOD = 800; // fixed delay in milliseconds
+    public static final int POSITION_UPDATE_PERIOD_MILLISECONDS = 800;
     public static final int DEFAULT_PRECISION = 5;
 }

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Profile to offer the RollerShutterPosition ItemChannelLink
+ * Profile to implement the RollerShutterPosition ItemChannelLink
  *
  * @author Jeff James - Initial contribution
  *
@@ -74,6 +74,10 @@ public class RollerShutterPositionProfile implements StateProfile {
 
         if (configuration.downtime == 0) {
             configuration.downtime = configuration.uptime;
+        }
+
+        if (configuration.precision == 0) {
+            configuration.precision = DEFAULT_PRECISION;
         }
 
         this.isValidConfiguration = true;
@@ -147,7 +151,7 @@ public class RollerShutterPositionProfile implements StateProfile {
             newCmd = posOffset > 0 ? UpDownType.DOWN : UpDownType.UP;
         }
 
-        logger.info("moveTo() targetPosition: {} from currentPosition: {}", targetPos, curPos);
+        logger.debug("moveTo() targetPosition: {} from currentPosition: {}", targetPos, curPos);
 
         long time = (long) ((Math.abs(posOffset) / 100d)
                 * (posOffset > 0 ? (double) configuration.downtime * 1000 : (double) configuration.uptime * 1000));
@@ -187,7 +191,6 @@ public class RollerShutterPositionProfile implements StateProfile {
 
     private void stop() {
         callback.handleCommand(StopMoveType.STOP);
-        logger.trace("stop()");
 
         this.position = currentPosition();
         this.movingSince = Instant.MIN;
@@ -230,10 +233,10 @@ public class RollerShutterPositionProfile implements StateProfile {
         public void run() {
             if (targetPosition == 0 || targetPosition == 100) {
                 // Don't send stop command to re-sync position using the motor end stop
-                logger.info("arrived at end position, not stopping for calibration");
+                logger.debug("arrived at end position, not stopping for calibration");
             } else {
                 callback.handleCommand(StopMoveType.STOP);
-                logger.info("arrived at position, sending STOP command");
+                logger.debug("arrived at position, sending STOP command");
             }
 
             logger.trace("stopTimeoutTask() position: {}", targetPosition);

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.transform.rollershutterposition.internal;
 
-import java.math.BigDecimal;
-import java.time.ZonedDateTime;
+import static org.openhab.transform.rollershutterposition.internal.RollerShutterPositionConstants.*;
+
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,7 @@ import org.openhab.core.thing.profiles.ProfileTypeUID;
 import org.openhab.core.thing.profiles.StateProfile;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.transform.rollershutterposition.internal.config.RollerShutterPositionConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,75 +47,39 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class RollerShutterPositionProfile implements StateProfile {
-
-    public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID("rollershutter", "rollershutter-position");
-
+    private static final String PROFILE_THREADPOOL_NAME = "profile-rollershutterposition";
     private final Logger logger = LoggerFactory.getLogger(RollerShutterPositionProfile.class);
 
     private final ProfileCallback callback;
+    RollerShutterPositionConfig configuration;
 
-    private static final String UPTIME_PARAM = "uptime";
-    private static final String DOWNTIME_PARAM = "downtime";
-    private static final String PRECISION_PARAM = "precision";
-
-    @NonNullByDefault({})
-    private long uptime; // uptime in ms (set by param)
-    @NonNullByDefault({})
-    private long downtime; // downtime in ms (set by param)
-    @NonNullByDefault({})
-    private int precision; // minimum movement
-
-    @NonNullByDefault({})
-    private int position = 0; // current position of the blind (assumes 0 when system starts)
+    private int position = 0; // current position of the roller shutter (assumes 0 when system starts)
     private int targetPosition;
-    @Nullable
-    private Optional<ZonedDateTime> movingSince = Optional.empty();
-    private boolean isMoving = false;
+    private boolean isValidConfiguration = false;
+    private Instant movingSince = Instant.MIN;
     private UpDownType direction = UpDownType.DOWN;
 
-    private final ScheduledExecutorService scheduler = ThreadPoolManager
-            .getScheduledPool("profile-rollershutterposition");
-    private Optional<ScheduledFuture<?>> stopTimer = Optional.empty();
-    private Optional<ScheduledFuture<?>> updateTimer = Optional.empty();
+    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(PROFILE_THREADPOOL_NAME);
+    protected @Nullable ScheduledFuture<?> stopTimer = null;
+    protected @Nullable ScheduledFuture<?> updateTimer = null;
 
     public RollerShutterPositionProfile(final ProfileCallback callback, final ProfileContext context) {
         this.callback = callback;
+        this.configuration = context.getConfiguration().as(RollerShutterPositionConfig.class);
 
-        Object uptimeParam = context.getConfiguration().get(UPTIME_PARAM);
-        if (uptimeParam != null) {
-            if (uptimeParam instanceof BigDecimal) {
-                uptime = (long) (((BigDecimal) uptimeParam).doubleValue() * 1000);
-            } else {
-                logger.error("Parameter '{}' is not of type decimal.", UPTIME_PARAM);
-            }
-        } else {
-            uptime = 0;
+        if (configuration.uptime == 0) {
+            logger.info("Profile paramater {} must not be 0", UPTIME_PARAM);
+            return;
         }
 
-        Object downtimeParam = context.getConfiguration().get(DOWNTIME_PARAM);
-        if (downtimeParam != null) {
-            if (downtimeParam instanceof BigDecimal) {
-                downtime = (long) (((BigDecimal) downtimeParam).doubleValue() * 1000);
-            } else {
-                logger.error("Parameter '{}' is not of type decimal.", UPTIME_PARAM);
-            }
-        } else {
-            downtime = uptime;
+        if (configuration.downtime == 0) {
+            configuration.downtime = configuration.uptime;
         }
 
-        Object precisionParam = context.getConfiguration().get(PRECISION_PARAM);
-        if (precisionParam != null) {
-            if (precisionParam instanceof BigDecimal) {
-                precision = ((BigDecimal) precisionParam).intValue();
-            } else {
-                logger.error("Parameter '{}' is not of type integer.", PRECISION_PARAM);
-            }
-        } else {
-            precision = 1;
-        }
+        this.isValidConfiguration = true;
 
-        logger.debug("Profile configured with '{}'='{}' ms, '{}'={} ms, '{}'={}", UPTIME_PARAM, uptime, DOWNTIME_PARAM,
-                downtime, PRECISION_PARAM, precision);
+        logger.debug("Profile configured with '{}'='{}' ms, '{}'={} ms, '{}'={}", UPTIME_PARAM, configuration.uptime,
+                DOWNTIME_PARAM, configuration.downtime, PRECISION_PARAM, configuration.precision);
     }
 
     @Override
@@ -122,14 +88,14 @@ public class RollerShutterPositionProfile implements StateProfile {
     }
 
     @Override
-    public void onStateUpdateFromItem(State state) {
-        logger.trace("onStateUpdateFromItem: {}", state);
-    }
-
-    @Override
     public void onCommandFromItem(Command command) {
         logger.debug("onCommandFromItem: {}", command);
-        logger.trace("uptime: {}, position: {}", uptime, position);
+
+        // pass through command if profile has not been configured properly
+        if (!isValidConfiguration) {
+            callback.handleCommand(command);
+            return;
+        }
 
         if (command instanceof UpDownType) {
             if (command == UpDownType.UP) {
@@ -144,12 +110,8 @@ public class RollerShutterPositionProfile implements StateProfile {
         }
     }
 
-    @Override
-    public void onCommandFromHandler(Command command) {
-    }
-
-    @Override
-    public void onStateUpdateFromHandler(State state) {
+    private boolean isMoving() {
+        return (!movingSince.equals(Instant.MIN));
     }
 
     private void moveTo(int targetPos) {
@@ -165,7 +127,7 @@ public class RollerShutterPositionProfile implements StateProfile {
 
         UpDownType newCmd;
 
-        if (targetPos == position && !isMoving) {
+        if (targetPos == position && !isMoving()) {
             logger.debug("moveTo() position already current: {}", targetPos);
             if (targetPos == 0) { // always send command if either 0 or 100 in case it is not already in that position
                 callback.handleCommand(UpDownType.UP);
@@ -176,10 +138,10 @@ public class RollerShutterPositionProfile implements StateProfile {
         } else if (targetPos == 0 || targetPos == 100) {
             logger.debug("moveTo() bounding position");
             newCmd = targetPos == 0 ? UpDownType.UP : UpDownType.DOWN;
-        } else if (Math.abs(posOffset) < precision) {
+        } else if (Math.abs(posOffset) < configuration.precision) {
             callback.sendUpdate(new PercentType(position)); // update position because autoupdate will assume the
                                                             // movement happened
-            logger.info("moveTo() is less than the precision setting of {}", precision);
+            logger.info("moveTo() is less than the precision setting of {}", configuration.precision);
             return;
         } else {
             newCmd = posOffset > 0 ? UpDownType.DOWN : UpDownType.UP;
@@ -187,10 +149,11 @@ public class RollerShutterPositionProfile implements StateProfile {
 
         logger.info("moveTo() targetPosition: {} from currentPosition: {}", targetPos, curPos);
 
-        long time = (long) ((Math.abs(posOffset) / 100d) * (posOffset > 0 ? (double) downtime : (double) uptime));
+        long time = (long) ((Math.abs(posOffset) / 100d)
+                * (posOffset > 0 ? (double) configuration.downtime * 1000 : (double) configuration.uptime * 1000));
         logger.debug("moveTo() computed movement offset: {} / {} / {} ms", posOffset, newCmd, time);
 
-        if (isMoving) {
+        if (isMoving()) {
             position = curPos; // Update "starting" position if already in motion since the last move did not finish
 
             if (direction == newCmd) {
@@ -198,15 +161,20 @@ public class RollerShutterPositionProfile implements StateProfile {
             }
         }
 
-        stopTimer.ifPresent(job -> job.cancel(false));
-        stopTimer = Optional.of(scheduler.schedule(stopTimeoutTask, time, TimeUnit.MILLISECONDS));
-        targetPosition = targetPos;
-        isMoving = true;
-        direction = newCmd;
-        movingSince = Optional.of(ZonedDateTime.now());
+        this.targetPosition = targetPos;
+        this.direction = newCmd;
+        this.movingSince = Instant.now();
 
-        updateTimer.ifPresent(job -> job.cancel(false));
-        updateTimer = Optional.of(scheduler.scheduleAtFixedRate(updateTimeoutTask, 0, 2000, TimeUnit.MILLISECONDS));
+        if (stopTimer != null) {
+            Objects.requireNonNull(stopTimer).cancel(true);
+        }
+        this.stopTimer = scheduler.schedule(stopTimeoutTask, time, TimeUnit.MILLISECONDS);
+
+        if (updateTimer != null) {
+            Objects.requireNonNull(updateTimer).cancel(true);
+        }
+        this.updateTimer = scheduler.scheduleWithFixedDelay(updateTimeoutTask, 0, POSITION_UPDATE_PERIOD,
+                TimeUnit.MILLISECONDS);
 
         if (!alreadyMoving) {
             logger.debug("moveTo() sending command for movement: {}, timer set in {} ms", direction, time);
@@ -221,35 +189,33 @@ public class RollerShutterPositionProfile implements StateProfile {
         callback.handleCommand(StopMoveType.STOP);
         logger.trace("stop()");
 
-        position = currentPosition();
+        this.position = currentPosition();
+        this.movingSince = Instant.MIN;
 
-        stopTimer.ifPresent(job -> job.cancel(false));
-        stopTimer = Optional.empty();
-
-        updateTimer.ifPresent(job -> job.cancel(false));
-        updateTimer = Optional.empty();
-
-        isMoving = false;
+        if (stopTimer != null) {
+            Objects.requireNonNull(stopTimer).cancel(true);
+            this.stopTimer = null;
+        }
+        if (updateTimer != null) {
+            Objects.requireNonNull(updateTimer).cancel(true);
+            this.updateTimer = null;
+        }
 
         callback.sendUpdate(new PercentType(position));
     }
 
     private int currentPosition() {
-        if (isMoving) {
+        if (isMoving()) {
             logger.trace("currentPosition() while moving");
-            if (movingSince == null) {
-                return -1;
-            }
 
-            // movingSince should always be set if moving
-            long millis = movingSince.get().until(ZonedDateTime.now(), ChronoUnit.MILLIS);
-
+            // movingSince is always set if moving
+            long millis = movingSince.until(Instant.now(), ChronoUnit.MILLIS);
             double delta = 0;
 
             if (direction == UpDownType.UP) {
-                delta = -(double) millis / uptime * 100d;
+                delta = -(millis / (configuration.uptime * 1000)) * 100d;
             } else {
-                delta = (double) millis / (double) downtime * 100d;
+                delta = (millis / (configuration.downtime * 1000)) * 100d;
             }
 
             return (int) Math.max(0, Math.min(100, Math.round(position + delta)));
@@ -258,6 +224,7 @@ public class RollerShutterPositionProfile implements StateProfile {
         }
     }
 
+    // Runnable task to time duration of the move to make
     private Runnable stopTimeoutTask = new Runnable() {
         @Override
         public void run() {
@@ -271,27 +238,42 @@ public class RollerShutterPositionProfile implements StateProfile {
 
             logger.trace("stopTimeoutTask() position: {}", targetPosition);
 
-            updateTimer.ifPresent(job -> job.cancel(false));
-            updateTimer = Optional.empty();
+            if (updateTimer != null) {
+                Objects.requireNonNull(updateTimer).cancel(true);
+                updateTimer = null;
+            }
 
-            isMoving = false;
+            movingSince = Instant.MIN;
             position = targetPosition;
             targetPosition = -1;
             callback.sendUpdate(new PercentType(position));
         }
     };
 
+    // Runnable task to update the item on position while the roller shutter is moving
     private Runnable updateTimeoutTask = new Runnable() {
         @Override
         public void run() {
-            if (isMoving) {
+            if (isMoving()) {
                 int pos = currentPosition();
                 if (pos < 0 || pos > 100) {
-                    logger.trace("updateTimeTask() position not in range: {}", pos);
+                    return;
                 }
                 callback.sendUpdate(new PercentType(pos));
                 logger.trace("updateTimeoutTask(): {}", pos);
             }
         }
     };
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+    }
 }

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
@@ -1,0 +1,297 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.rollershutterposition.internal;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StopMoveType;
+import org.openhab.core.library.types.UpDownType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Profile to offer the RollerShutterPosition ItemChannelLink
+ *
+ * @author Jeff James - Initial contribution
+ *
+ *         Core logic in this module has been heavily adapted from Tarag Gautier js script implementation
+ *         VASRollershutter.js
+ */
+@NonNullByDefault
+public class RollerShutterPositionProfile implements StateProfile {
+
+    public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID("rollershutter", "rollershutter-position");
+
+    private final Logger logger = LoggerFactory.getLogger(RollerShutterPositionProfile.class);
+
+    private final ProfileCallback callback;
+
+    private static final String UPTIME_PARAM = "uptime";
+    private static final String DOWNTIME_PARAM = "downtime";
+    private static final String PRECISION_PARAM = "precision";
+
+    @NonNullByDefault({})
+    private long uptime; // uptime in ms (set by param)
+    @NonNullByDefault({})
+    private long downtime; // downtime in ms (set by param)
+    @NonNullByDefault({})
+    private int precision; // minimum movement
+
+    @NonNullByDefault({})
+    private int position = 0; // current position of the blind (assumes 0 when system starts)
+    private int targetPosition;
+    @Nullable
+    private Optional<ZonedDateTime> movingSince = Optional.empty();
+    private boolean isMoving = false;
+    private UpDownType direction = UpDownType.DOWN;
+
+    private final ScheduledExecutorService scheduler = ThreadPoolManager
+            .getScheduledPool("profile-rollershutterposition");
+    private Optional<ScheduledFuture<?>> stopTimer = Optional.empty();
+    private Optional<ScheduledFuture<?>> updateTimer = Optional.empty();
+
+    public RollerShutterPositionProfile(final ProfileCallback callback, final ProfileContext context) {
+        this.callback = callback;
+
+        Object uptimeParam = context.getConfiguration().get(UPTIME_PARAM);
+        if (uptimeParam != null) {
+            if (uptimeParam instanceof BigDecimal) {
+                uptime = (long) (((BigDecimal) uptimeParam).doubleValue() * 1000);
+            } else {
+                logger.error("Parameter '{}' is not of type decimal.", UPTIME_PARAM);
+            }
+        } else {
+            uptime = 0;
+        }
+
+        Object downtimeParam = context.getConfiguration().get(DOWNTIME_PARAM);
+        if (downtimeParam != null) {
+            if (downtimeParam instanceof BigDecimal) {
+                downtime = (long) (((BigDecimal) downtimeParam).doubleValue() * 1000);
+            } else {
+                logger.error("Parameter '{}' is not of type decimal.", UPTIME_PARAM);
+            }
+        } else {
+            downtime = uptime;
+        }
+
+        Object precisionParam = context.getConfiguration().get(PRECISION_PARAM);
+        if (precisionParam != null) {
+            if (precisionParam instanceof BigDecimal) {
+                precision = ((BigDecimal) precisionParam).intValue();
+            } else {
+                logger.error("Parameter '{}' is not of type integer.", PRECISION_PARAM);
+            }
+        } else {
+            precision = 1;
+        }
+
+        logger.debug("Profile configured with '{}'='{}' ms, '{}'={} ms, '{}'={}", UPTIME_PARAM, uptime, DOWNTIME_PARAM,
+                downtime, PRECISION_PARAM, precision);
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return PROFILE_TYPE_UID;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        logger.trace("onStateUpdateFromItem: {}", state);
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        logger.debug("onCommandFromItem: {}", command);
+        logger.trace("uptime: {}, position: {}", uptime, position);
+
+        if (command instanceof UpDownType) {
+            if (command == UpDownType.UP) {
+                moveTo(0);
+            } else if (command == UpDownType.DOWN) {
+                moveTo(100);
+            }
+        } else if (command instanceof StopMoveType) {
+            stop();
+        } else {
+            moveTo(((PercentType) command).intValue());
+        }
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+    }
+
+    private void moveTo(int targetPos) {
+        boolean alreadyMoving = false;
+
+        if (targetPos < 0 || targetPos > 100) {
+            logger.debug("moveTo() position is invalid: {}", targetPos);
+            return;
+        }
+
+        int curPos = currentPosition();
+        int posOffset = targetPos - curPos;
+
+        UpDownType newCmd;
+
+        if (targetPos == position && !isMoving) {
+            logger.debug("moveTo() position already current: {}", targetPos);
+            if (targetPos == 0) { // always send command if either 0 or 100 in case it is not already in that position
+                callback.handleCommand(UpDownType.UP);
+            } else if (targetPos == 100) {
+                callback.handleCommand(UpDownType.DOWN);
+            }
+            return;
+        } else if (targetPos == 0 || targetPos == 100) {
+            logger.debug("moveTo() bounding position");
+            newCmd = targetPos == 0 ? UpDownType.UP : UpDownType.DOWN;
+        } else if (Math.abs(posOffset) < precision) {
+            callback.sendUpdate(new PercentType(position)); // update position because autoupdate will assume the
+                                                            // movement happened
+            logger.info("moveTo() is less than the precision setting of {}", precision);
+            return;
+        } else {
+            newCmd = posOffset > 0 ? UpDownType.DOWN : UpDownType.UP;
+        }
+
+        logger.info("moveTo() targetPosition: {} from currentPosition: {}", targetPos, curPos);
+
+        long time = (long) ((Math.abs(posOffset) / 100d) * (posOffset > 0 ? (double) downtime : (double) uptime));
+        logger.debug("moveTo() computed movement offset: {} / {} / {} ms", posOffset, newCmd, time);
+
+        if (isMoving) {
+            position = curPos; // Update "starting" position if already in motion since the last move did not finish
+
+            if (direction == newCmd) {
+                alreadyMoving = true;
+            }
+        }
+
+        stopTimer.ifPresent(job -> job.cancel(false));
+        stopTimer = Optional.of(scheduler.schedule(stopTimeoutTask, time, TimeUnit.MILLISECONDS));
+        targetPosition = targetPos;
+        isMoving = true;
+        direction = newCmd;
+        movingSince = Optional.of(ZonedDateTime.now());
+
+        updateTimer.ifPresent(job -> job.cancel(false));
+        updateTimer = Optional.of(scheduler.scheduleAtFixedRate(updateTimeoutTask, 0, 2000, TimeUnit.MILLISECONDS));
+
+        if (!alreadyMoving) {
+            logger.debug("moveTo() sending command for movement: {}, timer set in {} ms", direction, time);
+            callback.handleCommand(direction);
+        } else {
+            logger.debug("moveTo() updating timing but already moving in right directio: {}, timer set in {} ms",
+                    direction, time);
+        }
+    }
+
+    private void stop() {
+        callback.handleCommand(StopMoveType.STOP);
+        logger.trace("stop()");
+
+        position = currentPosition();
+
+        stopTimer.ifPresent(job -> job.cancel(false));
+        stopTimer = Optional.empty();
+
+        updateTimer.ifPresent(job -> job.cancel(false));
+        updateTimer = Optional.empty();
+
+        isMoving = false;
+
+        callback.sendUpdate(new PercentType(position));
+    }
+
+    private int currentPosition() {
+        if (isMoving) {
+            logger.trace("currentPosition() while moving");
+            if (movingSince == null) {
+                return -1;
+            }
+
+            // movingSince should always be set if moving
+            long millis = movingSince.get().until(ZonedDateTime.now(), ChronoUnit.MILLIS);
+
+            double delta = 0;
+
+            if (direction == UpDownType.UP) {
+                delta = -(double) millis / uptime * 100d;
+            } else {
+                delta = (double) millis / (double) downtime * 100d;
+            }
+
+            return (int) Math.max(0, Math.min(100, Math.round(position + delta)));
+        } else {
+            return position;
+        }
+    }
+
+    private Runnable stopTimeoutTask = new Runnable() {
+        @Override
+        public void run() {
+            if (targetPosition == 0 || targetPosition == 100) {
+                // Don't send stop command to re-sync position using the motor end stop
+                logger.info("arrived at end position, not stopping for calibration");
+            } else {
+                callback.handleCommand(StopMoveType.STOP);
+                logger.info("arrived at position, sending STOP command");
+            }
+
+            logger.trace("stopTimeoutTask() position: {}", targetPosition);
+
+            updateTimer.ifPresent(job -> job.cancel(false));
+            updateTimer = Optional.empty();
+
+            isMoving = false;
+            position = targetPosition;
+            targetPosition = -1;
+            callback.sendUpdate(new PercentType(position));
+        }
+    };
+
+    private Runnable updateTimeoutTask = new Runnable() {
+        @Override
+        public void run() {
+            if (isMoving) {
+                int pos = currentPosition();
+                if (pos < 0 || pos > 100) {
+                    logger.trace("updateTimeTask() position not in range: {}", pos);
+                }
+                callback.sendUpdate(new PercentType(pos));
+                logger.trace("updateTimeoutTask(): {}", pos);
+            }
+        }
+    };
+}

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -177,7 +177,7 @@ public class RollerShutterPositionProfile implements StateProfile {
         if (updateTimer != null) {
             Objects.requireNonNull(updateTimer).cancel(true);
         }
-        this.updateTimer = scheduler.scheduleWithFixedDelay(updateTimeoutTask, 0, POSITION_UPDATE_PERIOD,
+        this.updateTimer = scheduler.scheduleWithFixedDelay(updateTimeoutTask, 0, POSITION_UPDATE_PERIOD_MILLISECONDS,
                 TimeUnit.MILLISECONDS);
 
         if (!alreadyMoving) {

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfileFactory.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfileFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -32,7 +32,7 @@ import org.openhab.core.thing.profiles.ProfileTypeUID;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * {@link RollerShutterPositionProfileFactory } Factory to create the profile
+ * {@link RollerShutterPositionProfileFactory} Factory to create the profile
  *
  * @author Jeff James - Initial contribution
  */

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfileFactory.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfileFactory.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.rollershutterposition.internal;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.thing.profiles.Profile;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileFactory;
+import org.openhab.core.thing.profiles.ProfileType;
+import org.openhab.core.thing.profiles.ProfileTypeBuilder;
+import org.openhab.core.thing.profiles.ProfileTypeProvider;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * {@link ProfileFactory} that creates the transformation profile for the {@link ScaleTransformationService}
+ *
+ * @author Stefan Triller - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { ProfileFactory.class, ProfileTypeProvider.class })
+public class RollerShutterPositionProfileFactory implements ProfileFactory, ProfileTypeProvider {
+    @Override
+    public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
+        return List.of(ProfileTypeBuilder
+                .newState(RollerShutterPositionProfile.PROFILE_TYPE_UID,
+                        RollerShutterPositionProfile.PROFILE_TYPE_UID.getId())
+                .withSupportedItemTypes(CoreItemFactory.ROLLERSHUTTER).build());
+    }
+
+    @Override
+    public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
+            ProfileContext profileContext) {
+        return new RollerShutterPositionProfile(callback, profileContext);
+    }
+
+    @Override
+    public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
+        return List.of(RollerShutterPositionProfile.PROFILE_TYPE_UID);
+    }
+}

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfileFactory.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/RollerShutterPositionProfileFactory.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.transform.rollershutterposition.internal;
 
+import static org.openhab.transform.rollershutterposition.internal.RollerShutterPositionConstants.PROFILE_TYPE_UID;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -30,18 +32,16 @@ import org.openhab.core.thing.profiles.ProfileTypeUID;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * {@link ProfileFactory} that creates the transformation profile for the {@link ScaleTransformationService}
+ * {@link RollerShutterPositionProfileFactory } Factory to create the profile
  *
- * @author Stefan Triller - Initial contribution
+ * @author Jeff James - Initial contribution
  */
 @NonNullByDefault
 @Component(service = { ProfileFactory.class, ProfileTypeProvider.class })
 public class RollerShutterPositionProfileFactory implements ProfileFactory, ProfileTypeProvider {
     @Override
     public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
-        return List.of(ProfileTypeBuilder
-                .newState(RollerShutterPositionProfile.PROFILE_TYPE_UID,
-                        RollerShutterPositionProfile.PROFILE_TYPE_UID.getId())
+        return List.of(ProfileTypeBuilder.newState(PROFILE_TYPE_UID, PROFILE_TYPE_UID.getId())
                 .withSupportedItemTypes(CoreItemFactory.ROLLERSHUTTER).build());
     }
 
@@ -53,6 +53,6 @@ public class RollerShutterPositionProfileFactory implements ProfileFactory, Prof
 
     @Override
     public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
-        return List.of(RollerShutterPositionProfile.PROFILE_TYPE_UID);
+        return List.of(PROFILE_TYPE_UID);
     }
 }

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/config/RollerShutterPositionConfig.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/config/RollerShutterPositionConfig.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.transform.rollershutterposition.internal.config;
 
+import static org.openhab.transform.rollershutterposition.internal.RollerShutterPositionConstants.DEFAULT_PRECISION;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -24,5 +26,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class RollerShutterPositionConfig {
     public float uptime; // uptime in seconds (set by param)
     public float downtime; // downtime in seconds (set by param)
-    public int precision; // minimum movement
+    public int precision = DEFAULT_PRECISION; // minimum movement
 }

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/config/RollerShutterPositionConfig.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/config/RollerShutterPositionConfig.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.rollershutterposition.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link RollerShutterPositionConfig } class contains the parameters for RollerShutterPosition
+ *
+ * @author Jeff James - initial contribution
+ *
+ */
+@NonNullByDefault
+public class RollerShutterPositionConfig {
+    public float uptime; // uptime in seconds (set by param)
+    public float downtime; // downtime in seconds (set by param)
+    public int precision; // minimum movement
+}

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/config/RollerShutterPositionConfig.java
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/java/org/openhab/transform/rollershutterposition/internal/config/RollerShutterPositionConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -17,7 +17,7 @@ import static org.openhab.transform.rollershutterposition.internal.RollerShutter
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link RollerShutterPositionConfig } class contains the parameters for RollerShutterPosition
+ * The {@link RollerShutterPositionConfig} class contains the parameters for RollerShutterPosition
  *
  * @author Jeff James - initial contribution
  *

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
@@ -4,7 +4,7 @@
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="profile:rollershutter:rollershutter-position">
+	<config-description uri="profile:rollershutter:position">
 		<parameter name="uptime" type="decimal" required="true">
 			<label>Up Time</label>
 			<description>Time it takes for roller shutter to fully open (in seconds).</description>
@@ -13,12 +13,14 @@
 		<parameter name="downtime" type="decimal">
 			<label>Down Time</label>
 			<description>Time it takes for roller shutter to extend the full length (in seconds). Defaults to Up Time if not
-				specfied.</description>
+				specified.</description>
 		</parameter>
 		<parameter name="precision" type="integer">
 			<label>Precision</label>
-			<description>Minimum movement that can be requested. If the requested change is less than this amount, no action will
-				be taken. This may be required for systems where there is a lag in the stop command and consequently it is not
+			<description>Minimum movement (in percent) that can be requested. If the requested change is less than this amount,
+				no action will
+				be taken. This may be required for systems where there is a lag in the stop command and consequently
+				it is not
 				possible for fine control of movement. (default = 1)</description>
 			<default>1</default>
 		</parameter>

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
@@ -18,11 +18,10 @@
 		<parameter name="precision" type="integer">
 			<label>Precision</label>
 			<description>Minimum movement (in percent) that can be requested. If the requested change is less than this amount,
-				no action will
-				be taken. This may be required for systems where there is a lag in the stop command and consequently
-				it is not
-				possible for fine control of movement. (default = 1)</description>
-			<default>1</default>
+				no action will be taken. This may be required for systems where there is a lag in the stop command and
+				consequently
+				it is not possible for fine control of movement. (default = 5)</description>
+			<default>5</default>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:rollershutter:rollershutter-position">
+		<parameter name="uptime" type="decimal" required="true">
+			<label>Up Time</label>
+			<description>Time it takes for roller shutter to fully open (in seconds).</description>
+			<required>true</required>
+		</parameter>
+		<parameter name="downtime" type="decimal">
+			<label>Down Time</label>
+			<description>Time it takes for roller shutter to extend the full length (in seconds). Defaults to Up Time if not
+				specfied.</description>
+		</parameter>
+		<parameter name="precision" type="integer">
+			<label>Precision</label>
+			<description>Minimum movement that can be requested. If the requested change is less than this amount, no action will
+				be taken. This may be required for systems where there is a lag in the stop command and consequently it is not
+				possible for fine control of movement. (default = 1)</description>
+			<default>1</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/i18n/rollershutter.properties
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/i18n/rollershutter.properties
@@ -1,0 +1,6 @@
+profile.config.rollershutter.position.downtime.label = Down Time
+profile.config.rollershutter.position.downtime.description = Time it takes for roller shutter to extend the full length (in seconds). Defaults to Up Time if not specified.
+profile.config.rollershutter.position.precision.label = Precision
+profile.config.rollershutter.position.precision.description = Minimum movement (in percent) that can be requested. If the requested change is less than this amount, no action will be taken. This may be required for systems where there is a lag in the stop command and consequently it is not possible for fine control of movement. (default = 1)
+profile.config.rollershutter.position.uptime.label = Up Time
+profile.config.rollershutter.position.uptime.description = Time it takes for roller shutter to fully open (in seconds).

--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/i18n/rollershutter.properties
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/i18n/rollershutter.properties
@@ -1,6 +1,6 @@
 profile.config.rollershutter.position.downtime.label = Down Time
 profile.config.rollershutter.position.downtime.description = Time it takes for roller shutter to extend the full length (in seconds). Defaults to Up Time if not specified.
 profile.config.rollershutter.position.precision.label = Precision
-profile.config.rollershutter.position.precision.description = Minimum movement (in percent) that can be requested. If the requested change is less than this amount, no action will be taken. This may be required for systems where there is a lag in the stop command and consequently it is not possible for fine control of movement. (default = 1)
+profile.config.rollershutter.position.precision.description = Minimum movement (in percent) that can be requested. If the requested change is less than this amount, no action will be taken. This may be required for systems where there is a lag in the stop command and consequently it is not possible for fine control of movement. (default = 5)
 profile.config.rollershutter.position.uptime.label = Up Time
 profile.config.rollershutter.position.uptime.description = Time it takes for roller shutter to fully open (in seconds).

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -40,6 +40,7 @@
     <module>org.openhab.transform.map</module>
     <module>org.openhab.transform.regex</module>
     <module>org.openhab.transform.scale</module>
+    <module>org.openhab.transform.rollershutterposition</module>
     <module>org.openhab.transform.xpath</module>
     <module>org.openhab.transform.xslt</module>
     <!-- bindings -->

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -39,8 +39,8 @@
     <module>org.openhab.transform.jsonpath</module>
     <module>org.openhab.transform.map</module>
     <module>org.openhab.transform.regex</module>
-    <module>org.openhab.transform.scale</module>
     <module>org.openhab.transform.rollershutterposition</module>
+    <module>org.openhab.transform.scale</module>
     <module>org.openhab.transform.xpath</module>
     <module>org.openhab.transform.xslt</module>
     <!-- bindings -->


### PR DESCRIPTION
# Rollershutter Position emulation

# Description

This transform will emulate setting of absolute position for rollershutters which only support Up/Down/Stop commands.  By specifying the time it takes for the rollershutter to fully extend or close, the transform will estimate the time it will take for the rollershutter to move to an absolute position.