### PR TITLE
[miio] Qingping Air Monitor (cgllc.airmonitor.s1) support is broken

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/resources/database/cgllc.airmonitor.s1.json
+++ b/bundles/org.openhab.binding.miio/src/main/resources/database/cgllc.airmonitor.s1.json
@@ -13,6 +13,7 @@
 				"channelType": "system:battery-level",
 				"type": "Number",
 				"refresh": true,
+				"customRefreshCommand": "get_value[\"battery\"]",
 				"ChannelGroup": "Status",
 				"actions": []
 			},

--- a/bundles/org.openhab.binding.miio/src/main/resources/database/cgllc.airmonitor.s1.json
+++ b/bundles/org.openhab.binding.miio/src/main/resources/database/cgllc.airmonitor.s1.json
@@ -15,7 +15,8 @@
 				"refresh": true,
 				"customRefreshCommand": "get_value[\"battery\"]",
 				"ChannelGroup": "Status",
-				"actions": []
+				"actions": [],
+				"readmeComment": "The device with firmware \"4.1.8_9999\" stops recognizing parameter \"battery\" in \"get_value\" command. The \"battery\" value request was extracted to separate command in order to keep backward compatibility to the devices with older firmware."
 			},
 			{
 				"property": "pm25",


### PR DESCRIPTION
[miio] Qingping Air Monitor (cgllc.airmonitor.s1) support is broken #13258

1.  Custom refresh command for "battery" was defined . The device with "4.1.8_9999" firmware version does not allowed to obtain this information by this way which prevents to obtain other values. The solution should work for both old firmware (the battery information would be requested as before) and it does not prevent the device with new firmware from sending other values (I checked it).

fix #13258 