### PR TITLE
[automower] Adapt login due to Husqvarna API change

### DIFF
--- a/bundles/org.openhab.binding.automower/README.md
+++ b/bundles/org.openhab.binding.automower/README.md
@@ -21,8 +21,7 @@ Once the bridge is created and configured, OpenHab will automatically discover a
 `bridge:`
 
 - appKey (mandatory): The Application Key is required to communicate with the Automower Connect API. It can be obtained by registering an Application on [the Husqvarna Website](https://developer.husqvarnagroup.cloud/). This application also needs to be connected to the ["Authentication API" and the "Automower Connect API"](https://developer.husqvarnagroup.cloud/docs/getting-started)
-- userName (mandatory): The user name for which the application key has been issued
-- password (mandatory): The password for the given user
+- appSecret (mandatory): The Application Secret is required to communicate with the Automower Connect API. It can be obtained by registering an Application on [the Husqvarna Website](https://developer.husqvarnagroup.cloud/).
 - pollingInterval (optional): How often the bridge state should be queried in seconds. Default is 1h (3600s)
 
 Keep in mind that the status of the bridge should not be queried too often.

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridge.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridge.java
@@ -40,17 +40,13 @@ import org.openhab.core.auth.client.oauth2.OAuthResponseException;
 public class AutomowerBridge {
     private final OAuthClientService authService;
     private final String appKey;
-    private final String userName;
-    private final String password;
 
     private final AutomowerConnectApi automowerApi;
 
-    public AutomowerBridge(OAuthClientService authService, String appKey, String userName, String password,
-            HttpClient httpClient, ScheduledExecutorService scheduler) {
+    public AutomowerBridge(OAuthClientService authService, String appKey, HttpClient httpClient,
+            ScheduledExecutorService scheduler) {
         this.authService = authService;
         this.appKey = appKey;
-        this.userName = userName;
-        this.password = password;
 
         this.automowerApi = new AutomowerConnectApi(httpClient);
     }
@@ -59,7 +55,7 @@ public class AutomowerBridge {
         try {
             AccessTokenResponse result = authService.getAccessTokenResponse();
             if (result == null) {
-                result = authService.getAccessTokenByResourceOwnerPasswordCredentials(userName, password, null);
+                result = authService.getAccessTokenByClientCredentials(null);
             }
             return result;
         } catch (OAuthException | IOException | OAuthResponseException e) {

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridgeConfiguration.java
@@ -23,8 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public final class AutomowerBridgeConfiguration {
     private @Nullable String appKey;
-    private @Nullable String userName;
-    private @Nullable String password;
+    private @Nullable String appSecret;
 
     private @Nullable Integer pollingInterval;
 
@@ -47,19 +46,11 @@ public final class AutomowerBridgeConfiguration {
         this.appKey = appKey;
     }
 
-    public @Nullable String getUserName() {
-        return userName;
+    public @Nullable String getAppSecret() {
+        return appSecret;
     }
 
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
-    public @Nullable String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
+    public void setAppSecret(String appSecret) {
+        this.appSecret = appSecret;
     }
 }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridgeHandler.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridgeHandler.java
@@ -93,26 +93,22 @@ public class AutomowerBridgeHandler extends BaseBridgeHandler {
         AutomowerBridgeConfiguration bridgeConfiguration = getConfigAs(AutomowerBridgeConfiguration.class);
 
         final String appKey = bridgeConfiguration.getAppKey();
-        final String userName = bridgeConfiguration.getUserName();
-        final String password = bridgeConfiguration.getPassword();
+        final String appSecret = bridgeConfiguration.getAppSecret();
         final Integer pollingIntervalS = bridgeConfiguration.getPollingInterval();
 
         if (appKey == null || appKey.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "@text/conf-error-no-app-key");
-        } else if (userName == null || userName.isEmpty()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "@text/conf-error-no-username");
-        } else if (password == null || password.isEmpty()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "@text/conf-error-no-password");
+        } else if (appSecret == null || appSecret.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "@text/conf-error-no-app-secret");
         } else if (pollingIntervalS != null && pollingIntervalS < 1) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/conf-error-invalid-polling-interval");
         } else {
             oAuthService = oAuthFactory.createOAuthClientService(thing.getUID().getAsString(), HUSQVARNA_API_TOKEN_URL,
-                    null, appKey, null, null, null);
+                    null, appKey, appSecret, null, null);
 
             if (bridge == null) {
-                AutomowerBridge currentBridge = new AutomowerBridge(oAuthService, appKey, userName, password,
-                        httpClient, scheduler);
+                AutomowerBridge currentBridge = new AutomowerBridge(oAuthService, appKey, httpClient, scheduler);
                 bridge = currentBridge;
                 startAutomowerBridgePolling(currentBridge, pollingIntervalS);
             }

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower.properties
@@ -19,11 +19,10 @@ thing-type.config.automower.automower.pollingInterval.label = Polling Interval
 thing-type.config.automower.automower.pollingInterval.description = How often the current automower state should be polled in seconds
 thing-type.config.automower.bridge.appKey.label = Application Key
 thing-type.config.automower.bridge.appKey.description = The Application Key is required to communication with the Automower Connect Api at https://developer.husqvarnagroup.cloud/. It can be obtained by registering an Application on the Husqvarna Website. This application also needs to be connected to the "Authentication API" and the "Automower Connect API"
-thing-type.config.automower.bridge.password.description = The password for the given user
+thing-type.config.automower.bridge.appSecret.label = Application Secret
+thing-type.config.automower.bridge.appSecret.description = The Application Secret is required to communication with the Automower Connect Api at https://developer.husqvarnagroup.cloud/. It can be obtained by registering an Application on the Husqvarna Website.
 thing-type.config.automower.bridge.pollingInterval.label = Polling Interval
 thing-type.config.automower.bridge.pollingInterval.description = How often the available automowers should be queried in seconds
-thing-type.config.automower.bridge.userName.label = User Name
-thing-type.config.automower.bridge.userName.description = The user name for which the application key has been issued
 
 # channel types
 
@@ -118,8 +117,7 @@ comm-error-query-mower-failed = Unable to query the automower status
 comm-error-send-mower-command-failed = Unable to send automower command
 comm-error-mower-not-connected-to-cloud = Automower not connected to the cloud
 conf-error-no-app-key = Cannot connect to Automower bridge as no app key is available in the configuration
-conf-error-no-username = Cannot connect to Automower bridge as no username is available in the configuration
-conf-error-no-password = Cannot connect to Automower bridge as no password is available in the configuration
+conf-error-no-app-secret = Cannot connect to Automower bridge as no app secret is available in the configuration
 conf-error-invalid-polling-interval = Invalid polling interval specified. The polling interval has to be >= 1
 conf-error-no-mower-id = No Automower ID specified. Unable to communicate with the mower without an ID
 conf-error-no-bridge = No valid bridge for the automower is available

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower.properties
@@ -18,9 +18,9 @@ thing-type.config.automower.automower.mowerId.description = The Id of an automow
 thing-type.config.automower.automower.pollingInterval.label = Polling Interval
 thing-type.config.automower.automower.pollingInterval.description = How often the current automower state should be polled in seconds
 thing-type.config.automower.bridge.appKey.label = Application Key
-thing-type.config.automower.bridge.appKey.description = The Application Key is required to communication with the Automower Connect Api at https://developer.husqvarnagroup.cloud/. It can be obtained by registering an Application on the Husqvarna Website. This application also needs to be connected to the "Authentication API" and the "Automower Connect API"
+thing-type.config.automower.bridge.appKey.description = The Application Key is required to communicate with the Automower Connect API at https://developer.husqvarnagroup.cloud/. It can be obtained by registering an Application on the Husqvarna Website. This application also needs to be connected to the "Authentication API" and the "Automower Connect API"
 thing-type.config.automower.bridge.appSecret.label = Application Secret
-thing-type.config.automower.bridge.appSecret.description = The Application Secret is required to communication with the Automower Connect Api at https://developer.husqvarnagroup.cloud/. It can be obtained by registering an Application on the Husqvarna Website.
+thing-type.config.automower.bridge.appSecret.description = The Application Secret is required to communicate with the Automower Connect API at https://developer.husqvarnagroup.cloud/. It can be obtained by registering an Application on the Husqvarna Website.
 thing-type.config.automower.bridge.pollingInterval.label = Polling Interval
 thing-type.config.automower.bridge.pollingInterval.description = How often the available automowers should be queried in seconds
 

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower_de.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower_de.properties
@@ -7,12 +7,6 @@ thing-type.automower.bridge.description = Erlaubt die Kommunikation mit der Husq
 thing-type.config.automower.bridge.appKey.label = Application Key
 thing-type.config.automower.bridge.appKey.description = Der Application Key wird für die Kommunication mit der Automower Connect API benötigt. Um diesen zu erhalten muss eine Anwendung auf der Husqvarna Website registriert werden. Diese Anwendung muss mit der "Authentication API" und der "Automower Connect API" verknüpft werden.
 
-thing-type.config.automower.bridge.userName.label = Benutzername
-thing-type.config.automower.bridge.userName.description = Der Benutzername für den der Application Key ausgestellt wurde.
-
-thing-type.config.automower.bridge.password.label = Passwort
-thing-type.config.automower.bridge.password.description = Das Passwort für den angegebenen Benutzer.
-
 thing-type.config.automower.bridge.pollingInterval.label = Polling Intervall
 thing-type.config.automower.bridge.pollingInterval.description = Das Intervall in dem die Verbindung mit dem Automower Connect API überprüft werden soll. Der Standardwert ist 3600s (1h)
 

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower_fr.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower_fr.properties
@@ -31,8 +31,6 @@ channel-type.automower.calendar-tasks.label = Les informations du planning au fo
 channel-type.automower.calendar-tasks.description = Les informations du planning au format JSON
 
 conf-error-no-app-key = Impossible de se connecter à la passerelle Automower car aucune clé d'application n'est définie dans la configuration
-conf-error-no-username = Impossible de se connecter à la passerelle Automower car il n'y a aucun nom d'utilisateur défini dans la configuration
-conf-error-no-password = Impossible de se connecter à la passerelle Automower car il n'y a aucun mot de passe défini dans la configuration
 conf-error-invalid-polling-interval = Définition invalide de l'intervalle d'interrogation. Il doit être >\= 1
 
 conf-error-no-mower-id = Aucun identifiant de robot tondeuse spécifié. Impossible de communiquer avec la tondeuse sans ID

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower_hu.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/i18n/automower_hu.properties
@@ -31,8 +31,6 @@ channel-type.automower.calendar-tasks.label = A tervező információi JSON form
 channel-type.automower.calendar-tasks.description = A tervező információi JSON formátumban
 
 conf-error-no-app-key = Nem tudok a robotfűnyíró hídhoz kapcsolódni, mivel nincs alkalmazás kulcs megadva a beállításokban
-conf-error-no-username = Nem tudok a robotfűnyíró hídhoz kapcsolódni, mivel nincs felhasználó megadva a beállításokban
-conf-error-no-password = Nem tudok a robotfűnyíró hídhoz kapcsolódni, mivel nincs jelszó megadva a beállításokban
 conf-error-invalid-polling-interval = Érvénytelen lekérdezési időköz lett megadva. A lekérdezési időköz >\= 1 kell legyen
 
 conf-error-no-mower-id = Nincs megadva robotfűnyíró azonosító. Nem tudok a fűnyíróval kommunikálni azonosító nélkül

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -12,7 +12,7 @@
 		<config-description>
 			<parameter name="appKey" type="text" required="true">
 				<label>Application Key</label>
-				<description>The Application Key is required to communication with the Automower Connect Api at
+				<description>The Application Key is required to communicate with the Automower Connect API at
 					https://developer.husqvarnagroup.cloud/. It can be obtained by
 					registering an Application on the Husqvarna Website.
 					This application also needs to be connected to the
@@ -20,7 +20,7 @@
 			</parameter>
 			<parameter name="appSecret" type="text" required="true">
 				<label>Application Secret</label>
-				<description>The Application Secret is required to communication with the Automower Connect Api at
+				<description>The Application Secret is required to communicate with the Automower Connect API at
 					https://developer.husqvarnagroup.cloud/. It can be obtained by
 					registering an Application on the Husqvarna Website.</description>
 			</parameter>

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -18,13 +18,11 @@
 					This application also needs to be connected to the
 					"Authentication API" and the "Automower Connect API"</description>
 			</parameter>
-			<parameter name="userName" type="text" required="true">
-				<label>User Name</label>
-				<description>The user name for which the application key has been issued</description>
-			</parameter>
-			<parameter name="password" type="text" required="true">
-				<context>password</context>
-				<description>The password for the given user</description>
+			<parameter name="appSecret" type="text" required="true">
+				<label>Application Secret</label>
+				<description>The Application Secret is required to communication with the Automower Connect Api at
+					https://developer.husqvarnagroup.cloud/. It can be obtained by
+					registering an Application on the Husqvarna Website.</description>
 			</parameter>
 			<parameter name="pollingInterval" type="integer" required="false" unit="s">
 				<label>Polling Interval</label>


### PR DESCRIPTION
The Automower Connect API Authentication does not work anymore as they moved to a new authentication method (AppKey and AppSecret) - adopted. 

Fix #12980

Signed-off-by: Boris Krivonog [boris.krivonog@inova.si](mailto:boris.krivonog@inova.si)