### PR TITLE
[velux] Vane position channel is visible when required

### DIFF
--- a/bundles/org.openhab.binding.velux/README.md
+++ b/bundles/org.openhab.binding.velux/README.md
@@ -176,11 +176,12 @@ The supported Channels and their associated channel types are shown below.
 | position     | Rollershutter | Actual position of the window or device.        |
 | limitMinimum | Rollershutter | Minimum limit position of the window or device. |
 | limitMaximum | Rollershutter | Maximum limit position of the window or device. |
-| vanePosition | Dimmer        | Vane position of a Venetian blind.              |
+| vanePosition | Dimmer        | Vane position of a Venetian blind. (optional)   |
 
 The `position`, `limitMinimum`, and `limitMaximum` are the same as described above for "window" Things.
 
 The `vanePosition` Channel only applies to Venetian blinds that have tiltable slats.
+The binding detects whether the device supports a vane position, and if so, it adds the `vanePosition` Channel automatically.
 
 ### Channels for "actuator" Things
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBindingConstants.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBindingConstants.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * The {@link VeluxBindingConstants} class defines common constants, which are
@@ -158,8 +157,4 @@ public class VeluxBindingConstants {
 
     public static final String UNKNOWN_THING_TYPE_ID = "FAILED";
     public static final String UNKNOWN_IP_ADDRESS = "xxx.xxx.xxx.xxx";
-
-    // Channel Type UIDs
-    public static final ChannelTypeUID CHANNEL_TYPE_MAIN = new ChannelTypeUID(BINDING_ID, CHANNEL_ACTUATOR_POSITION);
-    public static final ChannelTypeUID CHANNEL_TYPE_VANE = new ChannelTypeUID(BINDING_ID, CHANNEL_VANE_POSITION);
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBindingConstants.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBindingConstants.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * The {@link VeluxBindingConstants} class defines common constants, which are
@@ -157,4 +158,8 @@ public class VeluxBindingConstants {
 
     public static final String UNKNOWN_THING_TYPE_ID = "FAILED";
     public static final String UNKNOWN_IP_ADDRESS = "xxx.xxx.xxx.xxx";
+
+    // Channel Type UIDs
+    public static final ChannelTypeUID CHANNEL_TYPE_MAIN = new ChannelTypeUID(BINDING_ID, CHANNEL_ACTUATOR_POSITION);
+    public static final ChannelTypeUID CHANNEL_TYPE_VANE = new ChannelTypeUID(BINDING_ID, CHANNEL_VANE_POSITION);
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -466,7 +466,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
             }
         }
 
-        initializeVanePositionChannels();
+        updateDynamicChannels();
 
         veluxBridgeConfiguration.hasChanged = false;
         logger.debug("Velux veluxBridge is online, now.");
@@ -964,11 +964,11 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
     /**
      * Ask all things in the hub to initialise their dynamic vane position channel if they support it.
      */
-    private void initializeVanePositionChannels() {
+    private void updateDynamicChannels() {
         getThing().getThings().stream().forEach(thing -> {
             ThingHandler thingHandler = thing.getHandler();
             if (thingHandler instanceof VeluxHandler) {
-                ((VeluxHandler) thingHandler).initializeVanePositionChannel(this);
+                ((VeluxHandler) thingHandler).updateDynamicChannels(this);
             }
         });
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -1004,8 +1004,6 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         final boolean vaneChannelExisting = channels.stream().anyMatch(vaneChannelFilter);
         final boolean vaneChannelRequired = product.supportsVanePosition();
 
-        logger.warn("channelExisting:{} channelRequired:{}", vaneChannelExisting, vaneChannelRequired);
-
         if (vaneChannelExisting == vaneChannelRequired) {
             // no change needed
             return;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -1002,7 +1002,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
 
         // current and required state of the vane channel
         final boolean vaneChannelExisting = channels.stream().anyMatch(vaneChannelFilter);
-        final boolean vaneChannelRequired = !product.supportsVanePosition();
+        final boolean vaneChannelRequired = product.supportsVanePosition();
 
         logger.warn("channelExisting:{} channelRequired:{}", vaneChannelExisting, vaneChannelRequired);
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -1021,8 +1021,8 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
 
         if (vaneChannelRequired) {
             // build the vane channel
-            Channel newChannel = ChannelBuilder.create(vaneChannelUID).withAcceptedItemType(CoreItemFactory.DIMMER)
-                    .withKind(ChannelKind.STATE)
+            Channel newChannel = ChannelBuilder.create(vaneChannelUID).withType(VeluxBindingConstants.CHANNEL_TYPE_VANE)
+                    .withKind(ChannelKind.STATE).withAcceptedItemType(CoreItemFactory.DIMMER)
                     .withDescription(localization.getText("channel-type.velux.vanePosition.description"))
                     .withLabel(localization.getText("channel-type.velux.vanePosition.label")).build();
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -1044,8 +1044,6 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
          * that it uses the newly modified channel list instead of the original one.
          */
         final Thing newThing = veluxHandler.editThing().withChannels(channels).build();
-        scheduler.submit(() -> {
-            veluxHandler.updateThing(newThing);
-        });
+        scheduler.submit(() -> veluxHandler.updateThing(newThing));
     }
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -989,7 +989,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         final VeluxProduct product = existingProducts()
                 .get((new Thing2VeluxActuator(this, vaneChannelUID)).getProductBridgeIndex());
         if (product.equals(VeluxProduct.UNKNOWN)) {
-            // product unknown");
+            // product unknown
             return;
         }
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.velux.internal.handler;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -23,7 +21,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -64,21 +61,16 @@ import org.openhab.binding.velux.internal.things.VeluxProductPosition.PositionTy
 import org.openhab.binding.velux.internal.utils.Localization;
 import org.openhab.core.common.AbstractUID;
 import org.openhab.core.common.NamedThreadFactory;
-import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.Bridge;
-import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
-import org.openhab.core.thing.binding.builder.ChannelBuilder;
-import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
@@ -970,80 +962,14 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
     }
 
     /**
-     * Iterate over all roller shutter type things in the hub, and initialise the dynamic vane position channel if the
-     * respective device supports it.
+     * Ask all things in the hub to initialise their dynamic vane position channel if they support it.
      */
     private void initializeVanePositionChannels() {
-        getThing().getThings().stream()
-                .filter(thing -> VeluxBindingConstants.THING_TYPE_VELUX_ROLLERSHUTTER.equals(thing.getThingTypeUID()))
-                .forEach(thing -> initializeVanePositionChannel(thing));
-    }
-
-    /**
-     * For the given roller shutter type thing, initialise the dynamic vane position channel if the respective device
-     * supports it.
-     */
-    private void initializeVanePositionChannel(Thing thing) {
-        final ChannelUID vaneChannelUID = new ChannelUID(thing.getUID(), VeluxBindingConstants.CHANNEL_VANE_POSITION);
-
-        final VeluxProduct product = existingProducts()
-                .get((new Thing2VeluxActuator(this, vaneChannelUID)).getProductBridgeIndex());
-        if (product.equals(VeluxProduct.UNKNOWN)) {
-            // product unknown
-            return;
-        }
-
-        // predicate to filter the vane position channel
-        final Predicate<Channel> vaneChannelFilter = c -> VeluxBindingConstants.CHANNEL_TYPE_VANE
-                .equals(c.getChannelTypeUID());
-
-        // note: this is an immutable list
-        List<Channel> channels = thing.getChannels();
-
-        // current and required state of the vane channel
-        final boolean vaneChannelExisting = channels.stream().anyMatch(vaneChannelFilter);
-        final boolean vaneChannelRequired = product.supportsVanePosition();
-
-        if (vaneChannelExisting == vaneChannelRequired) {
-            // no change needed
-            return;
-        }
-
-        ThingHandler handler = thing.getHandler();
-        if (!(handler instanceof VeluxHandler)) {
-            // handler is of the wrong wrong type
-            return;
-        }
-        VeluxHandler veluxHandler = (VeluxHandler) handler;
-
-        // make a mutable copy of the original immutable channel list
-        channels = new ArrayList<>(channels);
-
-        if (vaneChannelRequired) {
-            // build the vane channel
-            Channel newChannel = ChannelBuilder.create(vaneChannelUID).withType(VeluxBindingConstants.CHANNEL_TYPE_VANE)
-                    .withKind(ChannelKind.STATE).withAcceptedItemType(CoreItemFactory.DIMMER)
-                    .withDescription(localization.getText("channel-type.velux.vanePosition.description"))
-                    .withLabel(localization.getText("channel-type.velux.vanePosition.label")).build();
-
-            // add the vane channel
-            if (!channels.add(newChannel)) {
-                // failed to add vane channel
-                return;
+        getThing().getThings().stream().forEach(thing -> {
+            ThingHandler thingHandler = thing.getHandler();
+            if (thingHandler instanceof VeluxHandler) {
+                ((VeluxHandler) thingHandler).initializeVanePositionChannel(this);
             }
-        } else {
-            // remove the vane channel
-            if (!channels.removeIf(vaneChannelFilter)) {
-                // failed to remove vane channel
-                return;
-            }
-        }
-
-        /*
-         * If we got this far then we will update the thing by building an identical copy of the target thing, except
-         * that it uses the newly modified channel list instead of the original one.
-         */
-        final Thing newThing = veluxHandler.editThing().withChannels(channels).build();
-        scheduler.submit(() -> veluxHandler.updateThing(newThing));
+        });
     }
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxHandler.java
@@ -26,6 +26,7 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BridgeHandler;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -124,5 +125,21 @@ public class VeluxHandler extends ExtendedBaseThingHandler {
         } else {
             super.handleConfigurationUpdate(configurationParameters);
         }
+    }
+
+    /**
+     * Set public visibility on the protected super.editThing() method.
+     */
+    @Override
+    public ThingBuilder editThing() {
+        return super.editThing();
+    }
+
+    /**
+     * Set public visibility on the protected super.updateThing() method.
+     */
+    @Override
+    public void updateThing(Thing thing) {
+        super.updateThing(thing);
     }
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxHandler.java
@@ -17,7 +17,6 @@ import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velux.internal.VeluxBindingConstants;
-import org.openhab.binding.velux.internal.config.VeluxThingConfiguration;
 import org.openhab.binding.velux.internal.handler.utils.ExtendedBaseThingHandler;
 import org.openhab.binding.velux.internal.handler.utils.Thing2VeluxActuator;
 import org.openhab.binding.velux.internal.things.VeluxProduct;
@@ -44,8 +43,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class VeluxHandler extends ExtendedBaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(VeluxHandler.class);
-
-    private VeluxThingConfiguration configuration = new VeluxThingConfiguration();
 
     public VeluxHandler(Thing thing, Localization localization) {
         super(thing);
@@ -74,7 +71,6 @@ public class VeluxHandler extends ExtendedBaseThingHandler {
     }
 
     private synchronized void initializeProperties() {
-        configuration = getConfigAs(VeluxThingConfiguration.class);
         logger.trace("initializeProperties() done.");
     }
 
@@ -149,7 +145,7 @@ public class VeluxHandler extends ExtendedBaseThingHandler {
         VeluxProduct product = bridgeHandler.existingProducts().get(actuator.getProductBridgeIndex());
 
         if (product.equals(VeluxProduct.UNKNOWN)) {
-            throw new IllegalStateException("initializeVanePositionChannel(): Product unknown in the bridge");
+            throw new IllegalStateException("updateDynamicChannels(): Product unknown in the bridge");
         }
 
         Channel channel = thing.getChannel(id);
@@ -157,9 +153,9 @@ public class VeluxHandler extends ExtendedBaseThingHandler {
 
         if (!required && channel != null) {
             logger.debug("Removing unsupported channel for {}: {}", thing.getUID(), id);
-            scheduler.submit(() -> updateThing(editThing().withoutChannels(channel).build()));
+            updateThing(editThing().withoutChannels(channel).build());
         } else if (required && channel == null) {
-            logger.warn("Thing {} does not have a '{}' channel => please reinitialize it", thing.getUID(), id);
+            logger.warn("Thing {} does not have a '{}' channel => please re-create it", thing.getUID(), id);
         }
     }
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxHandler.java
@@ -144,7 +144,7 @@ public class VeluxHandler extends ExtendedBaseThingHandler {
      * @param bridgeHandler the calling bridge handler.
      * @throws IllegalStateException if something went wrong.
      */
-    public void initializeVanePositionChannel(VeluxBridgeHandler bridgeHandler) throws IllegalStateException {
+    public void updateDynamicChannels(VeluxBridgeHandler bridgeHandler) throws IllegalStateException {
         // roller shutters are the only things allowed to have vane support
         if (!VeluxBindingConstants.THING_TYPE_VELUX_ROLLERSHUTTER.equals(thing.getThingTypeUID())) {
             return;

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/i18n/velux.properties
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/i18n/velux.properties
@@ -133,6 +133,8 @@ channel-type.velux.scenes.description = Scenes which are configured on the Bridg
 channel-type.velux.check.label = Check of configuration
 channel-type.velux.check.description = Result of the check of current item configuration.
 #
+channel-type.velux.windowPosition.label = Position
+channel-type.velux.windowPosition.description = Device control (UP, DOWN, STOP, closure 0-100%).
 channel-type.velux.position.label = Position
 channel-type.velux.position.description = Device control (UP, DOWN, STOP, closure 0-100%).
 channel-type.velux.vanePosition.label = Vane Position

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/channels.xml
@@ -132,6 +132,13 @@
 
 	<!-- Channel Type - Generic Things -->
 
+	<channel-type id="windowPosition">
+		<item-type>Rollershutter</item-type>
+		<label>@text/channel-type.velux.windowPosition.label</label>
+		<description>@text/channel-type.velux.windowPosition.description</description>
+		<category>Window</category>
+	</channel-type>
+
 	<channel-type id="position">
 		<item-type>Rollershutter</item-type>
 		<label>@text/channel-type.velux.position.label</label>

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/channels.xml
@@ -150,7 +150,6 @@
 		<item-type>Dimmer</item-type>
 		<label>@text/channel-type.velux.vanePosition.label</label>
 		<description>@text/channel-type.velux.vanePosition.description</description>
-		<category>Blinds</category>
 		<state min="0" max="100"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/channels.xml
@@ -137,6 +137,7 @@
 		<label>@text/channel-type.velux.windowPosition.label</label>
 		<description>@text/channel-type.velux.windowPosition.description</description>
 		<category>Window</category>
+		<state min="0" max="100"/>
 	</channel-type>
 
 	<channel-type id="position">
@@ -144,6 +145,7 @@
 		<label>@text/channel-type.velux.position.label</label>
 		<description>@text/channel-type.velux.position.description</description>
 		<category>Blinds</category>
+		<state min="0" max="100"/>
 	</channel-type>
 
 	<channel-type id="vanePosition">
@@ -164,14 +166,14 @@
 		<item-type>Rollershutter</item-type>
 		<label>@text/channel-type.velux.limitMinimum.label</label>
 		<description>@text/channel-type.velux.limitMinimum.description</description>
-		<category>Blinds</category>
+		<state min="0" max="100"/>
 	</channel-type>
 
 	<channel-type id="limitMaximum" advanced="true">
 		<item-type>Rollershutter</item-type>
 		<label>@text/channel-type.velux.limitMaximum.label</label>
 		<description>@text/channel-type.velux.limitMaximum.description</description>
-		<category>Blinds</category>
+		<state min="0" max="100"/>
 	</channel-type>
 
 	<channel-type id="action">

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
@@ -17,6 +17,7 @@
 		<category>Blinds</category>
 		<channels>
 			<channel id="position" typeId="position"/>
+			<channel id="vanePosition" typeId="vanePosition"/>
 			<channel id="limitMinimum" typeId="limitMinimum"/>
 			<channel id="limitMaximum" typeId="limitMaximum"/>
 		</channels>

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
@@ -19,7 +19,6 @@
 			<channel id="position" typeId="position"/>
 			<channel id="limitMinimum" typeId="limitMinimum"/>
 			<channel id="limitMaximum" typeId="limitMaximum"/>
-			<channel id="vanePosition" typeId="vanePosition"/>
 		</channels>
 		<representation-property>serial</representation-property>
 		<config-description-ref uri="thing-type:velux:rollershutter"/>

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
@@ -8,7 +8,7 @@
 	<!-- -->
 	<!-- Velux rollershutter Binding -->
 	<!-- -->
-	<thing-type id="rollershutter">
+	<thing-type id="rollershutter" extensible="position, limitMinimum, limitMaximum, vanePosition">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="klf200"/>
 		</supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/rollershutter.xml
@@ -8,7 +8,7 @@
 	<!-- -->
 	<!-- Velux rollershutter Binding -->
 	<!-- -->
-	<thing-type id="rollershutter" extensible="position, limitMinimum, limitMaximum, vanePosition">
+	<thing-type id="rollershutter">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="klf200"/>
 		</supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/window.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/thing/window.xml
@@ -16,7 +16,7 @@
 		<description>@text/thing-type.velux.window.description</description>
 		<category>Window</category>
 		<channels>
-			<channel id="position" typeId="position"></channel>
+			<channel id="position" typeId="windowPosition"></channel>
 			<channel id="limitMinimum" typeId="limitMinimum"/>
 			<channel id="limitMaximum" typeId="limitMaximum"/>
 		</channels>


### PR DESCRIPTION
### Background

In #12618 we added support for a vane position channel on venetian style blinds. And in that PR the respective `vanePosition` channel was created statically for ALL types of shutters and blinds regardless of whether the actual shutter/blind does physically support vanes. This could be confusing for users who have shutters / blinds that do not support vanes.

### Solution

In this PR the binding queries each shutter/blind in the hub, and if that device actually supports vanes, then the binding will create a `vanePosition` channel dynamically.

Resolves #13260

### Acknowledgments

PS many thanks to @pacive, @splatch, @lolodomo and @jlaur for support via the community forum..

https://community.openhab.org/t/dynamically-created-channel-not-showing-up-in-main-ui/138150

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>