### PR TITLE
[automower] Refresh token if it's expired

### DIFF
--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridge.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/bridge/AutomowerBridge.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.automower.internal.bridge;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -54,7 +55,7 @@ public class AutomowerBridge {
     private AccessTokenResponse authenticate() throws AutomowerCommunicationException {
         try {
             AccessTokenResponse result = authService.getAccessTokenResponse();
-            if (result == null) {
+            if (result == null || result.isExpired(LocalDateTime.now(), 120)) {
                 result = authService.getAccessTokenByClientCredentials(null);
             }
             return result;


### PR DESCRIPTION
Automower binding stops updating after ~24h because access token expires after 86399s and token was not checked for expiration.

Signed-off-by: Boris Krivonog boris.krivonog@inova.si
