### PR TITLE
[transformation.jinja] Update jinjava to 2.6.0 from 2.5.7

### DIFF
--- a/bundles/org.openhab.transform.jinja/pom.xml
+++ b/bundles/org.openhab.transform.jinja/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
-      <version>2.5.7</version>
+      <version>2.6.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updated jinjava library used by jinja transformation to 2.6.0 version (released 2021-10), from 2.5.7 (released 2021-04)


Changes compared to 2.5.7 version, from https://github.com/HubSpot/jinjava/releases

```
2021-10-29 Version 2.6.0 ([Maven Central](https://search.maven.org/artifact/com.hubspot.jinjava/jinjava/2.6.0/jar))
Create interface for object truth values
Catch concurrent modification in for loop
Add Originating Exception Message For A TemplateSyntaxException
Throw a template error when attempting to divide by zero
Make unixtimestamp behave the same as System.currentTimeMillis()
handle null argument in range function
Track Current Processed Node In The Context
Add Base 64 encode and decode filters

2021-09-03 Version 2.5.10 ([Maven Central](https://search.maven.org/artifact/com.hubspot.jinjava/jinjava/2.5.10/jar))
Make LazyExpression memoization disable-able
Add new MapELResolver with type coercion to support accessing enum keys
Add methods to remove error from interpreter,
get the last error,
and remove the last error
Pass value of throwInterpreterErrors to child contexts
Support Assignment Blocks with Set tags
Handle spaces better in for loop expressions
Support "not in"
Set propertyResolved after evaluating the AbstractCallableMethod
Limit infinite evaluation from recursive extends tags
Fix striptags to clean HTML instead of parsing
Various PRs for eager execution to support two-phase rendering.

2021-05-20 Version 2.5.8 ([Maven Central]Various PRs for eager execution to support two-phase rendering.
Add rangeLimit to JinjavaConfig
Add namespace functionality
Fix capitalize and title filters
```

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unuseable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
