### PR TITLE
[arcam] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,7 @@
 /bundles/org.openhab.binding.amplipi/ @kaikreuzer
 /bundles/org.openhab.binding.androiddebugbridge/ @GiviMAD
 /bundles/org.openhab.binding.anel/ @paphko
+/bundles/org.openhab.binding.arcam/ @joepadmiraal
 /bundles/org.openhab.binding.astro/ @gerrieg
 /bundles/org.openhab.binding.atlona/ @tmrobert8
 /bundles/org.openhab.binding.autelis/ @digitaldan

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -113,6 +113,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.arcam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.astro</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.arcam/NOTICE
+++ b/bundles/org.openhab.binding.arcam/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.arcam/README.md
+++ b/bundles/org.openhab.binding.arcam/README.md
@@ -15,8 +15,8 @@ This binding supports the following models:
 | AVR30               | AVR30          | No     |
 | AVR40               | AVR40          | No     |
 | SA10                | SA10           | No     |
-| SA20                | SA20           | Yes    |
-| SA30                | SA30           | No     |
+| SA20                | SA20           | No     |
+| SA30                | SA30           | Yes    |
 
 Each device seems to have different options and the protocol differs between each series.
 Which is why not all Arcam models are supported yet.

--- a/bundles/org.openhab.binding.arcam/README.md
+++ b/bundles/org.openhab.binding.arcam/README.md
@@ -1,0 +1,119 @@
+# Arcam Binding
+
+This binding add support for [Arcam](https://www.arcam.co.uk/) audio products.
+These products have their own protocol on top of TCP which is what this binding uses to communicate.
+
+## Supported Things
+
+This binding supports the following models:
+
+| Model               | ThingTypeUID   | Tested | 
+|---------------------|----------------|--------|
+| AVR5                | AVR5           | No     |
+| AVR10               | AVR10          | No     |
+| AVR20               | AVR20          | No     |
+| AVR30               | AVR30          | No     |
+| AVR40               | AVR40          | No     |
+| SA10                | SA10           | No     |
+| SA20                | SA20           | Yes    |
+| SA30                | SA30           | No     |
+
+Each device seems to have different options and the protocol differs between each series.
+Which is why not all Arcam models are supported yet.
+If you own an Arcam device you can help out by validating whether this binding works correctly with your device.
+You can get in touch via the OpenHAB forum by either sending a direct message or start a post and mention me (joepadmiraal).
+Also let me know if you have an Arcam device which is not in the list, I'm happy to add support for more models.
+
+## Discovery
+
+The Arcam devices are discovered through UPnP in the local network and all devices are put in the Inbox.
+
+## Binding Configuration
+
+This binding does not require any configuration.
+
+## Thing Configuration
+
+The most easy way of using this binding is via UPnP discovery.
+This will automatically configure the `hostname` for your device.
+You can manually configure this if you don't want to use the discovery mechanism.
+
+### `sample` Thing Configuration
+
+| Name            | Type    | Description                           | Default | Required |
+|-----------------|---------|---------------------------------------|---------|----------|
+| hostname        | text    | Hostname or IP address of the device  | N/A     | yes      |
+
+## Channels
+
+Dependent on the model that you are using, these channels will be available.
+All generic channels are placed in the masterZone.
+
+| Channel ID                            | Item Type | Access Mode | Description                                                           | Thing types                            |
+|---------------------------------------|-----------|-------------|-----------------------------------------------------------------------|----------------------------------------|
+| masterZone#balance                    | Number    | W           | Get or set the balance, min/max value differs per model               | all                                    |
+| masterZone#dacFilter                  | String    | W           | Get or set the DAC filter, available filters differ per model         | SA10/SA20/SA30                         |
+| masterZone#dcOffset                   | Switch    | R           | Get the output DC offset status                                       | SA10/SA20/SA30                         |
+| masterZone#directMode                 | Switch    | R           | Get the Analogue input direct mode of the current input               | SA20/SA30/AVR5/AVR10/AVR20/AVR30/AVR40 |
+| masterZone#displaybrightness          | String    | W           | Get or set the display brightness                                     | all                                    |
+| masterZone#headphones                 | Switch    | R           | Get whether headphones are connected                                  | all                                    |
+| masterZone#incomingSampleRate         | String    | R           | Get the incoming audio sample rate                                    | all                                    |
+| masterZone#input                      | String    | W           | Get or set the input source, available options differ per model       | all                                    |
+| masterZone#inputDetect                | Switch    | R           | Get the status of the active input                                    | SA10/SA20/SA30                         |
+| masterZone#lifterTemperature          | Number    | R           | Get the temperature of the lifter                                     | SA20/SA30                              |
+| masterZone#mute                       | Switch    | W           | Get or set whether the device should be muted                         | all                                    |
+| masterZone#nowPlayingTitle            | String    | R           | Get the title of the song that is currently playing                   | SA30                                   |
+| masterZone#nowPlayingArtist           | String    | R           | Get the artist of the song that is currently playing                  | SA30                                   |
+| masterZone#masterZone#nowPlayingAlbum | String    | R           | Get the ablum of the song that is currently playing                   | SA30                                   |
+| masterZone#nowPlayingApplication      | String    | R           | Get the GoogleCast source application                                 | SA30                                   |
+| masterZone#nowPlayingSampleRate       | String    | R           | Get the sample rate of the song that is currently playing             | SA30                                   |
+| masterZone#nowPlayingAudioEncoder     | String    | R           | Get the audio encoder of the song that is currently playing           | SA30                                   |
+| masterZone#outputTemperature          | Number    | R           | Get the temperature of the output stage                               | SA10/SA20/SA30                         |
+| masterZone#power                      | Switch    | W           | Get or set the power status of the device or the master zone          | all                                    |
+| masterZone#reboot                     | Switch    | W           | Forces a reboot of the device                                         | all                                    |
+| masterZone#roomEqualisation           | String    | W           | Get or set the room equalisation preset or turn it off                | SA30/AVR5/AVR10/AVR20/AVR30/AVR40      |
+| masterZone#shortCircuit               | Switch    | R           | Get the short circuit status                                          | SA20/SA30                              |
+| masterZone#softwareVersion            | String    | R           | Get the software (firmware) version                                   | all                                    |
+| masterZone#timeoutCounter             | Number    | R           | Get the time left (in minutes) until unit enters auto standby         | SA10/SA20/SA30                         |
+| masterZone#volume                     | Number    | W           | Get or set the volume                                                 | all                                    |
+| zone2#balance                         | Number    | W           | Get or set the balance, min/max value differs per model               | AVR20/AVR30/AVR40                      |
+| zone2#directMode                      | Switch    | R           | Get the Analogue input direct mode of the current input               | AVR20/AVR30/AVR40                      |
+| zone2#input                           | String    | W           | Get or set the input source, available options differ per model       | AVR20/AVR30/AVR40                      |
+| zone2#mute                            | Switch    | W           | Get or set whether the device should be muted                         | AVR20/AVR30/AVR40                      |
+| zone2#power                           | Switch    | W           | Get or set the power status of zone 2                                 | AVR20/AVR30/AVR40                      |
+| zone2#roomEqualisation                | String    | W           | Get or set the room equalisation preset or turn it off                | AVR20/AVR30/AVR40                      |
+| zone2#volume                          | Number    | W           | Get or set the volume                                                 | AVR20/AVR30/AVR40                      |
+
+## Full Example
+
+`.things` file:
+
+```
+Thing arcam:SA30:living [ hostname="192.168.0.10"]
+```
+
+`.items` file:
+
+```
+Dimmer Arcam_Volume       "Volume [%.1f %%]" <soundvolume>      {channel="arcam:SA30:living:sa30MasterZone#volume"}
+Switch Arcam_Mute         "Mute"             <soundvolume_mute> {channel="arcam:SA30:living:sa30MasterZone#mute"}
+String Arcam_Input        "Input"            <mediacontrol>     {channel="arcam:SA30:living:sa30MasterZone#input"}
+```
+
+`.sitemap` file:
+
+```
+Frame label="Arcam" {
+    Default item=Arcam_Volume
+    Default item=Arcam_Mute
+    Default item=Arcam_Input
+}
+```
+
+## Development 
+
+When adding a new Arcam device you need to do the following.
+
+- Add the device to ArcamDeviceUtil.java and ArcamBindingConstants.java
+- Create an Arcam<model>.java and Arcam<model>ChannelTypeProvider.java vile
+- Create an <model>.xml file in the resources directory

--- a/bundles/org.openhab.binding.arcam/README.md
+++ b/bundles/org.openhab.binding.arcam/README.md
@@ -38,11 +38,17 @@ The most easy way of using this binding is via UPnP discovery.
 This will automatically configure the `hostname` for your device.
 You can manually configure this if you don't want to use the discovery mechanism.
 
+In theory the Arcam devices support pushing data to the binding whenever the values change.
+However during testing I found that this often does not happen.
+In order to work around this you can enable polling by setting the polling interval.
+A good starting value for this setting is 5 seconds.
+
 ### `sample` Thing Configuration
 
-| Name            | Type    | Description                           | Default | Required |
-|-----------------|---------|---------------------------------------|---------|----------|
-| hostname        | text    | Hostname or IP address of the device  | N/A     | yes      |
+| Name             | Type    | Description                           | Default | Required |
+|------------------|---------|---------------------------------------|---------|----------|
+| hostname         | text    | Hostname or IP address of the device  | N/A     | yes      |
+| Polling interval | integer | The amount of seconds to wait before polling the device for updated information. When set to 0 no polling is done and the binding relies on data being pushed from the device to the binding.  | 0       | yes      |
 
 ## Channels
 

--- a/bundles/org.openhab.binding.arcam/pom.xml
+++ b/bundles/org.openhab.binding.arcam/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.arcam</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Arcam Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.arcam/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.arcam-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-arcam" description="Arcam Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-upnp</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.arcam/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamBindingConstants.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamBindingConstants.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link ArcamBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamBindingConstants {
+
+    public static final String BINDING_ID = "arcam";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID AVR5_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "AVR5");
+    public static final ThingTypeUID AVR10_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "AVR10");
+    public static final ThingTypeUID AVR20_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "AVR20");
+    public static final ThingTypeUID AVR30_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "AVR30");
+    public static final ThingTypeUID AVR40_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "AVR40");
+    public static final ThingTypeUID SA10_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "SA10");
+    public static final ThingTypeUID SA20_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "SA20");
+    public static final ThingTypeUID SA30_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "SA30");
+    public static final Set<ThingTypeUID> SUPPORTED_KNOWN_THING_TYPES_UIDS = Set.of(AVR5_THING_TYPE_UID,
+            AVR10_THING_TYPE_UID, AVR20_THING_TYPE_UID, AVR30_THING_TYPE_UID, AVR40_THING_TYPE_UID, SA10_THING_TYPE_UID,
+            SA20_THING_TYPE_UID, SA30_THING_TYPE_UID);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(SUPPORTED_KNOWN_THING_TYPES_UIDS);
+
+    // List of all Channel ids
+    // Generic
+    public static final String CHANNEL_DAC_FILTER = "masterZone#dacFilter";
+    public static final String CHANNEL_DC_OFFSET = "masterZone#dcOffset";
+    public static final String CHANNEL_DISPLAY_BRIGHTNESS = "masterZone#displaybrightness";
+    public static final String CHANNEL_HEADPHONES = "masterZone#headphones";
+    public static final String CHANNEL_INCOMING_SAMPLE_RATE = "masterZone#incomingSampleRate";
+    public static final String CHANNEL_LIFTER_TEMPERATURE = "masterZone#lifterTemperature";
+    public static final String CHANNEL_OUTPUT_TEMPERATURE = "masterZone#outputTemperature";
+    public static final String CHANNEL_REBOOT = "masterZone#reboot";
+    public static final String CHANNEL_SOFTWARE_VERSION = "masterZone#softwareVersion";
+    public static final String CHANNEL_TIMEOUT_COUNTER = "masterZone#timeoutCounter";
+
+    // Master zone
+    public static final String CHANNEL_MASTER_BALANCE = "masterZone#balance";
+    public static final String CHANNEL_MASTER_DIRECT_MODE = "masterZone#directMode";
+    public static final String CHANNEL_MASTER_INPUT = "masterZone#input";
+    public static final String CHANNEL_MASTER_INPUT_DETECT = "masterZone#inputDetect";
+    public static final String CHANNEL_MASTER_MUTE = "masterZone#mute";
+    public static final String CHANNEL_MASTER_NOW_PLAYING_TITLE = "masterZone#nowPlayingTitle";
+    public static final String CHANNEL_MASTER_NOW_PLAYING_ARTIST = "masterZone#nowPlayingArtist";
+    public static final String CHANNEL_MASTER_NOW_PLAYING_ALBUM = "masterZone#nowPlayingAlbum";
+    public static final String CHANNEL_MASTER_NOW_PLAYING_APPLICATION = "masterZone#nowPlayingApplication";
+    public static final String CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE = "masterZone#nowPlayingSampleRate";
+    public static final String CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER = "masterZone#nowPlayingAudioEncoder";
+    public static final String CHANNEL_MASTER_POWER = "masterZone#power";
+    public static final String CHANNEL_MASTER_ROOM_EQUALISATION = "masterZone#roomEqualisation";
+    public static final String CHANNEL_MASTER_SHORT_CIRCUIT = "masterZone#shortCircuit";
+    public static final String CHANNEL_MASTER_VOLUME = "masterZone#volume";
+
+    // Zone 2
+    public static final String CHANNEL_ZONE2_BALANCE = "zone2#balance";
+    public static final String CHANNEL_ZONE2_DIRECT_MODE = "zone2#directMode";
+    public static final String CHANNEL_ZONE2_INPUT = "zone2#input";
+    public static final String CHANNEL_ZONE2_MUTE = "zone2#mute";
+    public static final String CHANNEL_ZONE2_POWER = "zone2#power";
+    public static final String CHANNEL_ZONE2_ROOM_EQUALISATION = "zone2#roomEqualisation";
+    public static final String CHANNEL_ZONE2_VOLUME = "zone2#volume";
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamHandler.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamHandler.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import static org.openhab.binding.arcam.internal.ArcamBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.arcam.internal.config.ArcamConfiguration;
+import org.openhab.binding.arcam.internal.connection.ArcamConnection;
+import org.openhab.binding.arcam.internal.connection.ArcamConnectionListener;
+import org.openhab.binding.arcam.internal.devices.ArcamDevice;
+import org.openhab.binding.arcam.internal.devices.ArcamDeviceUtil;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamHandler extends BaseThingHandler implements ArcamStateChangedListener, ArcamConnectionListener {
+
+    private final Logger logger = LoggerFactory.getLogger(ArcamHandler.class);
+
+    private ArcamConnection connection;
+    private ArcamState state;
+    private ArcamDevice device;
+
+    public ArcamHandler(Thing thing) {
+        super(thing);
+
+        logger.debug("Creating a ArcamHandler for thing '{}'", getThing().getUID());
+        state = new ArcamState(this);
+        ThingUID thingUID = getThing().getUID();
+        device = ArcamDeviceUtil.getDeviceFromThingUID(thingUID);
+        connection = new ArcamConnection(state, scheduler, this, device, thingUID.toString());
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            String channelId = channelUID.getId();
+
+            logger.debug("ArcamHandler handled generic refreshType for channelId: {}", channelId);
+
+            connection.requestState(channelId);
+
+            State value = state.getState(channelId);
+            if (value != null) {
+                stateChanged(channelId, value);
+            }
+
+            return;
+        }
+
+        if (equalsWithoutGroup(CHANNEL_DAC_FILTER, channelUID)) {
+            if (command instanceof StringType) {
+                StringType c = (StringType) command;
+                connection.setDacFilter(c.toFullString());
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_DISPLAY_BRIGHTNESS, channelUID)) {
+            if (command instanceof StringType) {
+                StringType c = (StringType) command;
+                connection.setDisplayBrightness(c.toFullString());
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_MASTER_BALANCE, channelUID)) {
+            if (command instanceof DecimalType) {
+                DecimalType p = (DecimalType) command;
+                connection.setBalance(p.intValue(), ArcamZone.MASTER);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_MASTER_INPUT, channelUID)) {
+            if (command instanceof StringType) {
+                StringType c = (StringType) command;
+                connection.setInput(c.toFullString(), ArcamZone.MASTER);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_MASTER_MUTE, channelUID)) {
+            boolean value = command == OnOffType.ON;
+            connection.setMute(value, ArcamZone.MASTER);
+        }
+
+        if (equalsWithoutGroup(CHANNEL_MASTER_POWER, channelUID)) {
+            boolean value = command == OnOffType.ON;
+            connection.setPower(value, ArcamZone.MASTER);
+        }
+
+        if (equalsWithoutGroup(CHANNEL_MASTER_ROOM_EQUALISATION, channelUID)) {
+            if (command instanceof StringType) {
+                StringType c = (StringType) command;
+                connection.setRoomEqualisation(c.toFullString(), ArcamZone.MASTER);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_MASTER_VOLUME, channelUID)) {
+            if (command instanceof PercentType) {
+                PercentType p = (PercentType) command;
+                connection.setVolume(p.intValue(), ArcamZone.MASTER);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_REBOOT, channelUID)) {
+            if (command == OnOffType.ON) {
+                connection.reboot();
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_ZONE2_BALANCE, channelUID)) {
+            if (command instanceof DecimalType) {
+                DecimalType p = (DecimalType) command;
+                connection.setBalance(p.intValue(), ArcamZone.ZONE2);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_ZONE2_INPUT, channelUID)) {
+            if (command instanceof StringType) {
+                StringType c = (StringType) command;
+                connection.setInput(c.toFullString(), ArcamZone.ZONE2);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_ZONE2_MUTE, channelUID)) {
+            boolean value = command == OnOffType.ON;
+            connection.setMute(value, ArcamZone.ZONE2);
+        }
+
+        if (equalsWithoutGroup(CHANNEL_ZONE2_POWER, channelUID)) {
+            boolean value = command == OnOffType.ON;
+            connection.setPower(value, ArcamZone.ZONE2);
+        }
+
+        if (equalsWithoutGroup(CHANNEL_ZONE2_ROOM_EQUALISATION, channelUID)) {
+            if (command instanceof StringType) {
+                StringType c = (StringType) command;
+                connection.setRoomEqualisation(c.toFullString(), ArcamZone.ZONE2);
+            }
+        }
+
+        if (equalsWithoutGroup(CHANNEL_ZONE2_VOLUME, channelUID)) {
+            if (command instanceof PercentType) {
+                PercentType p = (PercentType) command;
+                connection.setVolume(p.intValue(), ArcamZone.ZONE2);
+            }
+        }
+
+        // Note: if communication with thing fails for some reason,
+        // indicate that by setting the status with detail information:
+        // updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+        // "Could not control device at IP address x.x.x.x");
+    }
+
+    @Override
+    public void initialize() {
+        ArcamConfiguration config = getConfigAs(ArcamConfiguration.class);
+
+        // The framework requires you to return from this method quickly, i.e. any network access must be done in
+        // the background initialization below.
+        // Also, before leaving this method a thing status from one of ONLINE, OFFLINE or UNKNOWN must be set. This
+        // might already be the real thing status in case you can decide it directly.
+        // In case you can not decide the thing status directly (e.g. for long running connection handshake using WAN
+        // access or similar) you should set status UNKNOWN here and then decide the real status asynchronously in the
+        // background.
+
+        // set the thing status to UNKNOWN temporarily and let the background task decide for the real status.
+        // the framework is then able to reuse the resources from the thing handler initialization.
+        // we set this upfront to reliably check status updates in unit tests.
+        updateStatus(ThingStatus.UNKNOWN);
+
+        scheduler.execute(() -> {
+            String hostname = config.hostname;
+
+            try {
+                if (hostname == null) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No hostname specified");
+                    return;
+                }
+
+                connection.connect(hostname);
+            } catch (Exception e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+                return;
+            }
+
+            logger.debug("handler initialized. ip: {}", config.hostname);
+        });
+    }
+
+    @Override
+    public void dispose() {
+        connection.dispose();
+
+        super.dispose();
+    }
+
+    @Override
+    public void stateChanged(String channelID, State state) {
+        updateState(channelID, state);
+    }
+
+    @Override
+    public void onError() {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+    }
+
+    private boolean equalsWithoutGroup(String channelStr, ChannelUID channelUID) {
+        String[] parts = channelStr.split(ChannelUID.CHANNEL_GROUP_SEPARATOR);
+        if (parts.length - 1 < 0) {
+            logger.warn("Could not parse channelStr: {}, unable to change value", channelStr);
+            return false;
+        }
+        String id = parts[parts.length - 1];
+        return id.equals(channelUID.getIdWithoutGroup());
+    }
+
+    @Override
+    public void onConnection() {
+        updateStatus(ThingStatus.ONLINE);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamHandlerFactory.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamHandlerFactory.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.arcam", service = ThingHandlerFactory.class)
+public class ArcamHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(ArcamHandlerFactory.class);
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        boolean result = ArcamBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+        logger.debug("supportsThingType thingTypeUID: {}, result: {}", thingTypeUID.getAsString(), result);
+
+        return result;
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        logger.debug("ArcamHandlerFactory createHandler");
+        if (ArcamBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
+            return new ArcamHandler(thing);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamNowPlaying.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamNowPlaying.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamNowPlaying} POJO holds information about the current track that is playing.
+ * This is used to collect multiple data fields that are send via subsequent messages.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamNowPlaying {
+    public String track = "";
+    public String album = "";
+    public String artist = "";
+    public String application = "";
+    public String sampleRate = "";
+    public String audioEncoder = "";
+
+    public int rowNr;
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamState.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamState.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+
+/**
+ * The {@link ArcamState} class contains the device state as seen by the binding.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamState {
+
+    private Map<String, State> states = new ConcurrentHashMap<>();
+
+    private ArcamStateChangedListener handler;
+
+    public ArcamState(ArcamStateChangedListener handler) {
+        this.handler = handler;
+    }
+
+    public void setState(String channelId, @Nullable String value) {
+        StringType newValue = new StringType(value);
+        setState(channelId, newValue);
+    }
+
+    public void setState(String channelId, int value) {
+        DecimalType newValue = new DecimalType(value);
+        setState(channelId, newValue);
+    }
+
+    public void setPercentageState(String channelId, int value) {
+        PercentType newValue = new PercentType(value);
+        setState(channelId, newValue);
+    }
+
+    public void setState(String channelId, boolean value) {
+        OnOffType newValue = value ? OnOffType.ON : OnOffType.OFF;
+        setState(channelId, newValue);
+    }
+
+    private synchronized void setState(String channelId, State newValue) {
+        State oldValue = states.get(channelId);
+        if (newValue.equals(oldValue)) {
+            return;
+        }
+
+        states.put(channelId, newValue);
+        handler.stateChanged(channelId, newValue);
+    }
+
+    public @Nullable State getState(String channel) {
+        return states.get(channel);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamState.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamState.java
@@ -17,10 +17,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.library.types.OnOffType;
-import org.openhab.core.library.types.PercentType;
-import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
 
 /**
@@ -39,27 +35,7 @@ public class ArcamState {
         this.handler = handler;
     }
 
-    public void setState(String channelId, @Nullable String value) {
-        StringType newValue = new StringType(value);
-        setState(channelId, newValue);
-    }
-
-    public void setState(String channelId, int value) {
-        DecimalType newValue = new DecimalType(value);
-        setState(channelId, newValue);
-    }
-
-    public void setPercentageState(String channelId, int value) {
-        PercentType newValue = new PercentType(value);
-        setState(channelId, newValue);
-    }
-
-    public void setState(String channelId, boolean value) {
-        OnOffType newValue = value ? OnOffType.ON : OnOffType.OFF;
-        setState(channelId, newValue);
-    }
-
-    private synchronized void setState(String channelId, State newValue) {
+    public synchronized void setState(String channelId, State newValue) {
         State oldValue = states.get(channelId);
         if (newValue.equals(oldValue)) {
             return;

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamStateChangedListener.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamStateChangedListener.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.types.State;
+
+/**
+ * The {@link ArcamStateChangeListener} interface is used to signal events from the {@link ArcamState} class
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public interface ArcamStateChangedListener {
+    void stateChanged(String channelID, State state);
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamUtil.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamUtil.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamUtil} class contains some small utility methods
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamUtil {
+    private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+
+    public static byte[] byteListToArray(List<Byte> bytes) {
+        byte[] byteArray = new byte[bytes.size()];
+        for (int i = 0; i < bytes.size(); i++) {
+            byteArray[i] = bytes.get(i);
+        }
+        return byteArray;
+    }
+
+    public static String bytesToHex(List<Byte> bytes) {
+        byte[] byteArray = byteListToArray(bytes);
+        for (int i = 0; i < bytes.size(); i++) {
+            byteArray[i] = bytes.get(i);
+        }
+
+        return bytesToHex(byteArray);
+    }
+
+    public static String byteListToUTF(List<Byte> bytes) {
+        byte[] byteArray = byteListToArray(bytes);
+
+        return new String(byteArray, StandardCharsets.UTF_8);
+    }
+
+    public static String bytesToHex(byte[] bytes) {
+        byte[] hexChars = new byte[bytes.length * 3];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 3] = 'x';
+            hexChars[j * 3 + 1] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 3 + 2] = HEX_ARRAY[v & 0x0F];
+
+        }
+        return new String(hexChars, StandardCharsets.UTF_8);
+    }
+
+    public static String byteToHex(byte b) {
+        int v = b & 0xFF;
+        byte[] hexChars = new byte[3];
+        hexChars[0] = 'x';
+        hexChars[1] = HEX_ARRAY[v >>> 4];
+        hexChars[2] = HEX_ARRAY[v & 0x0F];
+        return new String(hexChars, StandardCharsets.UTF_8);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamZone.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/ArcamZone.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This enum represents the zones that are available on the Arcam devices.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public enum ArcamZone {
+    MASTER,
+    ZONE2
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/config/ArcamConfiguration.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/config/ArcamConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ArcamConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamConfiguration {
+
+    public static final String HOSTNAME = "hostname";
+    public static final String SERIAL = "serial";
+    public static final String NAME = "name";
+    public static final String MODEL = "model";
+
+    public @Nullable String hostname;
+    public @Nullable String serial;
+    public @Nullable String name;
+    public @Nullable String model;
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/config/ArcamConfiguration.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/config/ArcamConfiguration.java
@@ -24,12 +24,14 @@ import org.eclipse.jdt.annotation.Nullable;
 public class ArcamConfiguration {
 
     public static final String HOSTNAME = "hostname";
-    public static final String SERIAL = "serial";
-    public static final String NAME = "name";
     public static final String MODEL = "model";
+    public static final String NAME = "name";
+    public static final String POLLING_INTERVAL = "pollingInterval";
+    public static final String SERIAL = "serial";
 
     public @Nullable String hostname;
-    public @Nullable String serial;
-    public @Nullable String name;
     public @Nullable String model;
+    public @Nullable String name;
+    public @Nullable Integer pollingInterval;
+    public @Nullable String serial;
 }

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommand.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommand.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamCommand} class is a POJO to store the bytes that are used to send a command.
+ * Used to create dynamic lookup tables so we can share logic between multiple devices.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamCommand {
+    public final ArcamCommandCode code;
+    public final byte[] data;
+
+    public ArcamCommand(ArcamCommandCode code, byte[] data) {
+        this.code = code;
+        this.data = data;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandCode.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandCode.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import static org.openhab.binding.arcam.internal.ArcamBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ArcamCommandCode} enum provides a way specify the supported commands and link them to a channel
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public enum ArcamCommandCode {
+    // Non channel commands
+    HEARTBEAT(""),
+    SYSTEM_STATUS(""),
+
+    // Generic channel commands
+    DAC_FILTER(CHANNEL_DAC_FILTER),
+    DISPLAY_BRIGHTNESS(CHANNEL_DISPLAY_BRIGHTNESS),
+    HEADPHONES(CHANNEL_HEADPHONES),
+    INCOMING_SAMPLE_RATE(CHANNEL_INCOMING_SAMPLE_RATE),
+    LIFTER_TEMPERATURE(CHANNEL_LIFTER_TEMPERATURE),
+    OUTPUT_TEMPERATURE(CHANNEL_OUTPUT_TEMPERATURE),
+    REBOOT(CHANNEL_REBOOT),
+    SOFTWARE_VERSION(CHANNEL_SOFTWARE_VERSION),
+    TIMEOUT_COUNTER(CHANNEL_TIMEOUT_COUNTER),
+
+    // Master channel commands
+    MASTER_BALANCE(CHANNEL_MASTER_BALANCE),
+    MASTER_DC_OFFSET(CHANNEL_DC_OFFSET),
+    MASTER_DIRECT_MODE(CHANNEL_MASTER_DIRECT_MODE),
+    MASTER_INPUT(CHANNEL_MASTER_INPUT),
+    MASTER_INPUT_DETECT(CHANNEL_MASTER_INPUT_DETECT),
+    MASTER_MUTE(CHANNEL_MASTER_MUTE),
+    MASTER_NOW_PLAYING_ALBUM(CHANNEL_MASTER_NOW_PLAYING_ALBUM),
+    MASTER_NOW_PLAYING_APPLICATION(CHANNEL_MASTER_NOW_PLAYING_APPLICATION),
+    MASTER_NOW_PLAYING_ARTIST(CHANNEL_MASTER_NOW_PLAYING_ARTIST),
+    MASTER_NOW_PLAYING_AUDIO_ENCODER(CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER),
+    MASTER_NOW_PLAYING_SAMPLE_RATE(CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE),
+    MASTER_NOW_PLAYING_TITLE(CHANNEL_MASTER_NOW_PLAYING_TITLE),
+    MASTER_POWER(CHANNEL_MASTER_POWER),
+    MASTER_ROOM_EQUALISATION(CHANNEL_MASTER_ROOM_EQUALISATION),
+    MASTER_SHORT_CIRCUIT(CHANNEL_MASTER_SHORT_CIRCUIT),
+    MASTER_VOLUME(CHANNEL_MASTER_VOLUME),
+
+    // Zone2 channel commands
+    ZONE2_BALANCE(CHANNEL_ZONE2_BALANCE),
+    ZONE2_DIRECT_MODE(CHANNEL_ZONE2_DIRECT_MODE),
+    ZONE2_INPUT(CHANNEL_ZONE2_INPUT),
+    ZONE2_MUTE(CHANNEL_ZONE2_MUTE),
+    ZONE2_POWER(CHANNEL_ZONE2_POWER),
+    ZONE2_ROOM_EQUALISATION(CHANNEL_ZONE2_ROOM_EQUALISATION),
+    ZONE2_VOLUME(CHANNEL_ZONE2_VOLUME);
+
+    public final String channel;
+
+    private ArcamCommandCode(String channel) {
+        this.channel = channel;
+    }
+
+    @Nullable
+    public static ArcamCommandCode getFromChannel(String channel) {
+        for (ArcamCommandCode c : ArcamCommandCode.values()) {
+            if (c.channel.equalsIgnoreCase(channel)) {
+                return c;
+            }
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandData.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandData.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamCommandData} POJO is used to specify options for commands with the corresponding byte.
+ * Used for both interpreting the response from the device as well as generating the command to send to the device.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamCommandData {
+    public final String code;
+    public final String name;
+    public final byte dataByte;
+
+    public ArcamCommandData(String code, String name, byte dataByte) {
+        this.code = code;
+        this.name = name;
+        this.dataByte = dataByte;
+    }
+
+    public ArcamCommandData(String code, byte dataByte) {
+        this.code = code;
+        this.name = code;
+        this.dataByte = dataByte;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandDataFinder.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandDataFinder.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.StateDescriptionFragment;
+import org.openhab.core.types.StateDescriptionFragmentBuilder;
+import org.openhab.core.types.StateOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamCommandDataFinder} class provides lookup methods, used to lookup CommandData from the device specific
+ * lists.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamCommandDataFinder {
+    private final Logger logger = LoggerFactory.getLogger(ArcamCommandDataFinder.class);
+
+    @Nullable
+    public ArcamCommandData getCommandDataFromCode(String code, List<ArcamCommandData> list) {
+        for (ArcamCommandData commandData : list) {
+            if (commandData.code.equals(code)) {
+                return commandData;
+            }
+        }
+
+        logger.warn("Could not find ArcamCommandData for code: {}", code);
+        return null;
+    }
+
+    @Nullable
+    public ArcamCommandData getCommandDataFromByte(byte dataByte, List<ArcamCommandData> list) {
+        for (ArcamCommandData commandData : list) {
+            if (commandData.dataByte == dataByte) {
+                return commandData;
+            }
+        }
+
+        logger.warn("Could not find ArcamCommandData for dataByte: {}", dataByte);
+        return null;
+    }
+
+    @Nullable
+    public String getCommandCodeFromByte(byte dataByte, List<ArcamCommandData> list) {
+        ArcamCommandData commandData = getCommandDataFromByte(dataByte, list);
+        if (commandData == null) {
+            return "";
+        }
+        return commandData.code;
+    }
+
+    public byte getByteFromCommandDataCode(String code, List<ArcamCommandData> list) {
+        ArcamCommandData commandData = getCommandDataFromCode(code, list);
+        if (commandData == null) {
+            return 0;
+        }
+        return commandData.dataByte;
+    }
+
+    public static ChannelType generateStringOptionChannelType(ChannelTypeUID channelTypeUID, String label,
+            String description, List<ArcamCommandData> list) {
+        List<StateOption> options = new ArrayList<>();
+
+        for (ArcamCommandData db : list) {
+            options.add(new StateOption(db.code, db.name));
+        }
+
+        StateDescriptionFragment stateDescFrag = StateDescriptionFragmentBuilder.create().withOptions(options).build();
+
+        return ChannelTypeBuilder.state(channelTypeUID, label, "String").withDescription(description)
+                .withStateDescriptionFragment(stateDescFrag).build();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandFinder.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandFinder.java
@@ -31,7 +31,7 @@ public class ArcamCommandFinder {
     public byte[] getCommandDataFromCode(ArcamCommandCode code, List<ArcamCommand> list) {
         for (ArcamCommand command : list) {
             if (command.code.equals(code)) {
-                return command.data;
+                return command.data.clone();
             }
         }
 

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandFinder.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandFinder.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamCommandFinder} class provides lookup methods, used to lookup ArcamCommandCode's from the device
+ * specific lists.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamCommandFinder {
+    private final Logger logger = LoggerFactory.getLogger(ArcamCommandFinder.class);
+
+    public byte[] getCommandFromCode(ArcamCommandCode code, List<ArcamCommand> list) {
+        for (ArcamCommand command : list) {
+            if (command.code.equals(code)) {
+                return command.data;
+            }
+        }
+
+        logger.error("Could not find ArcamCommandfor code: {}.", code);
+        return new byte[] {};
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandFinder.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandFinder.java
@@ -28,14 +28,14 @@ import org.slf4j.LoggerFactory;
 public class ArcamCommandFinder {
     private final Logger logger = LoggerFactory.getLogger(ArcamCommandFinder.class);
 
-    public byte[] getCommandFromCode(ArcamCommandCode code, List<ArcamCommand> list) {
+    public byte[] getCommandDataFromCode(ArcamCommandCode code, List<ArcamCommand> list) {
         for (ArcamCommand command : list) {
             if (command.code.equals(code)) {
                 return command.data;
             }
         }
 
-        logger.error("Could not find ArcamCommandfor code: {}.", code);
+        logger.trace("Could not find ArcamCommand data for code: {}.", code);
         return new byte[] {};
     }
 }

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandInTransit.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamCommandInTransit.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class allows thread safe access to a command that is currently being executed on the Arcam device.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamCommandInTransit {
+
+    private final Logger logger = LoggerFactory.getLogger(ArcamCommandInTransit.class);
+
+    @Nullable
+    private ArcamCommandCode commandInTransit;
+
+    public void waitFor() {
+        int counter = 0;
+        while (hasCommand()) {
+            counter++;
+            if (counter > 20) {
+                synchronized (this) {
+                    logger.debug("Stop waiting for a command to finish, command: {}", commandInTransit);
+                    commandInTransit = null;
+                }
+                return;
+            }
+
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+
+    public synchronized void set(ArcamCommandCode commandCode) {
+        commandInTransit = commandCode;
+    }
+
+    public synchronized void finish(ArcamCommandCode commandCode) {
+        if (commandCode.equals(commandInTransit)) {
+            commandInTransit = null;
+        }
+    }
+
+    public synchronized boolean hasCommand() {
+        return commandInTransit != null;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnection.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnection.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamState;
+import org.openhab.binding.arcam.internal.ArcamUtil;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.devices.ArcamDevice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamConnection} class manages the socket connection with the device.
+ * It will trigger state changes when new messages are received and writes commands to the socket.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamConnection implements ArcamSocketListener {
+    private final Logger logger = LoggerFactory.getLogger(ArcamConnection.class);
+
+    private ArcamState state;
+    private ArcamDevice device;
+    private ArcamSocket socket;
+    private ArcamConnectionListener connectionListener;
+
+    @Nullable
+    private ArcamCommandCode nowPlayingInTransit;
+
+    public ArcamConnection(ArcamState state, ScheduledExecutorService scheduler,
+            ArcamConnectionListener connectionListener, ArcamDevice device, String thingUID) {
+        this.state = state;
+        this.device = device;
+        byte[] heartbeatCommand = device.getHeartbeatCommand();
+        this.socket = new ArcamSocket(thingUID, scheduler, heartbeatCommand, this);
+        this.connectionListener = connectionListener;
+    }
+
+    public void connect(String hostname) throws UnknownHostException, IOException {
+        socket.connect(hostname);
+    }
+
+    public void dispose() {
+        socket.dispose();
+    }
+
+    public void reboot() {
+        byte[] data = device.getRebootCommand();
+
+        logger.debug("Sending reboot array: {}", ArcamUtil.bytesToHex(data));
+        socket.sendCommand(data);
+    }
+
+    public void requestAllValues() {
+        logger.debug("requestAllValues");
+
+        byte[] data = device.getStateCommandByte(ArcamCommandCode.SYSTEM_STATUS);
+        if (data.length == 0) {
+            return;
+        }
+        socket.sendCommand(data);
+    }
+
+    public void requestState(String channel) {
+        ArcamCommandCode commandCode = ArcamCommandCode.getFromChannel(channel);
+        if (commandCode == null) {
+            return;
+        }
+
+        byte[] data = device.getStateCommandByte(commandCode);
+        if (data.length == 0) {
+            return;
+        }
+
+        if (data[2] == 0x64) {
+            nowPlayingInTransit = commandCode;
+        }
+
+        socket.sendCommand(data);
+    }
+
+    public void setBalance(int balance, ArcamZone zone) {
+        byte[] data = device.getBalanceCommand(balance, zone);
+
+        logger.debug("Sending balance byte: {}, array: {}, zone: {}", balance, ArcamUtil.bytesToHex(data), zone);
+        socket.sendCommand(data);
+    }
+
+    public void setDacFilter(String dacFilter) {
+        byte[] data = device.getDacFilterCommand(dacFilter);
+
+        logger.debug("Sending dacFilter byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
+        socket.sendCommand(data);
+    }
+
+    public void setDisplayBrightness(String displayBrightness) {
+        byte[] data = device.getDisplayBrightnessCommand(displayBrightness);
+
+        logger.debug("Sending display brightness byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
+        socket.sendCommand(data);
+    }
+
+    public void setInput(String inputStr, ArcamZone zone) {
+        byte[] data = device.getInputCommand(inputStr, zone);
+
+        logger.debug("Sending input byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
+        socket.sendCommand(data);
+    }
+
+    public void setMute(boolean on, ArcamZone zone) {
+        byte[] data = device.getMuteCommand(on, zone);
+
+        logger.debug("Sending mute byte: {}, array: {}, zone: {}", on, ArcamUtil.bytesToHex(data), zone);
+        socket.sendCommand(data);
+    }
+
+    public void setPower(boolean on, ArcamZone zone) {
+        byte[] data = device.getPowerCommand(on, zone);
+
+        logger.debug("Sending power byte: {}, array: {}, zone: {}", on, ArcamUtil.bytesToHex(data), zone);
+        socket.sendCommand(data);
+    }
+
+    public void setRoomEqualisation(String eqStr, ArcamZone zone) {
+        byte[] data = device.getRoomEqualisationCommand(eqStr, zone);
+
+        logger.debug("Sending eq byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
+        socket.sendCommand(data);
+    }
+
+    public void setVolume(int volume, ArcamZone zone) {
+        byte[] data = device.getVolumeCommand(volume, zone);
+
+        logger.debug("Sending volume byte: {}, array: {}, zone: {}", volume, ArcamUtil.bytesToHex(data), zone);
+        socket.sendCommand(data);
+    }
+
+    @Override
+    public void onResponse(ArcamResponse response) {
+        if (response.ac != 0x00) {
+            logger.debug("There is an error with command: {}", response.cc);
+            return;
+        }
+        // Balance
+        if (response.cc == 0x3B) {
+            int balance = device.getBalance(response.data.get(0));
+            if (isMasterZone(response.zn)) {
+                state.setState(ArcamBindingConstants.CHANNEL_MASTER_BALANCE, balance);
+            } else {
+                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_BALANCE, balance);
+            }
+        }
+        // DAC filter
+        if (response.cc == 0x61) {
+            String dacFilter = device.getDacFilter(response.data.get(0));
+            logger.debug("Got DAC filter: {}, {}", ArcamUtil.bytesToHex(response.data), dacFilter);
+            state.setState(ArcamBindingConstants.CHANNEL_DAC_FILTER, dacFilter);
+        }
+        // DC offset
+        if (response.cc == 0x51) {
+            logger.debug("Got DC offset response: {}", response.data);
+            boolean dc = device.getBoolean(response.data.get(0));
+            state.setState(ArcamBindingConstants.CHANNEL_DC_OFFSET, dc);
+        }
+        // Direct mode
+        if (response.cc == 0x0F) {
+            logger.debug("Got direct mode response: {}", response.data);
+            if (response.data.size() > 1) {
+                boolean directMode = device.getBoolean(response.data.get(1));
+                state.setState(ArcamBindingConstants.CHANNEL_MASTER_DIRECT_MODE, directMode);
+            }
+        }
+        // Display brightness
+        if (response.cc == 0x01) {
+            String brightness = device.getDisplayBrightness(response.data.get(0));
+
+            logger.debug("brightness info: {}", brightness);
+            state.setState(ArcamBindingConstants.CHANNEL_DISPLAY_BRIGHTNESS, brightness);
+        }
+        // Headphones
+        if (response.cc == 0x02) {
+            logger.debug("Got headphones response: {}", response.data);
+            boolean headphones = device.getBoolean(response.data.get(0));
+            state.setState(ArcamBindingConstants.CHANNEL_HEADPHONES, headphones);
+        }
+        // Incoming audio sample rate
+        if (response.cc == 0x44) {
+            String sampleRate = device.getIncomingSampleRate(response.data.get(0));
+            logger.debug("Got incomingSampleRateresponse: {}, {}", ArcamUtil.bytesToHex(response.data), sampleRate);
+            state.setState(ArcamBindingConstants.CHANNEL_INCOMING_SAMPLE_RATE, sampleRate);
+        }
+        // Input detect
+        if (response.cc == 0x5A) {
+            logger.debug("Got Input detect response: {}", response.data);
+            boolean inputDetect = device.getBoolean(response.data.get(0));
+            state.setState(ArcamBindingConstants.CHANNEL_MASTER_INPUT_DETECT, inputDetect);
+        }
+        // Input source
+        if (response.cc == 0x1D) {
+            String input = device.getInputName(response.data.get(0));
+
+            if (isMasterZone(response.zn)) {
+                state.setState(ArcamBindingConstants.CHANNEL_MASTER_INPUT, input);
+            } else {
+                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_INPUT, input);
+            }
+        }
+        // Lifter temperature
+        if (response.cc == 0x56) {
+            int temperature = device.getTemperature(response.data, 0);
+            logger.debug("Got Lifter temperature: {}, value: {}", ArcamUtil.bytesToHex(response.data), temperature);
+            state.setState(ArcamBindingConstants.CHANNEL_LIFTER_TEMPERATURE, temperature);
+        }
+        // Mute
+        if (response.cc == 0x0E) {
+            logger.debug("Got mute response: {}", response.data);
+            boolean mute = device.getMute(response.data.get(0));
+            if (isMasterZone(response.zn)) {
+                state.setState(ArcamBindingConstants.CHANNEL_MASTER_MUTE, mute);
+            } else {
+                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_MUTE, mute);
+            }
+        }
+        // Now Playing information
+        if (response.cc == 0x64) {
+            logger.debug("Got now playing response: {}", response.data);
+            ArcamCommandCode nowPlayingCommandCode = nowPlayingInTransit;
+            if (nowPlayingCommandCode != null) {
+                String value = ArcamUtil.byteListToUTF(response.data);
+
+                switch (nowPlayingCommandCode) {
+                    case MASTER_NOW_PLAYING_ALBUM:
+                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ALBUM, value);
+                        break;
+
+                    case MASTER_NOW_PLAYING_APPLICATION:
+                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_APPLICATION, value);
+                        break;
+
+                    case MASTER_NOW_PLAYING_ARTIST:
+                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ARTIST, value);
+                        break;
+
+                    case MASTER_NOW_PLAYING_AUDIO_ENCODER:
+                        String audioEncoder = device.getNowPlayingEncoder(response.data.get(0));
+                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER, audioEncoder);
+                        break;
+
+                    case MASTER_NOW_PLAYING_SAMPLE_RATE:
+                        String sampleRate = device.getNowPlayingSampleRate(response.data.get(0));
+                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE, sampleRate);
+                        break;
+
+                    case MASTER_NOW_PLAYING_TITLE:
+                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_TITLE, value);
+                        break;
+                    default:
+                        break;
+                }
+                nowPlayingInTransit = null;
+            } else {
+                ArcamNowPlaying nowPlaying = device.setNowPlaying(response.data);
+                if (nowPlaying != null) {
+                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ALBUM, nowPlaying.album);
+                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_APPLICATION,
+                            nowPlaying.application);
+                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ARTIST, nowPlaying.artist);
+                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER,
+                            nowPlaying.audioEncoder);
+                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE, nowPlaying.sampleRate);
+                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_TITLE, nowPlaying.track);
+                }
+            }
+        }
+        // Output temperature
+        if (response.cc == 0x57) {
+            int temperature = device.getTemperature(response.data, 0);
+            logger.debug("Got Output temperature: {}, value: {}", ArcamUtil.bytesToHex(response.data), temperature);
+            state.setState(ArcamBindingConstants.CHANNEL_OUTPUT_TEMPERATURE, temperature);
+        }
+        // Power
+        if (response.cc == 0x00) {
+            logger.debug("Got power response: {}", response.data);
+            boolean power = device.getBoolean(response.data.get(0));
+            if (isMasterZone(response.zn)) {
+                state.setState(ArcamBindingConstants.CHANNEL_MASTER_POWER, power);
+            } else {
+                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_POWER, power);
+            }
+        }
+        // Room Equalisation
+        if (response.cc == 0x37) {
+            String eq = device.getRoomEqualisation(response.data.get(0));
+            if (isMasterZone(response.zn)) {
+                state.setState(ArcamBindingConstants.CHANNEL_MASTER_ROOM_EQUALISATION, eq);
+            } else {
+                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_ROOM_EQUALISATION, eq);
+            }
+        }
+        // Short circuit status
+        if (response.cc == 0x52) {
+            logger.debug("Got Short circuit status response: {}", response.data);
+            boolean shortCircuit = device.getBoolean(response.data.get(0));
+            state.setState(ArcamBindingConstants.CHANNEL_MASTER_SHORT_CIRCUIT, shortCircuit);
+        }
+        // SoftwareVersion
+        if (response.cc == 0x04) {
+            String version = device.getSoftwareVersion(response.data);
+            logger.debug("Got SoftwareVersion response: {}, {}", ArcamUtil.bytesToHex(response.data), version);
+            state.setState(ArcamBindingConstants.CHANNEL_SOFTWARE_VERSION, version);
+        }
+        // Timeout counter
+        if (response.cc == 0x55) {
+            int counter = device.getTimeoutCounter(response.data);
+            logger.debug("Got Timeout counter response: {}, {}", ArcamUtil.bytesToHex(response.data), counter);
+            state.setState(ArcamBindingConstants.CHANNEL_TIMEOUT_COUNTER, counter);
+        }
+        // Volume
+        if (response.cc == 0x0D) {
+            int volume = Byte.valueOf(response.data.get(0)).intValue();
+            if (isMasterZone(response.zn)) {
+                state.setPercentageState(ArcamBindingConstants.CHANNEL_MASTER_VOLUME, volume);
+            } else {
+                state.setPercentageState(ArcamBindingConstants.CHANNEL_ZONE2_VOLUME, volume);
+            }
+        }
+    }
+
+    private boolean isMasterZone(byte zone) {
+        return zone == 0x01;
+    }
+
+    @Override
+    public void onConnection() {
+        connectionListener.onConnection();
+        requestAllValues();
+    }
+
+    @Override
+    public void onError() {
+        connectionListener.onError();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnection.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnection.java
@@ -69,9 +69,10 @@ public class ArcamConnection implements ArcamSocketListener {
 
     public void reboot() {
         byte[] data = device.getRebootCommand();
+        ArcamCommandCode commandCode = ArcamCommandCode.REBOOT;
 
         logger.debug("Sending reboot array: {}", ArcamUtil.bytesToHex(data));
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void requestState(String channel) {
@@ -86,71 +87,77 @@ public class ArcamConnection implements ArcamSocketListener {
             return;
         }
 
-        commandInTransit.set(commandCode);
-
-        if (data[2] == 0x64) {
-            nowPlayingInTransit = commandCode;
-        }
-
-        socket.sendCommand(data);
-
-        commandInTransit.waitFor();
+        sendCommand(data, commandCode);
     }
 
     public void setBalance(int balance, ArcamZone zone) {
         byte[] data = device.getBalanceCommand(balance, zone);
+        ArcamCommandCode commandCode = zone == ArcamZone.MASTER ? ArcamCommandCode.MASTER_BALANCE
+                : ArcamCommandCode.ZONE2_BALANCE;
 
         logger.debug("Sending balance byte: {}, array: {}, zone: {}", balance, ArcamUtil.bytesToHex(data), zone);
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setDacFilter(String dacFilter) {
         byte[] data = device.getDacFilterCommand(dacFilter);
+        ArcamCommandCode commandCode = ArcamCommandCode.DAC_FILTER;
 
         logger.debug("Sending dacFilter byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setDisplayBrightness(String displayBrightness) {
         byte[] data = device.getDisplayBrightnessCommand(displayBrightness);
+        ArcamCommandCode commandCode = ArcamCommandCode.DISPLAY_BRIGHTNESS;
 
         logger.debug("Sending display brightness byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setInput(String inputStr, ArcamZone zone) {
         byte[] data = device.getInputCommand(inputStr, zone);
+        ArcamCommandCode commandCode = zone == ArcamZone.MASTER ? ArcamCommandCode.MASTER_INPUT
+                : ArcamCommandCode.ZONE2_INPUT;
 
         logger.debug("Sending input byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setMute(boolean on, ArcamZone zone) {
         byte[] data = device.getMuteCommand(on, zone);
+        ArcamCommandCode commandCode = zone == ArcamZone.MASTER ? ArcamCommandCode.MASTER_MUTE
+                : ArcamCommandCode.ZONE2_MUTE;
 
         logger.debug("Sending mute byte: {}, array: {}, zone: {}", on, ArcamUtil.bytesToHex(data), zone);
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setPower(boolean on, ArcamZone zone) {
         byte[] data = device.getPowerCommand(on, zone);
+        ArcamCommandCode commandCode = zone == ArcamZone.MASTER ? ArcamCommandCode.MASTER_POWER
+                : ArcamCommandCode.ZONE2_POWER;
 
         logger.debug("Sending power byte: {}, array: {}, zone: {}", on, ArcamUtil.bytesToHex(data), zone);
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setRoomEqualisation(String eqStr, ArcamZone zone) {
         byte[] data = device.getRoomEqualisationCommand(eqStr, zone);
+        ArcamCommandCode commandCode = zone == ArcamZone.MASTER ? ArcamCommandCode.MASTER_ROOM_EQUALISATION
+                : ArcamCommandCode.ZONE2_ROOM_EQUALISATION;
 
         logger.debug("Sending eq byte: {}, array: {}", data[4], ArcamUtil.bytesToHex(data));
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     public void setVolume(int volume, ArcamZone zone) {
         byte[] data = device.getVolumeCommand(volume, zone);
+        ArcamCommandCode commandCode = zone == ArcamZone.MASTER ? ArcamCommandCode.MASTER_VOLUME
+                : ArcamCommandCode.ZONE2_VOLUME;
 
         logger.debug("Sending volume byte: {}, array: {}, zone: {}", volume, ArcamUtil.bytesToHex(data), zone);
-        socket.sendCommand(data);
+        sendCommand(data, commandCode);
     }
 
     @Override
@@ -379,6 +386,18 @@ public class ArcamConnection implements ArcamSocketListener {
         finishInTransit(channelId);
         OnOffType newValue = value ? OnOffType.ON : OnOffType.OFF;
         state.setState(channelId, newValue);
+    }
+
+    private void sendCommand(byte[] data, ArcamCommandCode commandCode) {
+        commandInTransit.set(commandCode);
+
+        if (data[2] == 0x64) {
+            nowPlayingInTransit = commandCode;
+        }
+
+        socket.sendCommand(data);
+
+        commandInTransit.waitFor();
     }
 
     @Override

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnection.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnection.java
@@ -24,6 +24,10 @@ import org.openhab.binding.arcam.internal.ArcamState;
 import org.openhab.binding.arcam.internal.ArcamUtil;
 import org.openhab.binding.arcam.internal.ArcamZone;
 import org.openhab.binding.arcam.internal.devices.ArcamDevice;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +45,7 @@ public class ArcamConnection implements ArcamSocketListener {
     private ArcamDevice device;
     private ArcamSocket socket;
     private ArcamConnectionListener connectionListener;
+    private ArcamCommandInTransit commandInTransit = new ArcamCommandInTransit();
 
     @Nullable
     private ArcamCommandCode nowPlayingInTransit;
@@ -69,19 +74,10 @@ public class ArcamConnection implements ArcamSocketListener {
         socket.sendCommand(data);
     }
 
-    public void requestAllValues() {
-        logger.debug("requestAllValues");
-
-        byte[] data = device.getStateCommandByte(ArcamCommandCode.SYSTEM_STATUS);
-        if (data.length == 0) {
-            return;
-        }
-        socket.sendCommand(data);
-    }
-
     public void requestState(String channel) {
         ArcamCommandCode commandCode = ArcamCommandCode.getFromChannel(channel);
         if (commandCode == null) {
+            logger.debug("commandCode not found, channel: {}", channel);
             return;
         }
 
@@ -90,11 +86,15 @@ public class ArcamConnection implements ArcamSocketListener {
             return;
         }
 
+        commandInTransit.set(commandCode);
+
         if (data[2] == 0x64) {
             nowPlayingInTransit = commandCode;
         }
 
         socket.sendCommand(data);
+
+        commandInTransit.waitFor();
     }
 
     public void setBalance(int balance, ArcamZone zone) {
@@ -159,33 +159,34 @@ public class ArcamConnection implements ArcamSocketListener {
             logger.debug("There is an error with command: {}", response.cc);
             return;
         }
+
         // Balance
         if (response.cc == 0x3B) {
             int balance = device.getBalance(response.data.get(0));
             if (isMasterZone(response.zn)) {
-                state.setState(ArcamBindingConstants.CHANNEL_MASTER_BALANCE, balance);
+                setState(ArcamBindingConstants.CHANNEL_MASTER_BALANCE, balance);
             } else {
-                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_BALANCE, balance);
+                setState(ArcamBindingConstants.CHANNEL_ZONE2_BALANCE, balance);
             }
         }
         // DAC filter
         if (response.cc == 0x61) {
             String dacFilter = device.getDacFilter(response.data.get(0));
             logger.debug("Got DAC filter: {}, {}", ArcamUtil.bytesToHex(response.data), dacFilter);
-            state.setState(ArcamBindingConstants.CHANNEL_DAC_FILTER, dacFilter);
+            setState(ArcamBindingConstants.CHANNEL_DAC_FILTER, dacFilter);
         }
         // DC offset
         if (response.cc == 0x51) {
             logger.debug("Got DC offset response: {}", response.data);
             boolean dc = device.getBoolean(response.data.get(0));
-            state.setState(ArcamBindingConstants.CHANNEL_DC_OFFSET, dc);
+            setState(ArcamBindingConstants.CHANNEL_DC_OFFSET, dc);
         }
         // Direct mode
         if (response.cc == 0x0F) {
             logger.debug("Got direct mode response: {}", response.data);
             if (response.data.size() > 1) {
                 boolean directMode = device.getBoolean(response.data.get(1));
-                state.setState(ArcamBindingConstants.CHANNEL_MASTER_DIRECT_MODE, directMode);
+                setState(ArcamBindingConstants.CHANNEL_MASTER_DIRECT_MODE, directMode);
             }
         }
         // Display brightness
@@ -193,50 +194,50 @@ public class ArcamConnection implements ArcamSocketListener {
             String brightness = device.getDisplayBrightness(response.data.get(0));
 
             logger.debug("brightness info: {}", brightness);
-            state.setState(ArcamBindingConstants.CHANNEL_DISPLAY_BRIGHTNESS, brightness);
+            setState(ArcamBindingConstants.CHANNEL_DISPLAY_BRIGHTNESS, brightness);
         }
         // Headphones
         if (response.cc == 0x02) {
             logger.debug("Got headphones response: {}", response.data);
             boolean headphones = device.getBoolean(response.data.get(0));
-            state.setState(ArcamBindingConstants.CHANNEL_HEADPHONES, headphones);
+            setState(ArcamBindingConstants.CHANNEL_HEADPHONES, headphones);
         }
         // Incoming audio sample rate
         if (response.cc == 0x44) {
             String sampleRate = device.getIncomingSampleRate(response.data.get(0));
             logger.debug("Got incomingSampleRateresponse: {}, {}", ArcamUtil.bytesToHex(response.data), sampleRate);
-            state.setState(ArcamBindingConstants.CHANNEL_INCOMING_SAMPLE_RATE, sampleRate);
+            setState(ArcamBindingConstants.CHANNEL_INCOMING_SAMPLE_RATE, sampleRate);
         }
         // Input detect
         if (response.cc == 0x5A) {
             logger.debug("Got Input detect response: {}", response.data);
             boolean inputDetect = device.getBoolean(response.data.get(0));
-            state.setState(ArcamBindingConstants.CHANNEL_MASTER_INPUT_DETECT, inputDetect);
+            setState(ArcamBindingConstants.CHANNEL_MASTER_INPUT_DETECT, inputDetect);
         }
         // Input source
         if (response.cc == 0x1D) {
             String input = device.getInputName(response.data.get(0));
 
             if (isMasterZone(response.zn)) {
-                state.setState(ArcamBindingConstants.CHANNEL_MASTER_INPUT, input);
+                setState(ArcamBindingConstants.CHANNEL_MASTER_INPUT, input);
             } else {
-                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_INPUT, input);
+                setState(ArcamBindingConstants.CHANNEL_ZONE2_INPUT, input);
             }
         }
         // Lifter temperature
         if (response.cc == 0x56) {
             int temperature = device.getTemperature(response.data, 0);
             logger.debug("Got Lifter temperature: {}, value: {}", ArcamUtil.bytesToHex(response.data), temperature);
-            state.setState(ArcamBindingConstants.CHANNEL_LIFTER_TEMPERATURE, temperature);
+            setState(ArcamBindingConstants.CHANNEL_LIFTER_TEMPERATURE, temperature);
         }
         // Mute
         if (response.cc == 0x0E) {
             logger.debug("Got mute response: {}", response.data);
             boolean mute = device.getMute(response.data.get(0));
             if (isMasterZone(response.zn)) {
-                state.setState(ArcamBindingConstants.CHANNEL_MASTER_MUTE, mute);
+                setState(ArcamBindingConstants.CHANNEL_MASTER_MUTE, mute);
             } else {
-                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_MUTE, mute);
+                setState(ArcamBindingConstants.CHANNEL_ZONE2_MUTE, mute);
             }
         }
         // Now Playing information
@@ -248,29 +249,29 @@ public class ArcamConnection implements ArcamSocketListener {
 
                 switch (nowPlayingCommandCode) {
                     case MASTER_NOW_PLAYING_ALBUM:
-                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ALBUM, value);
+                        setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ALBUM, value);
                         break;
 
                     case MASTER_NOW_PLAYING_APPLICATION:
-                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_APPLICATION, value);
+                        setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_APPLICATION, value);
                         break;
 
                     case MASTER_NOW_PLAYING_ARTIST:
-                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ARTIST, value);
+                        setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ARTIST, value);
                         break;
 
                     case MASTER_NOW_PLAYING_AUDIO_ENCODER:
                         String audioEncoder = device.getNowPlayingEncoder(response.data.get(0));
-                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER, audioEncoder);
+                        setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER, audioEncoder);
                         break;
 
                     case MASTER_NOW_PLAYING_SAMPLE_RATE:
                         String sampleRate = device.getNowPlayingSampleRate(response.data.get(0));
-                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE, sampleRate);
+                        setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE, sampleRate);
                         break;
 
                     case MASTER_NOW_PLAYING_TITLE:
-                        state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_TITLE, value);
+                        setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_TITLE, value);
                         break;
                     default:
                         break;
@@ -279,14 +280,12 @@ public class ArcamConnection implements ArcamSocketListener {
             } else {
                 ArcamNowPlaying nowPlaying = device.setNowPlaying(response.data);
                 if (nowPlaying != null) {
-                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ALBUM, nowPlaying.album);
-                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_APPLICATION,
-                            nowPlaying.application);
-                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ARTIST, nowPlaying.artist);
-                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER,
-                            nowPlaying.audioEncoder);
-                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE, nowPlaying.sampleRate);
-                    state.setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_TITLE, nowPlaying.track);
+                    setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ALBUM, nowPlaying.album);
+                    setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_APPLICATION, nowPlaying.application);
+                    setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_ARTIST, nowPlaying.artist);
+                    setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_AUDIO_ENCODER, nowPlaying.audioEncoder);
+                    setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_SAMPLE_RATE, nowPlaying.sampleRate);
+                    setState(ArcamBindingConstants.CHANNEL_MASTER_NOW_PLAYING_TITLE, nowPlaying.track);
                 }
             }
         }
@@ -294,52 +293,53 @@ public class ArcamConnection implements ArcamSocketListener {
         if (response.cc == 0x57) {
             int temperature = device.getTemperature(response.data, 0);
             logger.debug("Got Output temperature: {}, value: {}", ArcamUtil.bytesToHex(response.data), temperature);
-            state.setState(ArcamBindingConstants.CHANNEL_OUTPUT_TEMPERATURE, temperature);
+            setState(ArcamBindingConstants.CHANNEL_OUTPUT_TEMPERATURE, temperature);
         }
         // Power
         if (response.cc == 0x00) {
             logger.debug("Got power response: {}", response.data);
             boolean power = device.getBoolean(response.data.get(0));
             if (isMasterZone(response.zn)) {
-                state.setState(ArcamBindingConstants.CHANNEL_MASTER_POWER, power);
+                setState(ArcamBindingConstants.CHANNEL_MASTER_POWER, power);
             } else {
-                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_POWER, power);
+                setState(ArcamBindingConstants.CHANNEL_ZONE2_POWER, power);
             }
         }
         // Room Equalisation
         if (response.cc == 0x37) {
             String eq = device.getRoomEqualisation(response.data.get(0));
             if (isMasterZone(response.zn)) {
-                state.setState(ArcamBindingConstants.CHANNEL_MASTER_ROOM_EQUALISATION, eq);
+                setState(ArcamBindingConstants.CHANNEL_MASTER_ROOM_EQUALISATION, eq);
             } else {
-                state.setState(ArcamBindingConstants.CHANNEL_ZONE2_ROOM_EQUALISATION, eq);
+                setState(ArcamBindingConstants.CHANNEL_ZONE2_ROOM_EQUALISATION, eq);
             }
         }
         // Short circuit status
         if (response.cc == 0x52) {
             logger.debug("Got Short circuit status response: {}", response.data);
             boolean shortCircuit = device.getBoolean(response.data.get(0));
-            state.setState(ArcamBindingConstants.CHANNEL_MASTER_SHORT_CIRCUIT, shortCircuit);
+            setState(ArcamBindingConstants.CHANNEL_MASTER_SHORT_CIRCUIT, shortCircuit);
         }
         // SoftwareVersion
         if (response.cc == 0x04) {
             String version = device.getSoftwareVersion(response.data);
             logger.debug("Got SoftwareVersion response: {}, {}", ArcamUtil.bytesToHex(response.data), version);
-            state.setState(ArcamBindingConstants.CHANNEL_SOFTWARE_VERSION, version);
+            setState(ArcamBindingConstants.CHANNEL_SOFTWARE_VERSION, version);
         }
         // Timeout counter
         if (response.cc == 0x55) {
             int counter = device.getTimeoutCounter(response.data);
             logger.debug("Got Timeout counter response: {}, {}", ArcamUtil.bytesToHex(response.data), counter);
-            state.setState(ArcamBindingConstants.CHANNEL_TIMEOUT_COUNTER, counter);
+            setState(ArcamBindingConstants.CHANNEL_TIMEOUT_COUNTER, counter);
         }
         // Volume
         if (response.cc == 0x0D) {
             int volume = Byte.valueOf(response.data.get(0)).intValue();
+            logger.debug("Got volume response: {}, {}", ArcamUtil.bytesToHex(response.data), volume);
             if (isMasterZone(response.zn)) {
-                state.setPercentageState(ArcamBindingConstants.CHANNEL_MASTER_VOLUME, volume);
+                setPercentageState(ArcamBindingConstants.CHANNEL_MASTER_VOLUME, volume);
             } else {
-                state.setPercentageState(ArcamBindingConstants.CHANNEL_ZONE2_VOLUME, volume);
+                setPercentageState(ArcamBindingConstants.CHANNEL_ZONE2_VOLUME, volume);
             }
         }
     }
@@ -348,10 +348,42 @@ public class ArcamConnection implements ArcamSocketListener {
         return zone == 0x01;
     }
 
+    private void finishInTransit(String channelId) {
+        ArcamCommandCode commandCode = ArcamCommandCode.getFromChannel(channelId);
+        if (commandCode == null) {
+            return;
+        }
+
+        commandInTransit.finish(commandCode);
+    }
+
+    private void setState(String channelId, @Nullable String value) {
+        finishInTransit(channelId);
+        StringType newValue = new StringType(value);
+        state.setState(channelId, newValue);
+    }
+
+    private void setState(String channelId, int value) {
+        finishInTransit(channelId);
+        DecimalType newValue = new DecimalType(value);
+        state.setState(channelId, newValue);
+    }
+
+    private void setPercentageState(String channelId, int value) {
+        finishInTransit(channelId);
+        PercentType newValue = new PercentType(value);
+        state.setState(channelId, newValue);
+    }
+
+    private void setState(String channelId, boolean value) {
+        finishInTransit(channelId);
+        OnOffType newValue = value ? OnOffType.ON : OnOffType.OFF;
+        state.setState(channelId, newValue);
+    }
+
     @Override
     public void onConnection() {
         connectionListener.onConnection();
-        requestAllValues();
     }
 
     @Override

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionListener.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionListener.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamConnectionListener} interface is used to signal events from the {@link ArcamConnection} class
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public interface ArcamConnectionListener {
+    public void onError();
+
+    public void onConnection();
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionReader.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionReader.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamConnectionReader} class manages the Socket.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamConnectionReader extends Thread {
+    private Socket socket;
+    private final Logger logger = LoggerFactory.getLogger(ArcamConnectionReader.class);
+    private ArcamConnectionReaderListener listener;
+
+    private ReentrantLock mutex = new ReentrantLock();
+    private boolean shouldStop;
+
+    public ArcamConnectionReader(Socket socket, ArcamConnectionReaderListener listener) {
+        this.socket = socket;
+        this.listener = listener;
+    }
+
+    private boolean shouldStop() {
+        boolean result = false;
+        mutex.lock();
+        if (shouldStop) {
+            result = true;
+        }
+        mutex.unlock();
+
+        if (result) {
+            logger.debug("Arcam Connection detected should stop");
+        }
+        return result;
+    }
+
+    @Override
+    public void run() {
+        ArcamResponseHandler responseHandler = new ArcamResponseHandler();
+        try {
+            InputStream input = socket.getInputStream();
+
+            while (!shouldStop()) {
+                // Checking with available() so we don't block with input.read() when no data is coming in.
+                if (input.available() == 0) {
+                    Thread.sleep(100);
+                    continue;
+                }
+
+                byte responseData[] = new byte[1];
+                int bytesRead = input.read(responseData);
+
+                for (int j = 0; j < bytesRead; j++) {
+                    ArcamResponse response = responseHandler.parseByte(responseData[j]);
+                    if (response != null) {
+                        listener.onResponse(response);
+                    }
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            logger.warn("Something went wrong in the connectionReader. Message: {}", e.getMessage());
+            listener.onConnReadError();
+        }
+
+        logger.debug("ACR thread done");
+    }
+
+    public void dispose() {
+        mutex.lock();
+        shouldStop = true;
+        mutex.unlock();
+        logger.debug("ACR dispose done");
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionReaderListener.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionReaderListener.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamConnectionReaderListener} interface is used to signal events from the {@link ArcamConnectionReader}
+ * class
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public interface ArcamConnectionReaderListener {
+    void onResponse(ArcamResponse response);
+
+    void onConnReadError();
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionState.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamConnectionState.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Specifies the connection state
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public enum ArcamConnectionState {
+    CONNECTING,
+    RECONNECTING,
+    CONNECTED
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamResponse.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ArcamResponse} POJO holds the data that is returned from the device.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamResponse {
+    public byte zn;
+    public byte cc;
+    public byte ac;
+    public int dl;
+    public List<Byte> data = new ArrayList<>();
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamResponseHandler.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamResponseHandler.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ArcamResponseHandler} class parses the incoming bytes and creates {@link ArcamResponse} objects out of
+ * them.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamResponseHandler {
+    private final Logger logger = LoggerFactory.getLogger(ArcamResponseHandler.class);
+    private int byteNr;
+    private boolean readyForNewResponse = true;
+    private ArcamResponse response;
+
+    public ArcamResponseHandler() {
+        response = new ArcamResponse();
+    }
+
+    @Nullable
+    public ArcamResponse parseByte(byte b) {
+        byteNr++;
+        if (readyForNewResponse && b == 0x21) {
+            byteNr = 0;
+            readyForNewResponse = false;
+            return null;
+        }
+        if (readyForNewResponse) {
+            return null;
+        }
+
+        if (byteNr == 1) {
+            response.zn = b;
+            return null;
+        }
+        if (byteNr == 2) {
+            response.cc = b;
+            return null;
+        }
+        if (byteNr == 3) {
+            response.ac = b;
+            return null;
+        }
+        if (byteNr == 4) {
+            response.dl = Byte.valueOf(b).intValue();
+            return null;
+        }
+        if (byteNr > 4 && byteNr <= response.dl + 4) {
+            response.data.add(b);
+            return null;
+        }
+
+        logger.debug("Got full response, cc: {}, zone: {}, length: {}, data: {}, ac: {}, et: {}",
+                ArcamUtil.byteToHex(response.cc), ArcamUtil.byteToHex(response.zn), response.dl,
+                ArcamUtil.bytesToHex(response.data), ArcamUtil.byteToHex(response.ac), ArcamUtil.byteToHex(b));
+        ArcamResponse retVal = response;
+        response = new ArcamResponse();
+        readyForNewResponse = true;
+        return retVal;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamSocket.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamSocket.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.time.Instant;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper around a Socket, including reconnection logic
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamSocket implements ArcamConnectionReaderListener {
+    private final Logger logger = LoggerFactory.getLogger(ArcamSocket.class);
+    private static final int ALIVE_INTERVAL = 10;
+    private static final int PORT = 50000;
+
+    @Nullable
+    private Socket socket;
+    @Nullable
+    private ArcamConnectionReader acr;
+    @Nullable
+    private String hostname;
+    @Nullable
+    private OutputStream outputStream;
+    @Nullable
+    private ScheduledFuture<?> pollingTask;
+
+    private String thingUID;
+    private ScheduledExecutorService scheduler;
+    private Instant lastResponseTime;
+    private ArcamSocketListener socketListener;
+    private byte[] heartbeatCommand;
+
+    private ArcamConnectionState connectionState;
+
+    public ArcamSocket(String thingUID, ScheduledExecutorService scheduler, byte[] heartbeatCommand,
+            ArcamSocketListener socketListener) {
+        this.thingUID = thingUID;
+        this.scheduler = scheduler;
+        this.lastResponseTime = Instant.MIN;
+        this.connectionState = ArcamConnectionState.CONNECTING;
+        this.socketListener = socketListener;
+        this.heartbeatCommand = heartbeatCommand;
+    }
+
+    public synchronized void connect(String hostname) {
+        String prevHostname = this.hostname;
+        if (hostname.equals(prevHostname)) {
+            logger.trace("Skip connect as we're already connected to {}", hostname);
+            return;
+        }
+
+        this.hostname = hostname;
+        try {
+            connect();
+        } catch (IOException e) {
+            handleConnectionIssue();
+        }
+
+        pollingTask = scheduler.scheduleWithFixedDelay(this::sendHeartbeat, ALIVE_INTERVAL, ALIVE_INTERVAL,
+                TimeUnit.SECONDS);
+        lastResponseTime = Instant.now();
+    }
+
+    private synchronized void connect() throws UnknownHostException, IOException {
+        logger.debug("connecting to: {} {}", hostname, PORT);
+        Socket s = new Socket(hostname, PORT);
+        socket = s;
+
+        outputStream = s.getOutputStream();
+        ArcamConnectionReader acr = new ArcamConnectionReader(s, this);
+        acr.setName("OH-binding-" + thingUID);
+        acr.setDaemon(true);
+        acr.start();
+        this.acr = acr;
+
+        socketListener.onConnection();
+        connectionState = ArcamConnectionState.CONNECTED;
+    }
+
+    private void reconnect() {
+        if (hostname == null) {
+            return;
+        }
+        logger.debug("Atempting to reconnect to: {}", hostname);
+
+        ArcamConnectionReader acr = this.acr;
+        if (acr != null) {
+            acr.dispose();
+            try {
+                acr.join();
+            } catch (InterruptedException e) {
+            }
+            acr = null;
+        }
+
+        // inputStream and outputStream are closed by socket.close()
+
+        Socket socket = this.socket;
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                // Since we're closing the socket anyways we're not interested in closing IO errors
+            }
+        }
+
+        try {
+            connect();
+        } catch (IOException e) {
+            scheduler.schedule(this::reconnect, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    // This method should be called from a synchronized method in order to be thread safe
+    private void handleConnectionIssue() {
+        logger.debug("handleConnectionIssue");
+        var x = System.out;
+        if (x != null) {
+            new Exception().printStackTrace(x);
+        }
+
+        if (connectionState == ArcamConnectionState.RECONNECTING) {
+            logger.debug("skip reconnect because already connecting");
+            return;
+        }
+
+        connectionState = ArcamConnectionState.RECONNECTING;
+        socketListener.onError();
+
+        reconnect();
+    }
+
+    private synchronized void sendHeartbeat() {
+        if (connectionState != ArcamConnectionState.CONNECTED) {
+            return;
+        }
+
+        if (Instant.now().getEpochSecond() - lastResponseTime.getEpochSecond() > ALIVE_INTERVAL + 10) {
+            handleConnectionIssue();
+        }
+
+        logger.debug("Sending heartbeat bytes: {}", ArcamUtil.bytesToHex(heartbeatCommand));
+        sendCommand(heartbeatCommand);
+    }
+
+    public synchronized void sendCommand(byte[] data) {
+        OutputStream os = outputStream;
+        if (os == null) {
+            return;
+        }
+
+        try {
+            logger.debug("outputStream write: {}", ArcamUtil.bytesToHex(data));
+            os.write(data);
+        } catch (IOException e) {
+            handleConnectionIssue();
+        }
+    }
+
+    public synchronized void dispose() {
+        final ScheduledFuture<?> pollingTask = this.pollingTask;
+
+        if (pollingTask != null) {
+            pollingTask.cancel(true);
+            this.pollingTask = null;
+        }
+
+        try {
+            OutputStream os = outputStream;
+            if (os != null) {
+                os.close();
+            }
+            ArcamConnectionReader acr = this.acr;
+            if (acr != null) {
+                acr.dispose();
+            }
+            Socket s = socket;
+            if (s != null) {
+                s.close();
+            }
+        } catch (IOException e) {
+            logger.debug("{}", e.getMessage());
+        }
+    }
+
+    @Override
+    public synchronized void onResponse(ArcamResponse response) {
+        lastResponseTime = Instant.now();
+        socketListener.onResponse(response);
+    }
+
+    @Override
+    public synchronized void onConnReadError() {
+        handleConnectionIssue();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamSocketListener.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/connection/ArcamSocketListener.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.connection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This interface is used to signal events from the {@link ArcamSocket} class
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public interface ArcamSocketListener {
+    public void onResponse(ArcamResponse response);
+
+    public void onConnection();
+
+    public void onError();
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR10.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR10.java
@@ -112,7 +112,7 @@ public class ArcamAVR10 implements ArcamDevice {
         // 0x00 – Set the balance to the centre
         // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
         // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
-        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
 
         byte balanceByte = (byte) balance;
 
@@ -131,7 +131,7 @@ public class ArcamAVR10 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -139,12 +139,12 @@ public class ArcamAVR10 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -174,7 +174,7 @@ public class ArcamAVR10 implements ArcamDevice {
 
     @Override
     public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
 
         data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
         return data;
@@ -182,7 +182,7 @@ public class ArcamAVR10 implements ArcamDevice {
 
     @Override
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         data[4] = (byte) volume;
 
         return data;
@@ -190,7 +190,7 @@ public class ArcamAVR10 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR10.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR10.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the AVR10
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamAVR10 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("FZONE1", "Follow Zone 1", (byte) 0x00), //
+            new ArcamCommandData("CD", (byte) 0x01), //
+            new ArcamCommandData("BD", (byte) 0x02), //
+            new ArcamCommandData("AV", (byte) 0x03), //
+            new ArcamCommandData("SAT", (byte) 0x04), //
+            new ArcamCommandData("PVR", (byte) 0x05), //
+            new ArcamCommandData("UHD", (byte) 0x06), //
+            new ArcamCommandData("AUX", (byte) 0x08), //
+            new ArcamCommandData("DISPLAY", (byte) 0x09), //
+            new ArcamCommandData("TUNERFM", "TUNER (FM)", (byte) 0x0B), //
+            new ArcamCommandData("TUNERDAB", "TUNER (DAB)", (byte) 0x0C), //
+            new ArcamCommandData("NET", (byte) 0x0E), //
+            new ArcamCommandData("STB", (byte) 0x10), //
+            new ArcamCommandData("GAME", (byte) 0x11), //
+            new ArcamCommandData("BT", (byte) 0x12) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", "Front panel is off", (byte) 0x00), //
+            new ArcamCommandData("L1", "Front panel L1", (byte) 0x01), //
+            new ArcamCommandData("L2", "Front panel L2", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DIRECT_MODE, new byte[] { 0x21, 0x01, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_ROOM_EQUALISATION, new byte[] { 0x21, 0x01, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static String AVR10 = "AVR10";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamAVR10() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
+        // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
+        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        // Using RC5 simulation
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x0D, 0x0D };
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        // Using RC5 simulation
+        if (on) {
+            return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7B, 0x0D };
+        }
+
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7C, 0x0D };
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+
+        data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
+        return data;
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, ArcamDeviceConstants.ROOM_EQ);
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR10ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR10ChannelTypeProvider.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link ArcamAVR10ChannelTypeProvider} class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamAVR10ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String AVR10_DISPLAY_BRIGHTNESS = "avr10DisplayBrightness";
+    public static final String AVR10_MASTER_INPUT = "avr10MasterInput";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+        channelTypeList.add(getChannelTypeOrThrow(AVR10_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR10_MASTER_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(AVR10_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamAVR10.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR10_MASTER_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "xMaster Input", //
+                    "Select the input source", //
+                    ArcamAVR10.INPUT_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR20.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR20.java
@@ -122,9 +122,9 @@ public class ArcamAVR20 implements ArcamDevice {
         // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_BALANCE, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_BALANCE, COMMANDS);
         }
         byte balanceByte = (byte) balance;
 
@@ -143,7 +143,7 @@ public class ArcamAVR20 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -151,12 +151,12 @@ public class ArcamAVR20 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -188,9 +188,9 @@ public class ArcamAVR20 implements ArcamDevice {
     public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
         }
         data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
         return data;
@@ -200,9 +200,9 @@ public class ArcamAVR20 implements ArcamDevice {
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_VOLUME, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_VOLUME, COMMANDS);
         }
         data[4] = (byte) volume;
 
@@ -211,7 +211,7 @@ public class ArcamAVR20 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR20.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR20.java
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the AVR20
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamAVR20 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("FZONE1", "Follow Zone 1", (byte) 0x00), //
+            new ArcamCommandData("CD", (byte) 0x01), //
+            new ArcamCommandData("BD", (byte) 0x02), //
+            new ArcamCommandData("AV", (byte) 0x03), //
+            new ArcamCommandData("SAT", (byte) 0x04), //
+            new ArcamCommandData("PVR", (byte) 0x05), //
+            new ArcamCommandData("UHD", (byte) 0x06), //
+            new ArcamCommandData("AUX", (byte) 0x08), //
+            new ArcamCommandData("DISPLAY", (byte) 0x09), //
+            new ArcamCommandData("TUNERFM", "TUNER (FM)", (byte) 0x0B), //
+            new ArcamCommandData("TUNERDAB", "TUNER (DAB)", (byte) 0x0C), //
+            new ArcamCommandData("NET", (byte) 0x0E), //
+            new ArcamCommandData("STB", (byte) 0x10), //
+            new ArcamCommandData("GAME", (byte) 0x11), //
+            new ArcamCommandData("BT", (byte) 0x12) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", "Front panel is off", (byte) 0x00), //
+            new ArcamCommandData("L1", "Front panel L1", (byte) 0x01), //
+            new ArcamCommandData("L2", "Front panel L2", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DIRECT_MODE, new byte[] { 0x21, 0x01, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_ROOM_EQUALISATION, new byte[] { 0x21, 0x01, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }), //
+            // Zone 2
+            new ArcamCommand(ZONE2_BALANCE, new byte[] { 0x21, 0x02, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_DIRECT_MODE, new byte[] { 0x21, 0x02, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_INPUT, new byte[] { 0x21, 0x02, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_MUTE, new byte[] { 0x21, 0x02, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_POWER, new byte[] { 0x21, 0x02, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_ROOM_EQUALISATION, new byte[] { 0x21, 0x02, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_VOLUME, new byte[] { 0x21, 0x02, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static String AVR20 = "AVR20";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamAVR20() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
+        // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_BALANCE, COMMANDS);
+        }
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        // Using RC5 simulation
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x0D, 0x0D };
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        // Using RC5 simulation
+        if (on) {
+            return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7B, 0x0D };
+        }
+
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7C, 0x0D };
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
+        }
+        data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
+        return data;
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_VOLUME, COMMANDS);
+        }
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, ArcamDeviceConstants.ROOM_EQ);
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR20ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR20ChannelTypeProvider.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link ArcamAVR20ChannelTypeProvider} class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamAVR20ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String AVR20_DISPLAY_BRIGHTNESS = "avr20DisplayBrightness";
+    public static final String AVR20_MASTER_INPUT = "avr20MasterInput";
+    public static final String AVR20_ZONE2_INPUT = "avr20Zone2Input";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+        channelTypeList.add(getChannelTypeOrThrow(AVR20_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR20_MASTER_INPUT, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR20_ZONE2_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(AVR20_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamAVR20.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR20_MASTER_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "xMaster Input", //
+                    "Select the input source", //
+                    ArcamAVR20.INPUT_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR20_ZONE2_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Zone2 Input", //
+                    "Select the input source", //
+                    ArcamAVR20.INPUT_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR30.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR30.java
@@ -122,9 +122,9 @@ public class ArcamAVR30 implements ArcamDevice {
         // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_BALANCE, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_BALANCE, COMMANDS);
         }
         byte balanceByte = (byte) balance;
 
@@ -143,7 +143,7 @@ public class ArcamAVR30 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -151,12 +151,12 @@ public class ArcamAVR30 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -188,9 +188,9 @@ public class ArcamAVR30 implements ArcamDevice {
     public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
         }
         data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
         return data;
@@ -200,9 +200,9 @@ public class ArcamAVR30 implements ArcamDevice {
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_VOLUME, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_VOLUME, COMMANDS);
         }
         data[4] = (byte) volume;
 
@@ -211,7 +211,7 @@ public class ArcamAVR30 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR30.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR30.java
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the AVR30
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamAVR30 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("FZONE1", "Follow Zone 1", (byte) 0x00), //
+            new ArcamCommandData("CD", (byte) 0x01), //
+            new ArcamCommandData("BD", (byte) 0x02), //
+            new ArcamCommandData("AV", (byte) 0x03), //
+            new ArcamCommandData("SAT", (byte) 0x04), //
+            new ArcamCommandData("PVR", (byte) 0x05), //
+            new ArcamCommandData("UHD", (byte) 0x06), //
+            new ArcamCommandData("AUX", (byte) 0x08), //
+            new ArcamCommandData("DISPLAY", (byte) 0x09), //
+            new ArcamCommandData("TUNERFM", "TUNER (FM)", (byte) 0x0B), //
+            new ArcamCommandData("TUNERDAB", "TUNER (DAB)", (byte) 0x0C), //
+            new ArcamCommandData("NET", (byte) 0x0E), //
+            new ArcamCommandData("STB", (byte) 0x10), //
+            new ArcamCommandData("GAME", (byte) 0x11), //
+            new ArcamCommandData("BT", (byte) 0x12) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", "Front panel is off", (byte) 0x00), //
+            new ArcamCommandData("L1", "Front panel L1", (byte) 0x01), //
+            new ArcamCommandData("L2", "Front panel L2", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DIRECT_MODE, new byte[] { 0x21, 0x01, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_ROOM_EQUALISATION, new byte[] { 0x21, 0x01, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }), //
+            // Zone 2
+            new ArcamCommand(ZONE2_BALANCE, new byte[] { 0x21, 0x02, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_DIRECT_MODE, new byte[] { 0x21, 0x02, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_INPUT, new byte[] { 0x21, 0x02, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_MUTE, new byte[] { 0x21, 0x02, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_POWER, new byte[] { 0x21, 0x02, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_ROOM_EQUALISATION, new byte[] { 0x21, 0x02, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_VOLUME, new byte[] { 0x21, 0x02, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static String AVR30 = "AVR30";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamAVR30() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
+        // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_BALANCE, COMMANDS);
+        }
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        // Using RC5 simulation
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x0D, 0x0D };
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        // Using RC5 simulation
+        if (on) {
+            return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7B, 0x0D };
+        }
+
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7C, 0x0D };
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
+        }
+        data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
+        return data;
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_VOLUME, COMMANDS);
+        }
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, ArcamDeviceConstants.ROOM_EQ);
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR30ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR30ChannelTypeProvider.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link ArcamAVR30ChannelTypeProvider} class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamAVR30ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String AVR30_DISPLAY_BRIGHTNESS = "avr30DisplayBrightness";
+    public static final String AVR30_MASTER_INPUT = "avr30MasterInput";
+    public static final String AVR30_ZONE2_INPUT = "avr30Zone2Input";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+        channelTypeList.add(getChannelTypeOrThrow(AVR30_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR30_MASTER_INPUT, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR30_ZONE2_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(AVR30_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamAVR30.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR30_MASTER_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "xMaster Input", //
+                    "Select the input source", //
+                    ArcamAVR30.INPUT_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR30_ZONE2_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Zone2 Input", //
+                    "Select the input source", //
+                    ArcamAVR30.INPUT_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR40.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR40.java
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the AVR40
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamAVR40 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("FZONE1", "Follow Zone 1", (byte) 0x00), //
+            new ArcamCommandData("CD", (byte) 0x01), //
+            new ArcamCommandData("BD", (byte) 0x02), //
+            new ArcamCommandData("AV", (byte) 0x03), //
+            new ArcamCommandData("SAT", (byte) 0x04), //
+            new ArcamCommandData("PVR", (byte) 0x05), //
+            new ArcamCommandData("UHD", (byte) 0x06), //
+            new ArcamCommandData("AUX", (byte) 0x08), //
+            new ArcamCommandData("DISPLAY", (byte) 0x09), //
+            new ArcamCommandData("TUNERFM", "TUNER (FM)", (byte) 0x0B), //
+            new ArcamCommandData("TUNERDAB", "TUNER (DAB)", (byte) 0x0C), //
+            new ArcamCommandData("NET", (byte) 0x0E), //
+            new ArcamCommandData("STB", (byte) 0x10), //
+            new ArcamCommandData("GAME", (byte) 0x11), //
+            new ArcamCommandData("BT", (byte) 0x12) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", "Front panel is off", (byte) 0x00), //
+            new ArcamCommandData("L1", "Front panel L1", (byte) 0x01), //
+            new ArcamCommandData("L2", "Front panel L2", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DIRECT_MODE, new byte[] { 0x21, 0x01, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_ROOM_EQUALISATION, new byte[] { 0x21, 0x01, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }), //
+            // Zone 2
+            new ArcamCommand(ZONE2_BALANCE, new byte[] { 0x21, 0x02, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_DIRECT_MODE, new byte[] { 0x21, 0x02, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_INPUT, new byte[] { 0x21, 0x02, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_MUTE, new byte[] { 0x21, 0x02, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_POWER, new byte[] { 0x21, 0x02, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_ROOM_EQUALISATION, new byte[] { 0x21, 0x02, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(ZONE2_VOLUME, new byte[] { 0x21, 0x02, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static String AVR40 = "AVR40";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamAVR40() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
+        // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_BALANCE, COMMANDS);
+        }
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        // Using RC5 simulation
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x0D, 0x0D };
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        // Using RC5 simulation
+        if (on) {
+            return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7B, 0x0D };
+        }
+
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7C, 0x0D };
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
+        }
+        data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
+        return data;
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data;
+        if (zone == ArcamZone.MASTER) {
+            data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        } else {
+            data = commandFinder.getCommandFromCode(ZONE2_VOLUME, COMMANDS);
+        }
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, ArcamDeviceConstants.ROOM_EQ);
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR40.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR40.java
@@ -122,9 +122,9 @@ public class ArcamAVR40 implements ArcamDevice {
         // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_BALANCE, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_BALANCE, COMMANDS);
         }
         byte balanceByte = (byte) balance;
 
@@ -143,7 +143,7 @@ public class ArcamAVR40 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -151,12 +151,12 @@ public class ArcamAVR40 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -188,9 +188,9 @@ public class ArcamAVR40 implements ArcamDevice {
     public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_ROOM_EQUALISATION, COMMANDS);
         }
         data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
         return data;
@@ -200,9 +200,9 @@ public class ArcamAVR40 implements ArcamDevice {
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
         byte[] data;
         if (zone == ArcamZone.MASTER) {
-            data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         } else {
-            data = commandFinder.getCommandFromCode(ZONE2_VOLUME, COMMANDS);
+            data = commandFinder.getCommandDataFromCode(ZONE2_VOLUME, COMMANDS);
         }
         data[4] = (byte) volume;
 
@@ -211,7 +211,7 @@ public class ArcamAVR40 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR40ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR40ChannelTypeProvider.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link ArcamAVR40ChannelTypeProvider} class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamAVR40ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String AVR40_DISPLAY_BRIGHTNESS = "avr40DisplayBrightness";
+    public static final String AVR40_MASTER_INPUT = "avr40MasterInput";
+    public static final String AVR40_ZONE2_INPUT = "avr40Zone2Input";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+        channelTypeList.add(getChannelTypeOrThrow(AVR40_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR40_MASTER_INPUT, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR40_ZONE2_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(AVR40_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamAVR40.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR40_MASTER_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "xMaster Input", //
+                    "Select the input source", //
+                    ArcamAVR40.INPUT_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR40_ZONE2_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Zone2 Input", //
+                    "Select the input source", //
+                    ArcamAVR40.INPUT_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR5.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR5.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the AVR5
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamAVR5 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("FZONE1", "Follow Zone 1", (byte) 0x00), //
+            new ArcamCommandData("CD", (byte) 0x01), //
+            new ArcamCommandData("BD", (byte) 0x02), //
+            new ArcamCommandData("AV", (byte) 0x03), //
+            new ArcamCommandData("SAT", (byte) 0x04), //
+            new ArcamCommandData("PVR", (byte) 0x05), //
+            new ArcamCommandData("UHD", (byte) 0x06), //
+            new ArcamCommandData("AUX", (byte) 0x08), //
+            new ArcamCommandData("DISPLAY", (byte) 0x09), //
+            new ArcamCommandData("TUNERFM", "TUNER (FM)", (byte) 0x0B), //
+            new ArcamCommandData("TUNERDAB", "TUNER (DAB)", (byte) 0x0C), //
+            new ArcamCommandData("NET", (byte) 0x0E), //
+            new ArcamCommandData("STB", (byte) 0x10), //
+            new ArcamCommandData("GAME", (byte) 0x11), //
+            new ArcamCommandData("BT", (byte) 0x12) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", "Front panel is off", (byte) 0x00), //
+            new ArcamCommandData("L1", "Front panel L1", (byte) 0x01), //
+            new ArcamCommandData("L2", "Front panel L2", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DIRECT_MODE, new byte[] { 0x21, 0x01, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_ROOM_EQUALISATION, new byte[] { 0x21, 0x01, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static String AVR5 = "AVR5";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamAVR5() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
+        // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
+        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        // Using RC5 simulation
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x0D, 0x0D };
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        // Using RC5 simulation
+        if (on) {
+            return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7B, 0x0D };
+        }
+
+        return new byte[] { 0x21, ArcamDeviceUtil.zoneToByte(zone), 0x08, 0x02, 0x10, 0x7C, 0x0D };
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+
+        data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
+        return data;
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, ArcamDeviceConstants.ROOM_EQ);
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR5.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR5.java
@@ -112,7 +112,7 @@ public class ArcamAVR5 implements ArcamDevice {
         // 0x00 – Set the balance to the centre
         // 0x01 – 0x06 – Set the balance to the right 1, 2, ..., 5, 6
         // 0x81 – 0x86 – Set the balance to the left 1, 2,..., 5, 6
-        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
 
         byte balanceByte = (byte) balance;
 
@@ -131,7 +131,7 @@ public class ArcamAVR5 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -139,12 +139,12 @@ public class ArcamAVR5 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -174,7 +174,7 @@ public class ArcamAVR5 implements ArcamDevice {
 
     @Override
     public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
 
         data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
         return data;
@@ -182,7 +182,7 @@ public class ArcamAVR5 implements ArcamDevice {
 
     @Override
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         data[4] = (byte) volume;
 
         return data;
@@ -190,7 +190,7 @@ public class ArcamAVR5 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR5ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamAVR5ChannelTypeProvider.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link ArcamAVR5ChannelTypeProvider} class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamAVR5ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String AVR5_DISPLAY_BRIGHTNESS = "avr5DisplayBrightness";
+    public static final String AVR5_MASTER_INPUT = "avr5MasterInput";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+        channelTypeList.add(getChannelTypeOrThrow(AVR5_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(AVR5_MASTER_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(AVR5_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamAVR5.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        if (channelID.equals(AVR5_MASTER_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "xMaster Input", //
+                    "Select the input source", //
+                    ArcamAVR5.INPUT_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamDevice.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamDevice.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+
+/**
+ * This interface allows splitting the device specific logic into separate classes.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public interface ArcamDevice {
+    // Methods used to get a value from the device
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode);
+
+    // Methods used to send a value to the device
+    public byte[] getBalanceCommand(int balance, ArcamZone zone);
+
+    public byte[] getDacFilterCommand(String dacFilter);
+
+    public byte[] getDisplayBrightnessCommand(String displayBrightness);
+
+    public byte[] getHeartbeatCommand();
+
+    public byte[] getInputCommand(String inputName, ArcamZone zone);
+
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone);
+
+    public byte[] getPowerCommand(boolean on, ArcamZone zone);
+
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone);
+
+    public byte[] getRebootCommand();
+
+    public byte[] getVolumeCommand(int volume, ArcamZone zone);
+
+    // Methods used to convert incoming data to a value
+    public int getBalance(byte dataByte);
+
+    public boolean getBoolean(byte dataByte);
+
+    @Nullable
+    public String getDacFilter(Byte dataByte);
+
+    @Nullable
+    public String getDisplayBrightness(byte dataByte);
+
+    public String getIncomingSampleRate(byte dataByte);
+
+    @Nullable
+    public String getInputName(byte dataByte);
+
+    // PA720 needs a byte array
+    public int getTemperature(List<Byte> dataBytes, int tempNr);
+
+    public boolean getMute(byte dataByte);
+
+    public String getNowPlayingSampleRate(byte dataByte);
+
+    public String getNowPlayingEncoder(byte dataByte);
+
+    @Nullable
+    public String getRoomEqualisation(byte dataByte);
+
+    public String getSoftwareVersion(List<Byte> dataBytes);
+
+    public int getTimeoutCounter(List<Byte> dataBytes);
+
+    // Methods used to successively provide dataByte arrays which belong together. When complete it will return an
+    // object with the parsed values
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes);
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamDeviceConstants.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamDeviceConstants.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+
+/**
+ * This class provides constants that are used by multiple devices.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamDeviceConstants {
+    public static final List<ArcamCommandData> ROOM_EQ = new ArrayList<>(List.of( //
+            new ArcamCommandData("ROOM_EQ_OFF", (byte) 0x00), //
+            new ArcamCommandData("ROOM_EQ_1", (byte) 0x01), //
+            new ArcamCommandData("ROOM_EQ_2", (byte) 0x02), //
+            new ArcamCommandData("ROOM_EQ_3", (byte) 0x03) //
+    ));
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamDeviceUtil.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamDeviceUtil.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+
+/**
+ * This class provides utility methods for the device classes
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamDeviceUtil {
+    public static ArcamDevice getDeviceFromThingUID(ThingUID thingUID) {
+        String id = thingUID.getAsString();
+
+        if (id.contains(ArcamAVR5.AVR5)) {
+            return new ArcamAVR5();
+        }
+        if (id.contains(ArcamAVR10.AVR10)) {
+            return new ArcamAVR10();
+        }
+        if (id.contains(ArcamAVR20.AVR20)) {
+            return new ArcamAVR20();
+        }
+        if (id.contains(ArcamAVR30.AVR30)) {
+            return new ArcamAVR30();
+        }
+        if (id.contains(ArcamAVR40.AVR40)) {
+            return new ArcamAVR40();
+        }
+        if (id.contains(ArcamSA10.SA10)) {
+            return new ArcamSA10();
+        }
+        if (id.contains(ArcamSA20.SA20)) {
+            return new ArcamSA20();
+        }
+        if (id.contains(ArcamSA30.SA30)) {
+            return new ArcamSA30();
+        }
+
+        throw new NotFoundException("Could not find an Arcam device from the thingUID: " + id);
+    }
+
+    @Nullable
+    public static ThingTypeUID getThingTypeUIDFromModelName(String modelName) {
+        if (modelName.contains("AVR5")) {
+            return ArcamBindingConstants.AVR5_THING_TYPE_UID;
+        }
+        if (modelName.contains("AVR10")) {
+            return ArcamBindingConstants.AVR10_THING_TYPE_UID;
+        }
+        if (modelName.contains("AVR20")) {
+            return ArcamBindingConstants.AVR20_THING_TYPE_UID;
+        }
+        if (modelName.contains("AVR30")) {
+            return ArcamBindingConstants.AVR30_THING_TYPE_UID;
+        }
+        if (modelName.contains("AVR40")) {
+            return ArcamBindingConstants.AVR40_THING_TYPE_UID;
+        }
+        if (modelName.contains("SA10")) {
+            return ArcamBindingConstants.SA10_THING_TYPE_UID;
+        }
+        if (modelName.contains("SA20")) {
+            return ArcamBindingConstants.SA20_THING_TYPE_UID;
+        }
+        if (modelName.contains("SA30")) {
+            return ArcamBindingConstants.SA30_THING_TYPE_UID;
+        }
+
+        return null;
+    }
+
+    public static byte zoneToByte(ArcamZone zone) {
+        if (zone == ArcamZone.MASTER) {
+            return 0x01;
+        }
+
+        return 0x02;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA10.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA10.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the SA10
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamSA10 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> DAC_FILTER_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("Linear Phase Fast Roll Off", (byte) 0x00), //
+            new ArcamCommandData("Linear Phase Slow Roll Off", (byte) 0x01), //
+            new ArcamCommandData("Minimum Phase Fast Roll Off", (byte) 0x02) //
+    ));
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("PHONO", (byte) 0x01), //
+            new ArcamCommandData("AUX", (byte) 0x02), //
+            new ArcamCommandData("PVR", (byte) 0x03), //
+            new ArcamCommandData("AV", (byte) 0x04), //
+            new ArcamCommandData("STB", (byte) 0x05), //
+            new ArcamCommandData("CD", (byte) 0x06), //
+            new ArcamCommandData("BD", (byte) 0x07), //
+            new ArcamCommandData("SAT", (byte) 0x08) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", (byte) 0x00), //
+            new ArcamCommandData("DIM", (byte) 0x01), //
+            new ArcamCommandData("FULL", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SYSTEM_STATUS, new byte[] { 0x21, 0x01, 0x5D, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DAC_FILTER, new byte[] { 0x21, 0x01, 0x61, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(OUTPUT_TEMPERATURE, new byte[] { 0x21, 0x01, 0x57, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(TIMEOUT_COUNTER, new byte[] { 0x21, 0x01, 0x55, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DC_OFFSET, new byte[] { 0x21, 0x01, 0x51, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT_DETECT, new byte[] { 0x21, 0x01, 0x5A, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static final String SA10 = "SA10";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamSA10() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12
+        // 0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12
+
+        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        byte[] data = commandFinder.getCommandFromCode(DAC_FILTER, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(dacFilter, DAC_FILTER_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_MUTE, COMMANDS);
+        if (mute) {
+            data[4] = (byte) 0x00;
+            return data;
+        }
+
+        data[4] = (byte) 0x01;
+        return data;
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_POWER, COMMANDS);
+        if (on) {
+            data[4] = (byte) 0x01;
+            return data;
+        }
+
+        data[4] = (byte) 0x00;
+        return data;
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DAC_FILTER_COMMANDS);
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        byte convertedByte = dataByte;
+        if (dataByte > 0x0D) {
+            convertedByte = (byte) (dataByte - 0x10);
+        }
+
+        return commandDataFinder.getCommandCodeFromByte(convertedByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        // The range of the value returned is from 0x0000 - 0x00F0 (0 - 240minutes)
+        return dataBytes.get(1);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA10.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA10.java
@@ -117,7 +117,7 @@ public class ArcamSA10 implements ArcamDevice {
         // 0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12
         // 0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12
 
-        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
         byte balanceByte = (byte) balance;
 
         if (balance < 0) {
@@ -130,7 +130,7 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getDacFilterCommand(String dacFilter) {
-        byte[] data = commandFinder.getCommandFromCode(DAC_FILTER, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DAC_FILTER, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(dacFilter, DAC_FILTER_COMMANDS);
 
         return data;
@@ -138,7 +138,7 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -146,12 +146,12 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -159,7 +159,7 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_MUTE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_MUTE, COMMANDS);
         if (mute) {
             data[4] = (byte) 0x00;
             return data;
@@ -171,7 +171,7 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getPowerCommand(boolean on, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_POWER, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_POWER, COMMANDS);
         if (on) {
             data[4] = (byte) 0x01;
             return data;
@@ -194,7 +194,7 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         data[4] = (byte) volume;
 
         return data;
@@ -202,7 +202,7 @@ public class ArcamSA10 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA10ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA10ChannelTypeProvider.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamSA10ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String SA10_DAC_FILTER = "sa10DacFilter";
+    public static final String SA10_DISPLAY_BRIGHTNESS = "sa10DisplayBrightness";
+    public static final String SA10_INPUT = "sa10Input";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+
+        channelTypeList.add(getChannelTypeOrThrow(SA10_DAC_FILTER, locale));
+        channelTypeList.add(getChannelTypeOrThrow(SA10_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(SA10_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(SA10_DAC_FILTER)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "DAC filter", //
+                    "Select DAC filter", //
+                    ArcamSA10.DAC_FILTER_COMMANDS); //
+        }
+
+        if (channelID.equals(SA10_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Input", //
+                    "Select the input source", //
+                    ArcamSA10.INPUT_COMMANDS); //
+        }
+
+        if (channelID.equals(SA10_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamSA10.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA20.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA20.java
@@ -123,7 +123,7 @@ public class ArcamSA20 implements ArcamDevice {
         // 0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12
         // 0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12
 
-        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
         byte balanceByte = (byte) balance;
 
         if (balance < 0) {
@@ -136,7 +136,7 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getDacFilterCommand(String dacFilter) {
-        byte[] data = commandFinder.getCommandFromCode(DAC_FILTER, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DAC_FILTER, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(dacFilter, DAC_FILTER_COMMANDS);
 
         return data;
@@ -144,7 +144,7 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -152,12 +152,12 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -165,7 +165,7 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_MUTE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_MUTE, COMMANDS);
         if (mute) {
             data[4] = (byte) 0x00;
             return data;
@@ -177,7 +177,7 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getPowerCommand(boolean on, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_POWER, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_POWER, COMMANDS);
         if (on) {
             data[4] = (byte) 0x01;
             return data;
@@ -200,7 +200,7 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         data[4] = (byte) volume;
 
         return data;
@@ -208,7 +208,7 @@ public class ArcamSA20 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA20.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA20.java
@@ -1,0 +1,311 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotSupportedException;
+
+/**
+ * This class contains the device specific implementation for the SA20
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamSA20 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> DAC_FILTER_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("Linear Phase Fast Roll Off", (byte) 0x00), //
+            new ArcamCommandData("Linear Phase Slow Roll Off", (byte) 0x01), //
+            new ArcamCommandData("Minimum Phase Fast Roll Off", (byte) 0x02), //
+            new ArcamCommandData("Minimum Phase Slow Roll Off", (byte) 0x03), //
+            new ArcamCommandData("Brick Wall", (byte) 0x04), //
+            new ArcamCommandData("Corrected Phase Fast Roll Off", (byte) 0x05), //
+            new ArcamCommandData("Apodizing", (byte) 0x06) //
+    ));
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("PHONO", (byte) 0x01), //
+            new ArcamCommandData("AUX", (byte) 0x02), //
+            new ArcamCommandData("PVR", (byte) 0x03), //
+            new ArcamCommandData("AV", (byte) 0x04), //
+            new ArcamCommandData("STB", (byte) 0x05), //
+            new ArcamCommandData("CD", (byte) 0x06), //
+            new ArcamCommandData("BD", (byte) 0x07), //
+            new ArcamCommandData("SAT", (byte) 0x08) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", (byte) 0x00), //
+            new ArcamCommandData("DIM", (byte) 0x01), //
+            new ArcamCommandData("FULL", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SYSTEM_STATUS, new byte[] { 0x21, 0x01, 0x5D, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DAC_FILTER, new byte[] { 0x21, 0x01, 0x61, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(LIFTER_TEMPERATURE, new byte[] { 0x21, 0x01, 0x56, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(OUTPUT_TEMPERATURE, new byte[] { 0x21, 0x01, 0x57, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(TIMEOUT_COUNTER, new byte[] { 0x21, 0x01, 0x55, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DC_OFFSET, new byte[] { 0x21, 0x01, 0x51, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT_DETECT, new byte[] { 0x21, 0x01, 0x5A, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_SHORT_CIRCUIT, new byte[] { 0x21, 0x01, 0x52, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static final String SA20 = "SA20";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+
+    public ArcamSA20() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12
+        // 0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12
+
+        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        byte[] data = commandFinder.getCommandFromCode(DAC_FILTER, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(dacFilter, DAC_FILTER_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_MUTE, COMMANDS);
+        if (mute) {
+            data[4] = (byte) 0x00;
+            return data;
+        }
+
+        data[4] = (byte) 0x01;
+        return data;
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_POWER, COMMANDS);
+        if (on) {
+            data[4] = (byte) 0x01;
+            return data;
+        }
+
+        data[4] = (byte) 0x00;
+        return data;
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DAC_FILTER_COMMANDS);
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        byte convertedByte = dataByte;
+        if (dataByte > 0x0D) {
+            convertedByte = (byte) (dataByte - 0x10);
+        }
+
+        return commandDataFinder.getCommandCodeFromByte(convertedByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        // The range of the value returned is from 0x0000 - 0x00F0 (0 - 240minutes)
+        return dataBytes.get(1);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA20ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA20ChannelTypeProvider.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamSA20ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String SA20_DAC_FILTER = "sa20DacFilter";
+    public static final String SA20_DISPLAY_BRIGHTNESS = "sa20DisplayBrightness";
+    public static final String SA20_INPUT = "sa20Input";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+
+        channelTypeList.add(getChannelTypeOrThrow(SA20_DAC_FILTER, locale));
+        channelTypeList.add(getChannelTypeOrThrow(SA20_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(SA20_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(SA20_DAC_FILTER)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "DAC filter", //
+                    "Select DAC filter", //
+                    ArcamSA20.DAC_FILTER_COMMANDS); //
+        }
+
+        if (channelID.equals(SA20_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Input", //
+                    "Select the input source", //
+                    ArcamSA20.INPUT_COMMANDS); //
+        }
+
+        if (channelID.equals(SA20_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamSA20.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA30.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA30.java
@@ -156,7 +156,7 @@ public class ArcamSA30 implements ArcamDevice {
         // 0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12
         // 0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12
 
-        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_BALANCE, COMMANDS);
         byte balanceByte = (byte) balance;
 
         if (balance < 0) {
@@ -169,7 +169,7 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getDacFilterCommand(String dacFilter) {
-        byte[] data = commandFinder.getCommandFromCode(DAC_FILTER, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DAC_FILTER, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(dacFilter, DAC_FILTER_COMMANDS);
 
         return data;
@@ -177,7 +177,7 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getDisplayBrightnessCommand(String displayBrightness) {
-        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
 
         return data;
@@ -185,12 +185,12 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getHeartbeatCommand() {
-        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+        return commandFinder.getCommandDataFromCode(HEARTBEAT, COMMANDS);
     }
 
     @Override
     public byte[] getInputCommand(String inputName, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_INPUT, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
 
         return data;
@@ -198,7 +198,7 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_MUTE, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_MUTE, COMMANDS);
         if (mute) {
             data[4] = (byte) 0x00;
             return data;
@@ -210,7 +210,7 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getPowerCommand(boolean on, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_POWER, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_POWER, COMMANDS);
         if (on) {
             data[4] = (byte) 0x01;
             return data;
@@ -228,14 +228,14 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
         data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
         return data;
     }
 
     @Override
     public byte[] getVolumeCommand(int volume, ArcamZone zone) {
-        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        byte[] data = commandFinder.getCommandDataFromCode(MASTER_VOLUME, COMMANDS);
         data[4] = (byte) volume;
 
         return data;
@@ -243,7 +243,7 @@ public class ArcamSA30 implements ArcamDevice {
 
     @Override
     public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
-        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+        return commandFinder.getCommandDataFromCode(commandCode, COMMANDS);
     }
 
     // Interpret incoming bytes

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA30.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA30.java
@@ -1,0 +1,391 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.openhab.binding.arcam.internal.connection.ArcamCommandCode.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamNowPlaying;
+import org.openhab.binding.arcam.internal.ArcamUtil;
+import org.openhab.binding.arcam.internal.ArcamZone;
+import org.openhab.binding.arcam.internal.connection.ArcamCommand;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandCode;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandData;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandFinder;
+
+/**
+ * This class contains the device specific implementation for the SA30
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class ArcamSA30 implements ArcamDevice {
+
+    public static final List<ArcamCommandData> DAC_FILTER_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("Linear Phase Fast Roll Off", (byte) 0x00), //
+            new ArcamCommandData("Linear Phase Slow Roll Off", (byte) 0x01), //
+            new ArcamCommandData("Minimum Phase Fast Roll Off", (byte) 0x02), //
+            new ArcamCommandData("Minimum Phase Slow Roll Off", (byte) 0x03), //
+            new ArcamCommandData("Brick Wall", (byte) 0x04), //
+            new ArcamCommandData("Corrected Phase Fast Roll Off", (byte) 0x05), //
+            new ArcamCommandData("Apodizing", (byte) 0x06) //
+    ));
+
+    public static final List<ArcamCommandData> INPUT_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("PHONO", (byte) 0x01), //
+            new ArcamCommandData("AUX", (byte) 0x02), //
+            new ArcamCommandData("PVR", (byte) 0x03), //
+            new ArcamCommandData("AV", (byte) 0x04), //
+            new ArcamCommandData("STB", (byte) 0x05), //
+            new ArcamCommandData("CD", (byte) 0x06), //
+            new ArcamCommandData("BD", (byte) 0x07), //
+            new ArcamCommandData("SAT", (byte) 0x08), //
+            new ArcamCommandData("GAME", (byte) 0x09), //
+            new ArcamCommandData("NETUSB", "NET/USB", (byte) 0x0B), //
+            new ArcamCommandData("ARC", (byte) 0x0D) //
+    ));
+
+    public static final List<ArcamCommandData> DISPLAY_BRIGHTNESS_COMMANDS = new ArrayList<>(List.of( //
+            new ArcamCommandData("OFF", (byte) 0x00), //
+            new ArcamCommandData("DIM", (byte) 0x01), //
+            new ArcamCommandData("FULL", (byte) 0x02) //
+    ));
+
+    /**
+     * List of commands, with the databytes set to the request state bytes
+     * Used to request one of the states of an Arcam device.
+     * Used to generate the commands to send to the Arcam device.
+     */
+    public static final List<ArcamCommand> COMMANDS = new ArrayList<>(List.of( //
+            // Non channel related
+            new ArcamCommand(HEARTBEAT, new byte[] { 0x21, 0x01, 0x25, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SYSTEM_STATUS, new byte[] { 0x21, 0x01, 0x5D, 0x01, (byte) 0xF0, 0x0D }), //
+            // Generic
+            new ArcamCommand(DAC_FILTER, new byte[] { 0x21, 0x01, 0x61, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(DISPLAY_BRIGHTNESS, new byte[] { 0x21, 0x01, 0x01, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(HEADPHONES, new byte[] { 0x21, 0x01, 0x02, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(INCOMING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x44, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(LIFTER_TEMPERATURE, new byte[] { 0x21, 0x01, 0x56, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(OUTPUT_TEMPERATURE, new byte[] { 0x21, 0x01, 0x57, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(SOFTWARE_VERSION, new byte[] { 0x21, 0x01, 0x04, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(TIMEOUT_COUNTER, new byte[] { 0x21, 0x01, 0x55, 0x01, (byte) 0xF0, 0x0D }), //
+            // Master zone
+            new ArcamCommand(MASTER_BALANCE, new byte[] { 0x21, 0x01, 0x3B, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DC_OFFSET, new byte[] { 0x21, 0x01, 0x51, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_MUTE, new byte[] { 0x21, 0x01, 0x0E, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT, new byte[] { 0x21, 0x01, 0x1D, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_INPUT_DETECT, new byte[] { 0x21, 0x01, 0x5A, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_DIRECT_MODE, new byte[] { 0x21, 0x01, 0x0F, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_NOW_PLAYING_TITLE, new byte[] { 0x21, 0x01, 0x64, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_NOW_PLAYING_ARTIST, new byte[] { 0x21, 0x01, 0x64, 0x01, (byte) 0xF1, 0x0D }), //
+            new ArcamCommand(MASTER_NOW_PLAYING_ALBUM, new byte[] { 0x21, 0x01, 0x64, 0x01, (byte) 0xF2, 0x0D }), //
+            new ArcamCommand(MASTER_NOW_PLAYING_APPLICATION, new byte[] { 0x21, 0x01, 0x64, 0x01, (byte) 0xF3, 0x0D }), //
+            new ArcamCommand(MASTER_NOW_PLAYING_SAMPLE_RATE, new byte[] { 0x21, 0x01, 0x64, 0x01, (byte) 0xF4, 0x0D }), //
+            new ArcamCommand(MASTER_NOW_PLAYING_AUDIO_ENCODER,
+                    new byte[] { 0x21, 0x01, 0x64, 0x01, (byte) 0xF5, 0x0D }), //
+            new ArcamCommand(MASTER_POWER, new byte[] { 0x21, 0x01, 0x00, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_ROOM_EQUALISATION, new byte[] { 0x21, 0x01, 0x37, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_SHORT_CIRCUIT, new byte[] { 0x21, 0x01, 0x52, 0x01, (byte) 0xF0, 0x0D }), //
+            new ArcamCommand(MASTER_VOLUME, new byte[] { 0x21, 0x01, 0x0D, 0x01, (byte) 0xF0, 0x0D }) //
+    ));
+
+    public static final Map<Byte, String> SAMPLE_RATES = Map.ofEntries( //
+            Map.entry((byte) 0x00, "32 kHz"), //
+            Map.entry((byte) 0x01, "44.1 kHz"), //
+            Map.entry((byte) 0x02, "48 kHz"), //
+            Map.entry((byte) 0x03, "88.2 kHz"), //
+            Map.entry((byte) 0x04, "96 kHz"), //
+            Map.entry((byte) 0x05, "176.4 kHz"), //
+            Map.entry((byte) 0x06, "192 kHz"), //
+            Map.entry((byte) 0x07, "Unknown"), //
+            Map.entry((byte) 0x08, "Undetected") //
+    );//
+
+    public static final Map<Byte, String> AUDIO_ENCODERS = Map.ofEntries( //
+            Map.entry((byte) 0x00, "Uknown"), //
+            Map.entry((byte) 0x01, "MP3"), //
+            Map.entry((byte) 0x02, "WMA"), //
+            Map.entry((byte) 0x03, "Ogg Vorbis"), //
+            Map.entry((byte) 0x04, "FLAC"), //
+            Map.entry((byte) 0x05, "WAV"), //
+            Map.entry((byte) 0x06, "AIFF"), //
+            Map.entry((byte) 0x07, "RealAudio"), //
+            Map.entry((byte) 0x08, "MPEG URL"), //
+            Map.entry((byte) 0x09, "SCPLS"), //
+            Map.entry((byte) 0x0A, "WPL"), //
+            Map.entry((byte) 0x0B, "MP4"), //
+            Map.entry((byte) 0x0C, "DSD"), //
+            Map.entry((byte) 0x0D, "Opus"), //
+            Map.entry((byte) 0x0E, "Sirius"), //
+            Map.entry((byte) 0x0F, "MQA") //
+    );//
+
+    public static final String SA30 = "SA30";
+
+    private ArcamCommandDataFinder commandDataFinder;
+    private ArcamCommandFinder commandFinder;
+    private ArcamNowPlaying nowPlaying = new ArcamNowPlaying();
+
+    public ArcamSA30() {
+        this.commandDataFinder = new ArcamCommandDataFinder();
+        this.commandFinder = new ArcamCommandFinder();
+    }
+
+    // Generate command bytes to send
+
+    @Override
+    public byte[] getBalanceCommand(int balance, ArcamZone zone) {
+        // 0x00 – Set the balance to the centre
+        // 0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12
+        // 0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12
+
+        byte[] data = commandFinder.getCommandFromCode(MASTER_BALANCE, COMMANDS);
+        byte balanceByte = (byte) balance;
+
+        if (balance < 0) {
+            balanceByte = (byte) ((balance * -1) + 0x80);
+        }
+        data[4] = balanceByte;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDacFilterCommand(String dacFilter) {
+        byte[] data = commandFinder.getCommandFromCode(DAC_FILTER, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(dacFilter, DAC_FILTER_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getDisplayBrightnessCommand(String displayBrightness) {
+        byte[] data = commandFinder.getCommandFromCode(DISPLAY_BRIGHTNESS, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(displayBrightness, DISPLAY_BRIGHTNESS_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getHeartbeatCommand() {
+        return commandFinder.getCommandFromCode(HEARTBEAT, COMMANDS);
+    }
+
+    @Override
+    public byte[] getInputCommand(String inputName, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_INPUT, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(inputName, INPUT_COMMANDS);
+
+        return data;
+    }
+
+    @Override
+    public byte[] getMuteCommand(boolean mute, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_MUTE, COMMANDS);
+        if (mute) {
+            data[4] = (byte) 0x00;
+            return data;
+        }
+
+        data[4] = (byte) 0x01;
+        return data;
+    }
+
+    @Override
+    public byte[] getPowerCommand(boolean on, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_POWER, COMMANDS);
+        if (on) {
+            data[4] = (byte) 0x01;
+            return data;
+        }
+
+        data[4] = (byte) 0x00;
+        return data;
+    }
+
+    @Override
+    public byte[] getRebootCommand() {
+        // Hard coded here instead of in the commands list as there is no way to retrieve the status reboot
+        return new byte[] { 0x21, 0x01, 0x26, 0x06, 0x52, 0x45, 0x42, 0x4F, 0x4F, 0x54, 0x0D };
+    }
+
+    @Override
+    public byte[] getRoomEqualisationCommand(String eq, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_ROOM_EQUALISATION, COMMANDS);
+        data[4] = commandDataFinder.getByteFromCommandDataCode(eq, ArcamDeviceConstants.ROOM_EQ);
+        return data;
+    }
+
+    @Override
+    public byte[] getVolumeCommand(int volume, ArcamZone zone) {
+        byte[] data = commandFinder.getCommandFromCode(MASTER_VOLUME, COMMANDS);
+        data[4] = (byte) volume;
+
+        return data;
+    }
+
+    @Override
+    public byte[] getStateCommandByte(ArcamCommandCode commandCode) {
+        return commandFinder.getCommandFromCode(commandCode, COMMANDS);
+    }
+
+    // Interpret incoming bytes
+
+    @Override
+    public int getBalance(byte dataByte) {
+        // 0x00 – Balance is Centered
+        // 0x00 – 0x0C – Balance is Right 1, 2,...,11, 12
+        // 0x81 – 0x8C – Balance is Left 1, 2,...,11, 12
+        if (dataByte < 0) {
+            int balance = (dataByte + 0x80) * -1;
+            return balance;
+        }
+
+        return dataByte;
+    }
+
+    @Override
+    public boolean getBoolean(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public String getDacFilter(Byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DAC_FILTER_COMMANDS);
+    }
+
+    @Override
+    @Nullable
+    public String getDisplayBrightness(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, DISPLAY_BRIGHTNESS_COMMANDS);
+    }
+
+    @Override
+    public String getIncomingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "Unknown";
+        }
+
+        return sampleRate;
+    }
+
+    @Override
+    @Nullable
+    public String getInputName(byte dataByte) {
+        byte convertedByte = dataByte;
+        if (dataByte > 0x0D) {
+            convertedByte = (byte) (dataByte - 0x10);
+        }
+
+        return commandDataFinder.getCommandCodeFromByte(convertedByte, INPUT_COMMANDS);
+    }
+
+    @Override
+    public boolean getMute(byte dataByte) {
+        return dataByte == 0x01;
+    }
+
+    @Override
+    @Nullable
+    public ArcamNowPlaying setNowPlaying(List<Byte> dataBytes) {
+        byte[] bytes = ArcamUtil.byteListToArray(dataBytes);
+
+        if (nowPlaying.rowNr == 0) {
+            nowPlaying.track = new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        if (nowPlaying.rowNr == 1) {
+            nowPlaying.artist = new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        if (nowPlaying.rowNr == 2) {
+            nowPlaying.album = new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        if (nowPlaying.rowNr == 3) {
+            nowPlaying.application = new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        if (nowPlaying.rowNr == 4) {
+            Byte b = dataBytes.get(0);
+            nowPlaying.sampleRate = getNowPlayingSampleRate(b);
+        }
+
+        if (nowPlaying.rowNr == 5) {
+            Byte b = dataBytes.get(0);
+            nowPlaying.audioEncoder = getNowPlayingEncoder(b);
+        }
+
+        nowPlaying.rowNr++;
+        if (nowPlaying.rowNr >= 6) {
+            nowPlaying.rowNr = 0;
+            return nowPlaying;
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getNowPlayingSampleRate(byte dataByte) {
+        String sampleRate = SAMPLE_RATES.get(dataByte);
+        if (sampleRate == null) {
+            return "";
+        } else {
+            return sampleRate;
+        }
+    }
+
+    @Override
+    public String getNowPlayingEncoder(byte dataByte) {
+        String audioEncoder = AUDIO_ENCODERS.get(dataByte);
+        if (audioEncoder == null) {
+            return "";
+        } else {
+            return audioEncoder;
+        }
+    }
+
+    @Override
+    @Nullable
+    public String getRoomEqualisation(byte dataByte) {
+        return commandDataFinder.getCommandCodeFromByte(dataByte, ArcamDeviceConstants.ROOM_EQ);
+    }
+
+    @Override
+    public String getSoftwareVersion(List<Byte> dataBytes) {
+        // According to the manual we should receive 3 bytes, however during testing I noticed we only receive 2 bytes.
+        int major = dataBytes.get(0);
+        int minor = dataBytes.get(1);
+        return major + "." + minor;
+    }
+
+    @Override
+    public int getTemperature(List<Byte> dataBytes, int tempNr) {
+        return dataBytes.get(tempNr);
+    }
+
+    @Override
+    public int getTimeoutCounter(List<Byte> dataBytes) {
+        // The range of the value returned is from 0x0000 - 0x00F0 (0 - 240minutes)
+        return dataBytes.get(1);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA30ChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/devices/ArcamSA30ChannelTypeProvider.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.connection.ArcamCommandDataFinder;
+import org.openhab.binding.arcam.internal.exceptions.NotFoundException;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This class provides the device specific channel types.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component(service = ChannelTypeProvider.class)
+@NonNullByDefault
+public class ArcamSA30ChannelTypeProvider implements ChannelTypeProvider {
+
+    public static final String SA30_DAC_FILTER = "sa30DacFilter";
+    public static final String SA30_DISPLAY_BRIGHTNESS = "sa30DisplayBrightness";
+    public static final String SA30_INPUT = "sa30Input";
+
+    @Override
+    public Collection<@NonNull ChannelType> getChannelTypes(@Nullable Locale locale) {
+        List<ChannelType> channelTypeList = new LinkedList<>();
+
+        channelTypeList.add(getChannelTypeOrThrow(SA30_DAC_FILTER, locale));
+        channelTypeList.add(getChannelTypeOrThrow(SA30_DISPLAY_BRIGHTNESS, locale));
+        channelTypeList.add(getChannelTypeOrThrow(SA30_INPUT, locale));
+
+        return channelTypeList;
+    }
+
+    @Override
+    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (!channelTypeUID.getBindingId().equals(ArcamBindingConstants.BINDING_ID)) {
+            return null;
+        }
+
+        String channelID = channelTypeUID.getId();
+
+        if (channelID.equals(SA30_DAC_FILTER)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "DAC filter", //
+                    "Select DAC filter", //
+                    ArcamSA30.DAC_FILTER_COMMANDS); //
+        }
+
+        if (channelID.equals(SA30_INPUT)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Input", //
+                    "Select the input source", //
+                    ArcamSA30.INPUT_COMMANDS); //
+        }
+
+        if (channelID.equals(SA30_DISPLAY_BRIGHTNESS)) {
+            return ArcamCommandDataFinder.generateStringOptionChannelType( //
+                    channelTypeUID, //
+                    "Display brightness", //
+                    "Select display brightness", //
+                    ArcamSA30.DISPLAY_BRIGHTNESS_COMMANDS); //
+        }
+
+        return null;
+    }
+
+    private ChannelType getChannelTypeOrThrow(String id, @Nullable Locale locale) {
+        ChannelType channelType = getChannelType(new ChannelTypeUID(ArcamBindingConstants.BINDING_ID, id), locale);
+        if (channelType == null) {
+            throw new NotFoundException("Could not find Arcam channelType " + id);
+        }
+
+        return channelType;
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/discovery/ArcamDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/discovery/ArcamDiscoveryParticipant.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.discovery;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.binding.arcam.internal.ArcamBindingConstants;
+import org.openhab.binding.arcam.internal.config.ArcamConfiguration;
+import org.openhab.binding.arcam.internal.devices.ArcamDeviceUtil;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/***
+ * The{@link ArcamDiscoveryParticipant} is responsible processing the
+ * results of searches for UPNP devices
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@Component
+@NonNullByDefault
+public class ArcamDiscoveryParticipant implements UpnpDiscoveryParticipant {
+
+    private final Logger logger = LoggerFactory.getLogger(ArcamDiscoveryParticipant.class);
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return ArcamBindingConstants.SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override
+    @Nullable
+    public DiscoveryResult createResult(RemoteDevice device) {
+        ThingUID uid = getThingUID(device);
+        if (uid == null) {
+            return null;
+        }
+
+        Map<String, Object> properties = new HashMap<>(3);
+        String model = device.getDetails().getModelDetails().getModelName();
+        String ipAddress = device.getIdentity().getDescriptorURL().getHost();
+        String serial = device.getDetails().getSerialNumber();
+        String name = device.getDetails().getFriendlyName();
+
+        properties.put(ArcamConfiguration.HOSTNAME, ipAddress);
+        properties.put(ArcamConfiguration.SERIAL, serial);
+        properties.put(ArcamConfiguration.NAME, name);
+        properties.put(ArcamConfiguration.MODEL, model);
+
+        DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(name)
+                .withRepresentationProperty(ArcamConfiguration.SERIAL).build();
+
+        logger.debug("Created a DiscoveryResult for device {} with UDN {}, IP: {}, serial: {}",
+                device.getDetails().getFriendlyName(), device.getIdentity().getUdn().getIdentifierString(), ipAddress,
+                serial);
+        return result;
+    }
+
+    @Override
+    @Nullable
+    public ThingUID getThingUID(RemoteDevice device) {
+        String manufacturer = device.getDetails().getManufacturerDetails().getManufacturer();
+        if (manufacturer == null || !manufacturer.toUpperCase().equals("HARMAN LUXURY AUDIO")) {
+            return null;
+        }
+
+        String modelName = device.getDetails().getModelDetails().getModelName();
+        ThingTypeUID thingTypeUID = ArcamDeviceUtil.getThingTypeUIDFromModelName(modelName);
+        if (thingTypeUID == null) {
+            return null;
+        }
+
+        String serial = device.getDetails().getSerialNumber();
+
+        logger.debug("Discovered an Arcam '{}' thing with serial {}", thingTypeUID, serial);
+        return new ThingUID(thingTypeUID, serial);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/exceptions/NotFoundException.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/exceptions/NotFoundException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.exceptions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown when an item cannot be found in a lookup table.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+@SuppressWarnings("serial")
+public class NotFoundException extends RuntimeException {
+    public NotFoundException() {
+    }
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/exceptions/NotSupportedException.java
+++ b/bundles/org.openhab.binding.arcam/src/main/java/org/openhab/binding/arcam/internal/exceptions/NotSupportedException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.exceptions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown when code is reached for a feature that is not supported by the Arcam device.
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+@SuppressWarnings("serial")
+public class NotSupportedException extends RuntimeException {
+    public NotSupportedException() {
+    }
+
+    public NotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="arcam" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Arcam Binding</name>
+	<description>This is the binding for the Arcam audio devices.</description>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR10.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR10.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="AVR10">
+
+		<label>Arcam Binding Thing</label>
+		<description>AVR10</description>
+		<channel-groups>
+			<channel-group id="avr10MasterZone" typeId="avr10MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="avr10MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="avr10Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="displaybrightness" typeId="avr10DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="avr10Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+
+
+	<channel-type id="avr10Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-6" max="6" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR10.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR10.xml
@@ -9,7 +9,7 @@
 		<label>Arcam Binding Thing</label>
 		<description>AVR10</description>
 		<channel-groups>
-			<channel-group id="avr10MasterZone" typeId="avr10MasterZone">
+			<channel-group id="masterZone" typeId="avr10MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
@@ -20,6 +20,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR20.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR20.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="AVR20">
+
+		<label>Arcam Binding Thing</label>
+		<description>AVR20</description>
+		<channel-groups>
+			<channel-group id="avr20MasterZone" typeId="avr20MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+			<channel-group id="avr20Zone2" typeId="avr20Zone2">
+				<label>Zone 2</label>
+				<description>zone.</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="avr20MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="avr20Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="displaybrightness" typeId="avr20DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="avr20Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="avr20Zone2">
+		<label>Zone2</label>
+		<description>Channels for zone2.</description>
+		<channels>
+			<channel id="balance" typeId="avr20Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="input" typeId="avr20Zone2Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-type id="avr20Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-6" max="6" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR20.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR20.xml
@@ -9,11 +9,11 @@
 		<label>Arcam Binding Thing</label>
 		<description>AVR20</description>
 		<channel-groups>
-			<channel-group id="avr20MasterZone" typeId="avr20MasterZone">
+			<channel-group id="masterZone" typeId="avr20MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
-			<channel-group id="avr20Zone2" typeId="avr20Zone2">
+			<channel-group id="zone2" typeId="avr20Zone2">
 				<label>Zone 2</label>
 				<description>zone.</description>
 			</channel-group>
@@ -24,6 +24,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR30.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR30.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="AVR30">
+
+		<label>Arcam Binding Thing</label>
+		<description>AVR30</description>
+		<channel-groups>
+			<channel-group id="avr30MasterZone" typeId="avr30MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+			<channel-group id="avr30Zone2" typeId="avr30Zone2">
+				<label>Zone 2</label>
+				<description>zone.</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="avr30MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="avr30Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="displaybrightness" typeId="avr30DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="avr30Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="avr30Zone2">
+		<label>Zone2</label>
+		<description>Channels for zone2.</description>
+		<channels>
+			<channel id="balance" typeId="avr30Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="input" typeId="avr30Zone2Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-type id="avr30Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-6" max="6" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR30.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR30.xml
@@ -9,11 +9,11 @@
 		<label>Arcam Binding Thing</label>
 		<description>AVR30</description>
 		<channel-groups>
-			<channel-group id="avr30MasterZone" typeId="avr30MasterZone">
+			<channel-group id="masterZone" typeId="avr30MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
-			<channel-group id="avr30Zone2" typeId="avr30Zone2">
+			<channel-group id="zone2" typeId="avr30Zone2">
 				<label>Zone 2</label>
 				<description>zone.</description>
 			</channel-group>
@@ -24,6 +24,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR40.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR40.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="AVR40">
+
+		<label>Arcam Binding Thing</label>
+		<description>AVR40</description>
+		<channel-groups>
+			<channel-group id="avr40MasterZone" typeId="avr40MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+			<channel-group id="avr40Zone2" typeId="avr40Zone2">
+				<label>Zone 2</label>
+				<description>zone.</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="avr40MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="avr40Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="displaybrightness" typeId="avr40DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="avr40Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="avr40Zone2">
+		<label>Zone2</label>
+		<description>Channels for zone2.</description>
+		<channels>
+			<channel id="balance" typeId="avr40Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="input" typeId="avr40Zone2Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-type id="avr40Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-6" max="6" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR40.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR40.xml
@@ -9,11 +9,11 @@
 		<label>Arcam Binding Thing</label>
 		<description>AVR40</description>
 		<channel-groups>
-			<channel-group id="avr40MasterZone" typeId="avr40MasterZone">
+			<channel-group id="masterZone" typeId="avr40MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
-			<channel-group id="avr40Zone2" typeId="avr40Zone2">
+			<channel-group id="zone2" typeId="avr40Zone2">
 				<label>Zone 2</label>
 				<description>zone.</description>
 			</channel-group>
@@ -24,6 +24,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR5.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR5.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="AVR5">
+
+		<label>Arcam Binding Thing</label>
+		<description>AVR5</description>
+		<channel-groups>
+			<channel-group id="avr5MasterZone" typeId="avr5MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="avr5MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="avr5Balance"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="displaybrightness" typeId="avr5DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="avr5Input"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+
+
+	<channel-type id="avr5Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-6" max="6" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR5.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/AVR5.xml
@@ -9,7 +9,7 @@
 		<label>Arcam Binding Thing</label>
 		<description>AVR5</description>
 		<channel-groups>
-			<channel-group id="avr5MasterZone" typeId="avr5MasterZone">
+			<channel-group id="masterZone" typeId="avr5MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
@@ -20,6 +20,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/GenericChannelTypes.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/GenericChannelTypes.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+
+	<channel-type id="dcOffset">
+		<item-type>Switch</item-type>
+		<label>DC offset</label>
+		<description>Output DC offset status.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="directMode">
+		<item-type>Switch</item-type>
+		<label>Direct mode</label>
+		<description>Analogue input direct mode of the current input.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="headphones">
+		<item-type>Switch</item-type>
+		<label>Headphones</label>
+		<description>Determine whether headphones are connected.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="incomingSampleRate">
+		<item-type>String</item-type>
+		<label>Incoming audio sample rate</label>
+		<description>Incoming audio sample rate.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="inputDetect">
+		<item-type>Switch</item-type>
+		<label>Input detect</label>
+		<description>the status of the active input.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="lifterTemperature">
+		<item-type>Number</item-type>
+		<label>Lifter temperature</label>
+		<description>The temperature of the lifter.</description>
+		<category>Temperature</category>
+		<state readOnly="true" pattern="%.1f °C"/>
+	</channel-type>
+	<channel-type id="nowPlayingAlbum">
+		<item-type>String</item-type>
+		<label>Album</label>
+		<description>Now playing album name.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="nowPlayingApplication">
+		<item-type>String</item-type>
+		<label>Application</label>
+		<description>Now playing GoogleCast source application.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="nowPlayingAudioEncoder">
+		<item-type>String</item-type>
+		<label>Audio encoder</label>
+		<description>Now playing audio encoder.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="nowPlayingSampleRate">
+		<item-type>String</item-type>
+		<label>Sample rate</label>
+		<description>Now playing sample rate.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="outputTemperature">
+		<item-type>Number</item-type>
+		<label>Output temperature</label>
+		<description>The temperature of the output stage.</description>
+		<category>Temperature</category>
+		<state readOnly="true" pattern="%.1f °C"/>
+	</channel-type>
+
+	<channel-type id="reboot">
+		<item-type>Switch</item-type>
+		<label>Reboot</label>
+		<description>Forces a reboot of the unit.</description>
+	</channel-type>
+	<channel-type id="roomEqualisation">
+		<item-type>String</item-type>
+		<label>Room Equalisation</label>
+		<description>Turn the room equalisation system on/off.</description>
+		<state>
+			<options>
+				<option value="ROOM_EQ_OFF">Room EQ off</option>
+				<option value="ROOM_EQ_1">Room EQ 1</option>
+				<option value="ROOM_EQ_2">Room EQ 2</option>
+				<option value="ROOM_EQ_3">Room EQ 3</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="shortCircuit">
+		<item-type>Switch</item-type>
+		<label>Short circuit status</label>
+		<description>Short circuit status.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="softwareVersion">
+		<item-type>String</item-type>
+		<label>Software version</label>
+		<description>Software (firmware) version.</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="timeoutCounter">
+		<item-type>Number</item-type>
+		<label>Timeout counter</label>
+		<description>The time left (in minutes) until unit enters auto standby.</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA10.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA10.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="SA10">
+
+		<label>Arcam Binding Thing</label>
+		<description>SA10</description>
+		<channel-groups>
+			<channel-group id="sa10MasterZone" typeId="sa10MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="sa10MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="sa10Balance"/>
+			<channel id="dacFilter" typeId="sa10DacFilter"/>
+			<channel id="dcOffset" typeId="dcOffset"/>
+			<channel id="displaybrightness" typeId="sa10DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="sa10Input"/>
+			<channel id="inputDetect" typeId="inputDetect"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="outputTemperature" typeId="outputTemperature"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="timeoutCounter" typeId="timeoutCounter"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-type id="sa10Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-12" max="12" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA10.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA10.xml
@@ -9,7 +9,7 @@
 		<label>Arcam Binding Thing</label>
 		<description>SA10</description>
 		<channel-groups>
-			<channel-group id="sa10MasterZone" typeId="sa10MasterZone">
+			<channel-group id="masterZone" typeId="sa10MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
@@ -20,6 +20,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA20.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA20.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="SA20">
+
+		<label>Arcam Binding Thing</label>
+		<description>SA20</description>
+		<channel-groups>
+			<channel-group id="sa20MasterZone" typeId="sa20MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="sa20MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="sa20Balance"/>
+			<channel id="dacFilter" typeId="sa20DacFilter"/>
+			<channel id="dcOffset" typeId="dcOffset"/>
+			<channel id="displaybrightness" typeId="sa20DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="sa20Input"/>
+			<channel id="inputDetect" typeId="inputDetect"/>
+			<channel id="lifterTemperature" typeId="lifterTemperature"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="outputTemperature" typeId="outputTemperature"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="shortCircuit" typeId="shortCircuit"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="timeoutCounter" typeId="timeoutCounter"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-type id="sa20Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-12" max="12" step="1.0"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA20.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA20.xml
@@ -9,7 +9,7 @@
 		<label>Arcam Binding Thing</label>
 		<description>SA20</description>
 		<channel-groups>
-			<channel-group id="sa20MasterZone" typeId="sa20MasterZone">
+			<channel-group id="masterZone" typeId="sa20MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
@@ -20,6 +20,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA30.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA30.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="arcam"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="SA30">
+
+		<label>Arcam Binding Thing</label>
+		<description>SA30</description>
+		<channel-groups>
+			<channel-group id="sa30MasterZone" typeId="sa30MasterZone">
+				<label>Master zone</label>
+				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
+			</channel-group>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-group-type id="sa30MasterZone">
+		<label>Master zone</label>
+		<description>Channels for the master zone.</description>
+		<channels>
+			<channel id="balance" typeId="sa30Balance"/>
+			<channel id="dacFilter" typeId="sa30DacFilter"/>
+			<channel id="dcOffset" typeId="dcOffset"/>
+			<channel id="directMode" typeId="directMode"/>
+			<channel id="displaybrightness" typeId="sa30DisplayBrightness"/>
+			<channel id="headphones" typeId="headphones"/>
+			<channel id="incomingSampleRate" typeId="incomingSampleRate"/>
+			<channel id="input" typeId="sa30Input"/>
+			<channel id="inputDetect" typeId="inputDetect"/>
+			<channel id="lifterTemperature" typeId="lifterTemperature"/>
+			<channel id="mute" typeId="system.mute"/>
+			<channel id="nowPlayingTitle" typeId="system.media-title"/>
+			<channel id="nowPlayingArtist" typeId="system.media-artist"/>
+			<channel id="nowPlayingAlbum" typeId="nowPlayingAlbum"/>
+			<channel id="nowPlayingApplication" typeId="nowPlayingApplication"/>
+			<channel id="nowPlayingSampleRate" typeId="nowPlayingSampleRate"/>
+			<channel id="nowPlayingAudioEncoder" typeId="nowPlayingAudioEncoder"/>
+			<channel id="outputTemperature" typeId="outputTemperature"/>
+			<channel id="power" typeId="system.power"/>
+			<channel id="reboot" typeId="reboot"/>
+			<channel id="roomEqualisation" typeId="roomEqualisation"/>
+			<channel id="shortCircuit" typeId="shortCircuit"/>
+			<channel id="softwareVersion" typeId="softwareVersion"/>
+			<channel id="timeoutCounter" typeId="timeoutCounter"/>
+			<channel id="volume" typeId="system.volume"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-type id="sa30Balance">
+		<item-type>Number</item-type>
+		<label>Balance</label>
+		<description>Adjust the balance control.</description>
+		<state min="-12" max="12" step="1.0"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA30.xml
+++ b/bundles/org.openhab.binding.arcam/src/main/resources/OH-INF/thing/SA30.xml
@@ -9,7 +9,7 @@
 		<label>Arcam Binding Thing</label>
 		<description>SA30</description>
 		<channel-groups>
-			<channel-group id="sa30MasterZone" typeId="sa30MasterZone">
+			<channel-group id="masterZone" typeId="sa30MasterZone">
 				<label>Master zone</label>
 				<description>The master zone. Commands that appear zone-less refer to the master zone</description>
 			</channel-group>
@@ -20,6 +20,12 @@
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="0">
+				<label>Polling interval</label>
+				<description>The amount of seconds to wait before polling the device for updated information. When set to 0 no
+					polling is done and the binding relies on data being pushed from the device to the binding.</description>
+				<default>0</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.arcam/src/test/java/org/openhab/binding/arcam/internal/ArcamResponseHandlerTest.java
+++ b/bundles/org.openhab.binding.arcam/src/test/java/org/openhab/binding/arcam/internal/ArcamResponseHandlerTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.arcam.internal.connection.ArcamResponse;
+import org.openhab.binding.arcam.internal.connection.ArcamResponseHandler;
+
+/**
+ * Tests for the response handler
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class ArcamResponseHandlerTest {
+
+    @InjectMocks
+    @NonNullByDefault({})
+    private ArcamResponseHandler sut;
+
+    @Test
+    public void parseByteShouldParsePowerOnResponse() {
+        byte[] command = new byte[] { 0x21, 0x01, 0x00, 0x00, 0x01, 0x01, 0x0D };
+
+        ArcamResponse result = new ArcamResponse();
+        for (byte b : command) {
+            result = sut.parseByte(b);
+        }
+
+        assertNotNull(result);
+        assertEquals(1, result.zn);
+        assertEquals((byte) 0x00, result.cc);
+        assertEquals((byte) 0x00, result.ac);
+        assertEquals(1, result.dl);
+        assertEquals((byte) 0x01, result.data.get(0));
+        assertEquals(1, result.data.size());
+    }
+
+    @Test
+    public void parseByteShouldBeAbleToParseStartByteInData() {
+        byte[] command = new byte[] { 0x21, 0x01, 0x00, 0x00, 0x04, 0x01, 0x21, 0x03, 0x04, 0x0D };
+
+        ArcamResponse result = new ArcamResponse();
+        for (byte b : command) {
+            result = sut.parseByte(b);
+        }
+
+        assertNotNull(result);
+        assertEquals(1, result.zn);
+        assertEquals((byte) 0x00, result.cc);
+        assertEquals((byte) 0x00, result.ac);
+        assertEquals(4, result.dl);
+        assertEquals((byte) 0x01, result.data.get(0));
+        assertEquals(4, result.data.size());
+    }
+
+    @Test
+    public void parseByteShouldBeAbleToParseMultipleResponses() {
+        byte[] firstCommand = new byte[] { 0x21, 0x01, 0x02, 0x03, 0x01, 0x05, 0x0D };
+
+        ArcamResponse result = new ArcamResponse();
+        for (byte b : firstCommand) {
+            result = sut.parseByte(b);
+        }
+
+        byte[] secondCommand = new byte[] { 0x21, 0x06, 0x07, 0x08, 0x01, 0x09, 0x0D };
+
+        for (byte b : secondCommand) {
+            result = sut.parseByte(b);
+        }
+
+        assertNotNull(result);
+        assertEquals(6, result.zn);
+        assertEquals((byte) 0x07, result.cc);
+        assertEquals((byte) 0x08, result.ac);
+        assertEquals(1, result.dl);
+        assertEquals((byte) 0x09, result.data.get(0));
+        assertEquals(1, result.data.size());
+    }
+}

--- a/bundles/org.openhab.binding.arcam/src/test/java/org/openhab/binding/arcam/internal/devices/ArcamSa30Test.java
+++ b/bundles/org.openhab.binding.arcam/src/test/java/org/openhab/binding/arcam/internal/devices/ArcamSa30Test.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.arcam.internal.devices;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for the SA30
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class ArcamSa30Test {
+
+    @InjectMocks
+    @NonNullByDefault({})
+    private ArcamSA30 sut;
+
+    @Test
+    public void getBalanceShouldParseNegativeValue() {
+        int result = sut.getBalance((byte) 0x83);
+        assertEquals(-3, result);
+    }
+
+    @Test
+    public void getBalanceShouldParsePositiveValue() {
+        int result = sut.getBalance((byte) 0x03);
+        assertEquals(3, result);
+    }
+
+    @Test
+    public void getTimeoutCounter() {
+        int result = sut.getTimeoutCounter(List.of((byte) 0x00, (byte) 0x03));
+        assertEquals(3, result);
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -56,6 +56,7 @@
     <module>org.openhab.binding.amplipi</module>
     <module>org.openhab.binding.androiddebugbridge</module>
     <module>org.openhab.binding.anel</module>
+    <module>org.openhab.binding.arcam</module>
     <module>org.openhab.binding.astro</module>
     <module>org.openhab.binding.atlona</module>
     <module>org.openhab.binding.autelis</module>


### PR DESCRIPTION
# [Arcam] new binding

Initial contribution of the [Arcam](https://www.arcam.co.uk/) binding.

# Description

This PR contains a new binding for the Arcam audio devices.
Currently the AVR and SA series of devices is supported.
It allows users to control and read status information from their Arcam amplifier.

I have tried to make the binding generic in order to prevent code duplication.
For this I have added a device specific class in the `devices` directory.
Unfortunately this is needed as each device has different capabilities and protocol nuances.
The protocol itself is a TCP based protocol and has different commands for the a single functionality, based on which device model you are communicating with.
The connection code contains retries etc. so temporarily connectivity issues will not break the binding. 

Each device also has a ChannelTypeProvider which allows the binding to have device specific OptionChannels, for example showing only the inputs that are actually available on that specific device.

Discovery is done with UPnP.

# Testing
This binding has been tested with the Arcam SA30

The jar can be downloaded [here](https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.arcam/3.4.0-SNAPSHOT/org.openhab.binding.arcam-3.4.0-SNAPSHOT.jar).