### PR TITLE
[wemo] Add Wemo Outdoor plug

### DIFF
--- a/bundles/org.openhab.binding.wemo/README.md
+++ b/bundles/org.openhab.binding.wemo/README.md
@@ -5,7 +5,7 @@ The integration happens either through the WeMo-Link bridge, which acts as an IP
 
 ## Supported Things
 
-The WeMo Binding supports the Socket, Insight, Lightswitch, Motion, Dimmer, Coffemaker and Maker devices, as well as the WeMo-Link bridge with WeMo LED bulbs. 
+The WeMo Binding supports the Socket, Outdoor Plug, Insight, Lightswitch, Motion, Dimmer, Coffemaker and Maker devices, as well as the WeMo-Link bridge with WeMo LED bulbs.
 The Binding also supports the Crock-Pot Smart Slow Cooker, Mr. Coffee Smart Coffemaker as well as the Holmes Smart Air Purifier, Holmes Smart Humidifier and Holmes Smart Heater.
 
 ## Discovery

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoDiscoveryParticipant.java
@@ -86,6 +86,12 @@ public class WemoDiscoveryParticipant implements UpnpDiscoveryParticipant {
                                     device.getIdentity().getUdn().getIdentifierString());
                             return new ThingUID(THING_TYPE_SOCKET, device.getIdentity().getUdn().getIdentifierString());
                         }
+                        if (device.getDetails().getModelDetails().getModelName().toLowerCase()
+                                .startsWith("outdoorplug")) {
+                            logger.debug("Discovered a WeMo Outdoor Plug thing with UDN '{}'",
+                                    device.getIdentity().getUdn().getIdentifierString());
+                            return new ThingUID(THING_TYPE_SOCKET, device.getIdentity().getUdn().getIdentifierString());
+                        }
                         if (device.getDetails().getModelDetails().getModelName().toLowerCase().startsWith("insight")) {
                             logger.debug("Discovered a WeMo Insight thing with UDN '{}'",
                                     device.getIdentity().getUdn().getIdentifierString());


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
# [wemo] Add Wemo Outdoor plug discovery.

# Description

This just adds the wemo outdoor plug identification so that it is picked up as a plug by the wemo binding. 

# Testing

I have tested this with my outdoor plug.
