### PR TITLE
[Konnected] Fixed null pointer exception on state update with missing state

### DIFF
--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/gson/KonnectedModuleGson.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/gson/KonnectedModuleGson.java
@@ -29,7 +29,7 @@ public class KonnectedModuleGson {
     private String zone;
     private String temp;
     private String humi;
-    private String state;
+    private Integer state;
     @SerializedName("Auth_Token")
     private String authToken;
     private String momentary;
@@ -79,11 +79,11 @@ public class KonnectedModuleGson {
         this.humi = setHumi;
     }
 
-    public String getState() {
+    public Integer getState() {
         return state;
     }
 
-    public void setState(String setState) {
+    public void setState(Integer setState) {
         this.state = setState;
     }
 

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -137,9 +137,12 @@ public class KonnectedHandler extends BaseThingHandler {
                 // check if the itemType has been defined for the zone received
                 // check the itemType of the Zone, if Contact, send the State if Temp send Temp, etc.
                 if (channelType.contains(CHANNEL_SWITCH) || channelType.contains(CHANNEL_ACTUATOR)) {
-                    OnOffType onOffType = event.getState().equalsIgnoreCase(getOnState(channel)) ? OnOffType.ON
-                            : OnOffType.OFF;
-                    updateState(channelId, onOffType);
+                    logger.debug("The event state is: {}", event.getState());
+                    if (event.getState() != null) {
+                        OnOffType onOffType = event.getState().equalsIgnoreCase(getOnState(channel)) ? OnOffType.ON
+                                : OnOffType.OFF;
+                        updateState(channelId, onOffType);
+                    }
                 } else if (channelType.contains(CHANNEL_HUMIDITY)) {
                     // if the state is of type number then this means it is the humidity channel of the dht22
                     updateState(channelId, new QuantityType<>(Double.parseDouble(event.getHumi()), Units.PERCENT));

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -94,7 +94,7 @@ public class KonnectedHandler extends BaseThingHandler {
                 int sendCommand = (OnOffType.OFF.compareTo((OnOffType) command));
                 logger.debug("The command being sent to zone {} for channel:{}  is {}", zone, channelUID.getAsString(),
                         sendCommand);
-                sendActuatorCommand(Integer.toString(sendCommand), zone, channelUID);
+                sendActuatorCommand(sendCommand, zone, channelUID);
             }
         } else if (command instanceof RefreshType) {
             // check to see if handler has been initialized before attempting to get state of pin, else wait one minute
@@ -137,10 +137,10 @@ public class KonnectedHandler extends BaseThingHandler {
                 // check if the itemType has been defined for the zone received
                 // check the itemType of the Zone, if Contact, send the State if Temp send Temp, etc.
                 if (channelType.contains(CHANNEL_SWITCH) || channelType.contains(CHANNEL_ACTUATOR)) {
-                    logger.debug("The event state is: {}", event.getState());
-                    if (event.getState() != null) {
-                        OnOffType onOffType = event.getState().equalsIgnoreCase(getOnState(channel)) ? OnOffType.ON
-                                : OnOffType.OFF;
+                    Integer state = event.getState();
+                    logger.debug("The event state is: {}", state);
+                    if (state != null) {
+                        OnOffType onOffType = state == getOnState(channel) ? OnOffType.ON : OnOffType.OFF;
                         updateState(channelId, onOffType);
                     }
                 } else if (channelType.contains(CHANNEL_HUMIDITY)) {
@@ -418,7 +418,7 @@ public class KonnectedHandler extends BaseThingHandler {
      * @param scommand the string command, either 0 or 1 to send to the actutor pin on the Konnected module
      * @param zone the zone to send the command to on the Konnected Module
      */
-    private void sendActuatorCommand(String scommand, String zone, ChannelUID channelId) {
+    private void sendActuatorCommand(Integer scommand, String zone, ChannelUID channelId) {
         try {
             Channel channel = getThing().getChannel(channelId.getId());
             if (!(channel == null)) {
@@ -432,7 +432,7 @@ public class KonnectedHandler extends BaseThingHandler {
 
                 // check to see if this is an On Command type, if so add the momentary, pause, times to the payload if
                 // they exist on the configuration.
-                if (scommand.equals(getOnState(channel))) {
+                if (scommand == getOnState(channel)) {
                     if (configuration.get(CHANNEL_ACTUATOR_TIMES) == null) {
                         logger.debug(
                                 "The times configuration was not set for channelID: {}, not adding it to the payload.",
@@ -525,12 +525,7 @@ public class KonnectedHandler extends BaseThingHandler {
         }
     }
 
-    private String getOnState(Channel channel) {
-        String config = (String) channel.getConfiguration().get(CHANNEL_ONVALUE);
-        if (config == null) {
-            return "1";
-        } else {
-            return config;
-        }
+    private int getOnState(Channel channel) {
+        return ((Number) channel.getConfiguration().get(CHANNEL_ONVALUE)).intValue();
     }
 }

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
@@ -37,7 +37,7 @@
 					<option value="alarm_out">Alarm/Out</option>
 				</options>
 			</parameter>
-			<parameter name="onvalue" type="text">
+			<parameter name="onvalue" type="integer">
 				<label>On Value</label>
 				<description>The value that will be treated by the binding as the on value. For sensors that activate with a high
 					value leave at the default of 1 and sensors that activate with a low value set to 0.</description>
@@ -122,7 +122,7 @@
 					<option value="alarm_out">Alarm/Out</option>
 				</options>
 			</parameter>
-			<parameter name="onvalue" type="text">
+			<parameter name="onvalue" type="integer">
 				<label>On Value</label>
 				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high
 					command set to 1 and actuators that activate with a low value set to 0.</description>
@@ -171,7 +171,7 @@
 					<option value="12">12</option>
 				</options>
 			</parameter>
-			<parameter name="onvalue" type="text">
+			<parameter name="onvalue" type="integer">
 				<label>On Value</label>
 				<description>The value that will be treated by the binding as the on value. For sensors that activate with a high
 					value, leave at the default of 1 and sensors that activate with a low value set to 0.</description>
@@ -206,7 +206,7 @@
 					<option value="alarm2_out2">Alarm2/Out2</option>
 				</options>
 			</parameter>
-			<parameter name="onvalue" type="text">
+			<parameter name="onvalue" type="integer">
 				<label>On Value</label>
 				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high
 					command set to 1 and actuators that activate with a low value set to 0.</description>


### PR DESCRIPTION
I was hitting a race condition when adding zones. The status seems to be missing from the panel's json response right after new configuration is pushed to the panel and the panel restarts. The was causing a NullPointerException.