### PR TITLE
[hdpowerview] Correct shade capabilities information

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -41,17 +41,18 @@ public class ShadeCapabilitiesDatabase {
      */
     private static final Map<Integer, Capabilities> CAPABILITIES_DATABASE = Arrays.asList(
     // @formatter:off
-            new Capabilities(0).primary()                                                       .text("Bottom Up"),
-            new Capabilities(1).primary()        .tiltOnClosed()                                .text("Bottom Up Tilt 90°"),
-            new Capabilities(2).primary()        .tiltAnywhere().tilt180()                      .text("Bottom Up Tilt 180°"),
-            new Capabilities(3).primary()        .tiltAnywhere().tilt180()                      .text("Vertical Tilt 180°"),
-            new Capabilities(4).primary()                                                       .text("Vertical"),
-            new Capabilities(5)                  .tiltAnywhere().tilt180()                      .text("Tilt Only 180°"),
-            new Capabilities(6).primaryInverted()                                               .text("Top Down"),
-            new Capabilities(7).primary()                                 .secondary()          .text("Top Down Bottom Up"),
-            new Capabilities(8).primary()                                 .secondaryOverlapped().text("Dual Overlapped"),
+            new Capabilities( 0).primary()                                                       .text("Bottom Up"),
+            new Capabilities( 1).primary()        .tiltOnClosed()                                .text("Bottom Up Tilt 90°"),
+            new Capabilities( 2).primary()        .tiltAnywhere().tilt180()                      .text("Bottom Up Tilt 180°"),
+            new Capabilities( 3).primary()                                                       .text("Vertical"),
+            new Capabilities( 4).primary()        .tiltAnywhere().tilt180()                      .text("Vertical Tilt 180°"),
+            new Capabilities( 5)                  .tiltAnywhere().tilt180()                      .text("Tilt Only 180°"),
+            new Capabilities( 6).primaryInverted()                                               .text("Top Down"),
+            new Capabilities( 7).primary()                                 .secondary()          .text("Top Down Bottom Up"),
+            new Capabilities( 8).primary()                                 .secondaryOverlapped().text("Dual Overlapped"),
             // note: for the following capabilities entry the 'tiltOnClosed()' applies to the primary shade
-            new Capabilities(9).primary()        .tiltOnClosed()          .secondaryOverlapped().text("Dual Overlapped Tilt 90°"),
+            new Capabilities( 9).primary()        .tiltOnClosed()          .secondaryOverlapped().text("Dual Overlapped Tilt 90°"),
+            new Capabilities(10).primary()        .tiltOnClosed().tilt180().secondaryOverlapped().text("Dual Overlapped Tilt 180°"),
     // @formatter:on
             new Capabilities()).stream().collect(Collectors.toMap(Capabilities::getValue, Function.identity()));
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -154,9 +154,9 @@ public class ShadeCapabilitiesDatabase {
         }
 
         /**
-         * Get shade's type specific 'capabilities'.
+         * Get shade's overridden 'capabilities'.
          *
-         * @return 'typeCapabilities'.
+         * @return 'capabilitiesOverride'.
          */
         public int getCapabilitiesOverride() {
             return capabilitiesOverride;

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/database/ShadeCapabilitiesDatabase.java
@@ -80,15 +80,16 @@ public class ShadeCapabilitiesDatabase {
             new Type(47).capabilities(7).text("Pleated Top Down Bottom Up"),
             new Type(49).capabilities(0).text("AC Roller"),
             new Type(51).capabilities(2).text("Venetian"),
-            new Type(54).capabilities(4).text("Vertical Slats Left Stack").capabilitiesOverride(3),
-            new Type(55).capabilities(4).text("Vertical Slats Right Stack").capabilitiesOverride(3),
-            new Type(56).capabilities(4).text("Vertical Slats Split Stack").capabilitiesOverride(3),
+            // note: sometimes shade type 54/55/56 wrongly report capabilities:3 so force capabilities:4
+            new Type(54).capabilities(4).text("Vertical Slats Left Stack").capabilitiesOverride(4),
+            new Type(55).capabilities(4).text("Vertical Slats Right Stack").capabilitiesOverride(4),
+            new Type(56).capabilities(4).text("Vertical Slats Split Stack").capabilitiesOverride(4),
             new Type(62).capabilities(2).text("Venetian"),
             new Type(65).capabilities(8).text("Vignette Duolite"),
             new Type(66).capabilities(5).text("Shutter"),
-            new Type(69).capabilities(4).text("Curtain Left Stack"),
-            new Type(70).capabilities(4).text("Curtain Right Stack"),
-            new Type(71).capabilities(4).text("Curtain Split Stack"),
+            new Type(69).capabilities(3).text("Curtain Left Stack"),
+            new Type(70).capabilities(3).text("Curtain Right Stack"),
+            new Type(71).capabilities(3).text("Curtain Split Stack"),
             new Type(79).capabilities(8).text("Duolite Lift"),
     // @formatter:on
             new Type()).stream().collect(Collectors.toMap(Type::getValue, Function.identity()));

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/ShadePositionTest.java
@@ -41,13 +41,14 @@ public class ShadePositionTest {
     public void testKnownTypesDatabase() {
         assertTrue(db.isTypeInDatabase(4));
         assertTrue(db.isCapabilitiesInDatabase(0));
+        assertTrue(db.isCapabilitiesInDatabase(10));
 
         assertTrue(db.getCapabilities(0).supportsPrimary());
         assertTrue(db.getCapabilities(1).supportsTiltOnClosed());
         assertTrue(db.getCapabilities(2).supportsTilt180());
         assertTrue(db.getCapabilities(2).supportsTiltAnywhere());
-        assertTrue(db.getCapabilities(3).supportsTilt180());
-        assertTrue(db.getCapabilities(3).supportsTiltAnywhere());
+        assertTrue(db.getCapabilities(4).supportsTilt180());
+        assertTrue(db.getCapabilities(4).supportsTiltAnywhere());
         assertTrue(db.getCapabilities(5).supportsTilt180());
         assertFalse(db.getCapabilities(5).supportsPrimary());
         assertTrue(db.getCapabilities(6).isPrimaryInverted());


### PR DESCRIPTION
### Background

Resolves #13320 

Hunter Douglas has introduced its Generation 3 hubs. And the documentation for Gen 3 includes information (among many other things) about the Shade Capabilities. See screenshot below. Until now the OH binding uses an unofficial Capabilities database that has been based on detective work and trial and error. The Gen 3 official information confirms that 8 out of the 10 Capabilities in OH are indeed correct, but it also indicates that two of the existing Capabilities are reversed, and that one additional Capabilities entry is missing.

![image](https://user-images.githubusercontent.com/893994/187084498-26725927-5b38-4f8a-ae14-a4c44d07f04b.png)

### Solution

This PR swaps Capabilities 3 and 4 to match the Gen 3 official information. And it adds the so far missing Capabilities 10 the binding.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
