### PR TITLE
[nuki] Disabled warning for things created from textual config

### DIFF
--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -28,7 +28,7 @@ This binding supports just one bridge type: The Nuki Bridge (`nuki:bridge`). Cre
 The following configuration options are available:  
 
 | Parameter       | Description                                                                                                                                                                                        | Comment      |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
 | ip              | The IP address of the Nuki Bridge. Look it up on your router. It is recommended to set a static IP address lease for the Nuki Bridge (and for your openHAB server too) on your router.             | Required     |
 | port            | The Port which you configured during [Initial Bridge setup](https://nuki.io/en/support/bridge/bridge-setup/initial-bridge-setup/).                                                                 | Default 8080 |
 | apiToken        | The API Token which you configured during [Initial Bridge setup](https://nuki.io/en/support/bridge/bridge-setup/initial-bridge-setup/).                                                            | Required     |
@@ -59,106 +59,110 @@ connected to is configured and online.
 
 This is a common thing for all Nuki smart lock products - Nuki Smart Lock 1.0/2.0/3.0 (Pro) and Nuki Smart Door. The following configuration options are available:
 
-  | Parameter | Description                                                                                                                                                                                               | Comment       |
-  |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-  | unlatch   | If set to `true` the Nuki Smart Lock will unlock the door but then also automatically pull the latch of the door lock. Usually, if the door hinges are correctly adjusted, the door will then swing open. | Default false |
+| Parameter  | Description                                                                                                                                                                                               | Comment                                                          |
+|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| nukiId     | The decimal or hexadecimal string that identifies the Nuki Smartlock.                                                                                                                                     | Only available in textual configuration, cannot be edited in UI. |
+| deviceType | Numeric device type as specified by bridge HTTP API - 0 = Nuki Smart Lock 1.0/2.0, 3 = Nuki Smart Door, 4 = Nuki Smart Lock 3.0 (Pro).                                                                    | Only available in textual configuration, cannot be edited in UI. |
+| unlatch    | If set to `true` the Nuki Smart Lock will unlock the door but then also automatically pull the latch of the door lock. Usually, if the door hinges are correctly adjusted, the door will then swing open. | Default false                                                    |
 
 #### Supported Channels
 
-  | Channel          | Type   | Description                                                                                                                                                                             |
-  |------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-  | lock             | Switch | Switch to lock and unlock doors. If `unlatch` configuration parameter is set, unlocking will also unlatch the door.                                                                     |
-  | lockState        | Number | Channel which accepts [Supported commands](#supported-lockstate-commands) for performing actions, and produces [supported values](#supported-lockstate-values) when lock state changes. |
-  | lowBattery       | Switch | Low battery warning channel                                                                                                                                                             |
-  | keypadLowBattery | Switch | Indicates if keypad connected to Nuki Lock has low battery                                                                                                                              |
-  | batteryLevel     | Number | Current battery level                                                                                                                                                                   |
-  | batteryCharging  | Swtich | Flag indicating if the batteries of the Nuki device are charging at the moment                                                                                                          |
-  | doorsensorState  | Number | Read only channel for monitoring door sensor state, see [supported values](#supported-doorsensorstate-values)                                                                           |
+| Channel          | Type   | Description                                                                                                                                                                             |
+|------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| lock             | Switch | Switch to lock and unlock doors. If `unlatch` configuration parameter is set, unlocking will also unlatch the door.                                                                     |
+| lockState        | Number | Channel which accepts [Supported commands](#supported-lockstate-commands) for performing actions, and produces [supported values](#supported-lockstate-values) when lock state changes. |
+| lowBattery       | Switch | Low battery warning channel                                                                                                                                                             |
+| keypadLowBattery | Switch | Indicates if keypad connected to Nuki Lock has low battery                                                                                                                              |
+| batteryLevel     | Number | Current battery level                                                                                                                                                                   |
+| batteryCharging  | Swtich | Flag indicating if the batteries of the Nuki device are charging at the moment                                                                                                          |
+| doorsensorState  | Number | Read only channel for monitoring door sensor state, see [supported values](#supported-doorsensorstate-values)                                                                           |
 
 ##### Supported lockState commands
 
 These values can be sent to _lockState_ channel as a commands:
 
-  | Command | Name                     |
-  |---------|--------------------------|
-  | 1       | Unlock                   |
-  | 2       | Lock                     |
-  | 3       | Unlatch                  |
-  | 4       | Lock 'n' Go              |
-  | 5       | Lock 'n' Go with Unlatch |
+| Command | Name                     |
+|---------|--------------------------|
+| 1       | Unlock                   |
+| 2       | Lock                     |
+| 3       | Unlatch                  |
+| 4       | Lock 'n' Go              |
+| 5       | Lock 'n' Go with Unlatch |
 
 ##### Supported lockState values
 
-  | State  | Name                     |
-  |--------|--------------------------|
-  | 0      | Uncalibrated             |
-  | 1      | Locked                   |
-  | 2      | Unlocking                |
-  | 3      | Unlocked                 |
-  | 4      | Locking                  |
-  | 5      | Unlatched                |
-  | 6      | Unlatched (Lock 'n' Go)  |
-  | 7      | Unlatching               |
-  | 254    | Motor blocked            |
-  | 255    | Undefined                |
+| State  | Name                     |
+|--------|--------------------------|
+| 0      | Uncalibrated             |
+| 1      | Locked                   |
+| 2      | Unlocking                |
+| 3      | Unlocked                 |
+| 4      | Locking                  |
+| 5      | Unlatched                |
+| 6      | Unlatched (Lock 'n' Go)  |
+| 7      | Unlatching               |
+| 254    | Motor blocked            |
+| 255    | Undefined                |
 
 Unfortunately the Nuki Bridge is not reporting any transition states (e.g. for Lock 'n' Go).
 
 ##### Supported doorSensorState values
 
-  | State | Name                |
-  |-------|---------------------|
-  | 1     | Deactivated         |
-  | 2     | Closed              |
-  | 3     | Open                |
-  | 4     | Door state unknonwn |
-  | 5     | Calibrating         |
-  | 16    | Uncalibrated        |
-  | 240   | Removed             |
-  | 255   | Unknown             |
+| State | Name                |
+|-------|---------------------|
+| 1     | Deactivated         |
+| 2     | Closed              |
+| 3     | Open                |
+| 4     | Door state unknonwn |
+| 5     | Calibrating         |
+| 16    | Uncalibrated        |
+| 240   | Removed             |
+| 255   | Unknown             |
 
 ### Nuki Opener
 
-Nuki Opener has no configuration properties.
+| Parameter | Description                                                        | Comment                                                          |
+|-----------|--------------------------------------------------------------------|------------------------------------------------------------------|
+| nukiId    | The decimal or hexadecimal string that identifies the Nuki Opener. | Only available in textual configuration, cannot be edited in UI. |
 
 #### Supported channels
 
-  | Channel             | Type     | Description                                                                                                                                                                      |
-  |---------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-  | openerState         | Number   | Channel for sending [supported commands](#supported-openerstate-commands) to Opener, produces one of [supported values](#supported-openerstate-values) when Opener state changes |
-  | openerMode          | Number   | Id of current Opener mode, see [Supported values](#supported-openermode-values)                                                                                                  |
-  | openerLowBattery    | Switch   | Low battery warning channel                                                                                                                                                      |
-  | ringActionState     | Trigger  | Channel triggers 'RINGING' event when the doorbell is being rung. This can trigger at most once every 30s                                                                        |
-  | ringActionTimestamp | DateTime | Timestamp of last time doorbell was rung.                                                                                                                                        |
+| Channel             | Type     | Description                                                                                                                                                                      |
+|---------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| openerState         | Number   | Channel for sending [supported commands](#supported-openerstate-commands) to Opener, produces one of [supported values](#supported-openerstate-values) when Opener state changes |
+| openerMode          | Number   | Id of current Opener mode, see [Supported values](#supported-openermode-values)                                                                                                  |
+| openerLowBattery    | Switch   | Low battery warning channel                                                                                                                                                      |
+| ringActionState     | Trigger  | Channel triggers 'RINGING' event when the doorbell is being rung. This can trigger at most once every 30s                                                                        |
+| ringActionTimestamp | DateTime | Timestamp of last time doorbell was rung.                                                                                                                                        |
 
 ##### Supported openerState commands
 
-  | Command | Name                       |
-  |---------|----------------------------|
-  | 1       | Activate ring to open      |
-  | 2       | Deactivate ring to open    |
-  | 3       | Electric strike actuation  |
-  | 4       | Activate continuous mode   |
-  | 5       | Deactivate continuous mode |
+| Command | Name                       |
+|---------|----------------------------|
+| 1       | Activate ring to open      |
+| 2       | Deactivate ring to open    |
+| 3       | Electric strike actuation  |
+| 4       | Activate continuous mode   |
+| 5       | Deactivate continuous mode |
 
 ##### Supported openerState values
 
-  | State  | Name                |
-  |--------|---------------------|
-  | 0      | Untrained           |
-  | 1      | Online              |
-  | 3      | Ring to open active |
-  | 5      | Open                |
-  | 7      | Opening             |
-  | 253    | Boot run            |
-  | 255    | Undefined           |
+| State  | Name                |
+|--------|---------------------|
+| 0      | Untrained           |
+| 1      | Online              |
+| 3      | Ring to open active |
+| 5      | Open                |
+| 7      | Opening             |
+| 253    | Boot run            |
+| 255    | Undefined           |
 
 ##### Supported openerMode values
   
-  | Mode   | Name            |
-  |--------|-----------------|
-  | 2      | Door mode       |
-  | 3      | Continuous mode |
+| Mode   | Name            |
+|--------|-----------------|
+| 2      | Door mode       |
+| 3      | Continuous mode |
 
 
 ## Troubleshooting
@@ -176,8 +180,9 @@ A manual setup through files could look like this:
 ### things/nuki.things
 
 ```
-Bridge nuki:bridge:NB1 [ ip="192.168.0.50", port=8080, apiToken="myS3cr3t!", manageCallbacks=true ] {
-    Thing smartlock SL1 [ nukiId="12AB89EF", deviceType=0, unlatch=false ]
+Bridge nuki:bridge:NB1 "Bridge Name" [ ip="192.168.0.50", port=8080, apiToken="myS3cr3t!", manageCallbacks=true, secureToken=true ] {
+    Thing smartlock SL1 "Nuki Smartlock Name" [ nukiId="12AB89EF", deviceType=0, unlatch=false ]
+    Thing opener OP1 "Nuki Opener Name" [ nukiId="254CF45A" ]
 }
 ```
 
@@ -186,7 +191,7 @@ Bridge nuki:bridge:NB1 [ ip="192.168.0.50", port=8080, apiToken="myS3cr3t!", man
 ```
 Switch Frontdoor_Lock		"Frontdoor (Unlock / Lock)"	<nukiwhite>		{ channel="nuki:smartlock:NB1:SL1:lock" }
 Number Frontdoor_LockState	"Frontdoor (Lock State)"	<nukisl>		{ channel="nuki:smartlock:NB1:SL1:lockState" }
-Switch Frontdoor_LowBattery	"Frontdoor Low Battery"		<nukibattery>		{ channel="nuki:smartlock:NB1:SL1:lowBattery" }
+Switch Frontdoor_LowBattery	"Frontdoor Low Battery"		<nukibattery>	{ channel="nuki:smartlock:NB1:SL1:lowBattery" }
 Number Frontdoor_DoorState	"Frontdoor (Door State)"	<door>			{ channel="nuki:smartlock:NB1:SL1:doorsensorState" }
 ```
 

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/NukiHandlerFactory.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/NukiHandlerFactory.java
@@ -26,6 +26,7 @@ import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.net.HttpServiceUtil;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -54,14 +55,17 @@ public class NukiHandlerFactory extends BaseThingHandlerFactory {
 
     private final HttpClient httpClient;
     private final NetworkAddressService networkAddressService;
+    private final ManagedThingProvider managedThingProvider;
     private NukiApiServlet nukiApiServlet;
 
     @Activate
     public NukiHandlerFactory(@Reference HttpService httpService, @Reference final HttpClientFactory httpClientFactory,
-            @Reference NetworkAddressService networkAddressService) {
+            @Reference NetworkAddressService networkAddressService,
+            @Reference ManagedThingProvider managedThingProvider) {
         this.httpClient = httpClientFactory.getCommonHttpClient();
         this.networkAddressService = networkAddressService;
         this.nukiApiServlet = new NukiApiServlet(httpService);
+        this.managedThingProvider = managedThingProvider;
     }
 
     @Override
@@ -72,6 +76,7 @@ public class NukiHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        boolean readOnly = managedThingProvider.get(thing.getUID()) == null;
 
         if (NukiBindingConstants.THING_TYPE_BRIDGE_UIDS.contains(thingTypeUID)) {
             String callbackUrl = createCallbackUrl(InstanceUUID.get());
@@ -79,9 +84,9 @@ public class NukiHandlerFactory extends BaseThingHandlerFactory {
             nukiApiServlet.add(nukiBridgeHandler);
             return nukiBridgeHandler;
         } else if (NukiBindingConstants.THING_TYPE_SMARTLOCK_UIDS.contains(thingTypeUID)) {
-            return new NukiSmartLockHandler(thing);
+            return new NukiSmartLockHandler(thing, readOnly);
         } else if (NukiBindingConstants.THING_TYPE_OPENER_UIDS.contains(thingTypeUID)) {
-            return new NukiOpenerHandler(thing);
+            return new NukiOpenerHandler(thing, readOnly);
         }
         logger.warn("No valid Handler found for Thing[{}]!", thingTypeUID);
         return null;

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/AbstractNukiDeviceHandler.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/AbstractNukiDeviceHandler.java
@@ -70,9 +70,11 @@ public abstract class AbstractNukiDeviceHandler<T extends NukiDeviceConfiguratio
     protected T configuration;
     @Nullable
     private NukiHttpClient nukiHttpClient;
+    protected final boolean readOnly;
 
-    public AbstractNukiDeviceHandler(Thing thing) {
+    public AbstractNukiDeviceHandler(Thing thing, boolean readOnly) {
         super(thing);
+        this.readOnly = readOnly;
         this.configuration = getConfigAs(getConfigurationClass());
     }
 
@@ -108,9 +110,11 @@ public abstract class AbstractNukiDeviceHandler<T extends NukiDeviceConfiguratio
         // legacy support - check if nukiId is hexadecimal (which might have been set by previous binding version)
         // and convert it to decimal
         if (NUKI_ID_HEX_PATTERN.matcher(nukiId).matches()) {
-            logger.warn(
-                    "SmartLock '{}' was created by old version of binding. It is recommended to delete it and discover again",
-                    thing.getUID());
+            if (!readOnly) {
+                logger.warn(
+                        "SmartLock '{}' was created by old version of binding. It is recommended to delete it and discover again",
+                        thing.getUID());
+            }
             Configuration newConfig = editConfiguration();
             newConfig.put(NukiBindingConstants.PROPERTY_NUKI_ID, hexToDecimal(nukiId));
             updateConfiguration(newConfig);

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/NukiOpenerHandler.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/NukiOpenerHandler.java
@@ -36,8 +36,8 @@ import org.openhab.core.types.Command;
 @NonNullByDefault
 public class NukiOpenerHandler extends AbstractNukiDeviceHandler<NukiDeviceConfiguration> {
 
-    public NukiOpenerHandler(Thing thing) {
-        super(thing);
+    public NukiOpenerHandler(Thing thing, boolean readOnly) {
+        super(thing, readOnly);
     }
 
     private volatile Instant lastRingAction = Instant.EPOCH;

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/NukiSmartLockHandler.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/NukiSmartLockHandler.java
@@ -35,8 +35,8 @@ import org.openhab.core.types.Command;
 @NonNullByDefault
 public class NukiSmartLockHandler extends AbstractNukiDeviceHandler<NukiSmartLockConfiguration> {
 
-    public NukiSmartLockHandler(Thing thing) {
-        super(thing);
+    public NukiSmartLockHandler(Thing thing, boolean readOnly) {
+        super(thing, readOnly);
     }
 
     @Override


### PR DESCRIPTION
Disabled migration warning for read-only things (created from textual config) so that users can use hexadecimal nukiIds in .things files.

Added documentation for all configuration parameters (not only for those editable in UI) and updated textual configuration example.
