### PR TITLE
[Konnected] Removed defaults for zone configuration parameter from the channels

### DIFF
--- a/bundles/org.openhab.binding.konnected/README.md
+++ b/bundles/org.openhab.binding.konnected/README.md
@@ -92,19 +92,19 @@ Switch item=Siren label="Alarm Siren" icon="Siren" mappings=[ON="Open", OFF="Clo
 
 ```
 Thing konnected:wifi-module:generic "Konnected Module" [baseUrl="http://192.168.30.153:9586", macAddress="1586517"]{
-   Type switch      : switch-wifi      "Front Door"          [channel_zone=1]
-   Type actuator    : actuator-wifi    "Siren"               [channel_zone=1, momentary = 50, times = 2, pause = 50]
-   Type humidity    : humidity-wifi    "DHT - Humidity"      [channel_zone=1]
-   Type temperature : temperature-wifi "DHT Temperature"     [channel_zone=1, tempsensorType = true, pollinterval = 1]
-   Type temperature : temperature-wifi "DS18B20 Temperature" [channel_zone=1, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
+   Type switch      : switch-wifi      "Front Door"          [zone=1]
+   Type actuator    : actuator-wifi    "Siren"               [zone=2, momentary = 50, times = 2, pause = 50]
+   Type humidity    : humidity-wifi    "DHT - Humidity"      [zone=3]
+   Type temperature : temperature-wifi "DHT Temperature"     [zone=4, tempsensorType = true, pollinterval = 1]
+   Type temperature : temperature-wifi "DS18B20 Temperature" [zone=5, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
 }
 
 Thing konnected:pro-module:generic "Konnected Module" [baseUrl="http://192.168.30.154:9586", macAddress="1684597"]{
-   Type switch      : switch-pro      "Front Door"          [channel_zone=1]
-   Type actuator    : actuator-pro    "Siren"               [channel_zone=1, momentary = 50, times = 2, pause = 50]
-   Type humidity    : humidity-pro    "DHT - Humidity"      [channel_zone=1]
-   Type temperature : temperature-pro "DHT Temperature"     [channel_zone=1, tempsensorType = true, pollinterval = 1]
-   Type temperature : temperature-pro "DS18B20 Temperature" [channel_zone=1, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
+   Type switch      : switch-pro      "Front Door"          [zone=1]
+   Type actuator    : actuator-pro    "Siren"               [zone=2, momentary = 50, times = 2, pause = 50]
+   Type humidity    : humidity-pro    "DHT - Humidity"      [zone=3]
+   Type temperature : temperature-pro "DHT Temperature"     [zone=4, tempsensorType = true, pollinterval = 1]
+   Type temperature : temperature-pro "DS18B20 Temperature" [zone=5, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
 }
 ```
 

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
@@ -26,7 +26,6 @@
 			<parameter name="zone" type="text" required="true">
 				<label>Zone Number</label>
 				<description>The Zone Number of the channel.</description>
-				<default>6</default>
 				<options>
 					<option value="1">1</option>
 					<option value="2">2</option>
@@ -111,7 +110,6 @@
 			<parameter name="zone" type="text" required="true">
 				<label>Zone Number</label>
 				<description>The Zone Number of the channel.</description>
-				<default>7</default>
 				<options>
 					<option value="1">1</option>
 					<option value="2">2</option>
@@ -155,7 +153,6 @@
 			<parameter name="zone" type="text" required="true">
 				<label>Zone Number</label>
 				<description>The zone number of the channel.</description>
-				<default>4</default>
 				<options>
 					<option value="1">1</option>
 					<option value="2">2</option>
@@ -191,7 +188,6 @@
 			<parameter name="zone" type="text" required="true">
 				<label>Zone Number</label>
 				<description>The zone number of the channel.</description>
-				<default>2</default>
 				<options>
 					<option value="1">1</option>
 					<option value="2">2</option>


### PR DESCRIPTION
Bugfix for issue when adding channels with the default zone configured. The thing get into an invalid config state when adding a channel with the default zone selected. The only way to add channel for the default zone is to add a channel for a different zone, then go back and edit it to the default value.

The cause is that the zone parameter was marked as required and had a default.

The default value did not make sense to me, so I removed it. 