### PR TITLE
[pulseaudio] Apply real disconnection when needed

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSink.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSink.java
@@ -66,6 +66,7 @@ public class PulseAudioAudioSink extends PulseaudioSimpleProtocolStream implemen
         if (audioStream == null) {
             return;
         }
+        addClientCount();
         try (ConvertedInputStream normalizedPCMStream = new ConvertedInputStream(audioStream)) {
             for (int countAttempt = 1; countAttempt <= 2; countAttempt++) { // two attempts allowed
                 try {
@@ -107,7 +108,7 @@ public class PulseAudioAudioSink extends PulseaudioSimpleProtocolStream implemen
             throw new UnsupportedAudioFormatException("Cannot send sound to the pulseaudio sink",
                     audioStream.getFormat(), e);
         } finally {
-            scheduleDisconnect();
+            minusClientCount();
         }
     }
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSink.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSink.java
@@ -73,7 +73,6 @@ public class PulseAudioAudioSink extends PulseaudioSimpleProtocolStream implemen
                     final Socket clientSocketLocal = clientSocket;
                     if (clientSocketLocal != null) {
                         // send raw audio to the socket and to pulse audio
-                        setIdle(false);
                         Instant start = Instant.now();
                         normalizedPCMStream.transferTo(clientSocketLocal.getOutputStream());
                         if (normalizedPCMStream.getDuration() != -1) { // ensure, if the sound has a duration
@@ -110,7 +109,6 @@ public class PulseAudioAudioSink extends PulseaudioSimpleProtocolStream implemen
         } finally {
             scheduleDisconnect();
         }
-        setIdle(true);
     }
 
     @Override

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -84,7 +84,6 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                     if (!audioFormat.isCompatible(sourceFormat)) {
                         throw new AudioException("Incompatible audio format requested");
                     }
-                    setIdle(true);
                     var pipeOutput = new PipedOutputStream();
                     var pipeInput = new PipedInputStream(pipeOutput, 1024 * 10) {
                         @Override
@@ -96,7 +95,6 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                     registerPipe(pipeOutput);
                     // get raw audio from the pulse audio socket
                     return new PulseAudioStream(sourceFormat, pipeInput, (idle) -> {
-                        setIdle(idle);
                         if (idle) {
                             scheduleDisconnect();
                         } else {
@@ -113,12 +111,10 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
                         logger.warn(
                                 "Error while trying to get audio from pulseaudio audio source. Cannot connect to {}:{}, error: {}",
                                 pulseaudioHandler.getHost(), port, e.getMessage());
-                        setIdle(true);
                         throw e;
                     }
                 } catch (InterruptedException ie) {
                     logger.info("Interrupted during source audio connection: {}", ie.getMessage());
-                    setIdle(true);
                     throw new AudioException(ie);
                 }
                 countAttempt++;
@@ -128,7 +124,6 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
         } finally {
             scheduleDisconnect();
         }
-        setIdle(true);
         throw new AudioException("Unable to create input stream");
     }
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java
@@ -128,7 +128,18 @@ public class PulseAudioAudioSource extends PulseaudioSimpleProtocolStream implem
         startPipeWrite();
     }
 
-    private synchronized void startPipeWrite() {
+    /**
+     * As startPipeWrite is called for every chunk read,
+     * this wrapper method make the test before effectively
+     * locking the object (which is a costly operation)
+     */
+    private void startPipeWrite() {
+        if (this.pipeWriteTask == null) {
+            startPipeWriteSynchronized();
+        }
+    }
+
+    private synchronized void startPipeWriteSynchronized() {
         if (this.pipeWriteTask == null) {
             this.pipeWriteTask = executor.submit(() -> {
                 int lengthRead;

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioSimpleProtocolStream.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioSimpleProtocolStream.java
@@ -43,8 +43,6 @@ public abstract class PulseaudioSimpleProtocolStream {
 
     protected @Nullable Socket clientSocket;
 
-    private boolean isIdle = true;
-
     private @Nullable ScheduledFuture<?> scheduledDisconnection;
 
     public PulseaudioSimpleProtocolStream(PulseaudioHandler pulseaudioHandler, ScheduledExecutorService scheduler) {
@@ -75,7 +73,7 @@ public abstract class PulseaudioSimpleProtocolStream {
      */
     public void disconnect() {
         final Socket clientSocketLocal = clientSocket;
-        if (clientSocketLocal != null && isIdle) {
+        if (clientSocketLocal != null) {
             logger.debug("Simple TCP Stream disconnecting");
             try {
                 clientSocketLocal.close();
@@ -113,9 +111,5 @@ public abstract class PulseaudioSimpleProtocolStream {
     public String getLabel(@Nullable Locale locale) {
         var label = pulseaudioHandler.getThing().getLabel();
         return label != null ? label : pulseaudioHandler.getThing().getUID().getId();
-    }
-
-    public void setIdle(boolean idle) {
-        isIdle = idle;
     }
 }

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioSimpleProtocolStream.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioSimpleProtocolStream.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -43,6 +44,9 @@ public abstract class PulseaudioSimpleProtocolStream {
 
     protected @Nullable Socket clientSocket;
 
+    private ReentrantLock countClientLock = new ReentrantLock();
+    private Integer countClient = 0;
+
     private @Nullable ScheduledFuture<?> scheduledDisconnection;
 
     public PulseaudioSimpleProtocolStream(PulseaudioHandler pulseaudioHandler, ScheduledExecutorService scheduler) {
@@ -52,6 +56,7 @@ public abstract class PulseaudioSimpleProtocolStream {
 
     /**
      * Connect to pulseaudio with the simple protocol
+     * Will schedule an attempt for disconnection after timeout
      *
      * @throws IOException
      * @throws InterruptedException when interrupted during the loading module wait
@@ -59,12 +64,13 @@ public abstract class PulseaudioSimpleProtocolStream {
     public void connectIfNeeded() throws IOException, InterruptedException {
         Socket clientSocketLocal = clientSocket;
         if (clientSocketLocal == null || !clientSocketLocal.isConnected() || clientSocketLocal.isClosed()) {
-            logger.debug("Simple TCP Stream connecting");
+            logger.debug("Simple TCP Stream connecting for {}", getLabel(null));
             String host = pulseaudioHandler.getHost();
             int port = pulseaudioHandler.getSimpleTcpPortAndLoadModuleIfNecessary();
             var clientSocketFinal = new Socket(host, port);
             clientSocketFinal.setSoTimeout(pulseaudioHandler.getBasicProtocolSOTimeout());
             clientSocket = clientSocketFinal;
+            scheduleDisconnectIfNoClient();
         }
     }
 
@@ -74,7 +80,7 @@ public abstract class PulseaudioSimpleProtocolStream {
     public void disconnect() {
         final Socket clientSocketLocal = clientSocket;
         if (clientSocketLocal != null) {
-            logger.debug("Simple TCP Stream disconnecting");
+            logger.debug("Simple TCP Stream disconnecting for {}", getLabel(null));
             try {
                 clientSocketLocal.close();
             } catch (IOException ignored) {
@@ -84,15 +90,23 @@ public abstract class PulseaudioSimpleProtocolStream {
         }
     }
 
-    public void scheduleDisconnect() {
-        var scheduledDisconnectionFinal = scheduledDisconnection;
-        if (scheduledDisconnectionFinal != null) {
-            scheduledDisconnectionFinal.cancel(true);
-        }
-        int idleTimeout = pulseaudioHandler.getIdleTimeout();
-        if (idleTimeout > -1) {
-            logger.debug("Scheduling disconnect");
-            scheduledDisconnection = scheduler.schedule(this::disconnect, idleTimeout, TimeUnit.MILLISECONDS);
+    private void scheduleDisconnectIfNoClient() {
+        countClientLock.lock();
+        try {
+            if (countClient <= 0) {
+                var scheduledDisconnectionFinal = scheduledDisconnection;
+                if (scheduledDisconnectionFinal != null) {
+                    logger.debug("Aborting next disconnect");
+                    scheduledDisconnectionFinal.cancel(true);
+                }
+                int idleTimeout = pulseaudioHandler.getIdleTimeout();
+                if (idleTimeout > -1) {
+                    logger.debug("Scheduling next disconnect");
+                    scheduledDisconnection = scheduler.schedule(this::disconnect, idleTimeout, TimeUnit.MILLISECONDS);
+                }
+            }
+        } finally {
+            countClientLock.unlock();
         }
     }
 
@@ -111,5 +125,37 @@ public abstract class PulseaudioSimpleProtocolStream {
     public String getLabel(@Nullable Locale locale) {
         var label = pulseaudioHandler.getThing().getLabel();
         return label != null ? label : pulseaudioHandler.getThing().getUID().getId();
+    }
+
+    protected void addClientCount() {
+        countClientLock.lock();
+        try {
+            countClient += 1;
+            logger.debug("Adding new client for pulseaudio sink/source {}. Current count: {}", getLabel(null),
+                    countClient);
+            if (countClient <= 0) { // safe against misuse
+                countClient = 1;
+            }
+            var scheduledDisconnectionFinal = scheduledDisconnection;
+            if (scheduledDisconnectionFinal != null) {
+                logger.debug("Aborting next disconnect");
+                scheduledDisconnectionFinal.cancel(true);
+            }
+        } finally {
+            countClientLock.unlock();
+        }
+    }
+
+    protected void minusClientCount() {
+        countClientLock.lock();
+        countClient -= 1;
+        logger.debug("Removing client for pulseaudio sink/source {}. Current count: {}", getLabel(null), countClient);
+        if (countClient < 0) { // safe against misuse
+            countClient = 0;
+        }
+        countClientLock.unlock();
+        if (countClient <= 0) {
+            scheduleDisconnectIfNoClient();
+        }
     }
 }

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
@@ -352,7 +352,7 @@ public class Parser {
     private static int parseVolume(String vol) {
         int volumeTotal = 0;
         int nChannels = 0;
-        for (String channel : vol.split(", ")) {
+        for (String channel : vol.split(",")) {
             Matcher matcher = VOLUME_PATTERN.matcher(channel.trim());
             if (matcher.find()) {
                 volumeTotal += Integer.valueOf(matcher.group(3));

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -140,8 +140,6 @@ public class PulseaudioHandler extends BaseThingHandler {
                 } catch (InterruptedException i) {
                     logger.info("Interrupted during sink audio connection: {}", i.getMessage());
                     return;
-                } finally {
-                    audioSink.scheduleDisconnect();
                 }
             }
         });
@@ -194,8 +192,6 @@ public class PulseaudioHandler extends BaseThingHandler {
                 } catch (InterruptedException i) {
                     logger.info("Interrupted during source audio connection: {}", i.getMessage());
                     return;
-                } finally {
-                    audioSource.scheduleDisconnect();
                 }
             }
         });


### PR DESCRIPTION
Bug description: 
When the pulseaudio server is shutdown and relaunched, the socket is dead. But the audiosink connection doesn't properly reset the next time it is needed. The isIdle boolean prevents this disconnection/reconnection by checking if it's in use before effectively disconnecting (and of course it's in use, because we are trying to use it when we see that the connection is broken...)
Additionnally, isIdle is not in a try catch block for the pulseaudio sink : so exception within an operation doesn't free the boolean.

Actually, isIdle seems not even relevant : we should always honnor the disconnection request, even if an operation is running (disconnection requests occur when we get I/O exception, or when shutting down the bridge/thing).

This PR remove the isIdle boolean.

+Little bug fix on volume parsing: in some case (audio source), a volume request doesn't respond with a space after the comma separating left/right channel, so I change the volume pattern.