### PR TITLE
[nuvo] Fix MPS4 flag and online status reporting

### DIFF
--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/communication/NuvoStatusCodes.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/communication/NuvoStatusCodes.java
@@ -43,9 +43,9 @@ public class NuvoStatusCodes {
         PLAY_MODE.put("6", "Play Shuffle");
         PLAY_MODE.put("7", "Play Repeat");
         PLAY_MODE.put("8", "Play Shuffle Repeat");
-        PLAY_MODE.put("9", "unknown-9");
-        PLAY_MODE.put("10", "unknown-10");
-        PLAY_MODE.put("11", "Radio"); // undocumented
+        PLAY_MODE.put("9", "Radio (Step Tune)");
+        PLAY_MODE.put("10", "Radio (Seek Tune)");
+        PLAY_MODE.put("11", "Radio (Preset Tune)");
         PLAY_MODE.put("12", "unknown-12");
     }
 

--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/communication/NuvoStatusCodes.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/communication/NuvoStatusCodes.java
@@ -43,9 +43,9 @@ public class NuvoStatusCodes {
         PLAY_MODE.put("6", "Play Shuffle");
         PLAY_MODE.put("7", "Play Repeat");
         PLAY_MODE.put("8", "Play Shuffle Repeat");
-        PLAY_MODE.put("9", "Radio (Step Tune)");
-        PLAY_MODE.put("10", "Radio (Seek Tune)");
-        PLAY_MODE.put("11", "Radio (Preset Tune)");
+        PLAY_MODE.put("9", "Step Tune");
+        PLAY_MODE.put("10", "Seek Tune");
+        PLAY_MODE.put("11", "Preset Tune");
         PLAY_MODE.put("12", "unknown-12");
     }
 

--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -182,19 +182,18 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
             return;
         }
 
-        if (serialPort != null) {
+        if (serialPort != null && !serialPort.isEmpty()) {
             connector = new NuvoSerialConnector(serialPortManager, serialPort, uid);
         } else if (port != null) {
             connector = new NuvoIpConnector(host, port, uid);
+            this.isMps4 = (port.intValue() == MPS4_PORT);
+            if (this.isMps4) {
+                logger.debug("Port set to {} configuring binding for MPS4 compatability", MPS4_PORT);
+            }
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "Either Serial port or Host & Port must be specifed");
             return;
-        }
-
-        this.isMps4 = (port != null && port.intValue() == MPS4_PORT);
-        if (this.isMps4) {
-            logger.debug("Port set to {} configuring binding for MPS4 compatability", MPS4_PORT);
         }
 
         if (numZones != null) {
@@ -462,7 +461,7 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
         String type = evt.getType();
         String key = evt.getKey();
         String updateData = evt.getValue().trim();
-        if (this.getThing().getStatus() == ThingStatus.OFFLINE) {
+        if (this.getThing().getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, this.versionString);
         }
 
@@ -598,7 +597,6 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
             if (!connector.isConnected()) {
                 logger.debug("Trying to reconnect...");
                 closeConnection();
-                String error = null;
                 if (openConnection()) {
                     logger.debug("Reconnected");
                     // Polling status will disconnect from MPS4 on reconnect
@@ -606,13 +604,8 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
                         pollStatus();
                     }
                 } else {
-                    error = "Reconnection failed";
-                }
-                if (error != null) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, error);
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Reconnection failed");
                     closeConnection();
-                } else {
-                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, this.versionString);
                 }
             }
         }, 1, RECON_POLLING_INTERVAL_SEC, TimeUnit.SECONDS);
@@ -630,7 +623,7 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
                 scheduleReconnectJob();
             }, PING_TIMEOUT_SEC, TimeUnit.SECONDS);
         } else {
-            logger.debug("Ping Timeout job on valid for MPS4 connections");
+            logger.debug("Ping Timeout job not valid for serial connections");
         }
     }
 


### PR DESCRIPTION
Fix two minor issues:

1. When thing is provisioned from the UI, the port config item was populated with a default value. This caused the MPS4 flag to be set erroneously even when using serial port connections.
2. For serial port connections, the thing was always showing as ONLINE even when the serial port was not actually connected to the amplifier.