### PR TITLE
[remoteopenhab] Fix the pattern to parse DateTime

### DIFF
--- a/bundles/org.openhab.binding.remoteopenhab/src/main/java/org/openhab/binding/remoteopenhab/internal/handler/RemoteopenhabBridgeHandler.java
+++ b/bundles/org.openhab.binding.remoteopenhab/src/main/java/org/openhab/binding/remoteopenhab/internal/handler/RemoteopenhabBridgeHandler.java
@@ -99,7 +99,7 @@ import com.google.gson.Gson;
 public class RemoteopenhabBridgeHandler extends BaseBridgeHandler
         implements RemoteopenhabStreamingDataListener, RemoteopenhabItemsDataListener {
 
-    private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS][.SSSSSSSS][.SSSSSSS][.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]]Z";
     private static final DateTimeFormatter FORMATTER_DATE = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN);
 
     private static final int MAX_STATE_SIZE_FOR_LOGGING = 50;


### PR DESCRIPTION
Re-use the same pattern as defined in class DateTimeTyoe.

Allows the support of 0 to 9 digits after the seconds.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>