### PR TITLE
[gpio] Set UP value on startup when inverted

### DIFF
--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalOutputHandler.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalOutputHandler.java
@@ -63,6 +63,10 @@ public class PigpioDigitalOutputHandler implements ChannelHandler {
             throw new NoGpioIdException();
         }
         this.gpio = new GPIO(jPigpio, gpioId, JPigpio.PI_OUTPUT);
+        if (configuration.invert) {
+            updateStatus.accept(OnOffType.ON);
+            gpio.setValue(true);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Description

By default, the GPIO output pins are OFF. Using the "invert" flag, the behavior is changed so that the default state is ON. This works fine unless the service is restarted. On startup, the GPIO values are not set to ON despite the inverted flag being set.

This PR fixes that problem by setting the value in the constructor.

Maybe @nils-bauer or @SloCompTech could review and/or test a bit?

This might also be a fix for issue #11296.