### PR TITLE
[jdbc] Fix date cast exception

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.jdbc.db;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -564,11 +565,17 @@ public class JdbcBaseDAO {
     }
 
     protected ZonedDateTime objectAsDate(Object v) {
-        if (v instanceof java.lang.String) {
+        if (v instanceof LocalDateTime) {
+            return ZonedDateTime.of((LocalDateTime) v, ZoneId.systemDefault());
+        } else if (v instanceof java.sql.Timestamp) {
+            return ZonedDateTime.ofInstant(((java.sql.Timestamp) v).toInstant(), ZoneId.systemDefault());
+        } else if (v instanceof Instant) {
+            return ZonedDateTime.ofInstant((Instant) v, ZoneId.systemDefault());
+        } else if (v instanceof java.lang.String) {
             return ZonedDateTime.ofInstant(java.sql.Timestamp.valueOf(v.toString()).toInstant(),
                     ZoneId.systemDefault());
         }
-        return ZonedDateTime.ofInstant(((java.sql.Timestamp) v).toInstant(), ZoneId.systemDefault());
+        throw new UnsupportedOperationException("Date of type " + v.getClass().getName() + " is not supported");
     }
 
     protected Long objectAsLong(Object v) {


### PR DESCRIPTION
After upgrading mysql-connector to 8.0.30 this exception was thrown: `class java.time.LocalDateTime cannot be cast to class java.sql.Timestamp`

The problem was introduced with 8.0.23 - more details here:
https://dev.mysql.com/blog-archive/support-for-date-time-types-in-connector-j-8-0/

Regression of #13242