### PR TITLE
[nibeheatpump] Support for ESP32 generic board + wifi + platform.io

### DIFF
--- a/bundles/org.openhab.binding.nibeheatpump/README.md
+++ b/bundles/org.openhab.binding.nibeheatpump/README.md
@@ -56,17 +56,18 @@ Obviously, this doesn't solve the problem when the Raspberry Pi is down, therefo
 `nibegw` is an application that reads telegrams from a serial port (which requires an RS-485 adapter), sends ACK/NAK to the heat pump and relays untouched telegrams to openHAB via UDP packets.
 The Nibe Heat Pump binding will listen to a UDP port and parse register data from UDP telegrams.
 
-### Arduino
+### Arduino / ESP32
 
-An Arduino-based solution has been tested with Arduino uno + RS485 and Ethernet shields.
-[PRODINo ESP32 Ethernet v1](https://kmpelectronics.eu/products/prodino-esp32-ethernet-v1/) and [ProDiNo Ethernet V2](https://kmpelectronics.eu/products/prodino-ethernet-v2/) boards are also supported.
-PRODINo boards have built-in Ethernet and RS-485 ports.
+Arduino- and ESP32 based solutions has been tested with:
+* Arduino uno + RS485 and Ethernet shield [ProDiNo Ethernet V2](https://kmpelectronics.eu/products/prodino-ethernet-v2/) 
+* ESP32 based [PRODINo ESP32 Ethernet v1](https://kmpelectronics.eu/products/prodino-esp32-ethernet-v1/) with built-in Ethernet and RS-485 ports.
+* Generic [ESP32 dev board](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html) and a [Waveshare RS485+CAN hat](https://www.waveshare.com/rs485-can-hat.htm)
 
-Arduino code is available [here](https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW).
+Arduino/ESP32 code is available [here](https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW).
 
-Arduino code can be build via Arduino IDE.
-For more details see [www.arduino.cc](https://www.arduino.cc/en/Main/Software). 
-NibeGW configuration (such IP addresses, ports, etc) can be adapted directly by editing the code files.
+Arduino/ESP32 code can be build via Arduino IDE or Platform.io.
+For more details see [www.arduino.cc](https://www.arduino.cc/en/Main/Software) and [www.platformio.org](https://platformio.org/platformio-ide). 
+NibeGW configuration (such IP addresses, ports, wifi credentials, etc) can be adapted directly by editing the code files.
 PRODINo ESP32 Ethernet v1 also supports dynamic configuration and OTA updates via Wi-Fi access point.
 
 ### Raspberry Pi (or other Linux/Unix based boards)

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/.gitignore
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Config.cpp
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Config.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Author: lassi.niemisto@gmail.com, pauli.anttila@gmail.com
+ *
+ */
+
+#include "Config.h"
+
+#if defined(PRODINO_BOARD_ESP32) && defined(ENABLE_DYNAMIC_CONFIG)
+  Config config;
+#else
+  Config config = {
+    BOARD_NAME,
+    
+    {
+      BOARD_MAC,
+      BOARD_IP,
+      DNS_SERVER,
+      GATEWAY_IP,
+      NETWORK_MASK,
+      ETH_INIT_DELAY
+    },
+  
+    {
+      TARGET_IP,
+      TARGET_PORT,
+      INCOMING_PORT_READCMDS,
+      INCOMING_PORT_WRITECMDS,
+
+      {
+        SEND_ACK,
+        ACK_MODBUS40,
+        ACK_SMS40,
+        ACK_RMU40,
+      },
+    },
+  
+    
+    #ifdef ENABLE_DEBUG
+    {
+      VERBOSE_LEVEL
+    }
+    #endif
+  
+  };
+#endif
+

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Config.h
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Config.h
@@ -16,13 +16,32 @@
 #ifndef Config_h
 #define Config_h
 
+#include <Arduino.h>
+
 // ######### BOARD SELECTION #######################
+
+// Possible target base architectures
+#define BASE_ARCH_ARDUINO  1
+#define BASE_ARCH_ESP32    2
+
+// Selected base architecture
+#define BASE_ARCH   BASE_ARCH_ESP32
+
+// Possible outgoing connectivity modes
+#define CONN_MODE_ETH  1
+#define CONN_MODE_WIFI 2
+
+// Selected outgoing connectivity mode
+#define CONN_MODE   CONN_MODE_ETH
 
 // Enable if you use ProDiNo NetBoard V2.1 board
 //#define PRODINO_BOARD
 
 // Enable if you use PRODINo ESP32 Ethernet v1 (Enable also HARDWARE_SERIAL_WITH_PINS in NibeGW.h)
 #define PRODINO_BOARD_ESP32
+
+// Enable if you use a generic ESP32 board (Enable also HARDWARE_SERIAL_WITH_PINS in NibeGW.h)
+//#define GENERIC_BOARD_ESP32
 
 // Enable if ENC28J60 LAN module is used
 //#define TRANSPORT_ETH_ENC28J60
@@ -43,16 +62,20 @@
 #define ENABLE_DEBUG
 #define VERBOSE_LEVEL           1
 #define ENABLE_SERIAL_DEBUG
-#define ENABLE_REMOTE_DEBUG     // Remote debug is available in telnet port 23
+#define ENABLE_REMOTE_DEBUG     // Remote debug is available in telnet port 23 
 
 #define BOARD_NAME              "Arduino NibeGW"
 
 // Ethernet configuration
-#define BOARD_MAC               "DE:AD:BE:EF:FE:ED"
+#define BOARD_MAC               "DE:AD:BE:EF:FE:ED" // Not used in wifi mode, as ESP32 has a default MAC
 #define BOARD_IP                "192.168.1.100"
 #define DNS_SERVER              "192.168.1.1"
 #define GATEWAY_IP              "192.168.1.1"
 #define NETWORK_MASK            "255.255.255.0"
+
+// Wifi configuration
+#define WIFI_SSID               ""
+#define WIFI_PASS               ""
 
 // UDP ports for incoming messages
 #define INCOMING_PORT_READCMDS  9999
@@ -84,13 +107,15 @@
   #define RS485_RX_PIN          4
   #define RS485_TX_PIN          16
   #define RS485_DIRECTION_PIN   2
+#elif defined(GENERIC_BOARD_ESP32)
+  #define WDT_TIMEOUT           2
+  #define RS485_RX_PIN          16
+  #define RS485_TX_PIN          17
+  #define RS485_DIRECTION_PIN   19
 #else
   #define RS485_PORT            Serial
   #define RS485_DIRECTION_PIN   2
 #endif
-
-
-
 
 
 // ######### VARIABLES #######################
@@ -99,8 +124,6 @@
 
   #include "Bleeper.h"    // https://github.com/workilabs/Bleeper
   #include "ElegantOTA.h" // https://github.com/ayushsharma82/ElegantOTA
-  
-  WebServer otaServer(8080);
 
   class EthConfig: public Configuration {
     public:
@@ -144,7 +167,7 @@
       #ifdef ENABLE_DEBUG
       subconfig(DebugConfig, debug);
       #endif
-  } config;
+  };
     
 #else
 
@@ -180,41 +203,8 @@
     #endif
   
   };
-  
-  Config config = {
-    BOARD_NAME,
-    
-    {
-      BOARD_MAC,
-      BOARD_IP,
-      DNS_SERVER,
-      GATEWAY_IP,
-      NETWORK_MASK,
-      ETH_INIT_DELAY
-    },
-  
-    {
-      TARGET_IP,
-      TARGET_PORT,
-      INCOMING_PORT_READCMDS,
-      INCOMING_PORT_WRITECMDS,
-
-      {
-        SEND_ACK,
-        ACK_MODBUS40,
-        ACK_SMS40,
-        ACK_RMU40,
-      },
-    },
-  
-    
-    #ifdef ENABLE_DEBUG
-    {
-      VERBOSE_LEVEL
-    }
-    #endif
-  
-  };
 #endif
+
+extern Config config;
 
 #endif

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
@@ -21,8 +21,13 @@
 char debugBuf[DEBUG_BUFFER_SIZE];
 
 #ifdef ENABLE_REMOTE_DEBUG
+
   #if (CONN_MODE == CONN_MODE_ETH)
-    #include "KMPProDinoESP32.h"
+    #if defined(PRODINO_BOARD)
+      #include "KmpDinoEthernet.h"
+    #else
+      #include "KMPProDinoESP32.h"
+    #endif
     EthernetServer telnet(23);
     EthernetClient client;
   #elif (CONN_MODE == CONN_MODE_WIFI)

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
@@ -14,7 +14,7 @@
  *
  */
 
-#include <Debug.h>
+#include "Debug.h"
 
 #ifdef ENABLE_DEBUG
 
@@ -22,11 +22,11 @@ char debugBuf[DEBUG_BUFFER_SIZE];
 
 #ifdef ENABLE_REMOTE_DEBUG
   #if (CONN_MODE == CONN_MODE_ETH)
-    #include "Ethernet.h"
+    #include <Ethernet.h>
     EthernetServer telnet(23);
     EthernetClient client;
   #elif (CONN_MODE == CONN_MODE_WIFI)
-    #include "WiFi.h"
+    #include <WiFi.h>
     WiFiServer telnet(23);
     WiFiClient client;
   #endif 

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Author: lassi.niemisto@gmail.com
+ * Author: lassi.niemisto@gmail.com, pauli.anttila@gmail.com
  *
  */
 
@@ -22,7 +22,7 @@ char debugBuf[DEBUG_BUFFER_SIZE];
 
 #ifdef ENABLE_REMOTE_DEBUG
   #if (CONN_MODE == CONN_MODE_ETH)
-    #include <Ethernet.h>
+    #include "KMPProDinoESP32.h"
     EthernetServer telnet(23);
     EthernetClient client;
   #elif (CONN_MODE == CONN_MODE_WIFI)
@@ -54,9 +54,7 @@ void initializeDebug()
 bool getDebugInput(char* pChar)
 {
 #ifdef ENABLE_REMOTE_DEBUG
-  if (telnet.hasClient()) {
-    client = telnet.available();
-  }
+  client = telnet.available();
 
   if (client && client.connected() && client.available()) {
     *pChar = client.read();

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Author: lassi.niemisto@gmail.com
+ *
+ */
+
+#include <Debug.h>
+
+#ifdef ENABLE_DEBUG
+
+char debugBuf[DEBUG_BUFFER_SIZE];
+
+#ifdef ENABLE_REMOTE_DEBUG
+  #if (CONN_MODE == CONN_MODE_ETH)
+    #include "Ethernet.h"
+    EthernetServer telnet(23);
+    EthernetClient client;
+  #elif (CONN_MODE == CONN_MODE_WIFI)
+    #include "WiFi.h"
+    WiFiServer telnet(23);
+    WiFiClient client;
+  #endif 
+#endif
+  
+void debugPrint(char* data) {
+  #ifdef ENABLE_SERIAL_DEBUG
+  Serial.print(data);
+  #endif
+
+  #ifdef ENABLE_REMOTE_DEBUG
+  if (client) {
+    client.write(data);
+  }
+  #endif
+}
+
+void initializeDebug()
+{
+  #ifdef ENABLE_REMOTE_DEBUG
+    telnet.begin();
+  #endif
+}
+
+bool getDebugInput(char* pChar)
+{
+#ifdef ENABLE_REMOTE_DEBUG
+  if (telnet.hasClient()) {
+    client = telnet.available();
+  }
+
+  if (client && client.connected() && client.available()) {
+    *pChar = client.read();
+    return true;
+  }
+#endif
+  return false;
+}
+
+void exitDebugSession()
+{
+#ifdef ENABLE_REMOTE_DEBUG
+  if (client) {
+    client.flush();
+    client.stop();
+  }
+#endif 
+}
+
+#endif

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.h
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.h
@@ -16,28 +16,20 @@
 #ifndef Debug_h
 #define Debug_h
 
+#include <Config.h>
+
 #ifdef ENABLE_DEBUG
   #define DEBUG_PRINT_MSG(level, message) if (config.debug.verboseLevel >= level) { debugPrint(message); }
   #define DEBUG_PRINT_VARS(level, message, ...) if (config.debug.verboseLevel >= level) { sprintf(debugBuf, message, __VA_ARGS__); debugPrint(debugBuf); }
   #define DEBUG_PRINT_ARRAY(level, data, len) if (config.debug.verboseLevel >= level) { for (int i = 0; i < len; i++) { sprintf(debugBuf, "%02X", data[i]); debugPrint(debugBuf); }}
 
   #define DEBUG_BUFFER_SIZE   80
-  char debugBuf[DEBUG_BUFFER_SIZE];
-
-  #ifdef ENABLE_REMOTE_DEBUG
-    EthernetServer telnet(23);
-  #endif
+  extern char debugBuf[DEBUG_BUFFER_SIZE];
   
-  void debugPrint(char* data) {
-    #ifdef ENABLE_SERIAL_DEBUG
-      Serial.print(data);
-    #endif
-  
-    #ifdef ENABLE_REMOTE_DEBUG
-      telnet.print(data);
-    #endif
-  }
-
+  void initializeDebug();
+  void debugPrint(char* data);
+  bool getDebugInput(char* pChar);
+  void exitDebugSession();
 #else
   #define DEBUG_PRINT_MSG(level, message)
   #define DEBUG_PRINT_VARS(level, message, ...)

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.h
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/Debug.h
@@ -16,7 +16,7 @@
 #ifndef Debug_h
 #define Debug_h
 
-#include <Config.h>
+#include "Config.h"
 
 #ifdef ENABLE_DEBUG
   #define DEBUG_PRINT_MSG(level, message) if (config.debug.verboseLevel >= level) { debugPrint(message); }

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/NibeGW.ino
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/NibeGW.ino
@@ -495,7 +495,9 @@ void handleDebugInput() {
 
       case 'E':
         DEBUG_PRINT_MSG(0, "Connection closed\n");
+        #ifdef ENABLE_DEBUG
         exitDebugSession();
+        #endif
         break;
 
       #ifdef ENABLE_DEBUG

--- a/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/platformio.ini
+++ b/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:esp32dev]
+platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
+board = esp32dev ; Correct for GENERIC_BOARD_ESP32 in Config.h, others untested
+framework = arduino
+
+platform_packages =
+   framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32#2.0.3
+
+lib_deps =
+    https://github.com/workilabs/Bleeper
+    https://github.com/ayushsharma82/ElegantOTA
+lib_ldf_mode = deep+


### PR DESCRIPTION
Generic ESP32+Wifi support for openhab.binding.nibeheatpump so you can use any ESP32 basic board.

PR classification: Improvement

* Platform.io support (previously supported Arduino IDE only)
	* Add proper function declarations to support platform.io
	* Add platform.io project file
* Hide prodino esp specific parts for regular ESP32
* Allow selecting wifi instead of ethernet
	* Reconnect wifi automatically in case the connection dies
* Refactor code
	* Move variable definitions out of headers
	* Modularize debug feature a bit further

Testing:
* Tested with https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html board and https://www.waveshare.com/rs485-can-hat.htm
* NOT tested with the prodino or arduino boards! Keeping their code untouched has been the target but as said, untested.
* Dynamic config mode and OTA not tested for generic ESP32, probably not yet working

