### PR TITLE
[radiothermostat] Ignore updates if thermostat data is invalid

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -372,14 +372,14 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
                 case DEFAULT_RESOURCE:
                     rthermData.setThermostatData(gson.fromJson(evtVal, RadioThermostatTstatDTO.class));
                     // if thermostat returned -1 for temperature, skip this update
-                    if (rthermData.getThermostatData().getTemperature() > 0) {
+                    if (rthermData.getThermostatData().getTemperature() >= 0) {
                         updateAllChannels();
                     }
                     break;
                 case HUMIDITY_RESOURCE:
                     RadioThermostatHumidityDTO dto = gson.fromJson(evtVal, RadioThermostatHumidityDTO.class);
                     // if thermostat returned -1 for humidity, skip this update
-                    if (dto != null && dto.getHumidity() > 0) {
+                    if (dto != null && dto.getHumidity() >= 0) {
                         rthermData.setHumidity(dto.getHumidity());
                         updateChannel(HUMIDITY, rthermData);
                     }

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -371,14 +371,18 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
             switch (evtKey) {
                 case DEFAULT_RESOURCE:
                     rthermData.setThermostatData(gson.fromJson(evtVal, RadioThermostatTstatDTO.class));
-                    updateAllChannels();
+                    // if thermostat returned -1 for temperature, skip this update
+                    if (rthermData.getThermostatData().getTemperature() > 0) {
+                        updateAllChannels();
+                    }
                     break;
                 case HUMIDITY_RESOURCE:
                     RadioThermostatHumidityDTO dto = gson.fromJson(evtVal, RadioThermostatHumidityDTO.class);
-                    if (dto != null) {
+                    // if thermostat returned -1 for humidity, skip this update
+                    if (dto != null && dto.getHumidity() > 0) {
                         rthermData.setHumidity(dto.getHumidity());
+                        updateChannel(HUMIDITY, rthermData);
                     }
-                    updateChannel(HUMIDITY, rthermData);
                     break;
                 case RUNTIME_RESOURCE:
                     rthermData.setRuntime(gson.fromJson(evtVal, RadioThermostatRuntimeDTO.class));


### PR DESCRIPTION
It could be that my thermostat is beginning to fail since it has started randomly returning -1 instead of the actual temperature. This change will cause a polling update with invalid data to be ignored so it will not update the channels. As a result, the temperature graphs will no longer look like this:

![temp dropout](https://user-images.githubusercontent.com/26532542/190551351-ceee6d85-f550-468c-8db3-b133063d7479.jpg)
