### PR TITLE
[ipcamera] Fix ONVIF fails to reconnect

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -492,9 +492,9 @@ public class IpCameraHandler extends BaseThingHandler {
     }
 
     private void checkCameraConnection() {
-        if (snapshotPolling) {// Already polling a real URL for snapshots so no need to check again.
+        if (snapshotPolling) {// Currently polling a real URL for snapshots, so camera must be online.
             return;
-        } else if (ffmpegSnapshotGeneration) {// check if RTSP stream has stopped and is needed for snapshots
+        } else if (ffmpegSnapshotGeneration) {// Check if RTSP stream is working for creating snapshots.
             Ffmpeg localSnapshot = ffmpegSnapshot;
             if (localSnapshot != null && !localSnapshot.getIsAlive()) {
                 cameraCommunicationError("FFmpeg Snapshots Stopped: Check your camera can be reached.");
@@ -502,6 +502,7 @@ public class IpCameraHandler extends BaseThingHandler {
             }
             return;// ffmpeg snapshot stream is still alive
         }
+        // Check if camera is online by trying a HTTP connection without sending any requests.
         Bootstrap localBootstrap = mainBootstrap;
         if (localBootstrap != null) {
             ChannelFuture chFuture = localBootstrap

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -494,7 +494,7 @@ public class IpCameraHandler extends BaseThingHandler {
     private void checkCameraConnection() {
         if (snapshotPolling) {// Currently polling a real URL for snapshots, so camera must be online.
             return;
-        } else if (ffmpegSnapshotGeneration) {// Check if RTSP stream is working for creating snapshots.
+        } else if (ffmpegSnapshotGeneration) {// Use RTSP stream creating snapshots to know camera is online.
             Ffmpeg localSnapshot = ffmpegSnapshot;
             if (localSnapshot != null && !localSnapshot.getIsAlive()) {
                 cameraCommunicationError("FFmpeg Snapshots Stopped: Check your camera can be reached.");
@@ -502,7 +502,7 @@ public class IpCameraHandler extends BaseThingHandler {
             }
             return;// ffmpeg snapshot stream is still alive
         }
-        // Check if camera is online by trying a HTTP connection without sending any requests.
+        // Open a HTTP connection without sending any requests as we do not need a snapshot.
         Bootstrap localBootstrap = mainBootstrap;
         if (localBootstrap != null) {
             ChannelFuture chFuture = localBootstrap

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -492,9 +492,15 @@ public class IpCameraHandler extends BaseThingHandler {
     }
 
     private void checkCameraConnection() {
-        if (snapshotUri.isEmpty() || snapshotPolling) {
-            // Already polling or camera has RTSP only and no HTTP server
+        if (snapshotPolling) {// Already polling a real URL for snapshots so no need to check again.
             return;
+        } else if (ffmpegSnapshotGeneration) {// check if RTSP stream has stopped and is needed for snapshots
+            Ffmpeg localSnapshot = ffmpegSnapshot;
+            if (localSnapshot != null && !localSnapshot.getIsAlive()) {
+                cameraCommunicationError("FFmpeg Snapshots Stopped: Check your camera can be reached.");
+                return;
+            }
+            return;// ffmpeg snapshot stream is still alive
         }
         Bootstrap localBootstrap = mainBootstrap;
         if (localBootstrap != null) {
@@ -1362,6 +1368,7 @@ public class IpCameraHandler extends BaseThingHandler {
             if (snapshotUri.isEmpty() || "ffmpeg".equals(snapshotUri)) {
                 snapshotIsFfmpeg();
             } else {
+                ffmpegSnapshotGeneration = false;
                 updateSnapshot();
             }
             return;
@@ -1374,6 +1381,7 @@ public class IpCameraHandler extends BaseThingHandler {
         if ("ffmpeg".equals(snapshotUri)) {
             snapshotIsFfmpeg();
         } else if (!snapshotUri.isEmpty()) {
+            ffmpegSnapshotGeneration = false;
             updateSnapshot();
         } else if (!rtspUri.isEmpty()) {
             snapshotIsFfmpeg();
@@ -1497,15 +1505,8 @@ public class IpCameraHandler extends BaseThingHandler {
         // what needs to be done every poll//
         switch (thing.getThingTypeUID().getId()) {
             case GENERIC_THING:
-                if (!snapshotUri.isEmpty() && !snapshotPolling) {
+                if (!snapshotPolling) {
                     checkCameraConnection();
-                }
-                // RTSP stream has stopped and we need it for snapshots
-                if (ffmpegSnapshotGeneration) {
-                    Ffmpeg localSnapshot = ffmpegSnapshot;
-                    if (localSnapshot != null && !localSnapshot.getIsAlive()) {
-                        localSnapshot.startConverting();
-                    }
                 }
                 break;
             case ONVIF_THING:

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -29,6 +29,7 @@ import java.util.TimeZone;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -114,6 +115,7 @@ public class OnvifConnection {
     private ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(2);
     private @Nullable Bootstrap bootstrap;
     private EventLoopGroup mainEventLoopGroup = new NioEventLoopGroup(2);
+    private ReentrantLock connecting = new ReentrantLock();
     private String ipAddress = "";
     private String user = "";
     private String password = "";
@@ -308,7 +310,12 @@ public class OnvifConnection {
         } else if (message.contains("RenewResponse")) {
             sendOnvifRequest(requestBuilder(RequestType.PullMessages, subscriptionXAddr));
         } else if (message.contains("GetSystemDateAndTimeResponse")) {// 1st to be sent.
-            isConnected = true;
+            connecting.lock();
+            try {
+                isConnected = true;
+            } finally {
+                connecting.unlock();
+            }
             sendOnvifRequest(requestBuilder(RequestType.GetCapabilities, deviceXAddr));
             parseDateAndTime(message);
             logger.debug("Openhabs UTC dateTime is:{}", getUTCdateTime());
@@ -355,7 +362,8 @@ public class OnvifConnection {
         } else if (message.contains("GetSnapshotUriResponse")) {
             snapshotUri = removeIPfromUrl(Helper.fetchXML(message, ":MediaUri", ":Uri"));
             logger.debug("GetSnapshotUri:{}", snapshotUri);
-            if (ipCameraHandler.snapshotUri.isEmpty()) {
+            if (ipCameraHandler.snapshotUri.isEmpty()
+                    && !"ffmpeg".equals(ipCameraHandler.cameraConfig.getSnapshotUrl())) {
                 ipCameraHandler.snapshotUri = snapshotUri;
             }
         } else if (message.contains("GetStreamUriResponse")) {
@@ -512,6 +520,7 @@ public class OnvifConnection {
     @SuppressWarnings("null")
     public void sendOnvifRequest(HttpRequest request) {
         if (bootstrap == null) {
+            mainEventLoopGroup = new NioEventLoopGroup(2);
             bootstrap = new Bootstrap();
             bootstrap.group(mainEventLoopGroup);
             bootstrap.channel(NioSocketChannel.class);
@@ -530,24 +539,28 @@ public class OnvifConnection {
                 }
             });
         }
-        bootstrap.connect(new InetSocketAddress(ipAddress, onvifPort)).addListener(new ChannelFutureListener() {
+        if (!mainEventLoopGroup.isShuttingDown()) {
+            bootstrap.connect(new InetSocketAddress(ipAddress, onvifPort)).addListener(new ChannelFutureListener() {
 
-            @Override
-            public void operationComplete(@Nullable ChannelFuture future) {
-                if (future == null) {
-                    return;
-                }
-                if (future.isDone() && future.isSuccess()) {
-                    Channel ch = future.channel();
-                    ch.writeAndFlush(request);
-                } else { // an error occured
-                    logger.debug("Camera is not reachable on ONVIF port:{} or the port may be wrong.", onvifPort);
-                    if (isConnected) {
-                        disconnect();
+                @Override
+                public void operationComplete(@Nullable ChannelFuture future) {
+                    if (future == null) {
+                        return;
+                    }
+                    if (future.isSuccess()) {
+                        Channel ch = future.channel();
+                        ch.writeAndFlush(request);
+                    } else { // an error occured
+                        logger.debug("Camera is not reachable on ONVIF port:{} or the port may be wrong.", onvifPort);
+                        if (isConnected) {
+                            disconnect();
+                        }
                     }
                 }
-            }
-        });
+            });
+        } else {
+            logger.debug("ONVIF message not sent as connection is shutting down");
+        }
     }
 
     OnvifConnection getHandle() {
@@ -833,42 +846,59 @@ public class OnvifConnection {
     }
 
     public void connect(boolean useEvents) {
-        if (!isConnected) {
-            sendOnvifRequest(requestBuilder(RequestType.GetSystemDateAndTime, deviceXAddr));
-            usingEvents = useEvents;
+        connecting.lock();
+        try {
+            if (!isConnected) {
+                logger.debug("Connecting {} to ONVIF", ipAddress);
+                threadPool = Executors.newScheduledThreadPool(2);
+                sendOnvifRequest(requestBuilder(RequestType.GetSystemDateAndTime, deviceXAddr));
+                usingEvents = useEvents;
+            }
+        } finally {
+            connecting.unlock();
         }
     }
 
     public boolean isConnected() {
-        return isConnected;
+        connecting.lock();
+        try {
+            return isConnected;
+        } finally {
+            connecting.unlock();
+        }
     }
 
     private void cleanup() {
-        mainEventLoopGroup.shutdownGracefully();
-        isConnected = false;
-        if (!mainEventLoopGroup.isShutdown()) {
+        if (!isConnected && !mainEventLoopGroup.isShuttingDown()) {
             try {
+                mainEventLoopGroup.shutdownGracefully();
                 mainEventLoopGroup.awaitTermination(3, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 logger.warn("ONVIF was not cleanly shutdown, due to being interrupted");
             } finally {
                 logger.debug("Eventloop is shutdown:{}", mainEventLoopGroup.isShutdown());
                 bootstrap = null;
+                threadPool.shutdown();
             }
         }
-        threadPool.shutdown();
     }
 
     public void disconnect() {
-        if (bootstrap != null) {
-            if (usingEvents && isConnected && !mainEventLoopGroup.isShuttingDown()) {
-                // Some cameras may continue to send events even when they can't reach a server.
-                sendOnvifRequest(requestBuilder(RequestType.Unsubscribe, subscriptionXAddr));
+        connecting.lock();// Lock out multiple disconnect()/connect() attempts as we try to send Unsubscribe.
+        try {
+            isConnected = false;// isConnected is not thread safe, connecting.lock() used as fix.
+            if (bootstrap != null) {
+                if (usingEvents && !mainEventLoopGroup.isShuttingDown()) {
+                    // Some cameras may continue to send events even when they can't reach a server.
+                    sendOnvifRequest(requestBuilder(RequestType.Unsubscribe, subscriptionXAddr));
+                }
+                // give time for the Unsubscribe request to be sent, shutdownGracefully will try to send it first.
+                threadPool.schedule(this::cleanup, 50, TimeUnit.MILLISECONDS);
+            } else {
+                cleanup();
             }
-            // give time for the Unsubscribe request to be sent to the camera.
-            threadPool.schedule(this::cleanup, 50, TimeUnit.MILLISECONDS);
-        } else {
-            cleanup();
+        } finally {
+            connecting.unlock();
         }
     }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1913,7 +1913,7 @@
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="nvrChannel" type="integer" required="true" min="1" max="9" groupName="Settings">
+			<parameter name="nvrChannel" type="integer" required="true" min="1" max="99" groupName="Settings">
 				<label>NVR Input Channel</label>
 				<description>Set this to 1 if it is a stand alone camera, or to the input channel number if you use a compatible
 					NVR.


### PR DESCRIPTION
+ Fixes multiple bugs that stop cameras from successfully re-connecting to ONVIF if the connection fails due to connection dropouts or a cameras automatic reboot etc.
+ Allows more than 9 cameras on Hikvision NVR's as per a request on the forum to increase the limit.
+ Fix bug where ffmpeg is still tried to be used, after the cameras settings are edited to stop using this feature.
+ Fix bug to allow all camera types to choose to use ffmpeg for snapshot creating to make further testing easier, or a user on the forum has an ONVIF camera that has no snapshot url.

Jar can be downloaded from:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/3.4.0-SNAPSHOT/org.openhab.binding.ipcamera-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>