### PR TITLE
[velux] Bridge status shows offline when communication fails

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -371,14 +371,18 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
             switch (evtKey) {
                 case DEFAULT_RESOURCE:
                     rthermData.setThermostatData(gson.fromJson(evtVal, RadioThermostatTstatDTO.class));
-                    updateAllChannels();
+                    // if thermostat returned -1 for temperature, skip this update
+                    if (rthermData.getThermostatData().getTemperature() >= 0) {
+                        updateAllChannels();
+                    }
                     break;
                 case HUMIDITY_RESOURCE:
                     RadioThermostatHumidityDTO dto = gson.fromJson(evtVal, RadioThermostatHumidityDTO.class);
-                    if (dto != null) {
+                    // if thermostat returned -1 for humidity, skip this update
+                    if (dto != null && dto.getHumidity() >= 0) {
                         rthermData.setHumidity(dto.getHumidity());
+                        updateChannel(HUMIDITY, rthermData);
                     }
-                    updateChannel(HUMIDITY, rthermData);
                     break;
                 case RUNTIME_RESOURCE:
                     rthermData.setRuntime(gson.fromJson(evtVal, RadioThermostatRuntimeDTO.class));

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -291,7 +291,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
          * When a binding call to the hub fails with a communication error, it will retry the call for a maximum of
          * veluxBridgeConfiguration.retries times, where the interval between retry attempts increases on each attempt
          * calculated as veluxBridgeConfiguration.refreshMSecs * 2^retry (i.e. 1, 2, 4, 8, 16, 32 etc.) so a complete
-         * retry series takes (veluxBridgeConfiguration.refreshMSecs * ((2^veluxBridgeConfiguration.retries + 1) - 1)
+         * retry series takes (veluxBridgeConfiguration.refreshMSecs * ((2^(veluxBridgeConfiguration.retries + 1)) - 1)
          * milliseconds. So we have to let this full retry series to have been tried (and failed), before we consider
          * the thing to be actually offline.
          */

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -287,8 +287,16 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         logger.trace("initialize(): initialize bridge configuration parameters.");
         veluxBridgeConfiguration = new VeluxBinding(getConfigAs(VeluxBridgeConfiguration.class)).checked();
 
-        offlineDelay = Duration.ofMillis((((long) Math.pow(2, veluxBridgeConfiguration.retries) * 2) - 1)
-                * veluxBridgeConfiguration.refreshMSecs);
+        /*
+         * When a binding call to the hub fails with a communication error, it will retry the call for a maximum of
+         * veluxBridgeConfiguration.retries times, where the interval between retry attempts increases on each attempt
+         * calculated as veluxBridgeConfiguration.refreshMSecs * 2^retry (i.e. 1, 2, 4, 8, 16, 32 etc.) so a complete
+         * retry series takes (veluxBridgeConfiguration.refreshMSecs * ((2^veluxBridgeConfiguration.retries + 1) - 1)
+         * milliseconds. So we have to let this full retry series to have been tried (and failed), before we consider
+         * the thing to be actually offline.
+         */
+        offlineDelay = Duration.ofMillis(
+                ((long) Math.pow(2, veluxBridgeConfiguration.retries + 1) - 1) * veluxBridgeConfiguration.refreshMSecs);
 
         scheduler.execute(() -> {
             disposing = false;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -823,17 +823,17 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         Instant lastCommunication = Instant.ofEpochMilli(thisBridge.lastCommunication());
         Instant lastSuccessfulCommunication = Instant.ofEpochMilli(thisBridge.lastSuccessfulCommunication());
         boolean lastCommunicationSucceeded = lastSuccessfulCommunication.equals(lastCommunication);
+        ThingStatus thingStatus = getThing().getStatus();
 
-        boolean thingOnline = getThing().getStatus() == ThingStatus.ONLINE;
-
-        if (thingOnline) {
-            if (!lastCommunicationSucceeded) {
-                if (lastSuccessfulCommunication.plus(offlineDelay).isBefore(lastCommunication)) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
-                }
+        if (lastCommunicationSucceeded) {
+            if (thingStatus == ThingStatus.OFFLINE || thingStatus == ThingStatus.UNKNOWN) {
+                updateStatus(ThingStatus.ONLINE);
             }
-        } else if (lastCommunicationSucceeded) {
-            updateStatus(ThingStatus.ONLINE);
+        } else {
+            if ((thingStatus == ThingStatus.ONLINE || thingStatus == ThingStatus.UNKNOWN)
+                    && lastSuccessfulCommunication.plus(offlineDelay).isBefore(lastCommunication)) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            }
         }
 
         ThingProperty.setValue(this, VeluxBindingConstants.PROPERTY_BRIDGE_TIMESTAMP_ATTEMPT,


### PR DESCRIPTION
Resolves #13383

### Background

As reported in issue #13383 the bridge thing does not indicate offline status when when the communication fails.

### Solution

In this PR the bridge thing status will change to offline when the communication fails, and return to online when it is restored.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>