### PR TITLE
Update Shelly and Tradfri bindings for upgrade to Californium 2.7.3

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapServer.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoapServer.java
@@ -15,7 +15,6 @@ package org.openhab.binding.shelly.internal.api1;
 import static org.openhab.binding.shelly.internal.api1.Shelly1CoapJSonDTO.COIOT_PORT;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Set;
@@ -84,10 +83,9 @@ public class Shelly1CoapServer {
             logger.debug("Initializing CoIoT listener (local IP={}:{})", localIp, port);
             NetworkConfig nc = NetworkConfig.getStandard();
             InetAddress localAddr = InetAddress.getByName(localIp);
-            InetSocketAddress localPort = new InetSocketAddress(port);
-
             // Join the multicast group on the selected network interface
-            statusConnector = new UdpMulticastConnector(localAddr, localPort, CoAP.MULTICAST_IPV4); // bind UDP listener
+            statusConnector = new UdpMulticastConnector.Builder().setLocalAddress(localAddr, port)
+                    .addMulticastGroup(CoAP.MULTICAST_IPV4).build(); // bind UDP listener
             statusEndpoint = new CoapEndpoint.Builder().setNetworkConfig(nc).setConnector(statusConnector).build();
             server = new CoapServer(NetworkConfig.getStandard(), port);
             server.addEndpoint(statusEndpoint);

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriGatewayHandler.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriGatewayHandler.java
@@ -32,7 +32,7 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
-import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.tradfri.internal.CoapCallback;
@@ -156,7 +156,8 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
         }
 
         DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-        builder.setPskStore(new StaticPskStore(configuration.identity, configuration.preSharedKey.getBytes()));
+        builder.setAdvancedPskStore(
+                new AdvancedSinglePskStore(configuration.identity, configuration.preSharedKey.getBytes()));
         builder.setMaxConnections(100);
         builder.setStaleConnectionThreshold(60);
         dtlsConnector = new DTLSConnector(builder.build());
@@ -186,7 +187,7 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
         String responseText = null;
         try {
             DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-            builder.setPskStore(new StaticPskStore("Client_identity", configuration.code.getBytes()));
+            builder.setAdvancedPskStore(new AdvancedSinglePskStore("Client_identity", configuration.code.getBytes()));
 
             DTLSConnector dtlsConnector = new DTLSConnector(builder.build());
             CoapEndpoint.Builder authEndpointBuilder = new CoapEndpoint.Builder();

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -20,9 +20,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	javax.jmdns;version='[3.5.8,3.5.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
-	org.eclipse.californium.core;version='[2.0.0,2.0.1)',\
-	org.eclipse.californium.element-connector;version='[2.0.0,2.0.1)',\
-	org.eclipse.californium.scandium;version='[2.0.0,2.0.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -77,4 +74,9 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.openhab.core.io.transport.mdns;version='[3.4.0,3.4.1)',\
 	org.openhab.core.test;version='[3.4.0,3.4.1)',\
 	org.openhab.core.thing;version='[3.4.0,3.4.1)',\
-	org.openhab.core.thing.xml;version='[3.4.0,3.4.1)'
+	org.openhab.core.thing.xml;version='[3.4.0,3.4.1)',\
+	net.i2p.crypto.eddsa;version='[0.3.0,0.3.1)',\
+	org.eclipse.californium.core;version='[2.7.3,2.7.4)',\
+	org.eclipse.californium.element-connector;version='[2.7.3,2.7.4)',\
+	org.eclipse.californium.scandium;version='[2.7.3,2.7.4)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.binding.tradfri.tests/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.tradfri.tests/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriHandlerOSGiTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.core.Is.is;
 import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
 import static org.openhab.binding.tradfri.internal.config.TradfriDeviceConfig.CONFIG_ID;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -103,6 +104,6 @@ public class TradfriHandlerOSGiTest extends JavaOSGiTest {
         Configuration configuration = thing.getConfiguration();
         assertThat(configuration, is(notNullValue()));
 
-        assertThat(configuration.get(CONFIG_ID), is("65537"));
+        assertThat(configuration.get(CONFIG_ID), is(BigDecimal.valueOf(65537)));
     }
 }


### PR DESCRIPTION
* Fixes deprecated API usages
* Resolves itest runbundles

Depends on openhab/openhab-core#3085