### PR TITLE
[openweathermap] onecall api version - property for setting API version to use.

### DIFF
--- a/bundles/org.openhab.binding.openweathermap/README.md
+++ b/bundles/org.openhab.binding.openweathermap/README.md
@@ -39,6 +39,11 @@ It requires coordinates of the location of your interest.
 Air pollution forecast is available for 5 days with hourly granularity.
 You can add as much `air-pollution` things for different locations to your setup as you like to observe.
 
+#### One Call API Version
+New Subscribers to the One Call API will require setting the API version to 3.0 (The API key will not work with 2.5). Existing subscribers can continue to use their existing API key with version 2.5.
+
+ One Call API Version 3.0 [requires payment details](https://openweathermap.org/price) for future forecast information. However, it is possible to set a [daily API call limit to 1000](https://openweathermap.org/faq#onecall), which will avoid charges. 
+
 ### One Call API Weather and Forecast
 
 The thing `onecall` supports the [current and forecast weather data](https://openweathermap.org/api/one-call-api#how) for a specific location using the One Call API.

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/config/OpenWeatherMapAPIConfiguration.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/config/OpenWeatherMapAPIConfiguration.java
@@ -35,4 +35,5 @@ public class OpenWeatherMapAPIConfiguration {
     public @Nullable String apikey;
     public int refreshInterval;
     public @Nullable String language;
+    public String apiVersion = "2.5";
 }

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
@@ -97,8 +97,9 @@ public class OpenWeatherMapConnection {
     // Weather icons (see https://openweathermap.org/weather-conditions)
     private static final String ICON_URL = "https://openweathermap.org/img/w/%s.png";
     // One Call API (see https://openweathermap.org/api/one-call-api )
-    private static final String ONECALL_URL = "https://api.openweathermap.org/data/2.5/onecall";
-    private static final String ONECALL_HISTORY_URL = "https://api.openweathermap.org/data/2.5/onecall/timemachine";
+    private static final String ONECALL_URL = "https://api.openweathermap.org/data";
+    private static final String ONECALL_DATA_SUFFIX_URL = "onecall";
+    private static final String ONECALL_HISTORY_SUFFIX_URL = "onecall/timemachine";
 
     private final OpenWeatherMapAPIHandler handler;
     private final HttpClient httpClient;
@@ -325,7 +326,8 @@ public class OpenWeatherMapConnection {
         if (!exclude.isEmpty()) {
             params.put(PARAM_EXCLUDE, exclude.stream().collect(Collectors.joining(",")));
         }
-        return gson.fromJson(getResponseFromCache(buildURL(ONECALL_URL, params)), OpenWeatherMapOneCallAPIData.class);
+        return gson.fromJson(getResponseFromCache(buildURL(buildOneCallURL(), params)),
+                OpenWeatherMapOneCallAPIData.class);
     }
 
     /**
@@ -346,7 +348,7 @@ public class OpenWeatherMapConnection {
         // the API requests the history as timestamp in Unix time format.
         params.put(PARAM_HISTORY_DATE,
                 Long.toString(ZonedDateTime.now(ZoneId.of("UTC")).minusDays(days).toEpochSecond()));
-        return gson.fromJson(getResponseFromCache(buildURL(ONECALL_HISTORY_URL, params)),
+        return gson.fromJson(getResponseFromCache(buildURL(buildOneCallHistoryURL(), params)),
                 OpenWeatherMapOneCallHistAPIData.class);
     }
 
@@ -381,6 +383,16 @@ public class OpenWeatherMapConnection {
     private String buildURL(String url, Map<String, String> requestParams) {
         return requestParams.keySet().stream().map(key -> key + "=" + encodeParam(requestParams.get(key)))
                 .collect(Collectors.joining("&", url + "?", ""));
+    }
+
+    private String buildOneCallURL() {
+        var config = handler.getOpenWeatherMapAPIConfig();
+        return ONECALL_URL + "/" + config.apiVersion + "/" + ONECALL_DATA_SUFFIX_URL;
+    }
+
+    private String buildOneCallHistoryURL() {
+        var config = handler.getOpenWeatherMapAPIConfig();
+        return ONECALL_URL + "/" + config.apiVersion + "/" + ONECALL_HISTORY_SUFFIX_URL;
     }
 
     private String encodeParam(@Nullable String value) {

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/config/config.xml
@@ -11,6 +11,15 @@
 			<label>API Key</label>
 			<description>API key to access the OpenWeatherMap API.</description>
 		</parameter>
+		<parameter name="apiVersion" type="text">
+			<label>One Call API Version</label>
+			<description>One Call API version (defaults to 2.5, version 3.0 is available, but needs different subscription).</description>
+			<default>2.5</default>
+			<options>
+				<option value="2.5">2.5</option>
+				<option value="3.0">3.0</option>
+			</options>
+		</parameter>
 		<parameter name="refreshInterval" type="integer" min="1" unit="min">
 			<label>Refresh Interval</label>
 			<description>Specifies the refresh interval (in minutes).</description>

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/i18n/openweathermap.properties
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/i18n/openweathermap.properties
@@ -76,6 +76,8 @@ thing-type.openweathermap.weather-api.description = Provides access to the OpenW
 
 bridge-type.config.openweathermap.weather-api.apikey.label = API Key
 bridge-type.config.openweathermap.weather-api.apikey.description = API key to access the OpenWeatherMap API.
+bridge-type.config.openweathermap.weather-api.apiVersion.label = One Call API Version
+bridge-type.config.openweathermap.weather-api.apiVersion.description = One Call API version (defaults to 2.5, version 3.0 is available, but needs different subscription).
 bridge-type.config.openweathermap.weather-api.language.label = Language
 bridge-type.config.openweathermap.weather-api.language.description = Language to be used by the OpenWeatherMap API.
 bridge-type.config.openweathermap.weather-api.language.option.af = Afrikaans


### PR DESCRIPTION
Fix for OpenWeatherMap OneCall API version 3.0
https://community.openhab.org/t/openweathermap-onecall-invalid-api-key/138296/14

#13314 

![image](https://user-images.githubusercontent.com/20972856/190986387-7fb6c0a4-5daa-42b3-80b9-5f55d8907506.png)
