### PR TITLE
Prevent new lines in bundles/pom.xml when creating binding skeleton

### DIFF
--- a/bundles/create_openhab_binding_skeleton.cmd
+++ b/bundles/create_openhab_binding_skeleton.cmd
@@ -19,7 +19,7 @@ SET GithubUser=%~3
 
 call :LoCase BindingIdInLowerCase
 
-call mvn -s archetype-settings.xml archetype:generate -N -Dspotless.check.skip=true -DarchetypeGroupId=org.openhab.core.tools.archetypes -DarchetypeArtifactId=org.openhab.core.tools.archetypes.binding -DarchetypeVersion=%OpenhabVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase% -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%OpenhabVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%" -DgithubUser="%GithubUser%"
+call mvn -s archetype-settings.xml org.apache.maven.plugins:maven-archetype-plugin:3.1.0:generate -N -Dspotless.check.skip=true -DarchetypeGroupId=org.openhab.core.tools.archetypes -DarchetypeArtifactId=org.openhab.core.tools.archetypes.binding -DarchetypeVersion=%OpenhabVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase% -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%OpenhabVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%" -DgithubUser="%GithubUser%"
 
 COPY ..\src\etc\NOTICE org.openhab.binding.%BindingIdInLowerCase%\
 

--- a/bundles/create_openhab_binding_skeleton.sh
+++ b/bundles/create_openhab_binding_skeleton.sh
@@ -10,7 +10,7 @@ id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`
 author=$2
 githubUser=$3
 
-mvn -s archetype-settings.xml archetype:generate -N \
+mvn -s archetype-settings.xml org.apache.maven.plugins:maven-archetype-plugin:3.1.0:generate -N \
   -Dspotless.check.skip=true \
   -DarchetypeGroupId=org.openhab.core.tools.archetypes \
   -DarchetypeArtifactId=org.openhab.core.tools.archetypes.binding \


### PR DESCRIPTION
Downgrades the Maven archetype plugin as workaround for:

* https://issues.apache.org/jira/browse/ARCHETYPE-584
* https://issues.apache.org/jira/browse/ARCHETYPE-587

Fixes #13405