### PR TITLE
[jdbc] Fix date cast exception

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -583,8 +583,14 @@ public class JdbcBaseDAO {
             return ((Number) v).longValue();
         } else if (v instanceof java.sql.Date) {
             return ((java.sql.Date) v).getTime();
+        } else if (v instanceof LocalDateTime) {
+            return ((LocalDateTime) v).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        } else if (v instanceof Instant) {
+            return ((Instant) v).toEpochMilli();
+        } else if (v instanceof java.sql.Timestamp) {
+            return ((java.sql.Timestamp) v).getTime();
         }
-        return ((java.sql.Timestamp) v).getTime();
+        throw new UnsupportedOperationException("Date of type " + v.getClass().getName() + " is not supported");
     }
 
     protected Integer objectAsInteger(Object v) {

--- a/bundles/org.openhab.persistence.jdbc/src/test/java/org/openhab/persistence/jdbc/db/JdbcBaseDAOTest.java
+++ b/bundles/org.openhab.persistence.jdbc/src/test/java/org/openhab/persistence/jdbc/db/JdbcBaseDAOTest.java
@@ -89,6 +89,11 @@ public class JdbcBaseDAOTest {
         assertInstanceOf(DateTimeType.class, dateTimeType);
         assertThat(dateTimeType, is(DateTimeType.valueOf("2021-02-01T23:30:02.049")));
 
+        dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                LocalDateTime.parse("2021-02-01T23:30:02.049"));
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertThat(dateTimeType, is(DateTimeType.valueOf("2021-02-01T23:30:02.049")));
+
         State hsbType = jdbcBaseDAO.objectAsState(new ColorItem("testColorItem"), null, "184,100,52");
         assertInstanceOf(HSBType.class, hsbType);
         assertThat(hsbType, is(HSBType.valueOf("184,100,52")));


### PR DESCRIPTION
After upgrading mysql-connector to 8.0.30 this exception was thrown twice during boot:

```
2022-09-21 15:23:29.985 [ERROR] [nal.common.AbstractInvocationHandler] - An error occurred while calling method 'QueryablePersistenceService.query()' on 'org.openhab.persistence.jdbc.internal.JdbcPersistenceService@b1af48': class java.time.LocalDateTime cannot be cast to class java.sql.Timestamp (java.time.LocalDateTime is in module java.base of loader 'bootstrap'; java.sql.Timestamp is in module java.sql of loader 'platform')
java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.sql.Timestamp (java.time.LocalDateTime is in module java.base of loader 'bootstrap'; java.sql.Timestamp is in module java.sql of loader 'platform')
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.objectAsLong(JdbcBaseDAO.java:587) ~[?:?]
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.objectAsState(JdbcBaseDAO.java:553) ~[?:?]
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.lambda$0(JdbcBaseDAO.java:364) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.doGetHistItemFilterQuery(JdbcBaseDAO.java:365) ~[?:?]
	at org.openhab.persistence.jdbc.internal.JdbcMapper.getHistItemFilterQuery(JdbcMapper.java:179) ~[?:?]
	at org.openhab.persistence.jdbc.internal.JdbcPersistenceService.query(JdbcPersistenceService.java:216) ~[?:?]
	at jdk.internal.reflect.GeneratedMethodAccessor196.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.openhab.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:154) [bundleFile:?]
	at org.openhab.core.internal.common.Invocation.call(Invocation.java:52) [bundleFile:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
2022-09-21 15:23:30.142 [ERROR] [ence.internal.PersistenceManagerImpl] - Exception occurred while querying persistence service 'jdbc': class java.time.LocalDateTime cannot be cast to class java.sql.Timestamp (java.time.LocalDateTime is in module java.base of loader 'bootstrap'; java.sql.Timestamp is in module java.sql of loader 'platform')
java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.sql.Timestamp (java.time.LocalDateTime is in module java.base of loader 'bootstrap'; java.sql.Timestamp is in module java.sql of loader 'platform')
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.objectAsLong(JdbcBaseDAO.java:587) ~[?:?]
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.objectAsState(JdbcBaseDAO.java:553) ~[?:?]
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.lambda$0(JdbcBaseDAO.java:364) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
	at org.openhab.persistence.jdbc.db.JdbcBaseDAO.doGetHistItemFilterQuery(JdbcBaseDAO.java:365) ~[?:?]
	at org.openhab.persistence.jdbc.internal.JdbcMapper.getHistItemFilterQuery(JdbcMapper.java:179) ~[?:?]
	at org.openhab.persistence.jdbc.internal.JdbcPersistenceService.query(JdbcPersistenceService.java:216) ~[?:?]
	at jdk.internal.reflect.GeneratedMethodAccessor196.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.openhab.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:154) [bundleFile:?]
	at org.openhab.core.internal.common.Invocation.call(Invocation.java:52) [bundleFile:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

The problem was introduced with 8.0.23 - more details here:
https://dev.mysql.com/blog-archive/support-for-date-time-types-in-connector-j-8-0/

Regression of #13242
See also #13382