### PR TITLE
[mqtt.generic] fix range of RGB values

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
@@ -46,6 +46,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class ColorValue extends Value {
+    private static BigDecimal factor = new BigDecimal("2.55"); // string to not lose precision
+
     private final Logger logger = LoggerFactory.getLogger(ColorValue.class);
 
     private final ColorMode colorMode;
@@ -119,8 +121,6 @@ public class ColorValue extends Value {
             }
         }
     }
-
-    private static BigDecimal factor = new BigDecimal(2.5);
 
     /**
      * Converts the color state to a string.

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -261,8 +261,8 @@ public class ChannelStateTests {
         c.processMessage("state", "12,18,231".getBytes());
         assertThat(value.getChannelState(), is(t)); // HSB
         // rgb -> hsv -> rgb is quite lossy
-        assertThat(value.getMQTTpublishValue(null), is("13,20,225"));
-        assertThat(value.getMQTTpublishValue("%3$d,%2$d,%1$d"), is("225,20,13"));
+        assertThat(value.getMQTTpublishValue(null), is("13,20,229"));
+        assertThat(value.getMQTTpublishValue("%3$d,%2$d,%1$d"), is("229,20,13"));
     }
 
     @Test


### PR DESCRIPTION
Range is 0..255, not 0..250.

rgb -> hsv -> rgb still isn't perfect, but it's better. In particular, I found this when using HSBType.BLUE in a test, and it was coming out as 0,0,250 in RGB. It now comes out as a proper 0,0,255.
