### PR TITLE
[jdbc] Fix warnings and apply null annotations

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -19,6 +19,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -616,7 +617,14 @@ public class JdbcBaseDAO {
                 logger.debug(
                         "JDBC::getItemType: Cannot detect ItemType for {} because the GroupItems' base type isn't set in *.items File.",
                         i.getName());
-                item = ((GroupItem) i).getMembers().iterator().next();
+                Iterator<Item> iterator = ((GroupItem) i).getMembers().iterator();
+                if (!iterator.hasNext()) {
+                    logger.debug(
+                            "JDBC::getItemType: No Child-Members of GroupItem {}, use ItemType for STRINGITEM as Fallback",
+                            i.getName());
+                    return def;
+                }
+                item = iterator.next();
             }
         }
         String itemType = item.getClass().getSimpleName().toUpperCase();

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -243,24 +243,19 @@ public class JdbcBaseDAO {
     /**************
      * ITEMS DAOs *
      **************/
-    public Integer doPingDB() {
-        @Nullable
-        Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
-        return result;
+    public @Nullable Integer doPingDB() {
+        return Yank.queryScalar(sqlPingDB, (Class<@Nullable Integer>) Integer.class, null);
     }
 
-    public String doGetDB() {
-        @Nullable
-        String result = Yank.queryScalar(sqlGetDB, String.class, null);
-        return result;
+    public @Nullable String doGetDB() {
+        return Yank.queryScalar(sqlGetDB, (Class<@Nullable String>) String.class, null);
     }
 
     public boolean doIfTableExists(ItemsVO vo) {
         String sql = StringUtilsExt.replaceArrayMerge(sqlIfTableExists, new String[] { "#searchTable#" },
                 new String[] { vo.getItemsManageTable() });
         logger.debug("JDBC::doIfTableExists sql={}", sql);
-        Yank.queryScalar(sql, String.class, null);
-        return true;
+        return Yank.queryScalar(sql, (Class<@Nullable String>) String.class, null) != null;
     }
 
     public Long doCreateNewEntryInItemsTable(ItemsVO vo) {

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
@@ -102,10 +102,8 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public Integer doPingDB() {
-        @Nullable
-        Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
-        return result;
+    public @Nullable Integer doPingDB() {
+        return Yank.queryScalar(sqlPingDB, (Class<@Nullable Integer>) Integer.class, null);
     }
 
     @Override
@@ -113,8 +111,7 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
         String sql = StringUtilsExt.replaceArrayMerge(sqlIfTableExists, new String[] { "#searchTable#" },
                 new String[] { vo.getItemsManageTable().toUpperCase() });
         logger.debug("JDBC::doIfTableExists sql={}", sql);
-        Yank.queryScalar(sql, String.class, null);
-        return true;
+        return Yank.queryScalar(sql, (Class<@Nullable String>) String.class, null) != null;
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
 import javax.measure.Quantity;
 import javax.measure.Unit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.NumberItem;
@@ -40,6 +42,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class JdbcDerbyDAO extends JdbcBaseDAO {
     private final Logger logger = LoggerFactory.getLogger(JdbcDerbyDAO.class);
 
@@ -100,7 +103,9 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
      **************/
     @Override
     public Integer doPingDB() {
-        return Yank.queryScalar(sqlPingDB, Integer.class, null);
+        @Nullable
+        Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
+        return result;
     }
 
     @Override
@@ -108,7 +113,8 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
         String sql = StringUtilsExt.replaceArrayMerge(sqlIfTableExists, new String[] { "#searchTable#" },
                 new String[] { vo.getItemsManageTable().toUpperCase() });
         logger.debug("JDBC::doIfTableExists sql={}", sql);
-        return Yank.queryScalar(sql, String.class, null) != null;
+        Yank.queryScalar(sql, String.class, null);
+        return true;
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcH2DAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcH2DAO.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.persistence.jdbc.db;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.knowm.yank.Yank;
 import org.openhab.core.items.Item;
 import org.openhab.core.types.State;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class JdbcH2DAO extends JdbcBaseDAO {
     private final Logger logger = LoggerFactory.getLogger(JdbcH2DAO.class);
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcHsqldbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcHsqldbDAO.java
@@ -78,10 +78,8 @@ public class JdbcHsqldbDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public Integer doPingDB() {
-        @Nullable
-        Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
-        return result;
+    public @Nullable Integer doPingDB() {
+        return Yank.queryScalar(sqlPingDB, (Class<@Nullable Integer>) Integer.class, null);
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcHsqldbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcHsqldbDAO.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.persistence.jdbc.db;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.openhab.core.items.Item;
 import org.openhab.core.types.State;
@@ -28,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class JdbcHsqldbDAO extends JdbcBaseDAO {
     private final Logger logger = LoggerFactory.getLogger(JdbcHsqldbDAO.class);
 
@@ -76,7 +79,9 @@ public class JdbcHsqldbDAO extends JdbcBaseDAO {
      **************/
     @Override
     public Integer doPingDB() {
-        return Yank.queryScalar(sqlPingDB, Integer.class, null);
+        @Nullable
+        Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
+        return result;
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMariadbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMariadbDAO.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.jdbc.db;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.openhab.persistence.jdbc.utils.DbMetaData;
 import org.slf4j.Logger;
@@ -75,7 +76,8 @@ public class JdbcMariadbDAO extends JdbcBaseDAO {
     @Override
     public void initAfterFirstDbConnection() {
         logger.debug("JDBC::initAfterFirstDbConnection: Initializing step, after db is connected.");
-        dbMeta = new DbMetaData();
+        DbMetaData dbMeta = new DbMetaData();
+        this.dbMeta = dbMeta;
         // Initialize sqlTypes, depending on DB version for example
         if (dbMeta.isDbVersionGreater(5, 1)) {
             sqlTypes.put("DATETIMEITEM", "TIMESTAMP(3)");
@@ -89,7 +91,9 @@ public class JdbcMariadbDAO extends JdbcBaseDAO {
      **************/
     @Override
     public Integer doPingDB() {
-        return Yank.queryScalar(sqlPingDB, Long.class, null).intValue();
+        @Nullable
+        Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
+        return result.intValue();
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMariadbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMariadbDAO.java
@@ -90,10 +90,9 @@ public class JdbcMariadbDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public Integer doPingDB() {
-        @Nullable
-        Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
-        return result.intValue();
+    public @Nullable Integer doPingDB() {
+        final @Nullable Long result = Yank.queryScalar(sqlPingDB, (Class<@Nullable Long>) Long.class, null);
+        return result != null ? result.intValue() : null;
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
@@ -93,10 +93,9 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public Integer doPingDB() {
-        @Nullable
-        Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
-        return result.intValue();
+    public @Nullable Integer doPingDB() {
+        final @Nullable Long result = Yank.queryScalar(sqlPingDB, (Class<@Nullable Long>) Long.class, null);
+        return result != null ? result.intValue() : null;
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.jdbc.db;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.openhab.persistence.jdbc.utils.DbMetaData;
 import org.slf4j.Logger;
@@ -78,7 +79,8 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
     @Override
     public void initAfterFirstDbConnection() {
         logger.debug("JDBC::initAfterFirstDbConnection: Initializing step, after db is connected.");
-        dbMeta = new DbMetaData();
+        DbMetaData dbMeta = new DbMetaData();
+        this.dbMeta = dbMeta;
         // Initialize sqlTypes, depending on DB version for example
         if (dbMeta.isDbVersionGreater(5, 5)) {
             sqlTypes.put("DATETIMEITEM", "TIMESTAMP(3)");
@@ -92,7 +94,9 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
      **************/
     @Override
     public Integer doPingDB() {
-        return Yank.queryScalar(sqlPingDB, Long.class, null).intValue();
+        @Nullable
+        Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
+        return result.intValue();
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcPostgresqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcPostgresqlDAO.java
@@ -15,6 +15,7 @@ package org.openhab.persistence.jdbc.db;
 import java.time.ZoneId;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.knowm.yank.Yank;
 import org.openhab.core.items.Item;
 import org.openhab.core.persistence.FilterCriteria;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class JdbcPostgresqlDAO extends JdbcBaseDAO {
     private final Logger logger = LoggerFactory.getLogger(JdbcPostgresqlDAO.class);
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcSqliteDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcSqliteDAO.java
@@ -13,6 +13,7 @@
 package org.openhab.persistence.jdbc.db;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.openhab.core.items.Item;
 import org.openhab.core.types.State;
@@ -75,8 +76,8 @@ public class JdbcSqliteDAO extends JdbcBaseDAO {
      **************/
 
     @Override
-    public String doGetDB() {
-        return Yank.queryColumn(sqlGetDB, "file", String.class, null).get(0);
+    public @Nullable String doGetDB() {
+        return Yank.queryColumn(sqlGetDB, "file", (Class<@Nullable String>) String.class, null).get(0);
     }
 
     @Override

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcSqliteDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcSqliteDAO.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.persistence.jdbc.db;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.knowm.yank.Yank;
 import org.openhab.core.items.Item;
 import org.openhab.core.types.State;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class JdbcSqliteDAO extends JdbcBaseDAO {
     private final Logger logger = LoggerFactory.getLogger(JdbcSqliteDAO.class);
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcTimescaledbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcTimescaledbDAO.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.jdbc.db;
 
 import java.util.Properties;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.knowm.yank.Yank;
 import org.openhab.persistence.jdbc.dto.ItemVO;
 import org.openhab.persistence.jdbc.utils.StringUtilsExt;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
  * @author Riccardo Nimser-Joseph - Initial contribution
  * @author Dan Cunningham - Fixes and refactoring
  */
+@NonNullByDefault
 public class JdbcTimescaledbDAO extends JdbcPostgresqlDAO {
     private final Logger logger = LoggerFactory.getLogger(JdbcTimescaledbDAO.class);
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -74,10 +74,15 @@ public class JdbcMapper {
                 logger.debug(
                         "JDBC::pingDB asking db for name as absolutely first db action, after connection is established.");
                 String dbName = conf.getDBDAO().doGetDB();
-                conf.setDbName(dbName);
-                ret = dbName.length() > 0;
+                if (dbName == null) {
+                    ret = false;
+                } else {
+                    conf.setDbName(dbName);
+                    ret = dbName.length() > 0;
+                }
             } else {
-                ret = conf.getDBDAO().doPingDB() > 0;
+                final @Nullable Integer result = conf.getDBDAO().doPingDB();
+                ret = result != null && result > 0;
             }
         }
         logTime("pingDB", timerStart, System.currentTimeMillis());
@@ -88,8 +93,8 @@ public class JdbcMapper {
         logger.debug("JDBC::getDB");
         long timerStart = System.currentTimeMillis();
         String res = conf.getDBDAO().doGetDB();
-        logTime("pingDB", timerStart, System.currentTimeMillis());
-        return res;
+        logTime("getDB", timerStart, System.currentTimeMillis());
+        return res != null ? res : "";
     }
 
     public ItemsVO createNewEntryInItemsTable(ItemsVO vo) {

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.openhab.core.i18n.TimeZoneProvider;
@@ -42,6 +43,7 @@ import com.zaxxer.hikari.pool.HikariPool.PoolInitializationException;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class JdbcMapper {
     private final Logger logger = LoggerFactory.getLogger(JdbcMapper.class);
 
@@ -50,7 +52,7 @@ public class JdbcMapper {
     // Error counter - used to reconnect to database on error
     protected int errCnt;
     protected boolean initialized = false;
-    protected JdbcConfiguration conf = null;
+    protected @NonNullByDefault({}) JdbcConfiguration conf;
     protected final Map<String, String> sqlTables = new HashMap<>();
     private long afterAccessMin = 10000;
     private long afterAccessMax = 0;
@@ -154,10 +156,6 @@ public class JdbcMapper {
     public Item storeItemValue(Item item, State itemState, @Nullable ZonedDateTime date) {
         logger.debug("JDBC::storeItemValue: item={} state={} date={}", item, itemState, date);
         String tableName = getTable(item);
-        if (tableName == null) {
-            logger.error("JDBC::store: Unable to store item '{}'.", item.getName());
-            return item;
-        }
         long timerStart = System.currentTimeMillis();
         if (date == null) {
             conf.getDBDAO().doStoreItemValue(item, itemState, new ItemVO(tableName, null));
@@ -173,40 +171,27 @@ public class JdbcMapper {
             Item item) {
         logger.debug(
                 "JDBC::getHistItemFilterQuery filter='{}' numberDecimalcount='{}' table='{}' item='{}' itemName='{}'",
-                (filter != null), numberDecimalcount, table, item, item.getName());
-        if (table != null) {
-            long timerStart = System.currentTimeMillis();
-            List<HistoricItem> result = conf.getDBDAO().doGetHistItemFilterQuery(item, filter, numberDecimalcount,
-                    table, item.getName(), timeZoneProvider.getTimeZone());
-            logTime("getHistItemFilterQuery", timerStart, System.currentTimeMillis());
-            errCnt = 0;
-            return result;
-        } else {
-            logger.error("JDBC::getHistItemFilterQuery: TABLE is NULL; cannot get data from non-existent table.");
-        }
-        return null;
+                true, numberDecimalcount, table, item, item.getName());
+        long timerStart = System.currentTimeMillis();
+        List<HistoricItem> result = conf.getDBDAO().doGetHistItemFilterQuery(item, filter, numberDecimalcount, table,
+                item.getName(), timeZoneProvider.getTimeZone());
+        logTime("getHistItemFilterQuery", timerStart, System.currentTimeMillis());
+        errCnt = 0;
+        return result;
     }
 
-    @SuppressWarnings("null")
     public boolean deleteItemValues(FilterCriteria filter, String table) {
-        logger.debug("JDBC::deleteItemValues filter='{}' table='{}' itemName='{}'", (filter != null), table,
-                filter.getItemName());
-        if (table != null) {
-            long timerStart = System.currentTimeMillis();
-            conf.getDBDAO().doDeleteItemValues(filter, table, timeZoneProvider.getTimeZone());
-            logTime("deleteItemValues", timerStart, System.currentTimeMillis());
-            errCnt = 0;
-            return true;
-        } else {
-            logger.error("JDBC::deleteItemValues: TABLE is NULL; cannot delete data from non-existent table.");
-            return false;
-        }
+        logger.debug("JDBC::deleteItemValues filter='{}' table='{}' itemName='{}'", true, table, filter.getItemName());
+        long timerStart = System.currentTimeMillis();
+        conf.getDBDAO().doDeleteItemValues(filter, table, timeZoneProvider.getTimeZone());
+        logTime("deleteItemValues", timerStart, System.currentTimeMillis());
+        errCnt = 0;
+        return true;
     }
 
     /***********************
      * DATABASE CONNECTION *
      ***********************/
-    @SuppressWarnings("null")
     protected boolean openConnection() {
         logger.debug("JDBC::openConnection isDriverAvailable: {}", conf.isDriverAvailable());
         if (conf.isDriverAvailable() && !conf.isDbConnected()) {
@@ -216,8 +201,9 @@ public class JdbcMapper {
                 conf.setDbConnected(true);
                 return true;
             } catch (PoolInitializationException e) {
-                if (e.getCause() instanceof SQLInvalidAuthorizationSpecException) {
-                    logger.warn("JDBC::openConnection: failed to open connection: {}", e.getCause().getMessage());
+                Throwable cause = e.getCause();
+                if (cause instanceof SQLInvalidAuthorizationSpecException) {
+                    logger.warn("JDBC::openConnection: failed to open connection: {}", cause.getMessage());
                 } else {
                     logger.warn("JDBC::openConnection: failed to open connection: {}", e.getMessage());
                 }
@@ -302,12 +288,6 @@ public class JdbcMapper {
         // Create the table name
         logger.debug("JDBC::getTable: getTableName with rowId={} itemName={}", rowId, itemName);
         tableName = getTableName(rowId, itemName);
-
-        // An error occurred adding the item name into the index list!
-        if (tableName == null) {
-            logger.error("JDBC::getTable: tableName was null; could not create a table for item '{}'", itemName);
-            return null;
-        }
 
         // Create table for item
         String dataType = conf.getDBDAO().getDataType(item);

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/utils/DbMetaData.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/utils/DbMetaData.java
@@ -15,6 +15,8 @@ package org.openhab.persistence.jdbc.utils;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +28,7 @@ import com.zaxxer.hikari.HikariDataSource;
  *
  * @author Helmut Lehmeyer - Initial contribution
  */
+@NonNullByDefault
 public class DbMetaData {
 
     private final Logger logger = LoggerFactory.getLogger(DbMetaData.class);
@@ -34,8 +37,8 @@ public class DbMetaData {
     private int dbMinorVersion;
     private int driverMajorVersion;
     private int driverMinorVersion;
-    private String dbProductName;
-    private String dbProductVersion;
+    private @Nullable String dbProductName;
+    private @Nullable String dbProductVersion;
 
     public DbMetaData() {
         HikariDataSource h = Yank.getDefaultConnectionPool();
@@ -116,11 +119,11 @@ public class DbMetaData {
         return false;
     }
 
-    public String getDbProductName() {
+    public @Nullable String getDbProductName() {
         return dbProductName;
     }
 
-    public String getDbProductVersion() {
+    public @Nullable String getDbProductVersion() {
         return dbProductVersion;
     }
 }

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/utils/StringUtilsExt.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/utils/StringUtilsExt.java
@@ -101,7 +101,7 @@ public class StringUtilsExt {
             props = new Properties(def);
         }
 
-        if (url == null || url.length() < 9) {
+        if (url.length() < 9) {
             return props;
         }
 

--- a/bundles/org.openhab.persistence.jdbc/src/test/java/org/openhab/persistence/jdbc/db/JdbcBaseDAOTest.java
+++ b/bundles/org.openhab.persistence.jdbc/src/test/java/org/openhab/persistence/jdbc/db/JdbcBaseDAOTest.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.jdbc.db;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.time.LocalDateTime;
@@ -79,32 +80,32 @@ public class JdbcBaseDAOTest {
     public void testObjectAsStateReturnsValidState() {
         State decimalType = jdbcBaseDAO.objectAsState(new NumberItem("testNumberItem"), null, 7.3);
         assertInstanceOf(DecimalType.class, decimalType);
-        assertThat(decimalType, is(DecimalType.valueOf("7.3")));
+        assertEquals(DecimalType.valueOf("7.3"), decimalType);
         State quantityType = jdbcBaseDAO.objectAsState(new NumberItem("testNumberItem"), SIUnits.CELSIUS, 7.3);
         assertInstanceOf(QuantityType.class, quantityType);
-        assertThat(quantityType, is(QuantityType.valueOf("7.3 °C")));
+        assertEquals(QuantityType.valueOf("7.3 °C"), quantityType);
 
         State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
                 java.sql.Timestamp.valueOf("2021-02-01 23:30:02.049"));
         assertInstanceOf(DateTimeType.class, dateTimeType);
-        assertThat(dateTimeType, is(DateTimeType.valueOf("2021-02-01T23:30:02.049")));
+        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
 
         dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
                 LocalDateTime.parse("2021-02-01T23:30:02.049"));
         assertInstanceOf(DateTimeType.class, dateTimeType);
-        assertThat(dateTimeType, is(DateTimeType.valueOf("2021-02-01T23:30:02.049")));
+        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
 
         State hsbType = jdbcBaseDAO.objectAsState(new ColorItem("testColorItem"), null, "184,100,52");
         assertInstanceOf(HSBType.class, hsbType);
-        assertThat(hsbType, is(HSBType.valueOf("184,100,52")));
+        assertEquals(HSBType.valueOf("184,100,52"), hsbType);
 
         State percentType = jdbcBaseDAO.objectAsState(new DimmerItem("testDimmerItem"), null, 52);
         assertInstanceOf(PercentType.class, percentType);
-        assertThat(percentType, is(PercentType.valueOf("52")));
+        assertEquals(PercentType.valueOf("52"), percentType);
 
         percentType = jdbcBaseDAO.objectAsState(new RollershutterItem("testRollershutterItem"), null, 39);
         assertInstanceOf(PercentType.class, percentType);
-        assertThat(percentType, is(PercentType.valueOf("39")));
+        assertEquals(PercentType.valueOf("39"), percentType);
 
         State openClosedType = jdbcBaseDAO.objectAsState(new ContactItem("testContactItem"), null, "OPEN");
         assertInstanceOf(OpenClosedType.class, openClosedType);
@@ -123,7 +124,7 @@ public class JdbcBaseDAOTest {
 
         State stringListType = jdbcBaseDAO.objectAsState(new CallItem("testCallItem"), null, "0699222222,0179999998");
         assertInstanceOf(StringListType.class, stringListType);
-        assertThat(stringListType, is(StringListType.valueOf("0699222222,0179999998")));
+        assertEquals(StringListType.valueOf("0699222222,0179999998"), stringListType);
 
         State expectedRawType = new RawType(new byte[0], "application/octet-stream");
         State rawType = jdbcBaseDAO.objectAsState(new ImageItem("testImageItem"), null, expectedRawType.toFullString());
@@ -132,11 +133,11 @@ public class JdbcBaseDAOTest {
 
         State pointType = jdbcBaseDAO.objectAsState(new LocationItem("testLocationItem"), null, "1,2,3");
         assertInstanceOf(PointType.class, pointType);
-        assertThat(pointType, is(PointType.valueOf("1,2,3")));
+        assertEquals(PointType.valueOf("1,2,3"), pointType);
 
         State stringType = jdbcBaseDAO.objectAsState(new StringItem("testStringItem"), null, "String");
         assertInstanceOf(StringType.class, stringType);
-        assertThat(stringType, is(StringType.valueOf("String")));
+        assertEquals(StringType.valueOf("String"), stringType);
     }
 
     @Test


### PR DESCRIPTION
Some reviewer notes:
- Where previously `NullPointerException` could be thrown, this has been replaced by explicit `UnsupportedOperationException`.
- To limit scope I have left things which could have been refactored further. For example, I have left logging of "filter='true'" since filter is now non-null.
- I couldn't figure out how to work around the hamcrest matcher generating _"Unsafe null type conversion (type annotations): The value of type 'org.hamcrest.Matcher<org.openhab.core.types.@NonNull State>' is made accessible using the less-annotated type 'org.hamcrest.Matcher<? super org.openhab.core.types"_ from `assertThat`, so switched to `assertEquals` although I prefer the constraint-based assert model.

Fixes #13428