### PR TITLE
[unifi] Detect all PoE ports, and set PoE thing offline if no data could be found

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiPoePortThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiPoePortThingHandler.java
@@ -137,9 +137,6 @@ public class UniFiPoePortThingHandler
 
     private State setOfflineOnNoPoEPortData() {
         if (getThing().getStatus() != ThingStatus.OFFLINE) {
-            logger.debug(
-                    "No PoE port information for thing '{}' could be found in the UniFi API data for port '{}'. Setting thing off line.",
-                    getThing().getUID(), config.getPortNumber());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/error.thing.poe.offline.nodata_error");
         }

--- a/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/i18n/unifi.properties
+++ b/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/i18n/unifi.properties
@@ -140,4 +140,5 @@ error.thing.client.offline.configuration_error = You must define a MAC address, 
 error.thing.offline.bridge_offline = The UniFi Controller is currently offline.
 error.thing.offline.configuration_error = You must choose a UniFi Controller for this thing.
 error.thing.poe.offline.configuration_error = The configuration parameter macAddress must be set and not be empty.
+error.thing.poe.offline.nodata_error = No data for the PoE port could be found in the UniFi API data. See TRACE log for actual API data.
 error.thing.site.offline.configuration_error = The configuration parameter sid must be set and not be empty.


### PR DESCRIPTION
*  Fix bug to detect PoE ports when first port is not PoE port. The binding assumed either all ports or no ports were PoE, and asssumed if port 0 was not PoE none was PoE. However, some switches have ports starting at port 5 to be PoE. Therefor changed code to just test each port if it is PoE.
* Set PoE thing offline if no data could be found . This would better reflect the PoE thing status if there is a problem with either the data from the api or a configuration problem (like invalid port number).
