### PR TITLE
[mqtt.homeassistant] ensure availability topics get subscribed

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.mqtt.generic.utils.FutureCollector;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
@@ -103,7 +104,10 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler
      * @param connection A started broker connection
      * @return A future that completes normal on success and exceptionally on any errors.
      */
-    protected abstract CompletableFuture<@Nullable Void> start(MqttBrokerConnection connection);
+    protected CompletableFuture<@Nullable Void> start(MqttBrokerConnection connection) {
+        return availabilityStates.values().parallelStream().map(cChannel -> cChannel.start(connection, scheduler, 0))
+                .collect(FutureCollector.allOf());
+    }
 
     /**
      * Called when the MQTT connection disappeared.


### PR DESCRIPTION
HASS registers availability topics before calling start(), so the AbstractMQTTThingHandler was never subscribing/starting the availability channel(s). So do so in start() of the base class.

I checked other implementations, and either they already handle re-registering availabilityTopics in their start() (GenericMQTTThingHandler), or they don't use availabilityTopics at all from the base class and manage it themselves (Homie).

Note that this shows up as newly-added HASS things not having a problem (because the components aren't discovered until after the ThingHandler is started), but if you restart OpenHAB or disable/enable the thing, the channels (and components) are cached, thus how availabilityTopics are known before starting.

