### PR TITLE
[tapobridge] Fix API Rate limit exceeded error

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoCloudConnector.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoCloudConnector.java
@@ -15,6 +15,7 @@ package org.openhab.binding.tapocontrol.internal.api;
 import static org.openhab.binding.tapocontrol.internal.constants.TapoBindingSettings.*;
 import static org.openhab.binding.tapocontrol.internal.constants.TapoErrorConstants.*;
 
+import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -83,7 +84,7 @@ public class TapoCloudConnector {
      * @return true if login was successfull
      */
     public Boolean login(String username, String password) {
-        this.token = getToken(username, password, TAPO_TERMINAL_UUID);
+        this.token = getToken(username, password, UUID.randomUUID().toString());
         this.url = TAPO_CLOUD_URL + "?token=" + token;
         return !this.token.isBlank();
     }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoBindingSettings.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoBindingSettings.java
@@ -32,7 +32,6 @@ public class TapoBindingSettings {
     public static final String CONTENT_TYPE_JSON = "application/json";
     public static final String TAPO_CLOUD_URL = "https://eu-wap.tplinkcloud.com";
     public static final String TAPO_APP_TYPE = "Tapo_Ios";
-    public static final String TAPO_TERMINAL_UUID = "0A950402-7224-46EB-A450-7362CDB902A2";
     public static final String TAPO_DEVICE_URL = "http://%s/app";
     public static final Integer HTTP_MAX_CONNECTIONS = 10; // setMaxConnectionsPerDestination for HTTP-Client
     public static final Integer HTTP_MAX_QUEUED_REQUESTS = 10; // setMaxRequestsQueuedPerDestination for HTTP-Client


### PR DESCRIPTION
When authenticating to the TP-Link cloud, the TapoCloudConnector uses a hard-coded UUID as a client identifier.  All client share the same token, therefore the API server believes the same client is repeatetly authenticating, and blocks it with an "API Rate limit exceeded (-20004)" error.

This PR removes the static terminal UUID and replaces it with a random UUID generated at login.  It has been discussed at https://community.openhab.org/t/tapocontrol-control-tapo-smart-wifi-devices-with-openhab/118389/201 and has been running on my OpenHAB server for ~12h without issue.

A compiled .jar is available at https://github.com/poggs/openhab-addons/releases/tag/fix-13465