### PR TITLE
[nuki] Fixed nukiId migration for devices with shorter nukiId (#13088)

### DIFF
--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -169,6 +169,15 @@ If secureToken property is enabled, make sure that time on device running openHA
 is enabled, all requests contain timestamp and bridge will only accept requests with small time difference. If it is not possible to 
 keep time synchronized, disable secureToken feature.
 
+### NukiId conversion when migrating from old binding version
+
+Older versions of binding used nukiId in hexadecimal format (as displayed in Nuki app, e.g. 5C4BC4B3). The new version
+expects nukiId to be in decimal format (e.g. 1548469427), since that's the format returned from API.
+The binding does the conversion automatically, but only if your nukiId contains any letters A-F, otherwise the binding
+has no way to tell whether the id is in hexadecimal or decimal format. If your nukiId in hexadecimal format
+contains only numbers, you'll have to convert it to decimal format manually, or preferably delete the old Thing 
+and use discovery to recreate it.
+
 ## Full Example
 
 A manual setup through files could look like this:

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/AbstractNukiDeviceHandler.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/AbstractNukiDeviceHandler.java
@@ -63,7 +63,8 @@ public abstract class AbstractNukiDeviceHandler<T extends NukiDeviceConfiguratio
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     private static final int JOB_INTERVAL = 60;
-    private static final Pattern NUKI_ID_HEX_PATTERN = Pattern.compile("[A-F\\d]{8}", Pattern.CASE_INSENSITIVE);
+    private static final Pattern NUKI_ID_HEX_PATTERN = Pattern.compile("[A-F\\d]*[A-F]+[A-F\\d]*",
+            Pattern.CASE_INSENSITIVE);
 
     @Nullable
     protected ScheduledFuture<?> reInitJob;


### PR DESCRIPTION
This fixes #13088:

When migrating from old version of binding, nukiId stored as hexadecimal number must be converted to decimal format used in newer versions. To detect whether the current nukiId is decimal or hexadecimal the binding used pattern which assumed all hexadecimal nukiIds are exactly 8 hex digits (A-F,0-9) long.

This turned out not to be true as some users reported their nukiId being only 7 hex digits long and it's corresponding decimal value being 8 digits, which triggered migration and the decimal nukiId was incorrectly converted as a hex number to decimal again, resulting in binding using invalid nukiId and not working.

Since we can't really tell with 100% certainty whether the nukiId is hexadecimal or not (it can be either hexadecimal number wihtout any A-F digits or just short decimal number), we will assume it's hexadecimal only if it contains at least one A-F digit. This might cause some false negatives (as someone's hexadecimal nukiId might be just 8 0-9 digits), but this case is rare (it only happens for users using old version of binding previously) and can be easily fixed by either creating Thing using discovery (which is recommended anyway) or by manually converting nukiId to it's decimal representation.


