### PR TITLE
[ecowatt] Fix a typo in a channel description

### DIFF
--- a/bundles/org.openhab.binding.ecowatt/src/main/resources/OH-INF/i18n/ecowatt.properties
+++ b/bundles/org.openhab.binding.ecowatt/src/main/resources/OH-INF/i18n/ecowatt.properties
@@ -10,7 +10,7 @@ thing-type.ecowatt.signals.description = The French electricity consumption fore
 thing-type.ecowatt.signals.channel.currentHourSignal.label = Current Hour Signal
 thing-type.ecowatt.signals.channel.currentHourSignal.description = The signal relating to the forecast consumption level for the current hour. Values are 1 for normal consumption (green), 2 for strained electrical system (orange) and 3 for very strained electrical system (red).
 thing-type.ecowatt.signals.channel.todaySignal.label = Today Signal
-thing-type.ecowatt.signals.channel.todaySignal.description = The signal relating to the forecast consumption level for today. Values are 1 for normal consumption (green), 2 for strained electrical system (orange) and 3 for very strained electrical system (red)).
+thing-type.ecowatt.signals.channel.todaySignal.description = The signal relating to the forecast consumption level for today. Values are 1 for normal consumption (green), 2 for strained electrical system (orange) and 3 for very strained electrical system (red).
 thing-type.ecowatt.signals.channel.tomorrowSignal.label = Tomorrow Signal
 thing-type.ecowatt.signals.channel.tomorrowSignal.description = The signal relating to the forecast consumption level for tomorrow. Values are 1 for normal consumption (green), 2 for strained electrical system (orange) and 3 for very strained electrical system (red).
 

--- a/bundles/org.openhab.binding.ecowatt/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecowatt/src/main/resources/OH-INF/thing/thing-types.xml
@@ -12,7 +12,7 @@
 			<channel id="todaySignal" typeId="signal">
 				<label>Today Signal</label>
 				<description>The signal relating to the forecast consumption level for today. Values are 1 for normal consumption
-					(green), 2 for strained electrical system (orange) and 3 for very strained electrical system (red)).</description>
+					(green), 2 for strained electrical system (orange) and 3 for very strained electrical system (red).</description>
 			</channel>
 			<channel id="tomorrowSignal" typeId="signal">
 				<label>Tomorrow Signal</label>


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>