### PR TITLE
[linky] Avoid internal server error (getting power peak early in the …

### DIFF
--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/LinkyHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/LinkyHandler.java
@@ -105,6 +105,12 @@ public class LinkyHandler extends BaseThingHandler {
         });
 
         this.cachedPowerData = new ExpiringDayCache<>("power cache", REFRESH_FIRST_HOUR_OF_DAY, () -> {
+            // We request data for yesterday and the day before yesterday, even if the data for the day before yesterday
+            // is not needed by the binding. This is only a workaround to an API bug that will return
+            // INTERNAL_SERVER_ERROR rather than the expected data with a NaN value when the data for yesterday is not
+            // yet available.
+            // By requesting two days, the API is not failing and you get the expected NaN value for yesterday when the
+            // data is not yet available.
             LocalDate today = LocalDate.now();
             Consumption consumption = getPowerData(today.minusDays(2), today);
             if (consumption != null) {

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/LinkyHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/LinkyHandler.java
@@ -105,13 +105,12 @@ public class LinkyHandler extends BaseThingHandler {
         });
 
         this.cachedPowerData = new ExpiringDayCache<>("power cache", REFRESH_FIRST_HOUR_OF_DAY, () -> {
-            LocalDate to = LocalDate.now();
-            LocalDate from = to.minusDays(1);
-            Consumption consumption = getPowerData(from, to);
+            LocalDate today = LocalDate.now();
+            Consumption consumption = getPowerData(today.minusDays(2), today);
             if (consumption != null) {
                 logData(consumption.aggregats.days, "Day (peak)", true, DateTimeFormatter.ISO_LOCAL_DATE_TIME,
                         Target.ALL);
-                consumption = getConsumptionAfterChecks(consumption, Target.FIRST);
+                consumption = getConsumptionAfterChecks(consumption, Target.LAST);
             }
             return consumption;
         });
@@ -199,8 +198,8 @@ public class LinkyHandler extends BaseThingHandler {
         if (isLinked(PEAK_POWER) || isLinked(PEAK_TIMESTAMP)) {
             cachedPowerData.getValue().ifPresentOrElse(values -> {
                 Aggregate days = values.aggregats.days;
-                updateVAChannel(PEAK_POWER, days.datas.get(0));
-                updateState(PEAK_TIMESTAMP, new DateTimeType(days.periodes.get(0).dateDebut));
+                updateVAChannel(PEAK_POWER, days.datas.get(days.datas.size() - 1));
+                updateState(PEAK_TIMESTAMP, new DateTimeType(days.periodes.get(days.datas.size() - 1).dateDebut));
             }, () -> {
                 updateKwhChannel(PEAK_POWER, Double.NaN);
                 updateState(PEAK_TIMESTAMP, UnDefType.UNDEF);


### PR DESCRIPTION
…morning)

Fix #13377

The binding now requests power peak data for 2 days (yesterday and the day before).

Signed-off-by: Laurent Garnier <lg.hc@free.fr>