### PR TITLE
[jdbc] Consolidate and optimize datetime conversions

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
@@ -174,7 +174,7 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
         Unit<? extends Quantity<?>> unit = item instanceof NumberItem ? ((NumberItem) item).getUnit() : null;
         return m.stream().map(o -> {
             logger.debug("JDBC::doGetHistItemFilterQuery 0='{}' 1='{}'", o[0], o[1]);
-            return new JdbcHistoricItem(itemName, objectAsState(item, unit, o[1]), objectAsDate(o[0]));
+            return new JdbcHistoricItem(itemName, objectAsState(item, unit, o[1]), objectAsZonedDateTime(o[0]));
         }).collect(Collectors.<HistoricItem> toList());
     }
 

--- a/bundles/org.openhab.persistence.jdbc/src/test/java/org/openhab/persistence/jdbc/db/JdbcBaseDAOTest.java
+++ b/bundles/org.openhab.persistence.jdbc/src/test/java/org/openhab/persistence/jdbc/db/JdbcBaseDAOTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -85,16 +86,6 @@ public class JdbcBaseDAOTest {
         assertInstanceOf(QuantityType.class, quantityType);
         assertEquals(QuantityType.valueOf("7.3 °C"), quantityType);
 
-        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
-                java.sql.Timestamp.valueOf("2021-02-01 23:30:02.049"));
-        assertInstanceOf(DateTimeType.class, dateTimeType);
-        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
-
-        dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
-                LocalDateTime.parse("2021-02-01T23:30:02.049"));
-        assertInstanceOf(DateTimeType.class, dateTimeType);
-        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
-
         State hsbType = jdbcBaseDAO.objectAsState(new ColorItem("testColorItem"), null, "184,100,52");
         assertInstanceOf(HSBType.class, hsbType);
         assertEquals(HSBType.valueOf("184,100,52"), hsbType);
@@ -138,6 +129,60 @@ public class JdbcBaseDAOTest {
         State stringType = jdbcBaseDAO.objectAsState(new StringItem("testStringItem"), null, "String");
         assertInstanceOf(StringType.class, stringType);
         assertEquals(StringType.valueOf("String"), stringType);
+    }
+
+    @Test
+    public void objectAsStateReturnsValiDateTimeTypeForTimestamp() {
+        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                java.sql.Timestamp.valueOf("2021-02-01 23:30:02.049"));
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
+    }
+
+    @Test
+    public void objectAsStateReturnsValidDateTimeTypeForLocalDateTime() {
+        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                LocalDateTime.parse("2021-02-01T23:30:02.049"));
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
+    }
+
+    @Test
+    public void objectAsStateReturnsValidDateTimeTypeForLong() {
+        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                Long.valueOf("1612222202049"));
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertEquals(
+                new DateTimeType(
+                        ZonedDateTime.ofInstant(Instant.parse("2021-02-01T23:30:02.049Z"), ZoneId.systemDefault())),
+                dateTimeType);
+    }
+
+    @Test
+    public void objectAsStateReturnsValidDateTimeTypeForSqlDate() {
+        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                java.sql.Date.valueOf("2021-02-01"));
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertEquals(DateTimeType.valueOf("2021-02-01T00:00:00.000"), dateTimeType);
+    }
+
+    @Test
+    public void objectAsStateReturnsValidDateTimeTypeForInstant() {
+        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                Instant.parse("2021-02-01T23:30:02.049Z"));
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertEquals(
+                new DateTimeType(
+                        ZonedDateTime.ofInstant(Instant.parse("2021-02-01T23:30:02.049Z"), ZoneId.systemDefault())),
+                dateTimeType);
+    }
+
+    @Test
+    public void objectAsStateReturnsValidDateTimeTypeForString() {
+        State dateTimeType = jdbcBaseDAO.objectAsState(new DateTimeItem("testDateTimeItem"), null,
+                "2021-02-01 23:30:02.049");
+        assertInstanceOf(DateTimeType.class, dateTimeType);
+        assertEquals(DateTimeType.valueOf("2021-02-01T23:30:02.049"), dateTimeType);
     }
 
     @Test


### PR DESCRIPTION
Minor refactoring:
- Optimize datetime conversions by avoiding multiple steps, for example `LocalDateTime` -> `Instant` -> epoch -> `Instant` -> `ZonedDateTime`. This will now be converted directly from `LocalDateTime` to `ZonedDateTime`.
- Eliminate redundant method after this.
- Introduce tests for all supported types.

Based on findings after #13382 and #13425.