### PR TITLE
[kostalinverter] Fix for the Kostal inverter binding to work with different firmware releases regarded to PIKO 10-20 V. 221004

### DIFF
--- a/bundles/org.openhab.binding.kostalinverter/README.md
+++ b/bundles/org.openhab.binding.kostalinverter/README.md
@@ -291,7 +291,7 @@ String SolarStatus "Solar status [%s]" <energy> { channel="kostalinverter:kostal
 demo.items:
 
 ```
-Number:Power                GridOutputPower             "PV Output Power"                           <energy> { channel="kostalinverter:piko1020:mypiko1020:gridOutputPower" }
+Number:Power                GridOutputPower             "Grid Output Power"                         <energy> { channel="kostalinverter:piko1020:mypiko1020:gridOutputPower" }
 Number:Energy               YieldDaySecondGen           "PV Output Power Day"                       <energy> { channel="kostalinverter:piko1020:mypiko1020:yieldDaySecondGen" }
 Number:Energy               YieldTotalSecondGen         "PV Output Power Total"                     <energy> { channel="kostalinverter:piko1020:mypiko1020:yieldTotalSecondgen" }  
 Number:Dimensionless        OperatingStatus             "Operating Status"                          <energy> { channel="kostalinverter:piko1020:mypiko1020:operatingStatus" }

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/secondgeneration/SecondGenerationHandler.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/secondgeneration/SecondGenerationHandler.java
@@ -151,6 +151,7 @@ public class SecondGenerationHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
+        Thread.currentThread().interrupt();
         // Set channel configuration parameters
         channelConfigs = SecondGenerationChannelConfiguration.getChannelConfiguration();
         channelConfigsExt = SecondGenerationChannelConfiguration.getChannelConfigurationExt();
@@ -187,147 +188,142 @@ public class SecondGenerationHandler extends BaseThingHandler {
     }
 
     private void refresh() {
-        try {
-            // Build posts for dxsEntries part
-            String dxsEntriesCall = inverterConfig.url + "/api/dxs.json?dxsEntries=" + channelConfigs.get(0).dxsEntries;
-            for (int i = 1; i < channelConfigs.size(); i++) {
-                dxsEntriesCall += ("&dxsEntries=" + channelConfigs.get(i).dxsEntries);
-            }
-            String jsonDxsEntriesResponse = callURL(dxsEntriesCall, httpClient);
-            SecondGenerationDxsEntriesContainerDTO dxsEntriesContainer = gson.fromJson(jsonDxsEntriesResponse,
-                    SecondGenerationDxsEntriesContainerDTO.class);
+        // Build posts for dxsEntries part
+        String dxsEntriesCall = inverterConfig.url + "/api/dxs.json?dxsEntries=" + channelConfigs.get(0).dxsEntries;
+        for (int i = 1; i < channelConfigs.size(); i++) {
+            dxsEntriesCall += ("&dxsEntries=" + channelConfigs.get(i).dxsEntries);
+        }
+        String jsonDxsEntriesResponse = callURL(dxsEntriesCall, httpClient);
+        SecondGenerationDxsEntriesContainerDTO dxsEntriesContainer = gson.fromJson(jsonDxsEntriesResponse,
+                SecondGenerationDxsEntriesContainerDTO.class);
 
-            String[] channelPosts = new String[23];
-            int channelPostsCounter = 0;
-            for (SecondGenerationDxsEntries dxsentries : dxsEntriesContainer.dxsEntries) {
-                channelPosts[channelPostsCounter] = dxsentries.getName();
-                channelPostsCounter++;
-            }
-            channelPostsTemp = List.of(channelPosts);
+        String[] channelPosts = new String[23];
+        int channelPostsCounter = 0;
+        for (SecondGenerationDxsEntries dxsentries : dxsEntriesContainer.dxsEntries) {
+            channelPosts[channelPostsCounter] = dxsentries.getName();
+            channelPostsCounter++;
+        }
+        channelPostsTemp = List.of(channelPosts);
 
-            // Build posts for dxsEntriesExt part
-            String dxsEntriesCallExt = inverterConfig.url + "/api/dxs.json?dxsEntries="
-                    + channelConfigsExt.get(0).dxsEntries;
-            for (int i = 1; i < channelConfigs.size(); i++) {
-                dxsEntriesCallExt += ("&dxsEntries=" + channelConfigsExt.get(i).dxsEntries);
-            }
-            String jsonDxsEntriesResponseExt = callURL(dxsEntriesCallExt, httpClient);
-            SecondGenerationDxsEntriesContainerDTO dxsEntriesContainerExt = gson.fromJson(jsonDxsEntriesResponseExt,
-                    SecondGenerationDxsEntriesContainerDTO.class);
-            String[] channelPostsExt = new String[23];
-            int channelPostsCounterExt = 0;
-            for (SecondGenerationDxsEntries dxsentriesExt : dxsEntriesContainerExt.dxsEntries) {
-                channelPostsExt[channelPostsCounterExt] = dxsentriesExt.getName();
-                channelPostsCounterExt++;
-            }
-            channelPostsTempExt = List.of(channelPostsExt);
+        // Build posts for dxsEntriesExt part
+        String dxsEntriesCallExt = inverterConfig.url + "/api/dxs.json?dxsEntries="
+                + channelConfigsExt.get(0).dxsEntries;
+        for (int i = 1; i < channelConfigs.size(); i++) {
+            dxsEntriesCallExt += ("&dxsEntries=" + channelConfigsExt.get(i).dxsEntries);
+        }
+        String jsonDxsEntriesResponseExt = callURL(dxsEntriesCallExt, httpClient);
+        SecondGenerationDxsEntriesContainerDTO dxsEntriesContainerExt = gson.fromJson(jsonDxsEntriesResponseExt,
+                SecondGenerationDxsEntriesContainerDTO.class);
+        String[] channelPostsExt = new String[23];
+        int channelPostsCounterExt = 0;
+        for (SecondGenerationDxsEntries dxsentriesExt : dxsEntriesContainerExt.dxsEntries) {
+            channelPostsExt[channelPostsCounterExt] = dxsentriesExt.getName();
+            channelPostsCounterExt++;
+        }
+        channelPostsTempExt = List.of(channelPostsExt);
 
-            // Build posts for dxsEntriesExtExt part
-            String dxsEntriesCallExtExt = inverterConfig.url + "/api/dxs.json?dxsEntries="
-                    + channelConfigsExtExt.get(0).dxsEntries;
-            for (int i = 1; i < channelConfigsExtExt.size(); i++) {
-                dxsEntriesCallExtExt += ("&dxsEntries=" + channelConfigsExtExt.get(i).dxsEntries);
-            }
-            String jsonDxsEntriesResponseExtExt = callURL(dxsEntriesCallExtExt, httpClient);
-            SecondGenerationDxsEntriesContainerDTO dxsEntriesContainerExtExt = gson
-                    .fromJson(jsonDxsEntriesResponseExtExt, SecondGenerationDxsEntriesContainerDTO.class);
-            String[] channelPostsExtExt = new String[3];
-            int channelPostsCounterExtExt = 0;
-            for (SecondGenerationDxsEntries dxsentriesExtExt : dxsEntriesContainerExtExt.dxsEntries) {
-                channelPostsExtExt[channelPostsCounterExtExt] = dxsentriesExtExt.getName();
-                channelPostsCounterExtExt++;
-            }
-            channelPostsTempExtExt = List.of(channelPostsExtExt);
+        // Build posts for dxsEntriesExtExt part
+        String dxsEntriesCallExtExt = inverterConfig.url + "/api/dxs.json?dxsEntries="
+                + channelConfigsExtExt.get(0).dxsEntries;
+        for (int i = 1; i < channelConfigsExtExt.size(); i++) {
+            dxsEntriesCallExtExt += ("&dxsEntries=" + channelConfigsExtExt.get(i).dxsEntries);
+        }
+        String jsonDxsEntriesResponseExtExt = callURL(dxsEntriesCallExtExt, httpClient);
+        SecondGenerationDxsEntriesContainerDTO dxsEntriesContainerExtExt = gson.fromJson(jsonDxsEntriesResponseExtExt,
+                SecondGenerationDxsEntriesContainerDTO.class);
+        String[] channelPostsExtExt = new String[3];
+        int channelPostsCounterExtExt = 0;
+        for (SecondGenerationDxsEntries dxsentriesExtExt : dxsEntriesContainerExtExt.dxsEntries) {
+            channelPostsExtExt[channelPostsCounterExtExt] = dxsentriesExtExt.getName();
+            channelPostsCounterExtExt++;
+        }
+        channelPostsTempExtExt = List.of(channelPostsExtExt);
 
-            // Concatenate posts for all parts except configurable channels
-            channelPostsTempAll = combinePostsLists(channelPostsTemp, channelPostsTempExt, channelPostsTempExtExt);
-            String[] channelPostsTempAll1 = channelPostsTempAll.toArray(new String[0]);
+        // Concatenate posts for all parts except configurable channels
+        channelPostsTempAll = combinePostsLists(channelPostsTemp, channelPostsTempExt, channelPostsTempExtExt);
+        String[] channelPostsTempAll1 = channelPostsTempAll.toArray(new String[0]);
 
-            // Build posts for dxsEntriesConfigureable part
-            String[] channelPostsConfigurable = new String[5];
-            if (inverterConfig.hasBattery) {
-                String dxsEntriesCallConfigurable = inverterConfig.url + "/api/dxs.json?dxsEntries="
-                        + channelConfigsConfigurable.get(0).dxsEntries;
-                for (int i = 1; i < channelConfigsConfigurable.size(); i++) {
-                    dxsEntriesCallConfigurable += ("&dxsEntries=" + channelConfigsConfigurable.get(i).dxsEntries);
+        // Build posts for dxsEntriesConfigureable part
+        String[] channelPostsConfigurable = new String[5];
+        if (inverterConfig.hasBattery) {
+            String dxsEntriesCallConfigurable = inverterConfig.url + "/api/dxs.json?dxsEntries="
+                    + channelConfigsConfigurable.get(0).dxsEntries;
+            for (int i = 1; i < channelConfigsConfigurable.size(); i++) {
+                dxsEntriesCallConfigurable += ("&dxsEntries=" + channelConfigsConfigurable.get(i).dxsEntries);
+            }
+            String jsonDxsEntriesResponseConfigurable = callURL(dxsEntriesCallConfigurable, httpClient);
+            SecondGenerationDxsEntriesContainerDTO dxsEntriesContainerConfigurable = gson
+                    .fromJson(jsonDxsEntriesResponseConfigurable, SecondGenerationDxsEntriesContainerDTO.class);
+            int channelPostsCounterConfigurable = 0;
+            for (SecondGenerationDxsEntries dxsentriesConfigurable : dxsEntriesContainerConfigurable.dxsEntries) {
+                channelPostsConfigurable[channelPostsCounterConfigurable] = dxsentriesConfigurable.getName();
+                channelPostsCounterConfigurable++;
+            }
+        }
+
+        // Create and update actual values for non-configurable channels
+        if (!inverterConfig.hasBattery) {
+            channelConfigsAll = combineChannelConfigLists(channelConfigs, channelConfigsExt, channelConfigsExtExt);
+            int channelValuesCounterAll = 0;
+            for (SecondGenerationChannelConfiguration cConfig : channelConfigsAll) {
+                String channel = cConfig.id;
+                updateState(channel, getState(channelPostsTempAll1[channelValuesCounterAll], cConfig.unit));
+                channelValuesCounterAll++;
+            }
+        }
+        // Create and update actual values for all channels
+        if (inverterConfig.hasBattery) {
+            // Part for updating non-configurable channels
+            channelConfigsAll = combineChannelConfigLists(channelConfigs, channelConfigsExt, channelConfigsExtExt);
+            // Update the non-configurable channels
+            int channelValuesCounterAll = 0;
+            for (SecondGenerationChannelConfiguration cConfig : channelConfigsAll) {
+                String channel = cConfig.id;
+                updateState(channel, getState(channelPostsTempAll1[channelValuesCounterAll], cConfig.unit));
+                channelValuesCounterAll++;
+            }
+
+            // Part for updating configurable channels
+            int channelValuesCounterConfigurable = 0;
+            for (SecondGenerationChannelConfiguration cConfig : channelConfigsConfigurable) {
+                String channel = cConfig.id;
+                String value = channelPostsConfigurable[channelValuesCounterConfigurable];
+                int dxsEntriesCheckCounter = 3;
+                if (cConfig.dxsEntries.equals("33556484")) {
+                    dxsEntriesCheckCounter = 1;
                 }
-                String jsonDxsEntriesResponseConfigurable = callURL(dxsEntriesCallConfigurable, httpClient);
-                SecondGenerationDxsEntriesContainerDTO dxsEntriesContainerConfigurable = gson
-                        .fromJson(jsonDxsEntriesResponseConfigurable, SecondGenerationDxsEntriesContainerDTO.class);
-                int channelPostsCounterConfigurable = 0;
-                for (SecondGenerationDxsEntries dxsentriesConfigurable : dxsEntriesContainerConfigurable.dxsEntries) {
-                    channelPostsConfigurable[channelPostsCounterConfigurable] = dxsentriesConfigurable.getName();
-                    channelPostsCounterConfigurable++;
+                if (cConfig.dxsEntries.equals("33556482")) {
+                    dxsEntriesCheckCounter = 2;
                 }
-            }
-
-            // Create and update actual values for non-configurable channels
-            if (!inverterConfig.hasBattery) {
-                channelConfigsAll = combineChannelConfigLists(channelConfigs, channelConfigsExt, channelConfigsExtExt);
-                int channelValuesCounterAll = 0;
-                for (SecondGenerationChannelConfiguration cConfig : channelConfigsAll) {
-                    String channel = cConfig.id;
-                    updateState(channel, getState(channelPostsTempAll1[channelValuesCounterAll], cConfig.unit));
-                    channelValuesCounterAll++;
-                }
-            }
-            // Create and update actual values for all channels
-            if (inverterConfig.hasBattery) {
-                // Part for updating non-configurable channels
-                channelConfigsAll = combineChannelConfigLists(channelConfigs, channelConfigsExt, channelConfigsExtExt);
-                // Update the non-configurable channels
-                int channelValuesCounterAll = 0;
-                for (SecondGenerationChannelConfiguration cConfig : channelConfigsAll) {
-                    String channel = cConfig.id;
-                    updateState(channel, getState(channelPostsTempAll1[channelValuesCounterAll], cConfig.unit));
-                    channelValuesCounterAll++;
-                }
-
-                // Part for updating configurable channels
-                int channelValuesCounterConfigurable = 0;
-                for (SecondGenerationChannelConfiguration cConfig : channelConfigsConfigurable) {
-                    String channel = cConfig.id;
-                    String value = channelPostsConfigurable[channelValuesCounterConfigurable];
-                    int dxsEntriesCheckCounter = 3;
-                    if (cConfig.dxsEntries.equals("33556484")) {
-                        dxsEntriesCheckCounter = 1;
-                    }
-                    if (cConfig.dxsEntries.equals("33556482")) {
-                        dxsEntriesCheckCounter = 2;
-                    }
-                    switch (dxsEntriesCheckCounter) {
-                        case 1:
-                            if ("false".equals(value)) {
-                                updateState(channel, OnOffType.OFF);
-                            }
-                            if ("true".equals(value)) {
-                                updateState(channel, OnOffType.ON);
-                            }
-                            channelValuesCounterConfigurable++;
-                            break;
-                        case 2:
-                            if ("false".equals(value)) {
-                                State stateFalse = new StringType("0");
-                                updateState(channel, stateFalse);
-                            }
-                            if ("true".equals(value)) {
-                                State stateTrue = new StringType("1");
-                                updateState(channel, stateTrue);
-                            }
-                            channelValuesCounterConfigurable++;
-                            break;
-                        case 3:
-                            State stateOther = getState(channelPostsConfigurable[channelValuesCounterConfigurable],
-                                    cConfig.unit);
-                            updateState(channel, stateOther);
-                            channelValuesCounterConfigurable++;
-                            break;
-                    }
+                switch (dxsEntriesCheckCounter) {
+                    case 1:
+                        if ("false".equals(value)) {
+                            updateState(channel, OnOffType.OFF);
+                        }
+                        if ("true".equals(value)) {
+                            updateState(channel, OnOffType.ON);
+                        }
+                        channelValuesCounterConfigurable++;
+                        break;
+                    case 2:
+                        if ("false".equals(value)) {
+                            State stateFalse = new StringType("0");
+                            updateState(channel, stateFalse);
+                        }
+                        if ("true".equals(value)) {
+                            State stateTrue = new StringType("1");
+                            updateState(channel, stateTrue);
+                        }
+                        channelValuesCounterConfigurable++;
+                        break;
+                    case 3:
+                        State stateOther = getState(channelPostsConfigurable[channelValuesCounterConfigurable],
+                                cConfig.unit);
+                        updateState(channel, stateOther);
+                        channelValuesCounterConfigurable++;
+                        break;
                 }
             }
-        } catch (final RuntimeException e) {
-            logger.debug("Updating inverter status failed: ", e);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }
 
@@ -347,7 +343,7 @@ public class SecondGenerationHandler extends BaseThingHandler {
     private final String callURL(String dxsEntriesCall, HttpClient httpClient) {
         String jsonDxsResponse = "";
         try {
-            jsonDxsResponse = httpClient.GET(dxsEntriesCall).getContentAsString();
+            jsonDxsResponse = httpClient.GET(dxsEntriesCall).getContentAsString().replace("null", "0.000000");
         } catch (InterruptedException | ExecutionException | TimeoutException e2) {
             logger.debug("Connection to inverter disturbed during scrape");
         }

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/secondgeneration/SecondGenerationHandler.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/secondgeneration/SecondGenerationHandler.java
@@ -151,7 +151,6 @@ public class SecondGenerationHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        Thread.currentThread().interrupt();
         // Set channel configuration parameters
         channelConfigs = SecondGenerationChannelConfiguration.getChannelConfiguration();
         channelConfigsExt = SecondGenerationChannelConfiguration.getChannelConfigurationExt();
@@ -325,6 +324,7 @@ public class SecondGenerationHandler extends BaseThingHandler {
                 }
             }
         }
+        return;
     }
 
     // Help method of handleCommand to with SecondGenerationConfigurationHandler.executeConfigurationChanges method send
@@ -335,6 +335,7 @@ public class SecondGenerationHandler extends BaseThingHandler {
             SecondGenerationConfigurationHandler.executeConfigurationChanges(httpClientHandleCommand, url, username,
                     password, dxsEntriesConf, valueConfiguration);
         } catch (InterruptedException | ExecutionException | TimeoutException | NoSuchAlgorithmException e) {
+            Thread.currentThread().interrupt();
             logger.debug("Connection to inverter disturbed during configuration");
         }
     }
@@ -345,6 +346,7 @@ public class SecondGenerationHandler extends BaseThingHandler {
         try {
             jsonDxsResponse = httpClient.GET(dxsEntriesCall).getContentAsString().replace("null", "0.000000");
         } catch (InterruptedException | ExecutionException | TimeoutException e2) {
+            Thread.currentThread().interrupt();
             logger.debug("Connection to inverter disturbed during scrape");
         }
         return jsonDxsResponse;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/secondgeneration/SecondGenerationHandler.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/secondgeneration/SecondGenerationHandler.java
@@ -324,7 +324,6 @@ public class SecondGenerationHandler extends BaseThingHandler {
                 }
             }
         }
-        return;
     }
 
     // Help method of handleCommand to with SecondGenerationConfigurationHandler.executeConfigurationChanges method send
@@ -334,8 +333,10 @@ public class SecondGenerationHandler extends BaseThingHandler {
         try {
             SecondGenerationConfigurationHandler.executeConfigurationChanges(httpClientHandleCommand, url, username,
                     password, dxsEntriesConf, valueConfiguration);
-        } catch (InterruptedException | ExecutionException | TimeoutException | NoSuchAlgorithmException e) {
+        } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            logger.debug("Connection to inverter interrupted during configuration");
+        } catch (ExecutionException | TimeoutException | NoSuchAlgorithmException e) {
             logger.debug("Connection to inverter disturbed during configuration");
         }
     }
@@ -345,8 +346,10 @@ public class SecondGenerationHandler extends BaseThingHandler {
         String jsonDxsResponse = "";
         try {
             jsonDxsResponse = httpClient.GET(dxsEntriesCall).getContentAsString().replace("null", "0.000000");
-        } catch (InterruptedException | ExecutionException | TimeoutException e2) {
+        } catch (InterruptedException e2) {
             Thread.currentThread().interrupt();
+            logger.debug("Connection to inverter interrupted during scrape");
+        } catch (ExecutionException | TimeoutException e2) {
             logger.debug("Connection to inverter disturbed during scrape");
         }
         return jsonDxsResponse;


### PR DESCRIPTION
[kostalinverter] Fix for the Kostal inverter binding to work with different firmware releases regarded to PIKO 10-20 V. 221004

This is the next version regarded to Closed PR #13464

Hi, lolodomo
The changes of code regarded to jsonDxsEntriesResponse in CallURL is for to have some FW versions to deliver the very same value as other versions does. ( 0.000000 instead of null )
Regarded to httpClient do I have a problem with as I think some FW-versions or maybe even HW-versions of inverter ( proberly not same as above, and mine works for both these issues ). Some causes the binding to get hanging after random time ( hours , days ) I have not been able to find the reason to that behavior, only the solution, a guess is about something like "Closed Channel Exception", but I have not been able to found out if it is so, even with use of different exceptions and a lot of tracing.
As you adviced have I take away this part of code, but I will be very pleased if you maybe have some idea how to handle this problem. 
Thanks again!!
Br Basse

Signed-off-by: Örjan Backsell <orjan.backsell@gmail.com>
