### PR TITLE
[homekit] small correction in README

### DIFF
--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -43,7 +43,7 @@ HomeKit integration supports following accessory types:
 
 ## Quick start
 
-- install homekit binding via UI
+- install homekit addon via UI
   
 - add metadata to an existing item (see [UI based configuration](#UI-based-Configuration))
   


### PR DESCRIPTION
Remove the wrong naming „binding“ in installation section
