### PR TITLE
[ipcamera] Fix ipcamera.mjpeg won't open multiples when port not 80

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1406,7 +1406,7 @@ public class IpCameraHandler extends BaseThingHandler {
         }
     }
 
-    boolean streamIsStopped(String url) {
+    private boolean streamIsStopped(String url) {
         ChannelTracking channelTracking = channelTrackingMap.get(url);
         if (channelTracking != null) {
             if (channelTracking.getChannel().isActive()) {
@@ -1732,7 +1732,9 @@ public class IpCameraHandler extends BaseThingHandler {
             localFfmpeg.stopConverting();
             ffmpegSnapshot = null;
         }
-        onvifCamera.disconnect();
+        if (!thing.getThingTypeUID().getId().equals(GENERIC_THING)) {// generic cameras do not have ONVIF support
+            onvifCamera.disconnect();
+        }
         openChannels.close();
     }
 

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/CameraServlet.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/CameraServlet.java
@@ -187,11 +187,10 @@ public class CameraServlet extends IpCameraServlet {
                     if (handler.mjpegUri.isEmpty() || "ffmpeg".equals(handler.mjpegUri)) {
                         output = new StreamOutput(resp);
                     } else {
-                        ChannelTracking tracker = handler.channelTrackingMap.get(handler.mjpegUri);
+                        ChannelTracking tracker = handler.channelTrackingMap.get(handler.getTinyUrl(handler.mjpegUri));
                         if (tracker == null || !tracker.getChannel().isOpen()) {
                             logger.debug("Not the first stream requested but the stream from camera was closed");
                             handler.openCamerasStream();
-                            openStreams.closeAllStreams();
                         }
                         output = new StreamOutput(resp, handler.mjpegContentType);
                     }


### PR DESCRIPTION
Fixes a bug reported on the forum here:
https://community.openhab.org/t/ipcamera-new-ip-camera-binding/42771/2786

Fixes for these bugs:

+ ipcamera.mjpeg won't open multiples when the port for the cameras stream is not 80
+ All in use mjpeg streams stop when the camera is offline and a new stream is opened.
+ Removes a wrong WARN for generic cameras that were getting an ONVIF error when restarting.

Jar can be downloaded from:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/3.4.0-SNAPSHOT/org.openhab.binding.ipcamera-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>