### PR TITLE
[homekit] Allow Long type in configuration for numbers

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -295,6 +295,12 @@ public class HomekitTaggedItem {
                 if ((value instanceof Double) && (defaultValue instanceof BigDecimal)) {
                     return (T) BigDecimal.valueOf(((Double) value).doubleValue());
                 }
+                if ((value instanceof Long) && (defaultValue instanceof Double)) {
+                    return (T) Double.valueOf((Long) value);
+                }
+                if ((value instanceof Long) && (defaultValue instanceof BigDecimal)) {
+                    return (T) BigDecimal.valueOf((Long) value);
+                }
             }
 
         }


### PR DESCRIPTION
I.e. if it's set from a Ruby script

