### PR TITLE
[network] Fix wake-on-lan functions in DSL rules

### DIFF
--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/action/NetworkActions.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/action/NetworkActions.java
@@ -56,6 +56,10 @@ public class NetworkActions implements ThingActions {
         sendWakeOnLanPacketViaMac();
     }
 
+    public static void sendWakeOnLanPacket(ThingActions actions) {
+        ((NetworkActions) actions).sendWakeOnLanPacketViaMac();
+    }
+
     @RuleAction(label = "send a WoL packet", description = "Send a Wake-on-LAN packet to wake the device via Mac.")
     public void sendWakeOnLanPacketViaMac() {
         NetworkHandler localHandler = handler;
@@ -64,6 +68,10 @@ public class NetworkActions implements ThingActions {
         } else {
             logger.warn("Failed to send Wake-on-LAN packet (handler null)");
         }
+    }
+
+    public static void sendWakeOnLanPacketViaMac(ThingActions actions) {
+        ((NetworkActions) actions).sendWakeOnLanPacketViaMac();
     }
 
     @RuleAction(label = "send a WoL packet", description = "Send a Wake-on-LAN packet to wake the device via IP.")
@@ -76,7 +84,7 @@ public class NetworkActions implements ThingActions {
         }
     }
 
-    public static void sendWakeOnLanPacket(ThingActions actions) {
-        ((NetworkActions) actions).sendWakeOnLanPacketViaMac();
+    public static void sendWakeOnLanPacketViaIp(ThingActions actions) {
+        ((NetworkActions) actions).sendWakeOnLanPacketViaIp();
     }
 }


### PR DESCRIPTION
Add static methods in actions to make them available in DSL rules.

Failed with `'sendWakeOnLanPacketViaMac' is not a member of 'org.openhab.core.thing.binding.ThingActions'`.

Discussed here: https://community.openhab.org/t/solved-wake-on-lan-in-oh3-not-working-not-a-member-of-org-openhab-core-thing-binding-thingactions/132476/9