### PR TITLE
[easee] Fix number conversion error

### DIFF
--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/EaseeBindingConstants.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/EaseeBindingConstants.java
@@ -150,7 +150,7 @@ public class EaseeBindingConstants {
     public static final String GENERIC_NO = "No";
     public static final int CHARGER_OP_STATE_WAITING = 2;
     public static final int CHARGER_OP_STATE_CHARGING = 3;
-    public static final int CHARGER_DYNAMIC_CURRENT_PAUSE = 0;
+    public static final double CHARGER_DYNAMIC_CURRENT_PAUSE = 0;
     public static final int CHARGER_REASON_FOR_NO_CURRENT_PAUSED = 52;
 
     public static final String THING_CONFIG_ID = "id";

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
@@ -81,7 +81,7 @@ class CustomResponseTransformer {
     private void updateChargerStartStop(Map<Channel, State> result, String value, JsonObject rawData) {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_START_STOP);
         if (channel != null) {
-            int val = Integer.valueOf(value);
+            int val = Integer.parseInt(value);
             // state >= 3 will mean charging, ready to charge or charging finished
             boolean charging = val >= CHARGER_OP_STATE_CHARGING;
 
@@ -97,7 +97,7 @@ class CustomResponseTransformer {
     private void updateChargerPauseResume(Map<Channel, State> result, String value) {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_PAUSE_RESUME);
         if (channel != null) {
-            int val = Integer.valueOf(value);
+            double val = Double.parseDouble(value);
             // value == 0 will mean paused
             boolean paused = val == CHARGER_DYNAMIC_CURRENT_PAUSE;
 


### PR DESCRIPTION
This bug was reported by the community.
https://community.openhab.org/t/easee-binding/135492/58

The binding tries to parse a decimal value as integer but fails as it should be parsed as double instead.
