### PR TITLE
[jpa] Fix Derby driver no longer included

### DIFF
--- a/bundles/org.openhab.persistence.jpa/pom.xml
+++ b/bundles/org.openhab.persistence.jpa/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: Persistence Service :: JPA</name>
 
   <properties>
-    <bnd.importpackage>!com.ibm.*,!com.sun.*,!oracle.*,!javax.interceptor.*,!javax.enterprise.*,!javax.rmi,!org.apache.bval.*,!net.sf.cglib.*,!org.apache.commons.beanutils.*,!org.apache.geronimo.*,!org.apache.avalon.*,!org.apache.log,!org.apache.tools.*,!org.apache.xerces.*,!org.jboss.*,!org.postgresql.*,!org.slf4j.impl,!weblogic.*</bnd.importpackage>
+    <bnd.importpackage>!com.ibm.*,!com.sun.*,!oracle.*,!javax.interceptor.*,!javax.enterprise.*,!javax.rmi,!org.apache.bval.*,!net.sf.cglib.*,!org.apache.commons.beanutils.*,!org.apache.geronimo.*,!org.apache.avalon.*,!org.apache.log,!org.apache.tools.*,!org.apache.xerces.*,!org.jboss.*,!org.postgresql.*,!org.slf4j.impl,!weblogic.*,org.apache.derby.*;resolution:=optional</bnd.importpackage>
     <openjpa.version>3.2.2</openjpa.version>
   </properties>
 
@@ -30,8 +30,7 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.16.1.1</version>
-      <scope>test</scope>
+      <version>10.14.2.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
According to the add-on documentation the Derby driver is included which was no longer the case. The derby version was also changed because 10.16.1.1 is for Java 17+.