### PR TITLE
[tibber] Fix Websocket reconnect after server failure

### DIFF
--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -341,10 +341,8 @@ public class TibberHandler extends BaseThingHandler {
                     Thread.sleep(10 * 1000);
                 } catch (InterruptedException e) {
                 }
-                Session session = this.session;
-                if (!session.isOpen()) {
-                    close();
-                    logger.warn("Unable to establish websocket session");
+                if (!isConnected()) {
+                    logger.warn("Unable to establish websocket session - Reattempting connection on next refresh");
                 } else {
                     logger.debug("Websocket session established");
                 }


### PR DESCRIPTION
Bug fix for websocket reconnect after Tibber server failure.

Closes #13417.

Signed-off-by: kjoglum <stiankj@online.no>
