### PR TITLE
[homekit] increase flexibility of ColorTemperature

### DIFF
--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -243,6 +243,38 @@ Examples:
  Dimmer dimmer_light_3   "Dimmer Light 3"     {homekit="Lighting, Lighting.Brightness" [dimmerMode="filterOnExceptBrightness100"]}
  ```
 
+### Color Temperature
+
+Color temperature can be represented various ways in OpenHAB. Given the base bulb configured like this:
+
+```xtend
+Group gLight "CCT Light" { homekit="Lighting" }
+Switch light_switch (gLight) { homekit="Lighting.OnState" }
+```
+
+The color temperature might be configured in any of these ways:
+
+```xtend
+// Number item presumed in mireds
+Number light_temp (gLight) { homekit="Lighting.ColorTemperature" }
+
+// Number item explicitly in mireds
+Number:Temperature light_temp "Temp [%.0f mired]" { homekit="Lighting.ColorTemperature" }
+
+// Number item explicitly in Kelvin
+Number:Temperature light_temp "Temp [%.0f K]" { homekit="Lighting.ColorTemperature" }
+
+// Dimmer item, with allowed range given in mireds
+Dimmer light_temp { homekit="Lighting.ColorTemperature"[ minValue=50, maxValue=400 ]}
+
+// Dimmer item, with allowed range given in Kelvin
+Dimmer light_temp { homekit="Lighting.ColorTemperature"[ minValue="2700 K", maxValue="5000 K" ]}
+
+// Dimmer item, where 0% represents "warm" instead of "cool" (i.e. if it's backed by a channel
+// that's ultimately interpreting the value in Kelvin instead of mireds)
+Dimmer light_temp { homekit="Lighting.ColorTemperature"[ minValue="2700 K", maxValue="5000 K", inverted=true ]}
+```
+
 ### Windows Covering (Blinds) / Window / Door
 
 HomeKit Windows Covering, Window and Door accessory types have following mandatory characteristics:
@@ -674,7 +706,7 @@ Support for this is planned for the future release of openHAB HomeKit binding.
 |                      |                             | Hue                          | Dimmer, Color                 | Hue                                                                                                                                                                                                                                                                                                                                                 |
 |                      |                             | Saturation                   | Dimmer, Color                 | Saturation in % (1-100)                                                                                                                                                                                                                                                                                                                             |
 |                      |                             | Brightness                   | Dimmer, Color                 | Brightness in % (1-100). See "Usage of dimmer modes" for configuration details.                                                                                                                                                                                                                                                                     |
-|                      |                             | ColorTemperature             | Number                        | Color temperature represented in reciprocal megaKelvin. The default value range is from 50 to 400. Color temperature should not be used in combination with hue, saturation and brightness. It supports following configuration parameters: minValue, maxValue                                                                                      |
+|                      |                             | ColorTemperature             | Number, Dimmer                | Color temperature. If the item is a Number with no units, it is represented in mireds. The default value range is from 50 to 400 (2500 K to 20,000 K). If the item is a Dimmer, it will be transformed linearly to mireds. Color temperature should not be used in combination with hue, saturation and brightness. It supports following configuration parameters: minValue, maxValue, inverted |
 | Fan                  |                             |                              |                               | Fan                                                                                                                                                                                                                                                                                                                                                 |
 |                      | ActiveStatus                |                              | Switch, Dimmer                | Accessory current working status. A value of "ON"/"OPEN" indicates that the accessory is active and is functioning without any errors.                                                                                                                                                                                                              |
 |                      |                             | CurrentFanState              | Number                        | Current fan state.  values: 0=INACTIVE, 1=IDLE, 2=BLOWING AIR                                                                                                                                                                                                                                                                                       |

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -655,7 +655,6 @@ public class HomekitCharacteristicFactory {
         final int finalMinValue = minValue;
         final int range = maxValue - minValue;
 
-        // final int defaultValue = minValue;
         return new ColorTemperatureCharacteristic(minValue, maxValue, () -> {
             int value = finalMinValue;
             final State state = taggedItem.getItem().getState();

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -43,6 +44,7 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.openhab.io.homekit.Homekit;
@@ -614,13 +616,84 @@ public class HomekitCharacteristicFactory {
 
     private static ColorTemperatureCharacteristic createColorTemperatureCharacteristic(HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
-        int minValue = taggedItem.getConfigurationAsInt(HomekitTaggedItem.MIN_VALUE,
-                ColorTemperatureCharacteristic.DEFAULT_MIN_VALUE);
-        return new ColorTemperatureCharacteristic(minValue,
-                taggedItem.getConfigurationAsInt(HomekitTaggedItem.MAX_VALUE,
-                        ColorTemperatureCharacteristic.DEFAULT_MAX_VALUE),
-                getIntSupplier(taggedItem, minValue), setIntConsumer(taggedItem),
-                getSubscriber(taggedItem, COLOR_TEMPERATURE, updater),
+        // Check if units are expressed in Kelvin, not mireds, and adjust
+        // the min/max appropriately
+        Unit unit = null;
+        var numberItem = taggedItem.getBaseItem();
+        if (numberItem instanceof NumberItem) {
+            unit = ((NumberItem) numberItem).getUnit();
+        }
+        if (unit == null) {
+            unit = Units.MIRED;
+        }
+        final Unit finalUnit = unit;
+
+        final boolean inverted = taggedItem.isInverted();
+
+        if (!unit.equals(Units.KELVIN) && !unit.equals(Units.MIRED)) {
+            logger.warn("Item {} must be in either K or mired. Given {}.", taggedItem.getName(), unit);
+            return new ColorTemperatureCharacteristic(null, null, null, null);
+        }
+
+        var minValueQt = taggedItem.getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE,
+                Objects.requireNonNull(new QuantityType(ColorTemperatureCharacteristic.DEFAULT_MIN_VALUE, Units.MIRED)
+                        .toInvertibleUnit(unit)));
+        var maxValueQt = taggedItem.getConfigurationAsQuantity(HomekitTaggedItem.MAX_VALUE,
+                Objects.requireNonNull(new QuantityType(ColorTemperatureCharacteristic.DEFAULT_MAX_VALUE, Units.MIRED)
+                        .toInvertibleUnit(unit)));
+
+        int minValue = minValueQt.toInvertibleUnit(Units.MIRED).intValue();
+        int maxValue = maxValueQt.toInvertibleUnit(Units.MIRED).intValue();
+
+        // It's common to swap these if you're providing in Kelvin instead of mired
+        if (minValue > maxValue) {
+            int temp = minValue;
+            minValue = maxValue;
+            maxValue = temp;
+        }
+
+        final int finalMinValue = minValue;
+        final int range = maxValue - minValue;
+
+        // final int defaultValue = minValue;
+        return new ColorTemperatureCharacteristic(minValue, maxValue, () -> {
+            int value = finalMinValue;
+            final State state = taggedItem.getItem().getState();
+            if (state instanceof QuantityType<?>) {
+                // Number:Temperature
+                QuantityType<?> qt = (QuantityType<?>) state;
+                qt = qt.toInvertibleUnit(Units.MIRED);
+                if (qt == null) {
+                    logger.warn("Item {}'s state '{}' is not convertible to mireds.", taggedItem.getName(), state);
+                } else {
+                    value = qt.intValue();
+                }
+            } else if (state instanceof PercentType) {
+                double percent = ((PercentType) state).doubleValue();
+                // invert so that 0% == coolest
+                if (inverted) {
+                    percent = 100.0 - percent;
+                }
+
+                // Dimmer
+                // scale to the originally configured range
+                value = (int) (percent * range / 100) + finalMinValue;
+            } else if (state instanceof DecimalType) {
+                value = ((DecimalType) state).intValue();
+            }
+            return CompletableFuture.completedFuture(value);
+        }, (value) -> {
+            if (taggedItem.getBaseItem() instanceof DimmerItem) {
+                // scale to a percent
+                double percent = (((double) value) - finalMinValue) * 100 / range;
+                if (inverted) {
+                    percent = 100.0 - percent;
+                }
+                taggedItem.send(new PercentType(BigDecimal.valueOf(percent)));
+            } else if (taggedItem.getBaseItem() instanceof NumberItem) {
+                taggedItem.send(new QuantityType(value, Units.MIRED));
+            }
+        }, getSubscriber(taggedItem, COLOR_TEMPERATURE, updater),
                 getUnsubscriber(taggedItem, COLOR_TEMPERATURE, updater));
     }
 


### PR DESCRIPTION
allow Number or Dimmer items, and mired or Kelvin units.

Dependent on https://github.com/openhab/openhab-core/pull/3108 and https://github.com/hap-java/HAP-Java/pull/167