### PR TITLE
[wled] Fix presets and playlists won't load the correct position.

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV0110.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV0110.java
@@ -63,9 +63,9 @@ public class WledApiV0110 extends WledApiV084 {
             PresetState preset = gson.fromJson(presetEntry.getValue(), PresetState.class);
             if (preset != null && counter > 0) {
                 if (preset.bri == 0) {
-                    playlistsOptions.add(new StateOption(Integer.toString(counter), preset.n));
+                    playlistsOptions.add(new StateOption(presetEntry.getKey(), preset.n));
                 } else {
-                    presetsOptions.add(new StateOption(Integer.toString(counter), preset.n));
+                    presetsOptions.add(new StateOption(presetEntry.getKey(), preset.n));
                 }
             }
             counter++;


### PR DESCRIPTION
These changes fix a reported issue where the wrong preset or playlist loads.

closes #13249

A working JAR can be downloaded here:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.wled/3.4.0-SNAPSHOT/org.openhab.binding.wled-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>