### PR TITLE
[benqprojector] Log invalid number when expecting numeric response from projector

### DIFF
--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
@@ -92,7 +92,12 @@ public class BenqProjectorDevice {
 
     protected int queryInt(String query) throws BenqProjectorCommandException, BenqProjectorException {
         String response = sendQuery(query);
-        return Integer.parseInt(response);
+        try {
+            return Integer.parseInt(response);
+        } catch (NumberFormatException nfe) {
+            throw new BenqProjectorCommandException(
+                    "Unable to parse response '" + response + "' as Integer for command: " + query);
+        }
     }
 
     protected String queryString(String query) throws BenqProjectorCommandException, BenqProjectorException {


### PR DESCRIPTION
Fixes very minor issue by catching the NumberFormatException that is thrown if queryInt() receives a non-numeric response from the projector. I have seen this very rarely, but when it occurs (due to noisy serial line, cosmic rays, buggy projector firmware, etc.) a warning is logged by updateChannelState(). With the change the NumberFormatException will be caught and logged to the debug log instead.