### PR TITLE
[epsonprojector] Log invalid number when expecting numeric response from projector

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -182,7 +182,7 @@ public class EpsonProjectorDevice {
             return Integer.parseInt(str, radix);
         } catch (NumberFormatException nfe) {
             throw new EpsonProjectorCommandException(
-                    "Unable to parse response '" + response + "' as Integer for command: " + query);
+                    "Unable to parse response '" + str + "' as Integer for command: " + query);
         }
     }
 

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -178,7 +178,12 @@ public class EpsonProjectorDevice {
             str = subStr[0];
         }
 
-        return Integer.parseInt(str, radix);
+        try {
+            return Integer.parseInt(str, radix);
+        } catch (NumberFormatException nfe) {
+            throw new EpsonProjectorCommandException(
+                    "Unable to parse response '" + response + "' as Integer for command: " + query);
+        }
     }
 
     protected int queryInt(String query, int timeout) throws EpsonProjectorCommandException, EpsonProjectorException {


### PR DESCRIPTION
Fixes same issue as #13549 but in the epsonprojector binding.