### PR TITLE
[homekit] improve bundle deactivation time

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/Debouncer.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/Debouncer.java
@@ -42,7 +42,7 @@ class Debouncer {
     private final Logger logger = LoggerFactory.getLogger(Debouncer.class);
 
     private volatile Long lastCallAttempt;
-    private ScheduledFuture<?> feature;
+    private ScheduledFuture<?> future;
 
     /**
      * Highly performant generic debouncer
@@ -76,14 +76,14 @@ class Debouncer {
         lastCallAttempt = clock.millis();
         calls.incrementAndGet();
         if (pending.compareAndSet(false, true)) {
-            feature = scheduler.schedule(this::tryActionOrPostpone, delayMs, TimeUnit.MILLISECONDS);
+            future = scheduler.schedule(this::tryActionOrPostpone, delayMs, TimeUnit.MILLISECONDS);
         }
     }
 
     public void stop() {
         logger.trace("stop debouncer");
-        if (feature != null) {
-            feature.cancel(true);
+        if (future != null) {
+            future.cancel(true);
             calls.set(0);
             pending.set(false);
         }
@@ -111,7 +111,7 @@ class Debouncer {
             // Note: we use Math.max as there's a _very_ small chance lastCallAttempt could advance in another thread,
             // and result in a negative calculation
             long delay = Math.max(1, lastCallAttempt - now + delayMs);
-            feature = scheduler.schedule(this::tryActionOrPostpone, delay, TimeUnit.MILLISECONDS);
+            future = scheduler.schedule(this::tryActionOrPostpone, delay, TimeUnit.MILLISECONDS);
         }
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -258,11 +258,6 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         accessoryRegistry.setBridge(bridge);
     }
 
-    public synchronized void unsetBridge() {
-        applyUpdatesDebouncer.stop();
-        accessoryRegistry.unsetBridge();
-    }
-
     public void setUpdater(HomekitAccessoryUpdater updater) {
         this.updater = updater;
     }
@@ -271,9 +266,11 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         this.settings = settings;
     }
 
-    public void stop() {
+    public synchronized void stop() {
         this.itemRegistry.removeRegistryChangeListener(this);
         this.metadataRegistry.removeRegistryChangeListener(metadataChangeListener);
+        applyUpdatesDebouncer.stop();
+        accessoryRegistry.unsetBridge();
     }
 
     public Map<String, HomekitAccessory> getAccessories() {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -257,12 +257,9 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
 
     private void stopHomekitServer() {
         logger.trace("stop HomeKit bridge");
-        for (int i = 0; i < homekitServers.size(); ++i) {
-            changeListeners.get(i).unsetBridge();
-            bridges.get(i).stop();
-            homekitServers.get(i).stop();
-            changeListeners.get(i).stop();
-        }
+        changeListeners.parallelStream().forEach(HomekitChangeListener::stop);
+        bridges.parallelStream().forEach(HomekitRoot::stop);
+        homekitServers.parallelStream().forEach(HomekitServer::stop);
         homekitServers.clear();
         bridges.clear();
         changeListeners.clear();


### PR DESCRIPTION
If you have many instances, it can take a while. So stop all the instances in parallel. Also, fix a race condition where the update debouncer might get called again after being stopped, because the change listener was deregistered _after_ the debouncer was stopped.


