### PR TITLE
[homekit] Improve output of console's `homekit show` command

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.console.Console;
 import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
@@ -25,6 +26,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.github.hapjava.services.Service;
 
 /**
  * Console commands for interacting with the HomeKit integration
@@ -119,6 +122,23 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
         });
     }
 
+    private void printService(Console console, Service service, int indent) {
+        console.println(StringUtils.repeat(' ', indent) + "Service Type: " + service.getClass().getSimpleName() + " ("
+                + service.getType() + ")");
+        console.println(StringUtils.repeat(' ', indent + 2) + "Characteristics:");
+        service.getCharacteristics().forEach((c) -> {
+            try {
+                console.println(StringUtils.repeat(' ', indent + 4) + c.getClass().getSimpleName() + ": "
+                        + c.toJson(0).get().toString());
+            } catch (InterruptedException | ExecutionException e) {
+            }
+        });
+        if (service.getLinkedServices().isEmpty())
+            return;
+        console.println(StringUtils.repeat(' ', indent + 2) + "Linked Services:");
+        service.getLinkedServices().forEach((s) -> printService(console, s, indent + 2));
+    }
+
     private void printAccessory(String id, Console console) {
         homekit.getAccessories().forEach(v -> {
             try {
@@ -126,11 +146,7 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
                         && (v.getName().get().toUpperCase().contains(id.toUpperCase())))) {
                     console.println(v.getId() + " " + v.getName().get());
                     console.println("Services:");
-                    v.getServices().forEach(s -> {
-                        console.println("    Service Type: " + s.getType());
-                        console.println("    Characteristics: ");
-                        s.getCharacteristics().forEach(c -> console.println("      : " + c.getClass()));
-                    });
+                    v.getServices().forEach(s -> printService(console, s, 2));
                     console.println("");
                 }
             } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
 * include the full JSON from all the characteristics, so you can confirm everything is configured correctly.
 * only use simple class names; the fully qualified package is just a distraction.
 * show linked services if they exist
 * include the class name of services, not just the GUID

