### PR TITLE
[jsscripting] Name timers created by polyfills

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -2,18 +2,19 @@
 (function (global) {
     'use strict';
 
-    //Append the script file name OR rule UID depending on which is available  
-    const defaultLoggerName = "org.openhab.automation.script" + (globalThis["javax.script.filename"] ? ".file." + globalThis["javax.script.filename"].replace(/^.*[\\\/]/, '') : globalThis["ruleUID"] ? ".ui." + globalThis["ruleUID"] : "");
+    // Append the script file name OR rule UID depending on which is available  
+    const defaultIdentifier = "org.openhab.automation.script" + (globalThis["javax.script.filename"] ? ".file." + globalThis["javax.script.filename"].replace(/^.*[\\\/]/, '') : globalThis["ruleUID"] ? ".ui." + globalThis["ruleUID"] : "");
+
     const System = Java.type('java.lang.System');
     const ScriptExecution = Java.type('org.openhab.core.model.script.actions.ScriptExecution');
     const ZonedDateTime = Java.type('java.time.ZonedDateTime');
     const formatRegExp = /%[sdj%]/g;
 
-    function createLogger(name = defaultLoggerName) {
+    function createLogger(name = defaultIdentifier) {
         return Java.type("org.slf4j.LoggerFactory").getLogger(name);
     }
 
-    //user configurable
+    // User configurable
     let log = createLogger();
 
     function stringify(value) {
@@ -82,6 +83,8 @@
 
     const counters = {};
     const timers = {};
+
+    // Polyfills for common NodeJS functions
 
     const console = {
         'assert': function (expression, message) {
@@ -160,7 +163,7 @@
             }
         },
 
-        //Allow user customizable logging names
+        // Allow user customizable logging names
         set loggerName(name) {
             log = createLogger(name);
             this._loggerName = name;
@@ -174,6 +177,7 @@
     function setTimeout(cb, delay) {
         const args = Array.prototype.slice.call(arguments, 2);
         return ScriptExecution.createTimerWithArgument(
+            defaultIdentifier + '.setTimeout',
             ZonedDateTime.now().plusNanos(delay * 1000000),
             args,
             function (args) {
@@ -192,6 +196,7 @@
         const args = Array.prototype.slice.call(arguments, 2);
         const delayNanos = delay * 1000000
         let timer = ScriptExecution.createTimerWithArgument(
+            defaultIdentifier + '.setInterval',
             ZonedDateTime.now().plusNanos(delayNanos),
             args,
             function (args) {
@@ -208,14 +213,14 @@
         clearTimeout(timer);
     }
 
-    //Polyfil common functions onto the global object
+    // Polyfill common NodeJS functions onto the global object
     globalThis.console = console;
     globalThis.setTimeout = setTimeout;
     globalThis.clearTimeout = clearTimeout;
     globalThis.setInterval = setInterval;
     globalThis.clearInterval = clearInterval;
 
-    //Support legacy NodeJS libraries 
+    // Support legacy NodeJS libraries 
     globalThis.global = globalThis;
     globalThis.process = { env: { NODE_ENV: '' } };
 })(this);


### PR DESCRIPTION
# Description

Name timers/scheduled jobs created by the `setTimeout` and `setInterval` polyfills after the ruleUID/filename + the function name.
This eases debugging of failed scheduled jobs/timers because you get some information from where the timer was created-

Fixes #13478.

# Testing

Building a kar bundle and installing it on my dev openHAB server, I added the following script in the UI:

```javascript
setTimeout(() => {
  console.log(info);
}, 500);
```

This script will fail as `info` is not defined, the log message:

```
2022-10-20 21:15:21.994 [WARN ] [ore.internal.scheduler.SchedulerImpl] - Scheduled job 'org.openhab.automation.script.ui.playground.setTimeout' failed and stopped
org.graalvm.polyglot.PolyglotException: ReferenceError: "info" is not defined
	at <js>.:=>(<eval>:2) ~[?:?]
	at <js>.:anonymous(/node_modules/@jsscripting-globals.js:184) ~[?:?]
	at com.oracle.truffle.polyglot.PolyglotFunctionProxyHandler.invoke(PolyglotFunctionProxyHandler.java:154) ~[?:?]
	at com.sun.proxy.$Proxy146.apply(Unknown Source) ~[?:?]
	at org.openhab.core.model.script.actions.ScriptExecution.lambda$1(ScriptExecution.java:130) ~[?:?]
	at org.openhab.core.internal.scheduler.SchedulerImpl.lambda$12(SchedulerImpl.java:191) ~[?:?]
	at org.openhab.core.internal.scheduler.SchedulerImpl.lambda$1(SchedulerImpl.java:88) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

Note that the failed scheduled job jas a name.

For those who want to try it out themselves:
1. Link to the build kar: https://1drv.ms/u/s!Al8cKKxosMjV7lBRjyUuHwWUcHIn?e=LUF4zK
2. Place it in the addons folder of your openHAB
3. Log into your openHAB console, and use `bundle:list org.openhab.automation.jsscripting` to check for the available bundles
4. Stop all listed bundles and enable the one with version `3.4.0.202210201809`

@rkoshak 
This should make debugging of failed timers a little bit easier as you know from where they were created.