### PR TITLE
[hue] Reinitialize bridge properties after configuration change

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -692,6 +692,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             localServiceRegistration.unregister();
             serviceRegistration = null;
         }
+        propertiesInitializedSuccessfully = false;
     }
 
     @Override


### PR DESCRIPTION
After saving bridge configuration and reinitializing the bridge, all dynamic properties (serial number, firmware version etc.) were lost:
![image](https://user-images.githubusercontent.com/19519842/197410245-8a6faf69-0199-426c-891e-9b24779d6727.png)

Related to #13586