### PR TITLE
[meater] Add console extension for showing IDs

### DIFF
--- a/bundles/org.openhab.binding.meater/README.md
+++ b/bundles/org.openhab.binding.meater/README.md
@@ -18,14 +18,18 @@ This binding supports the following thing types:
 
 ## Discovery
 
-The preferred way of adding MEATER probe(s) since the probe IDs are not easily found.
+The binding supports auto-discovery of all MEATER probe(s) belonging to the configured cloud API account.
 
 **NOTE**: For The Original MEATER and MEATER Plus you need to have your MEATER app running and the MEATER probe(s) must connected to the cloud (out of the charger box) before you start the discovery.
 
-
 After the configuration of the Bridge, you need to perform a manual scan and then your MEATER probe(s) will be automatically discovered and placed as a thing(s) in the inbox.
 
+## Thing Configuration
 
+When manually configuring the probes, the console command `openhab:meater showIds` can be used to identify the IDs of all connected probes.
+Since the probes are unnamed, they can be hard to identify.
+For this reason, the ambient temperature is included in the list.
+This might help isolating an individual probe.
 
 ## Supported Things and Channels
 

--- a/bundles/org.openhab.binding.meater/README.md
+++ b/bundles/org.openhab.binding.meater/README.md
@@ -18,7 +18,7 @@ This binding supports the following thing types:
 
 ## Discovery
 
-The binding supports auto-discovery of all MEATER probe(s) belonging to the configured cloud API account.
+The binding supports auto-discovery of all MEATER probes belonging to the configured cloud API account.
 
 **NOTE**: For The Original MEATER and MEATER Plus you need to have your MEATER app running and the MEATER probe(s) must connected to the cloud (out of the charger box) before you start the discovery.
 

--- a/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/MeaterBindingConstants.java
+++ b/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/MeaterBindingConstants.java
@@ -26,7 +26,7 @@ import org.openhab.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class MeaterBindingConstants {
 
-    private static final String BINDING_ID = "meater";
+    public static final String BINDING_ID = "meater";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_MEATER_PROBE = new ThingTypeUID(BINDING_ID, "meaterprobe");

--- a/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/console/MeaterCommandExtension.java
+++ b/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/console/MeaterCommandExtension.java
@@ -16,9 +16,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.meater.internal.MeaterBindingConstants;
 import org.openhab.binding.meater.internal.handler.MeaterBridgeHandler;
 import org.openhab.core.io.console.Console;
+import org.openhab.core.io.console.ConsoleCommandCompleter;
+import org.openhab.core.io.console.StringsCompleter;
 import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
 import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
 import org.openhab.core.thing.Thing;
@@ -35,9 +38,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @NonNullByDefault
 @Component(service = ConsoleCommandExtension.class)
-public class MeaterCommandExtension extends AbstractConsoleCommandExtension {
+public class MeaterCommandExtension extends AbstractConsoleCommandExtension implements ConsoleCommandCompleter {
 
     private static final String SHOW_IDS = "showIds";
+    private static final StringsCompleter SUBCMD_COMPLETER = new StringsCompleter(List.of(SHOW_IDS), false);
 
     private final ThingRegistry thingRegistry;
 
@@ -69,5 +73,18 @@ public class MeaterCommandExtension extends AbstractConsoleCommandExtension {
     @Override
     public List<String> getUsages() {
         return Arrays.asList(buildCommandUsage(SHOW_IDS, "list all probes"));
+    }
+
+    @Override
+    public @Nullable ConsoleCommandCompleter getCompleter() {
+        return this;
+    }
+
+    @Override
+    public boolean complete(String[] args, int cursorArgumentIndex, int cursorPosition, List<String> candidates) {
+        if (cursorArgumentIndex <= 0) {
+            return SUBCMD_COMPLETER.complete(args, cursorArgumentIndex, cursorPosition, candidates);
+        }
+        return false;
     }
 }

--- a/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/console/MeaterCommandExtension.java
+++ b/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/console/MeaterCommandExtension.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.meater.internal.console;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.meater.internal.MeaterBindingConstants;
+import org.openhab.binding.meater.internal.handler.MeaterBridgeHandler;
+import org.openhab.core.io.console.Console;
+import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
+import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link MeaterCommandExtension} is responsible for handling console commands
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = ConsoleCommandExtension.class)
+public class MeaterCommandExtension extends AbstractConsoleCommandExtension {
+
+    private static final String SHOW_IDS = "showIds";
+
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public MeaterCommandExtension(final @Reference ThingRegistry thingRegistry) {
+        super(MeaterBindingConstants.BINDING_ID, "Interact with the Meater binding.");
+        this.thingRegistry = thingRegistry;
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if (args.length != 1 || !SHOW_IDS.equals(args[0])) {
+            printUsage(console);
+            return;
+        }
+
+        for (Thing thing : thingRegistry.getAll()) {
+            ThingHandler thingHandler = thing.getHandler();
+            if (thingHandler instanceof MeaterBridgeHandler) {
+                console.println("API bridge: " + thing.getLabel());
+                ((MeaterBridgeHandler) thingHandler).getMeaterThings().entrySet().stream().forEach(t -> {
+                    console.println("    - ID: " + t.getKey() + " (ambient temperature: "
+                            + t.getValue().temperature.ambient + ")");
+                });
+            }
+        }
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return Arrays.asList(buildCommandUsage(SHOW_IDS, "list all probes"));
+    }
+}


### PR DESCRIPTION
Example session:
```
openhab> openhab:meater showIds
API bridge: MEATER Cloud REST API
    - ID: aaa (ambient temperature: 22.1)
    - ID: bbb (ambient temperature: 22.1)
    - ID: ccc (ambient temperature: 21.9)
    - ID: ddd (ambient temperature: 21.9)
```

Fixes #13599
Depends on openhab/openhab-core#3111