### PR TITLE
[mqtt] set the proper unit in the state description

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -149,6 +149,11 @@ public class NumberValue extends Value {
         if (min != null) {
             builder = builder.withMinimum(min);
         }
-        return builder.withStep(step).withPattern("%s %unit%");
+        if (!unit.equals(Units.ONE)) {
+            builder.withPattern("%s " + unit);
+        } else {
+            builder.withPattern("%s %unit%");
+        }
+        return builder.withStep(step);
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SensorTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SensorTests.java
@@ -75,7 +75,7 @@ public class SensorTests extends AbstractComponentTests {
         publishMessage("zigbee2mqtt/sensor/state", "20");
         assertState(component, Sensor.SENSOR_CHANNEL_ID, new QuantityType<>(20, Units.WATT));
         assertThat(component.getChannel(Sensor.SENSOR_CHANNEL_ID).getState().getCache().createStateDescription(true)
-                .build().getPattern(), is("%s %unit%"));
+                .build().getPattern(), is("%s W"));
 
         waitForAssert(() -> assertState(component, Sensor.SENSOR_CHANNEL_ID, UnDefType.UNDEF), 5000, 200);
 


### PR DESCRIPTION
So that other pieces of openhab can know what unit it's going to be, without it having a value yet. Importantly, any necessary conversion that need to be applied to the other portion of the state description - min, max, and step.

