### PR TITLE
[ipcamera] Fix multiple WARNs when HIK camera does not support alarm inputs

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -422,5 +422,4 @@ public class HikvisionHandler extends ChannelDuplexHandler {
                 return;
         }
     }
-
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -15,7 +15,6 @@ package org.openhab.binding.ipcamera.internal;
 import static org.openhab.binding.ipcamera.internal.IpCameraBindingConstants.*;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -424,11 +423,4 @@ public class HikvisionHandler extends ChannelDuplexHandler {
         }
     }
 
-    // If a camera does not need to poll a request as often as snapshots, it can be
-    // added here. Binding steps through the list.
-    public ArrayList<String> getLowPriorityRequests() {
-        ArrayList<String> lowPriorityRequests = new ArrayList<String>(1);
-        lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + nvrChannel + "/status"); // must stay in element 0.
-        return lowPriorityRequests;
-    }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1270,9 +1270,6 @@ public class IpCameraHandler extends BaseThingHandler {
             case HIKVISION_THING:
                 HikvisionHandler hikvisionHandler = new HikvisionHandler(getHandle(), cameraConfig.getNvrChannel());
                 hikvisionHandler.handleCommand(channelUID, command);
-                if (lowPriorityRequests.isEmpty()) {
-                    lowPriorityRequests = hikvisionHandler.getLowPriorityRequests();
-                }
                 break;
             case FOSCAM_THING:
                 FoscamHandler foscamHandler = new FoscamHandler(getHandle(), cameraConfig.getUser(),
@@ -1631,6 +1628,9 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (snapshotUri.isEmpty()) {
                     snapshotUri = "/ISAPI/Streaming/channels/" + cameraConfig.getNvrChannel() + "01/picture";
                 }
+                ArrayList<String> lowPriorityRequests = new ArrayList<String>(1);
+                lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
+                this.lowPriorityRequests = lowPriorityRequests;
                 break;
             case INSTAR_THING:
                 if (snapshotUri.isEmpty()) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1628,9 +1628,9 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (snapshotUri.isEmpty()) {
                     snapshotUri = "/ISAPI/Streaming/channels/" + cameraConfig.getNvrChannel() + "01/picture";
                 }
-                ArrayList<String> lowPriorityRequests = new ArrayList<String>(1);
-                lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
-                this.lowPriorityRequests = lowPriorityRequests;
+                if (lowPriorityRequests.isEmpty()) {
+                    lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
+                }
                 break;
             case INSTAR_THING:
                 if (snapshotUri.isEmpty()) {


### PR DESCRIPTION
This fixes a bug reported on the forum here:
https://community.openhab.org/t/ipcamera-new-ip-camera-binding/42771/2796

It was caused by the lowPriorityRequests having only 1 element. When the camera did not support any alarm inputs (common for a camera to have none) the binding would remove the request, then later on as lowPriorityRequests was empty it would fetch the list again which added it back in. This caused an endless WARN messages in the logs.

Jar can be downloaded from:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/3.4.0-SNAPSHOT/org.openhab.binding.ipcamera-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>