### PR TITLE
[hdpowerview] Add console extension for showing IDs

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -53,8 +53,8 @@ If in the future, you add additional shades, repeaters, scenes, scene groups or 
 ### Thing Configuration for PowerView Shades and Accessories
 
 PowerView shades and repeaters should preferably be configured via the automatic discovery process.
-It is quite difficult to configure manually as the `id` of the shade or repeater is not exposed in the
-PowerView app. However, the configuration parameters are described below.
+However, for manual configuration of shades and repeaters, the console command `openhab:hdpowerview showIds` can be used to identify the IDs of all connected equipment.
+This can be used for the `id` parameters described below.
 
 #### Thing Configuration for PowerView Shades
 
@@ -103,6 +103,7 @@ All of these channels appear in the binding, but only those which have a physica
 | repeaterRssi   | Number:Power             | Received Signal Strength Indicator for Repeater |
 
 Notes:
+
 - The channels `position`, `secondary` and `vane` exist if the shade physically supports such channels.
 - The shade's Power Option is set via the PowerView app with possible values 'Battery Wand', 'Rechargeable Battery Wand' or 'Hardwired Power Supply'.
 The channels `lowBattery` and `batteryLevel` exist if you have _not_ selected 'Hardwired Power Supply' in the app.

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/console/HDPowerViewCommandExtension.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/console/HDPowerViewCommandExtension.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.console;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hdpowerview.internal.HDPowerViewBindingConstants;
+import org.openhab.binding.hdpowerview.internal.HDPowerViewWebTargets;
+import org.openhab.binding.hdpowerview.internal.api.responses.RepeaterData;
+import org.openhab.binding.hdpowerview.internal.api.responses.Shades.ShadeData;
+import org.openhab.binding.hdpowerview.internal.exceptions.HubException;
+import org.openhab.binding.hdpowerview.internal.handler.HDPowerViewHubHandler;
+import org.openhab.core.io.console.Console;
+import org.openhab.core.io.console.ConsoleCommandCompleter;
+import org.openhab.core.io.console.StringsCompleter;
+import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
+import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link HDPowerViewCommandExtension} is responsible for handling console commands
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = ConsoleCommandExtension.class)
+public class HDPowerViewCommandExtension extends AbstractConsoleCommandExtension implements ConsoleCommandCompleter {
+
+    private static final String SHOW_IDS = "showIds";
+    private static final StringsCompleter SUBCMD_COMPLETER = new StringsCompleter(List.of(SHOW_IDS), false);
+
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public HDPowerViewCommandExtension(final @Reference ThingRegistry thingRegistry) {
+        super(HDPowerViewBindingConstants.BINDING_ID, "Interact with the Hunter Douglas PowerView binding.");
+        this.thingRegistry = thingRegistry;
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if (args.length != 1 || !SHOW_IDS.equals(args[0])) {
+            printUsage(console);
+            return;
+        }
+
+        for (Thing thing : thingRegistry.getAll()) {
+            ThingHandler thingHandler = thing.getHandler();
+            if (thingHandler instanceof HDPowerViewHubHandler) {
+                console.println("API bridge: " + thing.getLabel());
+                HDPowerViewWebTargets webTargets = ((HDPowerViewHubHandler) thingHandler).getWebTargets();
+
+                try {
+                    List<ShadeData> shades = webTargets.getShades().shadeData;
+                    if (shades != null) {
+                        console.println(" - Shades:");
+                        for (ShadeData shade : shades) {
+                            console.println("    - ID: " + shade.id + " (" + shade.getName() + ")");
+                        }
+                    }
+
+                    List<RepeaterData> repeaters = webTargets.getRepeaters().repeaterData;
+                    if (repeaters != null) {
+                        console.println(" - Repeaters:");
+                        for (RepeaterData repeater : repeaters) {
+                            console.println("    - ID: " + repeater.id + " (" + repeater.getName() + ")");
+                        }
+                    }
+                } catch (HubException e) {
+                    console.println("Error retrieving ID's: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return Arrays.asList(buildCommandUsage(SHOW_IDS, "list all shades and repeaters"));
+    }
+
+    @Override
+    public @Nullable ConsoleCommandCompleter getCompleter() {
+        return this;
+    }
+
+    @Override
+    public boolean complete(String[] args, int cursorArgumentIndex, int cursorPosition, List<String> candidates) {
+        if (cursorArgumentIndex <= 0) {
+            return SUBCMD_COMPLETER.complete(args, cursorArgumentIndex, cursorPosition, candidates);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Example session:
```
openhab> openhab:hdpowerview showIds
API bridge: PowerView Hub
 - Shades:
    - ID: 23137 (Gardin 7)
    - ID: 24076 (Gardin 10)
    - ID: 32544 (Gardin 6)
    - ID: 58120 (Gardin 2)
    - ID: 34896 (Gardin 5)
    - ID: 5868 (Gardin 8)
    - ID: 38196 (Gardin 1)
    - ID: 46532 (Gardin 3)
    - ID: 42949 (Gardin 4)
    - ID: 36137 (Gardin 11)
    - ID: 24927 (Gardin 9)
 - Repeaters:
    - ID: 17805 (Repeater soveværelse)
```

Fixes #13614
Depends on openhab/openhab-core#3111