### PR TITLE
[jsscripting] Reimplement timer polyfills to conform standard JS

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscripting.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openhab.automation.jsscripting.internal.threading.ThreadsafeTimers;
+
+/**
+ * Abstraction layer to collect all features injected into the JS runtime during the context creation.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+public class JSRuntimeFeatures {
+    /**
+     * All elements of this Map are injected into the JS runtime using their key as the name.
+     */
+    private final Map<String, Object> features = new HashMap<>();
+    private final Object lock;
+    public final ThreadsafeTimers threadsafeTimers;
+
+    JSRuntimeFeatures(Object lock) {
+        this.lock = lock;
+        this.threadsafeTimers = new ThreadsafeTimers(lock);
+
+        features.put("ThreadsafeTimers", threadsafeTimers);
+    }
+
+    /**
+     * Get the features that are to be injected into the JS runtime during context creation.
+     * 
+     * @return the runtime features
+     */
+    public Map<String, Object> getFeatures() {
+        return features;
+    }
+
+    /**
+     * Un-initialization hook, called when the engine is closed.
+     * Use this method to clean up resources or cancel operations that were created by the JS runtime.
+     */
+    public void close() {
+        threadsafeTimers.clearAll();
+    }
+}

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
@@ -15,6 +15,7 @@ package org.openhab.automation.jsscripting.internal;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.automation.jsscripting.internal.threading.ThreadsafeTimers;
 
 /**
@@ -22,16 +23,15 @@ import org.openhab.automation.jsscripting.internal.threading.ThreadsafeTimers;
  *
  * @author Florian Hotze - Initial contribution
  */
+@NonNullByDefault
 public class JSRuntimeFeatures {
     /**
      * All elements of this Map are injected into the JS runtime using their key as the name.
      */
     private final Map<String, Object> features = new HashMap<>();
-    private final Object lock;
     public final ThreadsafeTimers threadsafeTimers;
 
     JSRuntimeFeatures(Object lock) {
-        this.lock = lock;
         this.threadsafeTimers = new ThreadsafeTimers(lock);
 
         features.put("ThreadsafeTimers", threadsafeTimers);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -69,6 +69,8 @@ public class OpenhabGraalJSScriptEngine
     // final CommonJS search path for our library
     private static final Path NODE_DIR = Paths.get("node_modules");
 
+    // shared lock object for synchronization of multi-thread access
+    public final Object lock = new Object();
     private final JSRuntimeFeatures jsRuntimeFeatures = new JSRuntimeFeatures(lock);
 
     // these fields start as null because they are populated on first use
@@ -216,6 +218,14 @@ public class OpenhabGraalJSScriptEngine
             eval(globalScript);
         } catch (ScriptException e) {
             LOGGER.error("Could not inject global script", e);
+        }
+    }
+
+    @Override
+    public Object invokeFunction(String s, Object... objects) throws ScriptException, NoSuchMethodException {
+        // Synchronize multi-thread access to avoid exceptions when reloading a script file while the script is running
+        synchronized (lock) {
+            return super.invokeFunction(s, objects);
         }
     }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -69,8 +69,7 @@ public class OpenhabGraalJSScriptEngine
     // final CommonJS search path for our library
     private static final Path NODE_DIR = Paths.get("node_modules");
 
-    // shared lock object for synchronization of multi-thread access
-    private final Object lock = new Object();
+    private final ThreadsafeTimers threadsafeTimers = new ThreadsafeTimers(lock);
 
     // these fields start as null because they are populated on first use
     private String engineIdentifier;
@@ -209,7 +208,7 @@ public class OpenhabGraalJSScriptEngine
         delegate.getBindings(ScriptContext.ENGINE_SCOPE).put(REQUIRE_WRAPPER_NAME, wrapRequireFn);
         // Injections into the JS runtime
         delegate.put("require", wrapRequireFn.apply((Function<Object[], Object>) delegate.get("require")));
-        delegate.put("ThreadsafeTimers", new ThreadsafeTimers(lock));
+        delegate.put("ThreadsafeTimers", threadsafeTimers);
 
         initialized = true;
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -57,8 +57,8 @@ import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
  *
  * @author Jonathan Gilbert - Initial contribution
  * @author Dan Cunningham - Script injections
- * @author Florian Hotze - Create lock object for multi-thread synchronization
- * @author Florian Hotze - Inject the {@link JSRuntimeFeatures} into the JS context
+ * @author Florian Hotze - Create lock object for multi-thread synchronization; Inject the {@link JSRuntimeFeatures}
+ *         into the JS context
  */
 public class OpenhabGraalJSScriptEngine
         extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<GraalJSScriptEngine> {

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -70,7 +70,7 @@ public class OpenhabGraalJSScriptEngine
     private static final Path NODE_DIR = Paths.get("node_modules");
 
     // shared lock object for synchronization of multi-thread access
-    public final Object lock = new Object();
+    private final Object lock = new Object();
     private final JSRuntimeFeatures jsRuntimeFeatures = new JSRuntimeFeatures(lock);
 
     // these fields start as null because they are populated on first use

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -219,6 +219,11 @@ public class OpenhabGraalJSScriptEngine
         }
     }
 
+    @Override
+    public void close() {
+        threadsafeTimers.clearAll();
+    }
+
     /**
      * Tests if this is a root node directory, `/node_modules`, `C:\node_modules`, etc...
      *

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
@@ -27,9 +27,13 @@ import javax.script.ScriptException;
  *
  * @param <T> The delegate class
  * @author Jonathan Gilbert - Initial contribution
+ * @author Florian Hotze - Synchronize multi-thread access to invokeFunction using a lock object
  */
 public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<T extends ScriptEngine & Invocable & AutoCloseable>
         extends DelegatingScriptEngineWithInvocableAndAutocloseable<T> {
+
+    // shared lock object for synchronization of multi-thread access
+    public final Object lock = new Object();
 
     public InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable(T delegate) {
         super(delegate);
@@ -115,8 +119,11 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
     @Override
     public Object invokeFunction(String s, Object... objects) throws ScriptException, NoSuchMethodException {
         try {
-            beforeInvocation();
-            return super.invokeFunction(s, objects);
+            // Synchronize multi-thread access to avoid exceptions when reloading a script file while the script is running
+            synchronized (lock) {
+                beforeInvocation();
+                return super.invokeFunction(s, objects);
+            }
         } catch (ScriptException se) {
             throw afterThrowsInvocation(se);
         }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
@@ -119,7 +119,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
     @Override
     public Object invokeFunction(String s, Object... objects) throws ScriptException, NoSuchMethodException {
         try {
-            // Synchronize multi-thread access to avoid exceptions when reloading a script file while the script is running
+            // Synchronize multi-thread access to avoid exceptions when reloading a script file while the script is
+            // running
             synchronized (lock) {
                 beforeInvocation();
                 return super.invokeFunction(s, objects);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
@@ -27,13 +27,9 @@ import javax.script.ScriptException;
  *
  * @param <T> The delegate class
  * @author Jonathan Gilbert - Initial contribution
- * @author Florian Hotze - Synchronize multi-thread access to invokeFunction using a lock object
  */
 public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<T extends ScriptEngine & Invocable & AutoCloseable>
         extends DelegatingScriptEngineWithInvocableAndAutocloseable<T> {
-
-    // shared lock object for synchronization of multi-thread access
-    public final Object lock = new Object();
 
     public InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable(T delegate) {
         super(delegate);
@@ -119,12 +115,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
     @Override
     public Object invokeFunction(String s, Object... objects) throws ScriptException, NoSuchMethodException {
         try {
-            // Synchronize multi-thread access to avoid exceptions when reloading a script file while the script is
-            // running
-            synchronized (lock) {
-                beforeInvocation();
-                return super.invokeFunction(s, objects);
-            }
+            beforeInvocation();
+            return super.invokeFunction(s, objects);
         } catch (ScriptException se) {
             throw afterThrowsInvocation(se);
         }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -13,125 +13,92 @@
 package org.openhab.automation.jsscripting.internal.threading;
 
 import java.time.ZonedDateTime;
-import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.model.script.ScriptServiceUtil;
-import org.openhab.core.model.script.actions.Timer;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
 import org.openhab.core.scheduler.Scheduler;
-import org.openhab.core.scheduler.SchedulerRunnable;
 
 /**
  * A replacement for the timer functionality of {@link org.openhab.core.model.script.actions.ScriptExecution
  * ScriptExecution} which controls multithreaded execution access to the single-threaded GraalJS contexts.
  *
  * @author Florian Hotze - Initial contribution
+ * @author Florian Hotze - Reimplementation to conform standard JS setTimeout and setInterval
  */
 public class ThreadsafeTimers {
     private final Object lock;
+    private final Scheduler scheduler;
+    // Mapping of positive, non-zero integer values (used as timeoutID or intervalID) and the Scheduler
+    private final HashMap<Integer, ScheduledCompletableFuture<Object>> idSchedulerMapping = new HashMap<>();
 
     public ThreadsafeTimers(Object lock) {
         this.lock = lock;
+        this.scheduler = ScriptServiceUtil.getScheduler();
     }
 
-    public Timer createTimer(ZonedDateTime instant, Runnable callable) {
-        return createTimer(null, instant, callable);
-    }
-
-    public Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable callable) {
-        Scheduler scheduler = ScriptServiceUtil.getScheduler();
-
-        return new TimerImpl(scheduler, instant, () -> {
+    private ScheduledCompletableFuture<Object> createFuture(ZonedDateTime zdt, Runnable callback) {
+        return scheduler.schedule(() -> {
             synchronized (lock) {
-                callable.run();
+                callback.run();
             }
-
-        }, identifier);
+        }, zdt.toInstant());
     }
 
-    public Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Runnable callable) {
-        return createTimerWithArgument(null, instant, arg1, callable);
+    private Integer createNewId() {
+        Integer id = idSchedulerMapping.size() + 1;
+        while (idSchedulerMapping.get(id) != null)
+            id++;
+        return id;
     }
 
-    public Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
-            Runnable callable) {
-        Scheduler scheduler = ScriptServiceUtil.getScheduler();
-        return new TimerImpl(scheduler, instant, () -> {
+    public Integer setTimeout(Runnable callback, Long delay) {
+        return setTimeout(callback, delay, null);
+    }
+
+    public Integer setTimeout(Runnable callback, Long delay, Object... args) {
+        Integer id = createNewId();
+        ScheduledCompletableFuture<Object> future = createFuture(ZonedDateTime.now().plusNanos(delay * 1000000),
+                callback);
+        idSchedulerMapping.put(id, future);
+        return id;
+    }
+
+    public void clearTimeout(Integer id) {
+        ScheduledCompletableFuture<Object> scheduled = idSchedulerMapping.get(id);
+        scheduled.cancel(true);
+        idSchedulerMapping.remove(id);
+    }
+
+    private void createLoopingFuture(Integer id, Long delay, Runnable callback) {
+        ScheduledCompletableFuture<Object> future = scheduler.schedule(() -> {
             synchronized (lock) {
-                callable.run();
+                callback.run();
+                if (idSchedulerMapping.get(id) != null)
+                    createLoopingFuture(id, delay, callback);
             }
-
-        }, identifier);
+        }, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
+        idSchedulerMapping.put(id, future);
     }
 
-    /**
-     * This is an implementation of the {@link Timer} interface.
-     * Copy of {@link org.openhab.core.model.script.internal.actions.TimerImpl} as this is not accessible from outside
-     * the
-     * package.
-     *
-     * @author Kai Kreuzer - Initial contribution
-     */
-    @NonNullByDefault
-    public static class TimerImpl implements Timer {
+    public Integer setInterval(Runnable callback, Long delay) {
+        return setInterval(callback, delay, null);
+    }
 
-        private final Scheduler scheduler;
-        private final ZonedDateTime startTime;
-        private final SchedulerRunnable runnable;
-        private final @Nullable String identifier;
-        private ScheduledCompletableFuture<?> future;
+    public Integer setInterval(Runnable callback, Long delay, Object... args) {
+        Integer id = createNewId();
+        createLoopingFuture(id, delay, callback);
+        return id;
+    }
 
-        public TimerImpl(Scheduler scheduler, ZonedDateTime startTime, SchedulerRunnable runnable) {
-            this(scheduler, startTime, runnable, null);
-        }
+    public void clearInterval(Integer id) {
+        clearTimeout(id);
+    }
 
-        public TimerImpl(Scheduler scheduler, ZonedDateTime startTime, SchedulerRunnable runnable,
-                @Nullable String identifier) {
-            this.scheduler = scheduler;
-            this.startTime = startTime;
-            this.runnable = runnable;
-            this.identifier = identifier;
-
-            future = scheduler.schedule(runnable, identifier, startTime.toInstant());
-        }
-
-        @Override
-        public boolean cancel() {
-            return future.cancel(true);
-        }
-
-        @Override
-        public synchronized boolean reschedule(ZonedDateTime newTime) {
-            future.cancel(false);
-            future = scheduler.schedule(runnable, identifier, newTime.toInstant());
-            return true;
-        }
-
-        @Override
-        public @Nullable ZonedDateTime getExecutionTime() {
-            return future.isCancelled() ? null : ZonedDateTime.now().plusNanos(future.getDelay(TimeUnit.NANOSECONDS));
-        }
-
-        @Override
-        public boolean isActive() {
-            return !future.isDone();
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return future.isCancelled();
-        }
-
-        @Override
-        public boolean isRunning() {
-            return isActive() && ZonedDateTime.now().isAfter(startTime);
-        }
-
-        @Override
-        public boolean hasTerminated() {
-            return future.isDone();
-        }
+    public void cancelAll() {
+        idSchedulerMapping.forEach((id, future) -> {
+            future.cancel(true);
+        });
+        idSchedulerMapping.clear();
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -31,7 +31,7 @@ public class ThreadsafeTimers {
     private final Scheduler scheduler;
     // Mapping of positive, non-zero integer values (used as timeoutID or intervalID) and the Scheduler
     private final HashMap<Integer, ScheduledCompletableFuture<Object>> idSchedulerMapping = new HashMap<>();
-    private String identifier = "noIdentifier.timerId.";
+    private String identifier = "noIdentifier";
 
     public ThreadsafeTimers(Object lock) {
         this.lock = lock;
@@ -44,7 +44,7 @@ public class ThreadsafeTimers {
      * @param identifier identifier to use
      */
     public void setIdentifier(String identifier) {
-        this.identifier = identifier + ".timerId.";
+        this.identifier = identifier;
     }
 
     /**
@@ -72,7 +72,7 @@ public class ThreadsafeTimers {
             synchronized (lock) {
                 callback.run();
             }
-        }, identifier + id.toString(), zdt.toInstant());
+        }, identifier + ".setTimeout." + id, zdt.toInstant());
     }
 
     /**
@@ -133,7 +133,7 @@ public class ThreadsafeTimers {
                 if (idSchedulerMapping.get(id) != null)
                     createLoopingFuture(id, delay, callback);
             }
-        }, identifier + id, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
+        }, identifier + ".setInterval." + id, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
         idSchedulerMapping.put(id, future);
     }
 
@@ -178,7 +178,7 @@ public class ThreadsafeTimers {
         clearTimeout(intervalID);
     }
 
-    public void cancelAll() {
+    public void clearAll() {
         idSchedulerMapping.forEach((id, future) -> {
             future.cancel(true);
         });

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -20,8 +20,8 @@ import org.openhab.core.scheduler.ScheduledCompletableFuture;
 import org.openhab.core.scheduler.Scheduler;
 
 /**
- * A replacement for the timer functionality of {@link org.openhab.core.model.script.actions.ScriptExecution
- * ScriptExecution} which controls multithreaded execution access to the single-threaded GraalJS contexts.
+ * A polyfill implementation of NodeJS timer functionality (<code>setTimeout()</code>, <code>setInterval()</code> and
+ * the cancel methods) which controls multithreaded execution access to the single-threaded GraalJS contexts.
  *
  * @author Florian Hotze - Initial contribution
  * @author Florian Hotze - Reimplementation to conform standard JS setTimeout and setInterval
@@ -72,7 +72,7 @@ public class ThreadsafeTimers {
             synchronized (lock) {
                 callback.run();
             }
-        }, identifier + id, zdt.toInstant());
+        }, identifier + id.toString(), zdt.toInstant());
     }
 
     /**
@@ -81,7 +81,8 @@ public class ThreadsafeTimers {
      *
      * @param callback function to run after the given delay
      * @param delay time in milliseconds that the timer should wait before the callback is executed
-     * @return Positive integer value which identifies the timer created; this value can be passed to <code>clearTimeout()</code> to cancel the timeout.
+     * @return Positive integer value which identifies the timer created; this value can be passed to
+     *         <code>clearTimeout()</code> to cancel the timeout.
      */
     public Integer setTimeout(Runnable callback, Long delay) {
         return setTimeout(callback, delay, new Object());
@@ -94,7 +95,8 @@ public class ThreadsafeTimers {
      * @param callback function to run after the given delay
      * @param delay time in milliseconds that the timer should wait before the callback is executed
      * @param args
-     * @return Positive integer value which identifies the timer created; this value can be passed to <code>clearTimeout()</code> to cancel the timeout.
+     * @return Positive integer value which identifies the timer created; this value can be passed to
+     *         <code>clearTimeout()</code> to cancel the timeout.
      */
     public Integer setTimeout(Runnable callback, Long delay, Object... args) {
         Integer id = createNewId();
@@ -108,7 +110,8 @@ public class ThreadsafeTimers {
      * <a href="https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout"><code>clearTimeout()</code></a> polyfill.
      * Cancels a timeout previously created by <code>setTimeout()</code>.
      *
-     * @param timeoutId The identifier of the timeout you want to cancel. This ID was returned by the corresponding call to setTimeout().
+     * @param timeoutId The identifier of the timeout you want to cancel. This ID was returned by the corresponding call
+     *            to setTimeout().
      */
     public void clearTimeout(Integer timeoutId) {
         ScheduledCompletableFuture<Object> scheduled = idSchedulerMapping.get(timeoutId);
@@ -140,7 +143,8 @@ public class ThreadsafeTimers {
      *
      * @param callback function to run
      * @param delay time in milliseconds that the timer should delay in between executions of the callback
-     * @return Numeric, non-zero value which identifies the timer created; this value can be passed to <code>clearInterval()</code> to cancel the interval.
+     * @return Numeric, non-zero value which identifies the timer created; this value can be passed to
+     *         <code>clearInterval()</code> to cancel the interval.
      */
     public Integer setInterval(Runnable callback, Long delay) {
         return setInterval(callback, delay, new Object());
@@ -153,7 +157,8 @@ public class ThreadsafeTimers {
      * @param callback function to run
      * @param delay time in milliseconds that the timer should delay in between executions of the callback
      * @param args
-     * @return Numeric, non-zero value which identifies the timer created; this value can be passed to <code>clearInterval()</code> to cancel the interval.
+     * @return Numeric, non-zero value which identifies the timer created; this value can be passed to
+     *         <code>clearInterval()</code> to cancel the interval.
      */
     public Integer setInterval(Runnable callback, Long delay, Object... args) {
         Integer id = createNewId();
@@ -162,10 +167,12 @@ public class ThreadsafeTimers {
     }
 
     /**
-     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/clearInterval"><code>clearInterval()</code></a> polyfill.
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/clearInterval"><code>clearInterval()</code></a>
+     * polyfill.
      * Cancels a timed, repeating action which was previously established by a call to <code>setInterval()</code>.
      *
-     * @param intervalID The identifier of the repeated action you want to cancel. This ID was returned by the corresponding call to <code>setInterval()</code>.
+     * @param intervalID The identifier of the repeated action you want to cancel. This ID was returned by the
+     *            corresponding call to <code>setInterval()</code>.
      */
     public void clearInterval(Integer intervalID) {
         clearTimeout(intervalID);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -38,10 +38,35 @@ public class ThreadsafeTimers {
         this.scheduler = ScriptServiceUtil.getScheduler();
     }
 
+    /**
+     * Set the identifier base string used for naming scheduled jobs.
+     *
+     * @param identifier identifier to use
+     */
     public void setIdentifier(String identifier) {
         this.identifier = identifier + ".timerId.";
     }
 
+    /**
+     * Creates a new and unused timerId.
+     *
+     * @return an unused timerId
+     */
+    private Integer createNewId() {
+        Integer id = idSchedulerMapping.size() + 1;
+        while (idSchedulerMapping.get(id) != null)
+            id++;
+        return id;
+    }
+
+    /**
+     * Schedules a callback to run at a given time.
+     *
+     * @param id timerId to append to the identifier base for naming the scheduled job
+     * @param zdt time to schedule the job
+     * @param callback function to run at the given time
+     * @return a {@link ScheduledCompletableFuture}
+     */
     private ScheduledCompletableFuture<Object> createFuture(Integer id, ZonedDateTime zdt, Runnable callback) {
         return scheduler.schedule(() -> {
             synchronized (lock) {
@@ -50,17 +75,27 @@ public class ThreadsafeTimers {
         }, identifier + id, zdt.toInstant());
     }
 
-    private Integer createNewId() {
-        Integer id = idSchedulerMapping.size() + 1;
-        while (idSchedulerMapping.get(id) != null)
-            id++;
-        return id;
-    }
-
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/setTimeout"><code>setTimeout()</code></a> polyfill.
+     * Sets a timer which executes a given function once the timer expires.
+     *
+     * @param callback function to run after the given delay
+     * @param delay time in milliseconds that the timer should wait before the callback is executed
+     * @return Positive integer value which identifies the timer created; this value can be passed to <code>clearTimeout()</code> to cancel the timeout.
+     */
     public Integer setTimeout(Runnable callback, Long delay) {
-        return setTimeout(callback, delay, null);
+        return setTimeout(callback, delay, new Object());
     }
 
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/setTimeout"><code>setTimeout()</code></a> polyfill.
+     * Sets a timer which executes a given function once the timer expires.
+     *
+     * @param callback function to run after the given delay
+     * @param delay time in milliseconds that the timer should wait before the callback is executed
+     * @param args
+     * @return Positive integer value which identifies the timer created; this value can be passed to <code>clearTimeout()</code> to cancel the timeout.
+     */
     public Integer setTimeout(Runnable callback, Long delay, Object... args) {
         Integer id = createNewId();
         ScheduledCompletableFuture<Object> future = createFuture(id, ZonedDateTime.now().plusNanos(delay * 1000000),
@@ -69,12 +104,25 @@ public class ThreadsafeTimers {
         return id;
     }
 
-    public void clearTimeout(Integer id) {
-        ScheduledCompletableFuture<Object> scheduled = idSchedulerMapping.get(id);
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout"><code>clearTimeout()</code></a> polyfill.
+     * Cancels a timeout previously created by <code>setTimeout()</code>.
+     *
+     * @param timeoutId The identifier of the timeout you want to cancel. This ID was returned by the corresponding call to setTimeout().
+     */
+    public void clearTimeout(Integer timeoutId) {
+        ScheduledCompletableFuture<Object> scheduled = idSchedulerMapping.get(timeoutId);
         scheduled.cancel(true);
-        idSchedulerMapping.remove(id);
+        idSchedulerMapping.remove(timeoutId);
     }
 
+    /**
+     * Schedules a callback to run in a loop with a given delay between the executions.
+     *
+     * @param id timerId to append to the identifier base for naming the scheduled job
+     * @param delay time in milliseconds that the timer should delay in between executions of the callback
+     * @param callback function to run
+     */
     private void createLoopingFuture(Integer id, Long delay, Runnable callback) {
         ScheduledCompletableFuture<Object> future = scheduler.schedule(() -> {
             synchronized (lock) {
@@ -86,18 +134,41 @@ public class ThreadsafeTimers {
         idSchedulerMapping.put(id, future);
     }
 
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/setInterval"><code>setInterval()</code></a> polyfill.
+     * Repeatedly calls a function with a fixed time delay between each call.
+     *
+     * @param callback function to run
+     * @param delay time in milliseconds that the timer should delay in between executions of the callback
+     * @return Numeric, non-zero value which identifies the timer created; this value can be passed to <code>clearInterval()</code> to cancel the interval.
+     */
     public Integer setInterval(Runnable callback, Long delay) {
-        return setInterval(callback, delay, null);
+        return setInterval(callback, delay, new Object());
     }
 
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/setInterval"><code>setInterval()</code></a> polyfill.
+     * Repeatedly calls a function with a fixed time delay between each call.
+     *
+     * @param callback function to run
+     * @param delay time in milliseconds that the timer should delay in between executions of the callback
+     * @param args
+     * @return Numeric, non-zero value which identifies the timer created; this value can be passed to <code>clearInterval()</code> to cancel the interval.
+     */
     public Integer setInterval(Runnable callback, Long delay, Object... args) {
         Integer id = createNewId();
         createLoopingFuture(id, delay, callback);
         return id;
     }
 
-    public void clearInterval(Integer id) {
-        clearTimeout(id);
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/clearInterval"><code>clearInterval()</code></a> polyfill.
+     * Cancels a timed, repeating action which was previously established by a call to <code>setInterval()</code>.
+     *
+     * @param intervalID The identifier of the repeated action you want to cancel. This ID was returned by the corresponding call to <code>setInterval()</code>.
+     */
+    public void clearInterval(Integer intervalID) {
+        clearTimeout(intervalID);
     }
 
     public void cancelAll() {

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -178,6 +178,10 @@ public class ThreadsafeTimers {
         clearTimeout(intervalID);
     }
 
+    /**
+     * Cancels all timed actions (i.e. timeouts and intervals) that were created with this instance of {@link ThreadsafeTimers}.
+     * Should be called in a de-initialization/unload hook of the script engine to avoid having scheduled jobs that are running endless.
+     */
     public void clearAll() {
         idSchedulerMapping.forEach((id, future) -> {
             future.cancel(true);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -72,7 +72,7 @@ public class ThreadsafeTimers {
             synchronized (lock) {
                 callback.run();
             }
-        }, identifier + ".setTimeout." + id, zdt.toInstant());
+        }, identifier + ".timeout." + id, zdt.toInstant());
     }
 
     /**
@@ -133,7 +133,7 @@ public class ThreadsafeTimers {
                 if (idSchedulerMapping.get(id) != null)
                     createLoopingFuture(id, delay, callback);
             }
-        }, identifier + ".setInterval." + id, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
+        }, identifier + ".interval." + id, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
         idSchedulerMapping.put(id, future);
     }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -205,11 +205,14 @@ public class ThreadsafeTimers {
         }
 
         @Override
-        public Temporal adjustInto(@Nullable Temporal temporal) {
-            if (timeDone == null) {
-                timeDone = temporal;
+        public Temporal adjustInto(Temporal temporal) {
+            Temporal localTimeDone = timeDone;
+            Temporal nextTime;
+            if (localTimeDone != null) {
+                nextTime = localTimeDone.plus(delay);
+            } else {
+                nextTime = temporal.plus(delay);
             }
-            Temporal nextTime = timeDone.plus(delay);
             timeDone = nextTime;
             return nextTime;
         }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -179,13 +179,13 @@ public class ThreadsafeTimers {
     }
 
     /**
-     * Cancels all timed actions (i.e. timeouts and intervals) that were created with this instance of {@link ThreadsafeTimers}.
-     * Should be called in a de-initialization/unload hook of the script engine to avoid having scheduled jobs that are running endless.
+     * Cancels all timed actions (i.e. timeouts and intervals) that were created with this instance of
+     * {@link ThreadsafeTimers}.
+     * Should be called in a de-initialization/unload hook of the script engine to avoid having scheduled jobs that are
+     * running endless.
      */
     public void clearAll() {
-        idSchedulerMapping.forEach((id, future) -> {
-            future.cancel(true);
-        });
+        idSchedulerMapping.forEach((id, future) -> future.cancel(true));
         idSchedulerMapping.clear();
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -172,51 +172,13 @@
         }
     };
 
-    function setTimeout(cb, delay) {
-        const args = Array.prototype.slice.call(arguments, 2);
-        return ThreadsafeTimers.createTimerWithArgument(
-            defaultIdentifier + '.setTimeout',
-            ZonedDateTime.now().plusNanos(delay * 1000000),
-            args,
-            function (args) {
-                cb.apply(global, args);
-            }
-        );
-    }
-
-    function clearTimeout(timer) {
-        if (timer !== undefined && timer.isActive()) {
-            timer.cancel();
-        }
-    }
-
-    function setInterval(cb, delay) {
-        const args = Array.prototype.slice.call(arguments, 2);
-        const delayNanos = delay * 1000000
-        let timer = ThreadsafeTimers.createTimerWithArgument(
-            defaultIdentifier + '.setInterval',
-            ZonedDateTime.now().plusNanos(delayNanos),
-            args,
-            function (args) {
-                cb.apply(global, args);
-                if (!timer.isCancelled()) {
-                    timer.reschedule(ZonedDateTime.now().plusNanos(delayNanos));
-                }
-            }
-        );
-        return timer;
-    }
-
-    function clearInterval(timer) {
-        clearTimeout(timer);
-    }
-
     // Polyfill common NodeJS functions onto the global object
+    // ThreadsafeTimers is injected into the JS runtime
     globalThis.console = console;
-    globalThis.setTimeout = setTimeout;
-    globalThis.clearTimeout = clearTimeout;
-    globalThis.setInterval = setInterval;
-    globalThis.clearInterval = clearInterval;
+    globalThis.setTimeout = ThreadsafeTimers.setTimeout;
+    globalThis.clearTimeout = ThreadsafeTimers.clearTimeout;
+    globalThis.setInterval = ThreadsafeTimers.setInterval;
+    globalThis.clearInterval = ThreadsafeTimers.clearInterval;
 
     // Support legacy NodeJS libraries 
     globalThis.global = globalThis;

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -183,9 +183,6 @@
     globalThis.setInterval = ThreadsafeTimers.setInterval;
     globalThis.clearInterval = ThreadsafeTimers.clearInterval;
 
-    // Specific to the JS Scripting add-on
-    globalThis.clearAll = ThreadsafeTimers.clearAll;
-
     // Support legacy NodeJS libraries 
     globalThis.global = globalThis;
     globalThis.process = { env: { NODE_ENV: '' } };

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -5,8 +5,8 @@
     // Append the script file name OR rule UID depending on which is available
     const defaultIdentifier = "org.openhab.automation.script" + (globalThis["javax.script.filename"] ? ".file." + globalThis["javax.script.filename"].replace(/^.*[\\\/]/, '') : globalThis["ruleUID"] ? ".ui." + globalThis["ruleUID"] : "");
     const System = Java.type('java.lang.System');
-    const ZonedDateTime = Java.type('java.time.ZonedDateTime');
     const formatRegExp = /%[sdj%]/g;
+    // Pass the defaultIdentifier to ThreadsafeTimers to enable naming of scheduled jobs
     ThreadsafeTimers.setIdentifier(defaultIdentifier);
 
     function createLogger(name = defaultIdentifier) {
@@ -163,6 +163,7 @@
         },
 
         // Allow user customizable logging names
+        // Be aware that a log4j2 required a logger defined for the logger name, otherwise messages won't be logged!
         set loggerName(name) {
             log = createLogger(name);
             this._loggerName = name;

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -1,3 +1,4 @@
+// ThreadsafeTimers is injected into the JS runtime
 
 (function (global) {
     'use strict';
@@ -176,12 +177,14 @@
     };
 
     // Polyfill common NodeJS functions onto the global object
-    // ThreadsafeTimers is injected into the JS runtime
     globalThis.console = console;
     globalThis.setTimeout = ThreadsafeTimers.setTimeout;
     globalThis.clearTimeout = ThreadsafeTimers.clearTimeout;
     globalThis.setInterval = ThreadsafeTimers.setInterval;
     globalThis.clearInterval = ThreadsafeTimers.clearInterval;
+
+    // Specific to the JS Scripting add-on
+    globalThis.clearAll = ThreadsafeTimers.clearAll;
 
     // Support legacy NodeJS libraries 
     globalThis.global = globalThis;

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -7,6 +7,7 @@
     const System = Java.type('java.lang.System');
     const ZonedDateTime = Java.type('java.time.ZonedDateTime');
     const formatRegExp = /%[sdj%]/g;
+    ThreadsafeTimers.setIdentifier(defaultIdentifier);
 
     function createLogger(name = defaultIdentifier) {
         return Java.type("org.slf4j.LoggerFactory").getLogger(name);
@@ -165,10 +166,11 @@
         set loggerName(name) {
             log = createLogger(name);
             this._loggerName = name;
+            ThreadsafeTimers.setIdentifier(name);
         },
 
         get loggerName() {
-            return this._loggerName || defaultLoggerName;
+            return this._loggerName || defaultIdentifier;
         }
     };
 


### PR DESCRIPTION
Fixes #13594.

## Description

This PR reimplements the polyfills for the standard JS timers (`setTimeout` and `setInterval`) in the Java layer of the binding to conform standard JS.

This brings several improvements:
- Usage of `TimerImpl` from core is no longer required; instead the scheduler is accessed directly
- Mapping of ScheduledFutures to unique Integers to conform standard JS that returns a `timeoutId` or `intervalId` when the according funtion is run. FYI: Standard JS shares the same pool of integers for both, the binding does therefore the same.
- Scheduled jobs created by the polyfills are named by using the loggername, the type (`timeout` or `interval`) and the id (an Integer).
- All scheduled jobs created by the polyfills are automatically cancelled when the rule is unloaded to avoid having unmanagable scheduled jobs running endless (until restart of openHAB).

## Breaking Changes

- The polyfills do not return an openHAB Timer anymore, instead they return an interger id as standard JS does.
- Other ways of scheduling timers (`createTimer`, `createTimerWithArgument`) are not recommended to be used anymore as they are not threadsafe. But it is still possible to access them via the `ScriptExecution` actions from core.
- I propose to log a warning when someone tries to access those timer creation methods via the `ScriptExecution` action from the openhab-js library.

Therefore, the polyfills for the standard JS timer methods should be the only way taken for creating timers in JS Scripting!

## Testing

```javascript
const { rules, triggers } = require('openhab');

const Thread = Java.type('java.lang.Thread');

rules.JSRule({
  name: 'Test Rule',
  triggers: triggers.ItemCommandTrigger('test_switch'),
  execute: (event) => {
    console.info('Rule 2 ran');
    // console.loggerName = 'org.openhab.automation.js.1123';
    let myVar = 'Hello world';

    // Create timers for the same timeout to ensure that timers/scheduled jobs are threadsafe
    for (let i = 0; i < 15; i++) {
      setTimeout(() => {
        console.info('setTimeout ' + i + ' completed successfully with message: ' + myVar);
        Thread.sleep(500);
      }, 2000, myVar);
    }

    let id;
    if (true) {
      // Create interval to verify functionality of setInterval
      id = setInterval(() => {
        console.info('setInterval completed successfully');
      }, 100, myVar, myVar);
    }

    if (true) {
      // Make a scheduled job fail to check whether naming jobs works
      setTimeout(() => {
        console.info(uninizializedVar);
      }, 1000);
    }

    if (true) {
      // Cancel interval with a timeout by using the intervalId
      setTimeout(() => {
        console.info('Attempting to clear setInterval...');
        clearTimeout(id);
      }, 5000, myVar, myVar);
    }

    myVar = 'Hello mutation';
  }
});

```