### PR TITLE
[homematic] Some HM devices are using relative humidity (% rH/rF) as units

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/QuantityTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/QuantityTypeConverter.java
@@ -104,6 +104,8 @@ public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? 
                 return new QuantityType<>(number, SIUnits.CELSIUS);
             case "V":
                 return new QuantityType<>(number, Units.VOLT);
+            case "% rH":
+            case "% rF":
             case "%":
                 return new QuantityType<>(number, Units.PERCENT);
             case "mHz":

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/MetadataUtils.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/MetadataUtils.java
@@ -311,6 +311,8 @@ public class MetadataUtils {
                     case "V":
                         return ITEM_TYPE_NUMBER + ":ElectricPotential";
                     case "100%":
+                    case "% rH":
+                    case "% rF":
                     case "%":
                         return ITEM_TYPE_NUMBER + ":Dimensionless";
                     case "mHz":


### PR DESCRIPTION
Current versions of the Homematic CCU are using "% rH" resp. "% rF% (for german language as unit for humidity on some devices.

Fix #13553

Signed-off-by: Martin Herbst <develop@mherbst.de>
