### PR TITLE
[paradoxalarm] Fix issue that the config of paradox bridge handler gets overwritten when there are more than one bridge

### DIFF
--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/handlers/ParadoxIP150BridgeHandler.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/handlers/ParadoxIP150BridgeHandler.java
@@ -70,7 +70,7 @@ public class ParadoxIP150BridgeHandler extends BaseBridgeHandler
 
     private IParadoxCommunicator communicator;
 
-    private static ParadoxIP150BridgeConfiguration config;
+    private ParadoxIP150BridgeConfiguration config;
     private @Nullable ScheduledFuture<?> refreshCacheUpdateSchedule;
 
     private long timeStamp = 0;


### PR DESCRIPTION
* Change static config field in the main bridge handler to non-static (fixes #13628)

Signed-off-by: Konstantin Polihronov <polychronov@gmail.com>

