### PR TITLE
[linuxinput] handle keys not known by libevdev

### DIFF
--- a/bundles/org.openhab.binding.linuxinput/README.md
+++ b/bundles/org.openhab.binding.linuxinput/README.md
@@ -81,3 +81,10 @@ The following happens when pressing and releasing a key:
 #### Rationale
 
 Channel states are updated first to allow rules triggered by channel triggers to access the new state.
+
+#### Channel names
+
+The binding tries to translate the numeric event codes to their symbolic names; `KEY_1`, `KEY_A`, `KEY_BACKSPACE` etc.
+
+If the currently installed version of libevdev does not know the symbolic name of a key, the numeric value is used.
+Please note that future versions of libevdev may start translating the symbolic names.

--- a/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/LinuxInputHandler.java
+++ b/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/LinuxInputHandler.java
@@ -100,7 +100,8 @@ public final class LinuxInputHandler extends DeviceReadingHandler {
             }
             Channel channel = ChannelBuilder
                     .create(new ChannelUID(thing.getUID(), CHANNEL_GROUP_KEYPRESSES_ID, name), CoreItemFactory.CONTACT)
-                    .withLabel(name).withType(CHANNEL_TYPE_KEY_PRESS).build();
+                    .withLabel(name).withType(CHANNEL_TYPE_KEY_PRESS).withDescription("Event Code " + o.getCode())
+                    .build();
             channels.put(o.getCode(), channel);
             newChannels.add(channel);
         }

--- a/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/LinuxInputHandler.java
+++ b/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/LinuxInputHandler.java
@@ -95,6 +95,9 @@ public final class LinuxInputHandler extends DeviceReadingHandler {
         EvdevDevice newDevice = new EvdevDevice(config.path);
         for (EvdevDevice.Key o : newDevice.enumerateKeys()) {
             String name = o.getName();
+            if (name == null) {
+                name = Integer.toString(o.getCode());
+            }
             Channel channel = ChannelBuilder
                     .create(new ChannelUID(thing.getUID(), CHANNEL_GROUP_KEYPRESSES_ID, name), CoreItemFactory.CONTACT)
                     .withLabel(name).withType(CHANNEL_TYPE_KEY_PRESS).build();


### PR DESCRIPTION
As reported in https://community.openhab.org/t/linuxinput-binding-and-mouse-capture/122612/8 the binding would not properly handle channels for keys unknown by libevdev.
Fall back to the numeric event codes in this case.