### PR TITLE
[netatmo] eventBuffer in SecurityCapability should not be static

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/deserialization/NAPushType.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/deserialization/NAPushType.java
@@ -23,7 +23,7 @@ import org.openhab.binding.netatmo.internal.api.data.ModuleType;
  */
 @NonNullByDefault
 public class NAPushType {
-    public final static NAPushType UNKNOWN = new NAPushType(ModuleType.UNKNOWN, EventType.UNKNOWN);
+    public static final NAPushType UNKNOWN = new NAPushType(ModuleType.UNKNOWN, EventType.UNKNOWN);
 
     private final ModuleType moduleType;
     private final EventType event;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/SecurityCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/SecurityCapability.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 class SecurityCapability extends RestCapability<SecurityApi> {
     private final Logger logger = LoggerFactory.getLogger(SecurityCapability.class);
 
-    private static final Map<String, HomeEvent> eventBuffer = new HashMap<>();
+    private final Map<String, HomeEvent> eventBuffer = new HashMap<>();
     private @Nullable ZonedDateTime freshestEventTime;
 
     SecurityCapability(CommonInterface handler) {


### PR DESCRIPTION
Also fix few findings by code analysis

Signed-off-by: Laurent Garnier <lg.hc@free.fr>