### PR TITLE
[easee] adopted date parser due to changes in easeeAPI

### DIFF
--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/Utils.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/Utils.java
@@ -56,7 +56,12 @@ public final class Utils {
      * @return
      */
     public static ZonedDateTime parseDate(String date) throws DateTimeParseException {
-        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
+        DateTimeFormatter formatter;
+        if (date.length() == 24) {
+            formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+        } else {
+            formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
+        }
         LOGGER.trace("parsing: {}", date);
         ZonedDateTime zdt = ZonedDateTime.parse(date, formatter);
         return zdt;


### PR DESCRIPTION
The Easee API was recently changed. Instead of one common date/time format the API now provides dates in different formats. The parser now supports boths formats and detects the correct format by checking the length of the provided date string.