### PR TITLE
[jdbc] Fix MySQL deprecation notice on startup

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -165,7 +165,7 @@ public class JdbcBaseDAO {
      * HSQLDB: org.hsqldb.jdbcDriver
      * Jaybird: org.firebirdsql.jdbc.FBDriver
      * MariaDB: org.mariadb.jdbc.Driver
-     * MySQL: com.mysql.jdbc.Driver
+     * MySQL: com.mysql.cj.jdbc.Driver
      * MaxDB: com.sap.dbtech.jdbc.DriverSapDB
      * PostgreSQL: org.postgresql.Driver
      * SyBase: com.sybase.jdbc3.jdbc.SybDriver

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class JdbcMysqlDAO extends JdbcBaseDAO {
-    private static final String DRIVER_CLASS_NAME = com.mysql.jdbc.Driver.class.getName();
+    private static final String DRIVER_CLASS_NAME = com.mysql.cj.jdbc.Driver.class.getName();
     @SuppressWarnings("unused")
     private static final String DATA_SOURCE_CLASS_NAME = com.mysql.cj.jdbc.MysqlDataSource.class.getName();
 


### PR DESCRIPTION
Fix this notice on startup:

_Loading class \`com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary._

This was introduced when Connector/J was upgraded to 8.0 years ago:
https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-api-changes.html

Fixes #11157