### PR TITLE
[groheondus] Upgrade dependencies

### DIFF
--- a/bundles/org.openhab.binding.groheondus/pom.xml
+++ b/bundles/org.openhab.binding.groheondus/pom.xml
@@ -28,13 +28,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.6</version>
+      <version>1.10.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.12.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.groheondus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/feature/feature.xml
@@ -4,9 +4,7 @@
 
 	<feature name="openhab-binding-groheondus" description="GROHE ONDUS Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature prerequisite="true">wrap</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
-		<bundle dependency="true">wrap:mvn:org.apache.commons/commons-text/1.6</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.groheondus/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
* Upgrade commons-text to 1.10.0 (prevents CVE-2022-42889)
* Upgrade commons-lang3 to 3.12.0
* Remove commons-text, wrap from feature because it is embedded into the bundle