### PR TITLE
[squeezebox] Fix bridge initialization when parameter `quoteList` is not configured

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/thing/thing-types.xml
@@ -121,7 +121,7 @@
 		<description>Comma-separated list of favorites of form favoriteId=favoriteName</description>
 		<state readOnly="true" pattern="%s"></state>
 		<config-description>
-			<parameter name="quoteList" type="boolean" required="true">
+			<parameter name="quoteList" type="boolean">
 				<label>Quote Favorites</label>
 				<description>Wrap the right hand side of the favorites in quotes</description>
 				<default>false</default>


### PR DESCRIPTION
Fixes #13666