### PR TITLE
[kodi] Fix bridge initialization when parameter `group` is not configured

### DIFF
--- a/bundles/org.openhab.binding.kodi/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.kodi/src/main/resources/OH-INF/config/config.xml
@@ -64,7 +64,7 @@
 	</config-description>
 
 	<config-description uri="channel-type:kodi:pvr-channel">
-		<parameter name="group" type="text" required="true">
+		<parameter name="group" type="text">
 			<label>PVR Channel Group</label>
 			<description>The PVR channel group name used to identify the channel id.</description>
 			<default>All channels</default>


### PR DESCRIPTION
Fixes #13668