### PR TITLE
[regoheatpump] fixed polling stops problem if there is an unhandled runtime exception

### DIFF
--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/IpHusdataHandler.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/IpHusdataHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.regoheatpump.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.regoheatpump.internal.RegoHeatPumpBindingConstants;
 import org.openhab.binding.regoheatpump.internal.protocol.IpRegoConnection;
 import org.openhab.binding.regoheatpump.internal.protocol.RegoConnection;
@@ -23,6 +24,7 @@ import org.openhab.core.thing.Thing;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class IpHusdataHandler extends HusdataHandler {
     public IpHusdataHandler(Thing thing) {
         super(thing);

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/IpRego6xxHeatPumpHandler.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/IpRego6xxHeatPumpHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.regoheatpump.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.regoheatpump.internal.RegoHeatPumpBindingConstants;
 import org.openhab.binding.regoheatpump.internal.protocol.IpRegoConnection;
 import org.openhab.binding.regoheatpump.internal.protocol.RegoConnection;
@@ -23,6 +24,7 @@ import org.openhab.core.thing.Thing;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class IpRego6xxHeatPumpHandler extends Rego6xxHeatPumpHandler {
     public IpRego6xxHeatPumpHandler(Thing thing) {
         super(thing);

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/SerialHusdataHandler.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/SerialHusdataHandler.java
@@ -12,6 +12,10 @@
  */
 package org.openhab.binding.regoheatpump.internal.handler;
 
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.regoheatpump.internal.RegoHeatPumpBindingConstants;
 import org.openhab.binding.regoheatpump.internal.protocol.RegoConnection;
 import org.openhab.binding.regoheatpump.internal.protocol.SerialRegoConnection;
@@ -27,9 +31,10 @@ import org.openhab.core.thing.ThingStatusDetail;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class SerialHusdataHandler extends HusdataHandler {
     private final SerialPortManager serialPortManager;
-    private SerialPortIdentifier serialPortIdentifier;
+    private @Nullable SerialPortIdentifier serialPortIdentifier;
 
     public SerialHusdataHandler(Thing thing, SerialPortManager serialPortManager) {
         super(thing);
@@ -49,7 +54,11 @@ public class SerialHusdataHandler extends HusdataHandler {
     }
 
     @Override
-    protected RegoConnection createConnection() {
+    protected RegoConnection createConnection() throws IOException {
+        SerialPortIdentifier serialPortIdentifier = this.serialPortIdentifier;
+        if (serialPortIdentifier == null) {
+            throw new IOException("Serial port does not exist");
+        }
         return new SerialRegoConnection(serialPortIdentifier, 19200);
     }
 }

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/SerialRego6xxHeatPumpHandler.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/handler/SerialRego6xxHeatPumpHandler.java
@@ -12,6 +12,10 @@
  */
 package org.openhab.binding.regoheatpump.internal.handler;
 
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.regoheatpump.internal.RegoHeatPumpBindingConstants;
 import org.openhab.binding.regoheatpump.internal.protocol.RegoConnection;
 import org.openhab.binding.regoheatpump.internal.protocol.SerialRegoConnection;
@@ -27,9 +31,10 @@ import org.openhab.core.thing.ThingStatusDetail;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class SerialRego6xxHeatPumpHandler extends Rego6xxHeatPumpHandler {
     private final SerialPortManager serialPortManager;
-    private SerialPortIdentifier serialPortIdentifier;
+    private @Nullable SerialPortIdentifier serialPortIdentifier;
 
     public SerialRego6xxHeatPumpHandler(Thing thing, SerialPortManager serialPortManager) {
         super(thing);
@@ -49,7 +54,11 @@ public class SerialRego6xxHeatPumpHandler extends Rego6xxHeatPumpHandler {
     }
 
     @Override
-    protected RegoConnection createConnection() {
+    protected RegoConnection createConnection() throws IOException {
+        SerialPortIdentifier serialPortIdentifier = this.serialPortIdentifier;
+        if (serialPortIdentifier == null) {
+            throw new IOException("Serial port does not exist");
+        }
         return new SerialRegoConnection(serialPortIdentifier, 19200);
     }
 }

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/protocol/RegoConnection.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/protocol/RegoConnection.java
@@ -16,11 +16,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link RegoConnection} is responsible for creating connections to clients.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public interface RegoConnection {
     /**
      * Connect to the receiver. Return true if the connection has succeeded or if already connected.

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/protocol/SerialRegoConnection.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/protocol/SerialRegoConnection.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.serial.PortInUseException;
 import org.openhab.core.io.transport.serial.SerialPort;
 import org.openhab.core.io.transport.serial.SerialPortIdentifier;
@@ -26,10 +28,11 @@ import org.openhab.core.io.transport.serial.UnsupportedCommOperationException;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class SerialRegoConnection implements RegoConnection {
     private final int baudRate;
     private final String portName;
-    private SerialPort serialPort;
+    private @Nullable SerialPort serialPort;
     private final SerialPortIdentifier serialPortIdentifier;
 
     public SerialRegoConnection(SerialPortIdentifier serialPortIdentifier, int baudRate) {
@@ -41,10 +44,11 @@ public class SerialRegoConnection implements RegoConnection {
     @Override
     public void connect() throws IOException {
         try {
-            serialPort = serialPortIdentifier.open(SerialRegoConnection.class.getCanonicalName(), 2000);
+            SerialPort serialPort = serialPortIdentifier.open(SerialRegoConnection.class.getCanonicalName(), 2000);
             serialPort.enableReceiveTimeout(100);
             serialPort.setSerialPortParams(baudRate, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
                     SerialPort.PARITY_NONE);
+            this.serialPort = serialPort;
         } catch (PortInUseException e) {
             throw new IOException("Serial port already used: " + portName, e);
         } catch (UnsupportedCommOperationException e) {
@@ -59,19 +63,36 @@ public class SerialRegoConnection implements RegoConnection {
 
     @Override
     public void close() {
+        SerialPort serialPort = this.serialPort;
+        this.serialPort = null;
         if (serialPort != null) {
             serialPort.close();
-            serialPort = null;
         }
     }
 
     @Override
     public OutputStream outputStream() throws IOException {
-        return serialPort.getOutputStream();
+        OutputStream outputStream = getSerialPort().getOutputStream();
+        if (outputStream == null) {
+            throw new IOException("Sending data is not supported");
+        }
+        return outputStream;
     }
 
     @Override
     public InputStream inputStream() throws IOException {
-        return serialPort.getInputStream();
+        InputStream inputStream = getSerialPort().getInputStream();
+        if (inputStream == null) {
+            throw new IOException("Receiving data is not supported");
+        }
+        return inputStream;
+    }
+
+    private SerialPort getSerialPort() throws IOException {
+        SerialPort serialPort = this.serialPort;
+        if (serialPort == null) {
+            throw new IOException("Connection closed");
+        }
+        return serialPort;
     }
 }

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/AbstractLongResponseParser.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/AbstractLongResponseParser.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link AbstractLongResponseParser} is responsible for parsing long form responses.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 abstract class AbstractLongResponseParser<T> extends AbstractResponseParser<T> {
     @Override
     public int responseLength() {

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/AbstractResponseParser.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/AbstractResponseParser.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.util.HexUtils;
 
 /**
@@ -20,6 +21,7 @@ import org.openhab.core.util.HexUtils;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 abstract class AbstractResponseParser<T> implements ResponseParser<T> {
     private static final byte COMPUTER_ADDRESS = (byte) 0x01;
 

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/Checksum.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/Checksum.java
@@ -14,11 +14,14 @@ package org.openhab.binding.regoheatpump.internal.rego6xx;
 
 import java.util.Arrays;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link Checksum} is responsible for calculating checksum of given data.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 class Checksum {
     static byte calculate(byte[]... lists) {
         return Arrays.stream(lists).reduce((byte) 0, Checksum::calculate, (a, b) -> b);

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/CommandFactory.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/CommandFactory.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link CommandFactory} is responsible for creating different commands that can
  * be send to a rego 6xx unit.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class CommandFactory {
     private static final byte DEVICE_ADDRESS = (byte) 0x81;
 

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ErrorLine.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ErrorLine.java
@@ -15,14 +15,19 @@ package org.openhab.binding.regoheatpump.internal.rego6xx;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ErrorLine} is responsible for holding information about a single error line.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class ErrorLine {
     private final byte error;
     private final String timestamp;
+
+    public static final ErrorLine NO_ERROR = new ErrorLine((byte) 0, "");
 
     public ErrorLine(byte error, String timestamp) {
         this.error = error;

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ErrorLineResponseParser.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ErrorLineResponseParser.java
@@ -12,18 +12,21 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ErrorLineResponseParser} is responsible for parsing error information (log) entry.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 class ErrorLineResponseParser extends AbstractLongResponseParser<ErrorLine> {
 
     @Override
     protected ErrorLine convert(byte[] responseBytes) {
         // 255 marks no error.
         if (responseBytes[1] == (byte) 255) {
-            return null;
+            return ErrorLine.NO_ERROR;
         }
 
         return new ErrorLine(ValueConverter.arrayToByte(responseBytes, 1),

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/Rego6xxProtocolException.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/Rego6xxProtocolException.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link Rego6xxProtocolException} is responsible for holding information about an Rego6xx protocol error.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class Rego6xxProtocolException extends Exception {
 
     private static final long serialVersionUID = 7556083982084149686L;

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/RegoRegisterMapper.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/RegoRegisterMapper.java
@@ -19,6 +19,8 @@ import java.util.Map;
 
 import javax.measure.Unit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 
@@ -27,6 +29,7 @@ import org.openhab.core.library.unit.Units;
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class RegoRegisterMapper {
     public static final RegoRegisterMapper REGO600;
 
@@ -35,7 +38,7 @@ public class RegoRegisterMapper {
 
         public double scaleFactor();
 
-        public Unit<?> unit();
+        public @Nullable Unit<?> unit();
 
         public int convertValue(short value);
     }
@@ -44,9 +47,9 @@ public class RegoRegisterMapper {
         private static class ChannelImpl implements Channel {
             private final short address;
             private final double scaleFactor;
-            private final Unit<?> unit;
+            private @Nullable final Unit<?> unit;
 
-            private ChannelImpl(short address, double scaleFactor, Unit<?> unit) {
+            private ChannelImpl(short address, double scaleFactor, @Nullable Unit<?> unit) {
                 this.address = address;
                 this.scaleFactor = scaleFactor;
                 this.unit = unit;
@@ -63,7 +66,7 @@ public class RegoRegisterMapper {
             }
 
             @Override
-            public Unit<?> unit() {
+            public @Nullable Unit<?> unit() {
                 return unit;
             }
 
@@ -104,7 +107,7 @@ public class RegoRegisterMapper {
         this.mappings = mappings;
     }
 
-    public Channel map(String channelIID) {
+    public @Nullable Channel map(String channelIID) {
         return mappings.get(channelIID);
     }
 

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ResponseParser.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ResponseParser.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ResponseParser} is responsible for parsing arbitrary data coming from a rego 6xx unit.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public interface ResponseParser<T> {
     public int responseLength();
 

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ResponseParserFactory.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ResponseParserFactory.java
@@ -12,15 +12,18 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ResponseParserFactory} is responsible for providing parsers for all known data
  * forms coming from the rego 6xx unit.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 public class ResponseParserFactory {
     public static final ResponseParser<Short> SHORT = new ShortResponseParser();
     public static final ResponseParser<String> STRING = new StringResponseParser();
     public static final ResponseParser<ErrorLine> ERROR_LINE = new ErrorLineResponseParser();
-    public static final ResponseParser<Void> WRITE = new WriteResponse();
+    public static final ResponseParser<String> WRITE = new WriteResponse();
 }

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ShortResponseParser.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ShortResponseParser.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ShortResponseParser} is responsible for parsing short form data format
  * coming from the rego 6xx unit.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 class ShortResponseParser extends AbstractResponseParser<Short> {
 
     @Override

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/StringResponseParser.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/StringResponseParser.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link StringResponseParser} is responsible for parsing long (text) form data format
  * coming from the rego 6xx unit.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 class StringResponseParser extends AbstractLongResponseParser<String> {
 
     @Override

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ValueConverter.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/ValueConverter.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ValueConverter} is responsible for converting various rego 6xx specific data types.
  *
  * @author Boris Krivonog - Initial contribution
  */
+@NonNullByDefault
 class ValueConverter {
     public static byte[] shortToSevenBitFormat(short value) {
         byte b1 = (byte) ((value & 0xC000) >> 14);

--- a/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/WriteResponse.java
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/java/org/openhab/binding/regoheatpump/internal/rego6xx/WriteResponse.java
@@ -12,20 +12,23 @@
  */
 package org.openhab.binding.regoheatpump.internal.rego6xx;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link WriteResponse} is responsible for parsing write responses
  * coming from the rego 6xx unit.
  *
  * @author Boris Krivonog - Initial contribution
  */
-class WriteResponse extends AbstractResponseParser<Void> {
+@NonNullByDefault
+class WriteResponse extends AbstractResponseParser<String> {
     @Override
     public int responseLength() {
         return 1;
     }
 
     @Override
-    protected Void convert(byte[] responseBytes) {
-        return null;
+    protected String convert(byte[] responseBytes) {
+        return "";
     }
 }


### PR DESCRIPTION
If for some reason HP response fails to properly parse, i.e. `java.lang.NumberFormatException: For input string: "##"` exception is not handled and scheduler is not re-triggered (polling stops). Also fixed build warnings.

Signed-off-by: Boris Krivonog [boris.krivonog@inova.si](mailto:boris.krivonog@inova.si)