### PR TITLE
[jsscripting] Reimplement timer creation method of `ScriptExecution`

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -25,7 +25,7 @@
     <graal.version>22.3.0</graal.version>
     <asm.version>6.2.1</asm.version>
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@2.1.0</ohjs.version>
+    <ohjs.version>openhab@2.1.1</ohjs.version>
   </properties>
 
   <build>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -26,6 +26,7 @@ import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * An implementation of {@link ScriptEngineFactory} with customizations for GraalJS ScriptEngines.
@@ -42,6 +43,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     private boolean injectionEnabled = true;
 
     public static final String MIME_TYPE = "application/javascript;version=ECMAScript-2021";
+    private @Reference JSScriptServiceUtil jsScriptServiceUtil;
 
     @Override
     public List<String> getScriptTypes() {
@@ -71,7 +73,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     @Override
     public ScriptEngine createScriptEngine(String scriptType) {
         return new DebuggingGraalScriptEngine<>(
-                new OpenhabGraalJSScriptEngine(injectionEnabled ? INJECTION_CODE : null));
+                new OpenhabGraalJSScriptEngine(injectionEnabled ? INJECTION_CODE : null, jsScriptServiceUtil));
     }
 
     @Activate

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -21,7 +21,6 @@ import javax.script.ScriptEngine;
 
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.openhab.core.config.core.ConfigurableService;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -43,7 +42,14 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     private boolean injectionEnabled = true;
 
     public static final String MIME_TYPE = "application/javascript;version=ECMAScript-2021";
-    private @Reference JSScriptServiceUtil jsScriptServiceUtil;
+    private final JSScriptServiceUtil jsScriptServiceUtil;
+
+    @Activate
+    public GraalJSScriptEngineFactory(final @Reference JSScriptServiceUtil jsScriptServiceUtil,
+            Map<String, Object> config) {
+        this.jsScriptServiceUtil = jsScriptServiceUtil;
+        modified(config);
+    }
 
     @Override
     public List<String> getScriptTypes() {
@@ -74,11 +80,6 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     public ScriptEngine createScriptEngine(String scriptType) {
         return new DebuggingGraalScriptEngine<>(
                 new OpenhabGraalJSScriptEngine(injectionEnabled ? INJECTION_CODE : null, jsScriptServiceUtil));
-    }
-
-    @Activate
-    protected void activate(BundleContext context, Map<String, ?> config) {
-        modified(config);
     }
 
     @Modified

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptServiceUtil.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscripting.internal;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.action.ScriptExecution;
+import org.openhab.core.scheduler.Scheduler;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Utility class for providing easy access to script services.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@Component(immediate = true)
+@NonNullByDefault
+public class GraalJSScriptServiceUtil {
+    private static @Nullable Scheduler scheduler;
+    private static @Nullable ScriptExecution scriptExecution;
+
+    @Activate
+    public GraalJSScriptServiceUtil(final @Reference Scheduler scheduler, final @Reference ScriptExecution scriptExecution) {
+        GraalJSScriptServiceUtil.scheduler = scheduler;
+        GraalJSScriptServiceUtil.scriptExecution = scriptExecution;
+    }
+
+    public static Scheduler getScheduler() {
+        return Objects.requireNonNull(scheduler);
+    }
+
+    public static ScriptExecution getScriptExecution() {
+        return Objects.requireNonNull(scriptExecution);
+    }
+}

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptServiceUtil.java
@@ -34,7 +34,8 @@ public class GraalJSScriptServiceUtil {
     private static @Nullable ScriptExecution scriptExecution;
 
     @Activate
-    public GraalJSScriptServiceUtil(final @Reference Scheduler scheduler, final @Reference ScriptExecution scriptExecution) {
+    public GraalJSScriptServiceUtil(final @Reference Scheduler scheduler,
+            final @Reference ScriptExecution scriptExecution) {
         GraalJSScriptServiceUtil.scheduler = scheduler;
         GraalJSScriptServiceUtil.scriptExecution = scriptExecution;
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
@@ -31,8 +31,10 @@ public class JSRuntimeFeatures {
     private final Map<String, Object> features = new HashMap<>();
     public final ThreadsafeTimers threadsafeTimers;
 
-    JSRuntimeFeatures(ThreadsafeTimers threadSafeTimers) {
-        this.threadsafeTimers = threadSafeTimers;
+    JSRuntimeFeatures(Object lock, JSScriptServiceUtil jsScriptServiceUtil) {
+        this.threadsafeTimers = new ThreadsafeTimers(lock, jsScriptServiceUtil.getScriptExecution(),
+                jsScriptServiceUtil.getScheduler());
+
         features.put("ThreadsafeTimers", threadsafeTimers);
     }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
@@ -31,8 +31,8 @@ public class JSRuntimeFeatures {
     private final Map<String, Object> features = new HashMap<>();
     public final ThreadsafeTimers threadsafeTimers;
 
-    JSRuntimeFeatures(Object lock) {
-        this.threadsafeTimers = new ThreadsafeTimers(lock);
+    JSRuntimeFeatures(Object lock, JSScriptServiceUtil jsScriptServiceUtil) {
+        this.threadsafeTimers = new ThreadsafeTimers(lock, jsScriptServiceUtil);
 
         features.put("ThreadsafeTimers", threadsafeTimers);
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSRuntimeFeatures.java
@@ -31,9 +31,8 @@ public class JSRuntimeFeatures {
     private final Map<String, Object> features = new HashMap<>();
     public final ThreadsafeTimers threadsafeTimers;
 
-    JSRuntimeFeatures(Object lock, JSScriptServiceUtil jsScriptServiceUtil) {
-        this.threadsafeTimers = new ThreadsafeTimers(lock, jsScriptServiceUtil);
-
+    JSRuntimeFeatures(ThreadsafeTimers threadSafeTimers) {
+        this.threadsafeTimers = threadSafeTimers;
         features.put("ThreadsafeTimers", threadsafeTimers);
     }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.automation.jsscripting.internal;
 
-import java.util.Objects;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.action.ScriptExecution;
 import org.openhab.core.scheduler.Scheduler;
 import org.osgi.service.component.annotations.Activate;
@@ -23,27 +20,27 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * Utility class for providing easy access to script services.
+ * OSGi utility service for providing easy access to script services.
  *
  * @author Florian Hotze - Initial contribution
  */
-@Component(immediate = true)
+@Component(immediate = true, service = JSScriptServiceUtil.class)
 @NonNullByDefault
 public class JSScriptServiceUtil {
-    private static @Nullable Scheduler scheduler;
-    private static @Nullable ScriptExecution scriptExecution;
+    private final Scheduler scheduler;
+    private final ScriptExecution scriptExecution;
 
     @Activate
     public JSScriptServiceUtil(final @Reference Scheduler scheduler, final @Reference ScriptExecution scriptExecution) {
-        JSScriptServiceUtil.scheduler = scheduler;
-        JSScriptServiceUtil.scriptExecution = scriptExecution;
+        this.scheduler = scheduler;
+        this.scriptExecution = scriptExecution;
     }
 
-    public static Scheduler getScheduler() {
-        return Objects.requireNonNull(scheduler);
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
-    public static ScriptExecution getScriptExecution() {
-        return Objects.requireNonNull(scriptExecution);
+    public ScriptExecution getScriptExecution() {
+        return scriptExecution;
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
@@ -29,15 +29,15 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(immediate = true)
 @NonNullByDefault
-public class GraalJSScriptServiceUtil {
+public class JSScriptServiceUtil {
     private static @Nullable Scheduler scheduler;
     private static @Nullable ScriptExecution scriptExecution;
 
     @Activate
-    public GraalJSScriptServiceUtil(final @Reference Scheduler scheduler,
-            final @Reference ScriptExecution scriptExecution) {
-        GraalJSScriptServiceUtil.scheduler = scheduler;
-        GraalJSScriptServiceUtil.scriptExecution = scriptExecution;
+    public JSScriptServiceUtil(final @Reference Scheduler scheduler,
+                               final @Reference ScriptExecution scriptExecution) {
+        JSScriptServiceUtil.scheduler = scheduler;
+        JSScriptServiceUtil.scriptExecution = scriptExecution;
     }
 
     public static Scheduler getScheduler() {

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
@@ -34,8 +34,7 @@ public class JSScriptServiceUtil {
     private static @Nullable ScriptExecution scriptExecution;
 
     @Activate
-    public JSScriptServiceUtil(final @Reference Scheduler scheduler,
-                               final @Reference ScriptExecution scriptExecution) {
+    public JSScriptServiceUtil(final @Reference Scheduler scheduler, final @Reference ScriptExecution scriptExecution) {
         JSScriptServiceUtil.scheduler = scheduler;
         JSScriptServiceUtil.scriptExecution = scriptExecution;
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jsscripting.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.automation.jsscripting.internal.threading.ThreadsafeTimers;
 import org.openhab.core.automation.module.script.action.ScriptExecution;
 import org.openhab.core.scheduler.Scheduler;
 import org.osgi.service.component.annotations.Activate;
@@ -36,11 +37,7 @@ public class JSScriptServiceUtil {
         this.scriptExecution = scriptExecution;
     }
 
-    public Scheduler getScheduler() {
-        return scheduler;
-    }
-
-    public ScriptExecution getScriptExecution() {
-        return scriptExecution;
+    public JSRuntimeFeatures getJSRuntimeFeatures() {
+        return new JSRuntimeFeatures(new ThreadsafeTimers(scriptExecution, scheduler));
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/JSScriptServiceUtil.java
@@ -13,7 +13,6 @@
 package org.openhab.automation.jsscripting.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.automation.jsscripting.internal.threading.ThreadsafeTimers;
 import org.openhab.core.automation.module.script.action.ScriptExecution;
 import org.openhab.core.scheduler.Scheduler;
 import org.osgi.service.component.annotations.Activate;
@@ -37,7 +36,15 @@ public class JSScriptServiceUtil {
         this.scriptExecution = scriptExecution;
     }
 
-    public JSRuntimeFeatures getJSRuntimeFeatures() {
-        return new JSRuntimeFeatures(new ThreadsafeTimers(scriptExecution, scheduler));
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    public ScriptExecution getScriptExecution() {
+        return scriptExecution;
+    }
+
+    public JSRuntimeFeatures getJSRuntimeFeatures(Object lock) {
+        return new JSRuntimeFeatures(lock, this);
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -70,7 +70,7 @@ public class OpenhabGraalJSScriptEngine
     private static final Path NODE_DIR = Paths.get("node_modules");
 
     // shared lock object for synchronization of multi-thread access
-    public final Object lock;
+    private final Object lock = new Object();
     private final JSRuntimeFeatures jsRuntimeFeatures;
 
     // these fields start as null because they are populated on first use
@@ -87,8 +87,7 @@ public class OpenhabGraalJSScriptEngine
     public OpenhabGraalJSScriptEngine(@Nullable String injectionCode, JSScriptServiceUtil jsScriptServiceUtil) {
         super(null); // delegate depends on fields not yet initialised, so we cannot set it immediately
         this.globalScript = GLOBAL_REQUIRE + (injectionCode != null ? injectionCode : "");
-        this.jsRuntimeFeatures = jsScriptServiceUtil.getJSRuntimeFeatures();
-        this.lock = jsRuntimeFeatures.threadsafeTimers.getLock();
+        this.jsRuntimeFeatures = jsScriptServiceUtil.getJSRuntimeFeatures(lock);
 
         LOGGER.debug("Initializing GraalJS script engine...");
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -71,7 +71,7 @@ public class OpenhabGraalJSScriptEngine
 
     // shared lock object for synchronization of multi-thread access
     private final Object lock = new Object();
-    private final JSRuntimeFeatures jsRuntimeFeatures = new JSRuntimeFeatures(lock);
+    private JSRuntimeFeatures jsRuntimeFeatures;
 
     // these fields start as null because they are populated on first use
     private String engineIdentifier;
@@ -84,9 +84,10 @@ public class OpenhabGraalJSScriptEngine
      * Creates an implementation of ScriptEngine (& Invocable), wrapping the contained engine, that tracks the script
      * lifecycle and provides hooks for scripts to do so too.
      */
-    public OpenhabGraalJSScriptEngine(@Nullable String injectionCode) {
+    public OpenhabGraalJSScriptEngine(@Nullable String injectionCode, JSScriptServiceUtil jsScriptServiceUtil) {
         super(null); // delegate depends on fields not yet initialised, so we cannot set it immediately
         this.globalScript = GLOBAL_REQUIRE + (injectionCode != null ? injectionCode : "");
+        this.jsRuntimeFeatures = new JSRuntimeFeatures(lock, jsScriptServiceUtil);
 
         LOGGER.debug("Initializing GraalJS script engine...");
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -70,15 +70,15 @@ public class OpenhabGraalJSScriptEngine
     private static final Path NODE_DIR = Paths.get("node_modules");
 
     // shared lock object for synchronization of multi-thread access
-    private final Object lock = new Object();
-    private JSRuntimeFeatures jsRuntimeFeatures;
+    public final Object lock;
+    private final JSRuntimeFeatures jsRuntimeFeatures;
 
     // these fields start as null because they are populated on first use
     private String engineIdentifier;
     private Consumer<String> scriptDependencyListener;
 
     private boolean initialized = false;
-    private String globalScript;
+    private final String globalScript;
 
     /**
      * Creates an implementation of ScriptEngine (& Invocable), wrapping the contained engine, that tracks the script
@@ -87,7 +87,8 @@ public class OpenhabGraalJSScriptEngine
     public OpenhabGraalJSScriptEngine(@Nullable String injectionCode, JSScriptServiceUtil jsScriptServiceUtil) {
         super(null); // delegate depends on fields not yet initialised, so we cannot set it immediately
         this.globalScript = GLOBAL_REQUIRE + (injectionCode != null ? injectionCode : "");
-        this.jsRuntimeFeatures = new JSRuntimeFeatures(lock, jsScriptServiceUtil);
+        this.jsRuntimeFeatures = jsScriptServiceUtil.getJSRuntimeFeatures();
+        this.lock = jsRuntimeFeatures.threadsafeTimers.getLock();
 
         LOGGER.debug("Initializing GraalJS script engine...");
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -144,6 +144,7 @@ public class ThreadsafeTimers {
         ScheduledCompletableFuture<Object> future = scheduler.schedule(() -> {
             synchronized (lock) {
                 callback.run();
+                idSchedulerMapping.remove(id);
             }
         }, identifier + ".timeout." + id, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
         idSchedulerMapping.put(id, future);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.automation.jsscripting.internal.JSScriptServiceUtil;
 import org.openhab.core.automation.module.script.action.ScriptExecution;
 import org.openhab.core.automation.module.script.action.Timer;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
@@ -35,7 +34,7 @@ import org.openhab.core.scheduler.SchedulerTemporalAdjuster;
  *         Threadsafe reimplementation of the timer creation methods of {@link ScriptExecution}
  */
 public class ThreadsafeTimers {
-    private final Object lock = new Object();
+    private final Object lock;
     private final Scheduler scheduler;
     private final ScriptExecution scriptExecution;
     // Mapping of positive, non-zero integer values (used as timeoutID or intervalID) and the Scheduler
@@ -43,7 +42,8 @@ public class ThreadsafeTimers {
     private AtomicLong lastId = new AtomicLong();
     private String identifier = "noIdentifier";
 
-    public ThreadsafeTimers(ScriptExecution scriptExecution, Scheduler scheduler) {
+    public ThreadsafeTimers(Object lock, ScriptExecution scriptExecution, Scheduler scheduler) {
+        this.lock = lock;
         this.scheduler = scheduler;
         this.scriptExecution = scriptExecution;
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -43,10 +43,10 @@ public class ThreadsafeTimers {
     private AtomicLong lastId = new AtomicLong();
     private String identifier = "noIdentifier";
 
-    public ThreadsafeTimers(Object lock) {
+    public ThreadsafeTimers(Object lock, JSScriptServiceUtil jsScriptServiceUtil) {
         this.lock = lock;
-        this.scheduler = JSScriptServiceUtil.getScheduler();
-        this.scriptExecution = JSScriptServiceUtil.getScriptExecution();
+        this.scheduler = jsScriptServiceUtil.getScheduler();
+        this.scriptExecution = jsScriptServiceUtil.getScriptExecution();
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.automation.jsscripting.internal.GraalJSScriptServiceUtil;
+import org.openhab.automation.jsscripting.internal.JSScriptServiceUtil;
 import org.openhab.core.automation.module.script.action.ScriptExecution;
 import org.openhab.core.automation.module.script.action.Timer;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
@@ -46,8 +46,8 @@ public class ThreadsafeTimers {
 
     public ThreadsafeTimers(Object lock) {
         this.lock = lock;
-        this.scheduler = GraalJSScriptServiceUtil.getScheduler();
-        this.scriptExecution = GraalJSScriptServiceUtil.getScriptExecution();
+        this.scheduler = JSScriptServiceUtil.getScheduler();
+        this.scriptExecution = JSScriptServiceUtil.getScriptExecution();
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -35,7 +35,7 @@ import org.openhab.core.scheduler.SchedulerTemporalAdjuster;
  *         Threadsafe reimplementation of the timer creation methods of {@link ScriptExecution}
  */
 public class ThreadsafeTimers {
-    private final Object lock;
+    private final Object lock = new Object();
     private final Scheduler scheduler;
     private final ScriptExecution scriptExecution;
     // Mapping of positive, non-zero integer values (used as timeoutID or intervalID) and the Scheduler
@@ -43,10 +43,18 @@ public class ThreadsafeTimers {
     private AtomicLong lastId = new AtomicLong();
     private String identifier = "noIdentifier";
 
-    public ThreadsafeTimers(Object lock, JSScriptServiceUtil jsScriptServiceUtil) {
-        this.lock = lock;
-        this.scheduler = jsScriptServiceUtil.getScheduler();
-        this.scriptExecution = jsScriptServiceUtil.getScriptExecution();
+    public ThreadsafeTimers(ScriptExecution scriptExecution, Scheduler scheduler) {
+        this.scheduler = scheduler;
+        this.scriptExecution = scriptExecution;
+    }
+
+    /**
+     * get the lock object of this instance
+     *
+     * @return the lock object
+     */
+    public Object getLock() {
+        return lock;
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -18,7 +18,6 @@ import java.time.temporal.Temporal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.automation.jsscripting.internal.JSScriptServiceUtil;
@@ -82,36 +81,6 @@ public class ThreadsafeTimers {
         return scriptExecution.createTimer(identifier, instant, () -> {
             synchronized (lock) {
                 closure.run();
-            }
-        });
-    }
-
-    /**
-     * Schedules a block of code (with argument) for later execution
-     *
-     * @param instant the point in time when the code should be executed
-     * @param arg1 the argument to pass to the code block
-     * @param closure the code block to execute
-     * @return a handle to the created timer, so that it can be canceled or rescheduled
-     */
-    public Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Consumer<Object> closure) {
-        return createTimerWithArgument(identifier, instant, arg1, closure);
-    }
-
-    /**
-     * Schedules a block of code (with argument) for later execution
-     *
-     * @param identifier an optional identifier
-     * @param instant the point in time when the code should be executed
-     * @param arg1 the argument to pass to the code block
-     * @param closure the code block to execute
-     * @return a handle to the created timer, so that it can be canceled or rescheduled
-     */
-    public Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
-            Consumer<Object> closure) {
-        return scriptExecution.createTimerWithArgument(identifier, instant, arg1, var1 -> {
-            synchronized (lock) {
-                closure.accept(arg1);
             }
         });
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -49,15 +49,6 @@ public class ThreadsafeTimers {
     }
 
     /**
-     * get the lock object of this instance
-     *
-     * @return the lock object
-     */
-    public Object getLock() {
-        return lock;
-    }
-
-    /**
      * Set the identifier base string used for naming scheduled jobs.
      *
      * @param identifier identifier to use

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.model.script.ScriptServiceUtil;
+import org.openhab.automation.jsscripting.internal.GraalJSScriptServiceUtil;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
 import org.openhab.core.scheduler.Scheduler;
 import org.openhab.core.scheduler.SchedulerTemporalAdjuster;
@@ -29,8 +29,7 @@ import org.openhab.core.scheduler.SchedulerTemporalAdjuster;
  * A polyfill implementation of NodeJS timer functionality (<code>setTimeout()</code>, <code>setInterval()</code> and
  * the cancel methods) which controls multithreaded execution access to the single-threaded GraalJS contexts.
  *
- * @author Florian Hotze - Initial contribution
- * @author Florian Hotze - Reimplementation to conform standard JS setTimeout and setInterval
+ * @author Florian Hotze - Initial contribution; Reimplementation to conform standard JS setTimeout and setInterval
  */
 public class ThreadsafeTimers {
     private final Object lock;
@@ -42,7 +41,7 @@ public class ThreadsafeTimers {
 
     public ThreadsafeTimers(Object lock) {
         this.lock = lock;
-        this.scheduler = ScriptServiceUtil.getScheduler();
+        this.scheduler = GraalJSScriptServiceUtil.getScheduler();
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jsscripting.internal.threading;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.Map;
@@ -114,7 +115,7 @@ public class ThreadsafeTimers {
                 callback.run();
                 idSchedulerMapping.remove(id);
             }
-        }, identifier + ".timeout." + id, ZonedDateTime.now().plusNanos(delay * 1000000).toInstant());
+        }, identifier + ".timeout." + id, Instant.now().plusMillis(delay));
         idSchedulerMapping.put(id, future);
         return id;
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/threading/ThreadsafeTimers.java
@@ -59,22 +59,54 @@ public class ThreadsafeTimers {
         this.identifier = identifier;
     }
 
-    public Timer createTimer(ZonedDateTime instant, Runnable runnable) {
-        return createTimer(identifier, instant, runnable);
+    /**
+     * Schedules a block of code for later execution.
+     *
+     * @param instant the point in time when the code should be executed
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
+    public Timer createTimer(ZonedDateTime instant, Runnable closure) {
+        return createTimer(identifier, instant, closure);
     }
 
-    public Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable runnable) {
+    /**
+     * Schedules a block of code for later execution.
+     *
+     * @param identifier an optional identifier
+     * @param instant the point in time when the code should be executed
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
+    public Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable closure) {
         return scriptExecution.createTimer(identifier, instant, () -> {
             synchronized (lock) {
-                runnable.run();
+                closure.run();
             }
         });
     }
 
+    /**
+     * Schedules a block of code (with argument) for later execution
+     *
+     * @param instant the point in time when the code should be executed
+     * @param arg1 the argument to pass to the code block
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
     public Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Consumer<Object> closure) {
         return createTimerWithArgument(identifier, instant, arg1, closure);
     }
 
+    /**
+     * Schedules a block of code (with argument) for later execution
+     *
+     * @param identifier an optional identifier
+     * @param instant the point in time when the code should be executed
+     * @param arg1 the argument to pass to the code block
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
     public Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
             Consumer<Object> closure) {
         return scriptExecution.createTimerWithArgument(identifier, instant, arg1, var1 -> {


### PR DESCRIPTION
## Description

This PR reimplements the openHAB Core API for creating timers to make this also threadsafe.

As discussed on the forum https://community.openhab.org/t/js-scripting-why-are-we-deprecated-createtimer/140748, the `setTimeout` and `setInterval` methods do not provide the functionality that advanced users need, and to avoid that those users and users coming from Rules DSL leave JS Scripting because of this missing API, we have to provide thread-safe access to it.

Furthermore,  `JSScriptServiceUtil` was introduced to provide easy access from to script services provided by core. This replaces the usage of the `JSScriptServiceUtil` from the Rules DSL parts of core and therefore reduces dependency on a part that might become an addon in the future.

openhab-js is also upgraded to 2.1.1.

## Testing

Use the following file-based script to test:

```javascript
const { time} = require('openhab');

// Note that all timers are scheduled to nearly the same time, so without the synchronization mechanism in place, this would lead to a multi-thread exception
ThreadsafeTimers.createTimer(time.toZDT(), () => {
    console.info("Hello world from createTimer without identifier")
});

ThreadsafeTimers.createTimer('createTimer', time.toZDT(), () => {
    console.info("Hello world from createTimer with identifier")
});
```
