### PR TITLE
[ecobee] Add air quality channels for Ecobee Smart Thermostat Premium

### DIFF
--- a/bundles/org.openhab.binding.ecobee/README.md
+++ b/bundles/org.openhab.binding.ecobee/README.md
@@ -169,6 +169,10 @@ The following channels are available on the Ecobee Thermostat.
 | runtime | desiredHeatRangeHigh | Number:Temperature |     | Desired Heat Range High |
 | runtime | desiredCoolRangeLow | Number:Temperature |     | Desired Cool Range Low |
 | runtime | desiredCoolRangeHigh | Number:Temperature |     | Desired Cool Range High |
+| runtime | actualAQAccuracy | Number:Dimensionless |     | Actual Air Quality Accuracy |
+| runtime | actualAQScore | Number:Dimensionless |     | Actual Air Quality Score |
+| runtime | actualCO2 | Number:Dimensionless |     | Actual CO2 |
+| runtime | actualVOC | Number:Dimensionless |     | Actual VOC |
 ||||||
 | settings | hvacMode | String | yes | HVAC Mode |
 | settings | lastServiceDate | String | yes | Last Service Date |
@@ -853,6 +857,10 @@ Number:Temperature Runtime_DesiredHeatRangeLow "Desired Heat Range Low [%.1f %un
 Number:Temperature Runtime_DesiredHeatRangeHigh "Desired Heat Range High [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredHeatRangeHigh" }
 Number:Temperature Runtime_DesiredCoolRangeLow "Desired Cool Range Low [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredCoolRangeLow" }
 Number:Temperature Runtime_DesiredCoolRangeHigh "Desired Cool Range High [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredCoolRangeHigh" }
+Number:Dimensionless Runtime_ActualAQAccuracy "Actual Air Quality Accuracy [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQAccuracy" }
+Number:Dimensionless Runtime_ActualAQScore "Actual Air Quality Score [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQScore" }
+Number:Dimensionless Runtime_ActualCO2 "Actual CO2 [%.0f %unit%]" <carbondioxide> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualCO2" }
+Number:Dimensionless Runtime_ActualVOC "Actual VOC [%.0f %unit%]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualVOC" }
 
 // Settings group
 String Settings_HvacMode "HVAC Mode [%s]" <text> (gSettings) { channel="ecobee:thermostat:account:729318833078:settings#hvacMode" }

--- a/bundles/org.openhab.binding.ecobee/README.md
+++ b/bundles/org.openhab.binding.ecobee/README.md
@@ -857,10 +857,10 @@ Number:Temperature Runtime_DesiredHeatRangeLow "Desired Heat Range Low [%.1f %un
 Number:Temperature Runtime_DesiredHeatRangeHigh "Desired Heat Range High [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredHeatRangeHigh" }
 Number:Temperature Runtime_DesiredCoolRangeLow "Desired Cool Range Low [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredCoolRangeLow" }
 Number:Temperature Runtime_DesiredCoolRangeHigh "Desired Cool Range High [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredCoolRangeHigh" }
-Number Runtime_ActualAQAccuracy "Actual Air Quality Accuracy [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQAccuracy" }
-Number Runtime_ActualAQScore "Actual Air Quality Score [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQScore" }
-Number:Dimensionless Runtime_ActualCO2 "Actual CO2 [%.0f %unit%]" <carbondioxide> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualCO2" }
-Number:Dimensionless Runtime_ActualVOC "Actual VOC [%.0f %unit%]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualVOC" }
+Number Runtime_ActualAQAccuracy "Actual Air Quality Accuracy [%d]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQAccuracy" }
+Number Runtime_ActualAQScore "Actual Air Quality Score [%d]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQScore" }
+Number:Dimensionless Runtime_ActualCO2 "Actual CO2 [%d %unit%]" <carbondioxide> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualCO2" }
+Number:Dimensionless Runtime_ActualVOC "Actual VOC [%d %unit%]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualVOC" }
 
 // Settings group
 String Settings_HvacMode "HVAC Mode [%s]" <text> (gSettings) { channel="ecobee:thermostat:account:729318833078:settings#hvacMode" }

--- a/bundles/org.openhab.binding.ecobee/README.md
+++ b/bundles/org.openhab.binding.ecobee/README.md
@@ -169,8 +169,8 @@ The following channels are available on the Ecobee Thermostat.
 | runtime | desiredHeatRangeHigh | Number:Temperature |     | Desired Heat Range High |
 | runtime | desiredCoolRangeLow | Number:Temperature |     | Desired Cool Range Low |
 | runtime | desiredCoolRangeHigh | Number:Temperature |     | Desired Cool Range High |
-| runtime | actualAQAccuracy | Number:Dimensionless |     | Actual Air Quality Accuracy |
-| runtime | actualAQScore | Number:Dimensionless |     | Actual Air Quality Score |
+| runtime | actualAQAccuracy | Number |     | Actual Air Quality Accuracy |
+| runtime | actualAQScore | Number |     | Actual Air Quality Score |
 | runtime | actualCO2 | Number:Dimensionless |     | Actual CO2 |
 | runtime | actualVOC | Number:Dimensionless |     | Actual VOC |
 ||||||
@@ -857,8 +857,8 @@ Number:Temperature Runtime_DesiredHeatRangeLow "Desired Heat Range Low [%.1f %un
 Number:Temperature Runtime_DesiredHeatRangeHigh "Desired Heat Range High [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredHeatRangeHigh" }
 Number:Temperature Runtime_DesiredCoolRangeLow "Desired Cool Range Low [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredCoolRangeLow" }
 Number:Temperature Runtime_DesiredCoolRangeHigh "Desired Cool Range High [%.1f %unit%]" <temperature> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#desiredCoolRangeHigh" }
-Number:Dimensionless Runtime_ActualAQAccuracy "Actual Air Quality Accuracy [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQAccuracy" }
-Number:Dimensionless Runtime_ActualAQScore "Actual Air Quality Score [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQScore" }
+Number Runtime_ActualAQAccuracy "Actual Air Quality Accuracy [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQAccuracy" }
+Number Runtime_ActualAQScore "Actual Air Quality Score [%.0f]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualAQScore" }
 Number:Dimensionless Runtime_ActualCO2 "Actual CO2 [%.0f %unit%]" <carbondioxide> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualCO2" }
 Number:Dimensionless Runtime_ActualVOC "Actual VOC [%.0f %unit%]" <none> (gRuntime) { channel="ecobee:thermostat:account:729318833078:runtime#actualVOC" }
 

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
@@ -224,6 +224,10 @@ public class EcobeeBindingConstants {
     public static final String CH_DESIRED_HEAT_RANGE_HIGH = "desiredHeatRangeHigh";
     public static final String CH_DESIRED_COOL_RANGE_LOW = "desiredCoolRangeLow";
     public static final String CH_DESIRED_COOL_RANGE_HIGH = "desiredCoolRangeHigh";
+    public static final String CH_ACTUAL_AQ_ACCURACY = "actualAQAccuracy";
+    public static final String CH_ACTUAL_AQ_SCORE = "actualAQScore";
+    public static final String CH_ACTUAL_CO2 = "actualCO2";
+    public static final String CH_ACTUAL_VOC = "actualVOC";
 
     // Thermostat bridge SETTINGS channels
     public static final String CH_HVAC_MODE = "hvacMode";

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/ExtendedRuntimeDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/ExtendedRuntimeDTO.java
@@ -82,6 +82,26 @@ public class ExtendedRuntimeDTO {
     public List<Integer> desiredDehumidity;
 
     /*
+     * The last three 5 minute actual air quality accuracy readings
+     */
+    public List<Integer> actualAQAccuracy;
+
+    /*
+     * The last three 5 minute actual air quality score readings
+     */
+    public List<Integer> actualAQScore;
+
+    /*
+     * The last three 5 minute actual CO2 readings
+     */
+    public List<Integer> actualCO2;
+
+    /*
+     * The last three 5 minute actual VOC readings
+     */
+    public List<Integer> actualVOC;
+
+    /*
      * The last three 5 minute desired Demand Management temeprature offsets.
      * This value is Demand Management adjustment value which was applied by
      * the thermostat. If the thermostat decided not to honour the adjustment,

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/RuntimeDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/RuntimeDTO.java
@@ -152,4 +152,24 @@ public class RuntimeDTO {
      * minimum and maximim, e.g. [650,920].
      */
     public List<Integer> desiredCoolRange;
+
+    /*
+     * The current air quality accuracy
+     */
+    public Integer actualAQAccuracy;
+
+    /*
+     * The current air quality score
+     */
+    public Integer actualAQScore;
+
+    /*
+     * The current CO2 in ppm
+     */
+    public Integer actualCO2;
+
+    /*
+     * The current VOC in ppb
+     */
+    public Integer actualVOC;
 }

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
@@ -417,8 +417,8 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
             updateChannel(grp + CH_DESIRED_COOL_RANGE_HIGH,
                     EcobeeUtils.undefOrTemperature(runtime.desiredCoolRange.get(1)));
         }
-        updateChannel(grp + CH_ACTUAL_AQ_ACCURACY, EcobeeUtils.undefOrDecimal(runtime.actualAQAccuracy));
-        updateChannel(grp + CH_ACTUAL_AQ_SCORE, EcobeeUtils.undefOrDecimal(runtime.actualAQScore));
+        updateChannel(grp + CH_ACTUAL_AQ_ACCURACY, EcobeeUtils.undefOrLong(runtime.actualAQAccuracy));
+        updateChannel(grp + CH_ACTUAL_AQ_SCORE, EcobeeUtils.undefOrLong(runtime.actualAQScore));
         updateChannel(grp + CH_ACTUAL_CO2, EcobeeUtils.undefOrQuantity(runtime.actualCO2, Units.PARTS_PER_MILLION));
         updateChannel(grp + CH_ACTUAL_VOC, EcobeeUtils.undefOrQuantity(runtime.actualVOC, Units.PARTS_PER_BILLION));
     }

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
@@ -417,6 +417,10 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
             updateChannel(grp + CH_DESIRED_COOL_RANGE_HIGH,
                     EcobeeUtils.undefOrTemperature(runtime.desiredCoolRange.get(1)));
         }
+        updateChannel(grp + CH_ACTUAL_AQ_ACCURACY, EcobeeUtils.undefOrDecimal(runtime.actualAQAccuracy));
+        updateChannel(grp + CH_ACTUAL_AQ_SCORE, EcobeeUtils.undefOrDecimal(runtime.actualAQScore));
+        updateChannel(grp + CH_ACTUAL_CO2, EcobeeUtils.undefOrQuantity(runtime.actualCO2, Units.PARTS_PER_MILLION));
+        updateChannel(grp + CH_ACTUAL_VOC, EcobeeUtils.undefOrQuantity(runtime.actualVOC, Units.PARTS_PER_BILLION));
     }
 
     private void updateSettings(@Nullable SettingsDTO settings) {

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
@@ -70,6 +70,10 @@ public final class EcobeeUtils {
         return (value == null || isUnknown(value)) ? UnDefType.UNDEF : new DecimalType(value.doubleValue());
     }
 
+    public static State undefOrLong(@Nullable Number value) {
+        return (value == null || isUnknown(value)) ? UnDefType.UNDEF : new DecimalType(value.longValue());
+    }
+
     public static State undefOrQuantity(@Nullable Number value, Unit<?> unit) {
         return (value == null || isUnknown(value)) ? UnDefType.UNDEF : new QuantityType<>(value, unit);
     }

--- a/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/i18n/ecobee.properties
+++ b/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/i18n/ecobee.properties
@@ -70,8 +70,12 @@ channel-group-type.ecobee.weather.label = Weather
 
 # channel types
 
+channel-type.ecobee.actualAQAccuracy.label = Actual Air Quality Accuracy
+channel-type.ecobee.actualAQScore.label = Actual Air Quality Score
 channel-type.ecobee.actualHumidity.label = Actual Humidity
 channel-type.ecobee.actualTemperature.label = Actual Temperature
+channel-type.ecobee.actualCO2.label = Actual CO2
+channel-type.ecobee.actualVOC.label = Actual VOC
 channel-type.ecobee.alertAcknowledgeRef.label = Acknowledge Ref
 channel-type.ecobee.alertAcknowledgement.label = Acknowledgement
 channel-type.ecobee.alertDate.label = Date

--- a/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
@@ -320,12 +320,12 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="actualAQAccuracy" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number</item-type>
 		<label>Actual Air Quality Accuracy</label>
 		<state readOnly="true" pattern="%.0f"/>
 	</channel-type>
 	<channel-type id="actualAQScore" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number</item-type>
 		<label>Actual Air Quality Score</label>
 		<state readOnly="true" pattern="%.0f"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
@@ -322,22 +322,22 @@
 	<channel-type id="actualAQAccuracy" advanced="true">
 		<item-type>Number</item-type>
 		<label>Actual Air Quality Accuracy</label>
-		<state readOnly="true" pattern="%.0f"/>
+		<state readOnly="true" pattern="%d"/>
 	</channel-type>
 	<channel-type id="actualAQScore" advanced="true">
 		<item-type>Number</item-type>
 		<label>Actual Air Quality Score</label>
-		<state readOnly="true" pattern="%.0f"/>
+		<state readOnly="true" pattern="%d"/>
 	</channel-type>
 	<channel-type id="actualCO2" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Actual CO2</label>
-		<state readOnly="true" pattern="%.0f %unit%"/>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	<channel-type id="actualVOC" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Actual VOC</label>
-		<state readOnly="true" pattern="%.0f %unit%"/>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
 	<channel-group-type id="settings">

--- a/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
@@ -202,6 +202,10 @@
 			<channel id="desiredHeatRangeHigh" typeId="desiredHeatRangeHigh"/>
 			<channel id="desiredCoolRangeLow" typeId="desiredCoolRangeLow"/>
 			<channel id="desiredCoolRangeHigh" typeId="desiredCoolRangeHigh"/>
+			<channel id="actualAQAccuracy" typeId="actualAQAccuracy"/>
+			<channel id="actualAQScore" typeId="actualAQScore"/>
+			<channel id="actualCO2" typeId="actualCO2"/>
+			<channel id="actualVOC" typeId="actualVOC"/>
 		</channels>
 	</channel-group-type>
 
@@ -314,6 +318,26 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Desired Cool Range High</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+	<channel-type id="actualAQAccuracy" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Actual Air Quality Accuracy</label>
+		<state readOnly="true" pattern="%.0f"/>
+	</channel-type>
+	<channel-type id="actualAQScore" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Actual Air Quality Score</label>
+		<state readOnly="true" pattern="%.0f"/>
+	</channel-type>
+	<channel-type id="actualCO2" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Actual CO2</label>
+		<state readOnly="true" pattern="%.0f %unit%"/>
+	</channel-type>
+	<channel-type id="actualVOC" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Actual VOC</label>
+		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 
 	<channel-group-type id="settings">


### PR DESCRIPTION
The Ecobee Smart Thermostat Premium returns the following additional runtime parameters: 
```
"runtime": {
  ...
  "actualVOC": 1045, 
  "actualCO2": 738,
  "actualAQAccuracy": 4,
  "actualAQScore": 73,
...
}
```
This PR creates the associated channels for them.
