### PR TITLE
[evcc] Fix data type issues in DTO

### DIFF
--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * The {@link EvccHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
- * @author Florian Hotze - Initial contribution
+ * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
  */
 @NonNullByDefault
 public class EvccHandler extends BaseThingHandler {
@@ -85,7 +85,7 @@ public class EvccHandler extends BaseThingHandler {
                 return;
             }
             String channelIdWithoutGroup = channelUID.getIdWithoutGroup();
-            int loadpoint = Integer.parseInt(groupId.toString().substring(9));
+            int loadpoint = Integer.parseInt(groupId.substring(9));
             EvccAPI evccAPI = this.evccAPI;
             if (evccAPI == null) {
                 return;
@@ -186,7 +186,7 @@ public class EvccHandler extends BaseThingHandler {
      */
     private void refresh() {
         logger.debug("Running refresh job ...");
-        EvccAPI evccAPI = null;
+        EvccAPI evccAPI;
         evccAPI = this.evccAPI;
         if (evccAPI == null) {
             return;

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * The {@link EvccHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
- * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
+ * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
 public class EvccHandler extends BaseThingHandler {

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -309,7 +309,7 @@ public class EvccHandler extends BaseThingHandler {
         ChannelUID channel;
         boolean batteryConfigured = this.batteryConfigured;
         if (batteryConfigured) {
-            double batteryPower = result.getBatteryPower();
+            float batteryPower = result.getBatteryPower();
             channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_POWER);
             updateState(channel, new QuantityType<>(batteryPower, Units.WATT));
             int batterySoC = result.getBatterySoC();
@@ -321,16 +321,16 @@ public class EvccHandler extends BaseThingHandler {
         }
         boolean gridConfigured = this.gridConfigured;
         if (gridConfigured) {
-            double gridPower = result.getGridPower();
+            float gridPower = result.getGridPower();
             channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_GRID_POWER);
             updateState(channel, new QuantityType<>(gridPower, Units.WATT));
         }
-        double homePower = result.getHomePower();
+        float homePower = result.getHomePower();
         channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_HOME_POWER);
         updateState(channel, new QuantityType<>(homePower, Units.WATT));
         boolean pvConfigured = this.pvConfigured;
         if (pvConfigured) {
-            double pvPower = result.getPvPower();
+            float pvPower = result.getPvPower();
             channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_PV_POWER);
             updateState(channel, new QuantityType<>(pvPower, Units.WATT));
         }
@@ -347,22 +347,22 @@ public class EvccHandler extends BaseThingHandler {
         int activePhases = loadpoint.getActivePhases();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_ACTIVE_PHASES);
         updateState(channel, new DecimalType(activePhases));
-        double chargeCurrent = loadpoint.getChargeCurrent();
+        float chargeCurrent = loadpoint.getChargeCurrent();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_CURRENT);
         updateState(channel, new QuantityType<>(chargeCurrent, Units.AMPERE));
         long chargeDuration = loadpoint.getChargeDuration();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_DURATION);
         updateState(channel, new QuantityType<>(chargeDuration, MetricPrefix.NANO(Units.SECOND)));
-        double chargePower = loadpoint.getChargePower();
+        float chargePower = loadpoint.getChargePower();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_POWER);
         updateState(channel, new QuantityType<>(chargePower, Units.WATT));
         long chargeRemainingDuration = loadpoint.getChargeRemainingDuration();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_REMAINING_DURATION);
         updateState(channel, new QuantityType<>(chargeRemainingDuration, MetricPrefix.NANO(Units.SECOND)));
-        double chargeRemainingEnergy = loadpoint.getChargeRemainingEnergy();
+        float chargeRemainingEnergy = loadpoint.getChargeRemainingEnergy();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_REMAINING_ENERGY);
         updateState(channel, new QuantityType<>(chargeRemainingEnergy, Units.WATT_HOUR));
-        double chargedEnergy = loadpoint.getChargedEnergy();
+        float chargedEnergy = loadpoint.getChargedEnergy();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGED_ENERGY);
         updateState(channel, new QuantityType<>(chargedEnergy, Units.WATT_HOUR));
         boolean charging = loadpoint.getCharging();
@@ -380,10 +380,10 @@ public class EvccHandler extends BaseThingHandler {
         boolean hasVehicle = loadpoint.getHasVehicle();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_HAS_VEHICLE);
         updateState(channel, OnOffType.from(hasVehicle));
-        double maxCurrent = loadpoint.getMaxCurrent();
+        float maxCurrent = loadpoint.getMaxCurrent();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MAX_CURRENT);
         updateState(channel, new QuantityType<>(maxCurrent, Units.AMPERE));
-        double minCurrent = loadpoint.getMinCurrent();
+        float minCurrent = loadpoint.getMinCurrent();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MIN_CURRENT);
         updateState(channel, new QuantityType<>(minCurrent, Units.AMPERE));
         int minSoC = loadpoint.getMinSoC();
@@ -414,10 +414,10 @@ public class EvccHandler extends BaseThingHandler {
         String title = loadpoint.getTitle();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_TITLE);
         updateState(channel, new StringType(title));
-        double vehicleCapacity = loadpoint.getVehicleCapacity();
+        float vehicleCapacity = loadpoint.getVehicleCapacity();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_CAPACITY);
         updateState(channel, new QuantityType<>(vehicleCapacity, Units.WATT_HOUR));
-        double vehicleOdometer = loadpoint.getVehicleOdometer();
+        float vehicleOdometer = loadpoint.getVehicleOdometer();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_ODOMETER);
         updateState(channel, new QuantityType<>(vehicleOdometer, MetricPrefix.KILO(SIUnits.METRE)));
         boolean vehiclePresent = loadpoint.getVehiclePresent();

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -66,7 +66,7 @@ public class EvccHandler extends BaseThingHandler {
     private boolean gridConfigured = false;
     private boolean pvConfigured = false;
 
-    private int targetSoC = 100;
+    private float targetSoC = 100;
     private boolean targetTimeEnabled = false;
     private ZonedDateTime targetTimeZDT = ZonedDateTime.now().plusHours(12);
 
@@ -312,10 +312,10 @@ public class EvccHandler extends BaseThingHandler {
             float batteryPower = result.getBatteryPower();
             channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_POWER);
             updateState(channel, new QuantityType<>(batteryPower, Units.WATT));
-            int batterySoC = result.getBatterySoC();
+            float batterySoC = result.getBatterySoC();
             channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_SOC);
             updateState(channel, new QuantityType<>(batterySoC, Units.PERCENT));
-            int batteryPrioritySoC = result.getBatterySoC();
+            float batteryPrioritySoC = result.getBatterySoC();
             channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_PRIORITY_SOC);
             updateState(channel, new QuantityType<>(batteryPrioritySoC, Units.PERCENT));
         }
@@ -386,7 +386,7 @@ public class EvccHandler extends BaseThingHandler {
         float minCurrent = loadpoint.getMinCurrent();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MIN_CURRENT);
         updateState(channel, new QuantityType<>(minCurrent, Units.AMPERE));
-        int minSoC = loadpoint.getMinSoC();
+        float minSoC = loadpoint.getMinSoC();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MIN_SOC);
         updateState(channel, new QuantityType<>(minSoC, Units.PERCENT));
         String mode = loadpoint.getMode();
@@ -423,10 +423,10 @@ public class EvccHandler extends BaseThingHandler {
         boolean vehiclePresent = loadpoint.getVehiclePresent();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_PRESENT);
         updateState(channel, OnOffType.from(vehiclePresent));
-        long vehicleRange = loadpoint.getVehicleRange();
+        float vehicleRange = loadpoint.getVehicleRange();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_RANGE);
         updateState(channel, new QuantityType<>(vehicleRange, MetricPrefix.KILO(SIUnits.METRE)));
-        int vehicleSoC = loadpoint.getVehicleSoC();
+        float vehicleSoC = loadpoint.getVehicleSoC();
         channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_SOC);
         updateState(channel, new QuantityType<>(vehicleSoC, Units.PERCENT));
         String vehicleTitle = loadpoint.getVehicleTitle();

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -117,7 +117,7 @@ public class EvccHandler extends BaseThingHandler {
                                 try {
                                     evccAPI.setTargetCharge(loadpoint, targetSoC, targetTimeZDT);
                                 } catch (DateTimeParseException e) {
-                                    logger.debug("Failed to set target charge", e);
+                                    logger.debug("Failed to set target charge: ", e);
                                 }
                             }
                         }
@@ -194,7 +194,7 @@ public class EvccHandler extends BaseThingHandler {
         try {
             this.result = evccAPI.getResult();
         } catch (EvccApiException e) {
-            logger.debug("Failed to get state");
+            logger.debug("Failed to get state: ", e);
         }
         Result result = this.result;
         if (result == null) {

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/EvccAPI.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/EvccAPI.java
@@ -32,13 +32,13 @@ import com.google.gson.JsonSyntaxException;
 /**
  * The {@link EvccAPI} is responsible for API calls to evcc.
  * 
- * @author Florian Hotze - Initial contribution
+ * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
  */
 @NonNullByDefault
 public class EvccAPI {
     private final Logger logger = LoggerFactory.getLogger(EvccAPI.class);
     private final Gson gson = new Gson();
-    private String host = "";
+    private String host;
 
     public EvccAPI(String host) {
         this.host = host;
@@ -48,9 +48,9 @@ public class EvccAPI {
      * Make a HTTP request.
      * 
      * @param url full request URL
-     * @param method reguest method, e.g. GET, POST
+     * @param method request method, e.g. GET, POST
      * @return the response body
-     * @throws {@link EvccApiException} if HTTP request failed
+     * @throws EvccApiException if HTTP request failed
      */
     private String httpRequest(String url, String method) throws EvccApiException {
         try {
@@ -67,10 +67,9 @@ public class EvccAPI {
     // API calls to evcc
     /**
      * Get the status from evcc.
-     * 
-     * @param host hostname of IP address of the evcc instance
+     *
      * @return {@link Result} result object from API
-     * @throws {@link EvccApiException} if status request failed
+     * @throws EvccApiException if status request failed
      */
     public Result getResult() throws EvccApiException {
         final String response = httpRequest(this.host + EVCC_REST_API + "state", "GET");

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/EvccAPI.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/EvccAPI.java
@@ -110,7 +110,7 @@ public class EvccAPI {
         return httpRequest(this.host + EVCC_REST_API + "loadpoints/" + loadpoint + "/maxcurrent/" + maxCurrent, "POST");
     }
 
-    public String setTargetCharge(int loadpoint, int targetSoC, ZonedDateTime targetTime) throws EvccApiException {
+    public String setTargetCharge(int loadpoint, float targetSoC, ZonedDateTime targetTime) throws EvccApiException {
         DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
         return httpRequest(this.host + EVCC_REST_API + "loadpoints/" + loadpoint + "/targetcharge/" + targetSoC + "/"
                 + targetTime.toLocalDateTime().format(formatter), "POST");

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/EvccAPI.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/EvccAPI.java
@@ -32,7 +32,7 @@ import com.google.gson.JsonSyntaxException;
 /**
  * The {@link EvccAPI} is responsible for API calls to evcc.
  * 
- * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
+ * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
 public class EvccAPI {

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
  * This class represents a loadpoint object of the status response (/api/state).
  * This DTO was written for evcc version 0.106.3
  *
- * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
+ * @author Florian Hotze - Initial contribution
  */
 public class Loadpoint {
     // Data types from https://github.com/evcc-io/evcc/blob/master/api/api.go

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
  * This class represents a loadpoint object of the status response (/api/state).
  * This DTO was written for evcc version 0.106.3
  *
- * @author Florian Hotze - Initial contribution
+ * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
  */
 public class Loadpoint {
     // Data types from https://github.com/evcc-io/evcc/blob/master/api/api.go

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This class represents a loadpoint object of the status response (/api/state).
- * This DTO was written for evcc version 0.91.
+ * This DTO was written for evcc version 0.106.3
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -70,7 +70,7 @@ public class Loadpoint {
     private float minCurrent;
 
     @SerializedName("minSoC")
-    private int minSoC;
+    private float minSoC;
 
     @SerializedName("mode")
     private String mode;
@@ -85,7 +85,7 @@ public class Loadpoint {
     private long pvRemaining;
 
     @SerializedName("targetSoC")
-    private int targetSoC;
+    private float targetSoC;
 
     @SerializedName("targetTime")
     private String targetTime;
@@ -94,7 +94,7 @@ public class Loadpoint {
     private String title;
 
     @SerializedName("vehicleCapacity")
-    private long vehicleCapacity;
+    private float vehicleCapacity;
 
     @SerializedName("vehicleOdometer")
     private float vehicleOdometer;
@@ -103,10 +103,10 @@ public class Loadpoint {
     private boolean vehiclePresent;
 
     @SerializedName("vehicleRange")
-    private long vehicleRange;
+    private float vehicleRange;
 
     @SerializedName("vehicleSoC")
-    private int vehicleSoC;
+    private float vehicleSoC;
 
     @SerializedName("vehicleTitle")
     private String vehicleTitle;
@@ -219,7 +219,7 @@ public class Loadpoint {
     /**
      * @return minimum state of charge
      */
-    public int getMinSoC() {
+    public float getMinSoC() {
         return minSoC;
     }
 
@@ -254,7 +254,7 @@ public class Loadpoint {
     /**
      * @return target state of charge (SoC)
      */
-    public int getTargetSoC() {
+    public float getTargetSoC() {
         return targetSoC;
     }
 
@@ -296,14 +296,14 @@ public class Loadpoint {
     /**
      * @return vehicle's range
      */
-    public long getVehicleRange() {
+    public float getVehicleRange() {
         return vehicleRange;
     }
 
     /**
      * @return vehicle's state of charge (SoC)
      */
-    public int getVehicleSoC() {
+    public float getVehicleSoC() {
         return vehicleSoC;
     }
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
@@ -28,22 +28,22 @@ public class Loadpoint {
     private int activePhases;
 
     @SerializedName("chargeCurrent")
-    private double chargeCurrent;
+    private float chargeCurrent;
 
     @SerializedName("chargeDuration")
     private long chargeDuration;
 
     @SerializedName("chargePower")
-    private double chargePower;
+    private float chargePower;
 
     @SerializedName("chargeRemainingDuration")
     private long chargeRemainingDuration;
 
     @SerializedName("chargeRemainingEnergy")
-    private double chargeRemainingEnergy;
+    private float chargeRemainingEnergy;
 
     @SerializedName("chargedEnergy")
-    private double chargedEnergy;
+    private float chargedEnergy;
 
     @SerializedName("charging")
     private boolean charging;
@@ -64,10 +64,10 @@ public class Loadpoint {
     private int loadpoint;
 
     @SerializedName("maxCurrent")
-    private double maxCurrent;
+    private float maxCurrent;
 
     @SerializedName("minCurrent")
-    private double minCurrent;
+    private float minCurrent;
 
     @SerializedName("minSoC")
     private int minSoC;
@@ -97,7 +97,7 @@ public class Loadpoint {
     private long vehicleCapacity;
 
     @SerializedName("vehicleOdometer")
-    private double vehicleOdometer;
+    private float vehicleOdometer;
 
     @SerializedName("vehiclePresent")
     private boolean vehiclePresent;
@@ -121,7 +121,7 @@ public class Loadpoint {
     /**
      * @return charge current
      */
-    public double getChargeCurrent() {
+    public float getChargeCurrent() {
         return chargeCurrent;
     }
 
@@ -135,7 +135,7 @@ public class Loadpoint {
     /**
      * @return charge power
      */
-    public double getChargePower() {
+    public float getChargePower() {
         return chargePower;
     }
 
@@ -149,14 +149,14 @@ public class Loadpoint {
     /**
      * @return charge remaining energy until the target SoC is reached
      */
-    public double getChargeRemainingEnergy() {
+    public float getChargeRemainingEnergy() {
         return chargeRemainingEnergy;
     }
 
     /**
      * @return charged energy
      */
-    public double getChargedEnergy() {
+    public float getChargedEnergy() {
         return chargedEnergy;
     }
 
@@ -205,14 +205,14 @@ public class Loadpoint {
     /**
      * @return maximum current
      */
-    public double getMaxCurrent() {
+    public float getMaxCurrent() {
         return maxCurrent;
     }
 
     /**
      * @return minimum current
      */
-    public double getMinCurrent() {
+    public float getMinCurrent() {
         return minCurrent;
     }
 
@@ -275,14 +275,14 @@ public class Loadpoint {
     /**
      * @return vehicle's capacity
      */
-    public double getVehicleCapacity() {
+    public float getVehicleCapacity() {
         return vehicleCapacity;
     }
 
     /**
      * @return vehicle's odometer
      */
-    public double getVehicleOdometer() {
+    public float getVehicleOdometer() {
         return vehicleOdometer;
     }
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -18,15 +18,13 @@ import com.google.gson.annotations.SerializedName;
  * This class represents the result object of the status response (/api/state).
  * This DTO was written for evcc version 0.106.3
  *
- * @author Florian Hotze - Initial contribution
+ * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
  */
 public class Result {
     // Data types from https://github.com/evcc-io/evcc/blob/master/api/api.go
     // and from https://docs.evcc.io/docs/reference/configuration/messaging/#msg
 
-    // TO DO LATER
-    // @SerializedName("auth")
-    // private Auth auth;
+    // "auth" is left out because it does not provide any useful information
 
     @SerializedName("batteryConfigured")
     private boolean batteryConfigured;

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
  * This class represents the result object of the status response (/api/state).
  * This DTO was written for evcc version 0.106.3
  *
- * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
+ * @author Florian Hotze - Initial contribution
  */
 public class Result {
     // Data types from https://github.com/evcc-io/evcc/blob/master/api/api.go

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This class represents the result object of the status response (/api/state).
- * This DTO was written for evcc version 0.91.
+ * This DTO was written for evcc version 0.106.3
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -35,7 +35,7 @@ public class Result {
     private float batteryPower;
 
     @SerializedName("batterySoC")
-    private int batterySoC;
+    private float batterySoC;
 
     @SerializedName("gridConfigured")
     private boolean gridConfigured;
@@ -85,7 +85,7 @@ public class Result {
     /**
      * @return battery's state of charge
      */
-    public int getBatterySoC() {
+    public float getBatterySoC() {
         return batterySoC;
     }
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -32,7 +32,7 @@ public class Result {
     private boolean batteryConfigured;
 
     @SerializedName("batteryPower")
-    private double batteryPower;
+    private float batteryPower;
 
     @SerializedName("batterySoC")
     private int batterySoC;
@@ -41,22 +41,22 @@ public class Result {
     private boolean gridConfigured;
 
     @SerializedName("gridPower")
-    private double gridPower;
+    private float gridPower;
 
     @SerializedName("homePower")
-    private double homePower;
+    private float homePower;
 
     @SerializedName("loadpoints")
     private Loadpoint[] loadpoints;
 
     @SerializedName("prioritySoC")
-    private double batteryPrioritySoC;
+    private float batteryPrioritySoC;
 
     @SerializedName("pvConfigured")
     private boolean pvConfigured;
 
     @SerializedName("pvPower")
-    private double pvPower;
+    private float pvPower;
 
     @SerializedName("siteTitle")
     private String siteTitle;
@@ -71,14 +71,14 @@ public class Result {
     /**
      * @return battery's power
      */
-    public double getBatteryPower() {
+    public float getBatteryPower() {
         return batteryPower;
     }
 
     /**
      * @return battery's priority state of charge
      */
-    public double getBatteryPrioritySoC() {
+    public float getBatteryPrioritySoC() {
         return batteryPrioritySoC;
     }
 
@@ -99,14 +99,14 @@ public class Result {
     /**
      * @return grid's power
      */
-    public double getGridPower() {
+    public float getGridPower() {
         return gridPower;
     }
 
     /**
      * @return home's power
      */
-    public double getHomePower() {
+    public float getHomePower() {
         return homePower;
     }
 
@@ -127,7 +127,7 @@ public class Result {
     /**
      * @return pv's power
      */
-    public double getPvPower() {
+    public float getPvPower() {
         return pvPower;
     }
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This class represents the status response (/api/state).
- * This DTO was written for evcc version 0.91.
+ * This DTO was written for evcc version 0.106.3
  *
  * @author Florian Hotze - Initial contribution
  */

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
  * This class represents the status response (/api/state).
  * This DTO was written for evcc version 0.106.3
  *
- * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
+ * @author Florian Hotze - Initial contribution
  */
 public class Status {
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
  * This class represents the status response (/api/state).
  * This DTO was written for evcc version 0.106.3
  *
- * @author Florian Hotze - Initial contribution
+ * @author Florian Hotze - Initial contribution; Avoid data type issues by using float instead of int
  */
 public class Status {
 


### PR DESCRIPTION
Fixes #13646.

This PR fixes an issue, where evcc changed their API to return a float instead of an int for `vehicleCapacity`, but the DTO expected an int and parsing the JSON response failed.
To avoid such issues in the future, all JSON response fields that might be changed to float in the future now use float instead of int.
Furthermore, the usage of double was replaced by float, as the higher precision of double is not required.

@pauxus I will also publish this bugfix to the addon marketplace, so that you can update the binding ASAP. See https://community.openhab.org/t/evcc-binding-electric-vehicle-charging-control/135209.
@andig FYI: This fixes https://github.com/evcc-io/evcc/issues/5035.