### PR TITLE
Add steeringwheelheater channel for Model 3/Y things

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/model3.xml
+++ b/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/model3.xml
@@ -109,7 +109,7 @@
 			<channel id="soc" typeId="soc"/>
 			<channel id="speed" typeId="speed"/>
 			<channel id="state" typeId="state"/>
-            <channel id="steeringwheelheater" typeId="steeringwheelheater"/>
+			<channel id="steeringwheelheater" typeId="steeringwheelheater"/>
 			<channel id="combinedtemp" typeId="combinedtemp"/>
 			<channel id="timetofullcharge" typeId="timetofullcharge"/>
 			<channel id="tripcharging" typeId="tripcharging"/>

--- a/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/model3.xml
+++ b/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/model3.xml
@@ -109,6 +109,7 @@
 			<channel id="soc" typeId="soc"/>
 			<channel id="speed" typeId="speed"/>
 			<channel id="state" typeId="state"/>
+            <channel id="steeringwheelheater" typeId="steeringwheelheater"/>
 			<channel id="combinedtemp" typeId="combinedtemp"/>
 			<channel id="timetofullcharge" typeId="timetofullcharge"/>
 			<channel id="tripcharging" typeId="tripcharging"/>

--- a/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/modely.xml
+++ b/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/modely.xml
@@ -111,7 +111,7 @@
 			<channel id="soc" typeId="soc"/>
 			<channel id="speed" typeId="speed"/>
 			<channel id="state" typeId="state"/>
-            <channel id="steeringwheelheater" typeId="steeringwheelheater"/>
+			<channel id="steeringwheelheater" typeId="steeringwheelheater"/>
 			<channel id="combinedtemp" typeId="combinedtemp"/>
 			<channel id="timetofullcharge" typeId="timetofullcharge"/>
 			<channel id="tripcharging" typeId="tripcharging"/>

--- a/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/modely.xml
+++ b/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/modely.xml
@@ -111,6 +111,7 @@
 			<channel id="soc" typeId="soc"/>
 			<channel id="speed" typeId="speed"/>
 			<channel id="state" typeId="state"/>
+            <channel id="steeringwheelheater" typeId="steeringwheelheater"/>
 			<channel id="combinedtemp" typeId="combinedtemp"/>
 			<channel id="timetofullcharge" typeId="timetofullcharge"/>
 			<channel id="tripcharging" typeId="tripcharging"/>
@@ -120,7 +121,6 @@
 			<channel id="valetpin" typeId="valetpin"/>
 			<channel id="wakeup" typeId="wakeup"/>
 		</channels>
-
 		<config-description>
 			<parameter name="vin" type="text" required="true">
 				<label>Vehicle Identification Number</label>


### PR DESCRIPTION
Add Steering Wheel Heater channel to both model 3 and Y things in order to support the development of commands for these channels in the other PR (https://github.com/openhab/openhab-addons/pull/13704)