### PR TITLE
[nuvo] fix system_buttonpress not populating

### DIFF
--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -1322,6 +1322,7 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
                         .round((double) (MAX_VOLUME - volume) / (double) (MAX_VOLUME - MIN_VOLUME) * 100.0);
                 state = new PercentType(BigDecimal.valueOf(volumePct));
                 break;
+            case CHANNEL_TYPE_BUTTONPRESS:
             case CHANNEL_DISPLAY_LINE1:
             case CHANNEL_DISPLAY_LINE2:
             case CHANNEL_DISPLAY_LINE3:


### PR DESCRIPTION
Fix bug caused due to review changes for #13658... The system_buttonpress channel was not populating and always displaying UNDEF.