### PR TITLE
[jdbc] Improve error handling safety

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/console/JdbcCommandExtension.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/console/JdbcCommandExtension.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.knowm.yank.exceptions.YankSQLException;
 import org.openhab.core.io.console.Console;
 import org.openhab.core.io.console.ConsoleCommandCompleter;
 import org.openhab.core.io.console.StringsCompleter;
@@ -29,6 +28,7 @@ import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
 import org.openhab.persistence.jdbc.ItemTableCheckEntry;
 import org.openhab.persistence.jdbc.ItemTableCheckEntryStatus;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.internal.JdbcPersistenceService;
 import org.openhab.persistence.jdbc.internal.JdbcPersistenceServiceConstants;
 import org.osgi.service.component.annotations.Activate;
@@ -76,7 +76,7 @@ public class JdbcCommandExtension extends AbstractConsoleCommandExtension implem
                 printUsage(console);
                 return;
             }
-        } catch (YankSQLException e) {
+        } catch (JdbcSQLException e) {
             console.println(e.toString());
         }
     }
@@ -90,7 +90,8 @@ public class JdbcCommandExtension extends AbstractConsoleCommandExtension implem
         return null;
     }
 
-    private boolean execute(JdbcPersistenceService persistenceService, String[] args, Console console) {
+    private boolean execute(JdbcPersistenceService persistenceService, String[] args, Console console)
+            throws JdbcSQLException {
         if (SUBCMD_TABLES_LIST.equalsIgnoreCase(args[1])) {
             listTables(persistenceService, console, args.length == 3 && PARAMETER_ALL.equalsIgnoreCase(args[2]));
             return true;
@@ -109,7 +110,8 @@ public class JdbcCommandExtension extends AbstractConsoleCommandExtension implem
         return false;
     }
 
-    private void listTables(JdbcPersistenceService persistenceService, Console console, Boolean all) {
+    private void listTables(JdbcPersistenceService persistenceService, Console console, Boolean all)
+            throws JdbcSQLException {
         List<ItemTableCheckEntry> entries = persistenceService.getCheckedEntries();
         if (!all) {
             entries.removeIf(t -> t.getStatus() == ItemTableCheckEntryStatus.VALID);
@@ -138,7 +140,7 @@ public class JdbcCommandExtension extends AbstractConsoleCommandExtension implem
         }
     }
 
-    private void cleanupTables(JdbcPersistenceService persistenceService, Console console) {
+    private void cleanupTables(JdbcPersistenceService persistenceService, Console console) throws JdbcSQLException {
         console.println("Cleaning up all inconsistent items...");
         List<ItemTableCheckEntry> entries = persistenceService.getCheckedEntries();
         entries.removeIf(t -> t.getStatus() == ItemTableCheckEntryStatus.VALID || t.getItemName().isEmpty());
@@ -152,8 +154,8 @@ public class JdbcCommandExtension extends AbstractConsoleCommandExtension implem
         }
     }
 
-    private void cleanupItem(JdbcPersistenceService persistenceService, Console console, String itemName,
-            boolean force) {
+    private void cleanupItem(JdbcPersistenceService persistenceService, Console console, String itemName, boolean force)
+            throws JdbcSQLException {
         console.print("Cleaning up item " + itemName + "... ");
         if (persistenceService.cleanupItem(itemName, force)) {
             console.println("done.");

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -32,6 +32,7 @@ import javax.measure.Unit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
+import org.knowm.yank.exceptions.YankSQLException;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ColorItem;
@@ -58,6 +59,7 @@ import org.openhab.core.types.TypeParser;
 import org.openhab.persistence.jdbc.dto.ItemVO;
 import org.openhab.persistence.jdbc.dto.ItemsVO;
 import org.openhab.persistence.jdbc.dto.JdbcHistoricItem;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.utils.DbMetaData;
 import org.openhab.persistence.jdbc.utils.StringUtilsExt;
 import org.slf4j.Logger;
@@ -248,131 +250,196 @@ public class JdbcBaseDAO {
     /**************
      * ITEMS DAOs *
      **************/
-    public @Nullable Integer doPingDB() {
-        final @Nullable Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
-        return result;
+    public @Nullable Integer doPingDB() throws JdbcSQLException {
+        try {
+            final @Nullable Integer result = Yank.queryScalar(sqlPingDB, Integer.class, null);
+            return result;
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public @Nullable String doGetDB() {
-        final @Nullable String result = Yank.queryScalar(sqlGetDB, String.class, null);
-        return result;
+    public @Nullable String doGetDB() throws JdbcSQLException {
+        try {
+            final @Nullable String result = Yank.queryScalar(sqlGetDB, String.class, null);
+            return result;
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public boolean doIfTableExists(ItemsVO vo) {
+    public boolean doIfTableExists(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlIfTableExists, new String[] { "#searchTable#" },
                 new String[] { vo.getItemsManageTable() });
         logger.debug("JDBC::doIfTableExists sql={}", sql);
-        final @Nullable String result = Yank.queryScalar(sql, String.class, null);
-        return Objects.nonNull(result);
+        try {
+            final @Nullable String result = Yank.queryScalar(sql, String.class, null);
+            return Objects.nonNull(result);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public boolean doIfTableExists(String tableName) {
+    public boolean doIfTableExists(String tableName) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlIfTableExists, new String[] { "#searchTable#" },
                 new String[] { tableName });
         logger.debug("JDBC::doIfTableExists sql={}", sql);
-        final @Nullable String result = Yank.queryScalar(sql, String.class, null);
-        return Objects.nonNull(result);
+        try {
+            final @Nullable String result = Yank.queryScalar(sql, String.class, null);
+            return Objects.nonNull(result);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public Long doCreateNewEntryInItemsTable(ItemsVO vo) {
+    public Long doCreateNewEntryInItemsTable(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlCreateNewEntryInItemsTable,
                 new String[] { "#itemsManageTable#", "#itemname#" },
                 new String[] { vo.getItemsManageTable(), vo.getItemName() });
         logger.debug("JDBC::doCreateNewEntryInItemsTable sql={}", sql);
-        return Yank.insert(sql, null);
+        try {
+            return Yank.insert(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public ItemsVO doCreateItemsTableIfNot(ItemsVO vo) {
+    public ItemsVO doCreateItemsTableIfNot(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlCreateItemsTableIfNot,
                 new String[] { "#itemsManageTable#", "#colname#", "#coltype#" },
                 new String[] { vo.getItemsManageTable(), vo.getColname(), vo.getColtype() });
         logger.debug("JDBC::doCreateItemsTableIfNot sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
         return vo;
     }
 
-    public ItemsVO doDropItemsTableIfExists(ItemsVO vo) {
+    public ItemsVO doDropItemsTableIfExists(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlDropItemsTableIfExists, new String[] { "#itemsManageTable#" },
                 new String[] { vo.getItemsManageTable() });
         logger.debug("JDBC::doDropItemsTableIfExists sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
         return vo;
     }
 
-    public void doDropTable(String tableName) {
+    public void doDropTable(String tableName) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlDropTable, new String[] { "#tableName#" },
                 new String[] { tableName });
         logger.debug("JDBC::doDropTable sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public void doDeleteItemsEntry(ItemsVO vo) {
+    public void doDeleteItemsEntry(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlDeleteItemsEntry,
                 new String[] { "#itemsManageTable#", "#itemname#" },
                 new String[] { vo.getItemsManageTable(), vo.getItemName() });
         logger.debug("JDBC::doDeleteItemsEntry sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public List<ItemsVO> doGetItemIDTableNames(ItemsVO vo) {
+    public List<ItemsVO> doGetItemIDTableNames(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlGetItemIDTableNames, new String[] { "#itemsManageTable#" },
                 new String[] { vo.getItemsManageTable() });
         logger.debug("JDBC::doGetItemIDTableNames sql={}", sql);
-        return Yank.queryBeanList(sql, ItemsVO.class, null);
+        try {
+            return Yank.queryBeanList(sql, ItemsVO.class, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public List<ItemsVO> doGetItemTables(ItemsVO vo) {
+    public List<ItemsVO> doGetItemTables(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlGetItemTables,
                 new String[] { "#jdbcUriDatabaseName#", "#itemsManageTable#" },
                 new String[] { vo.getJdbcUriDatabaseName(), vo.getItemsManageTable() });
         logger.debug("JDBC::doGetItemTables sql={}", sql);
-        return Yank.queryBeanList(sql, ItemsVO.class, null);
+        try {
+            return Yank.queryBeanList(sql, ItemsVO.class, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /*************
      * ITEM DAOs *
      *************/
-    public void doUpdateItemTableNames(List<ItemVO> vol) {
+    public void doUpdateItemTableNames(List<ItemVO> vol) throws JdbcSQLException {
         logger.debug("JDBC::doUpdateItemTableNames vol.size = {}", vol.size());
         for (ItemVO itemTable : vol) {
             String sql = updateItemTableNamesProvider(itemTable);
-            Yank.execute(sql, null);
+            try {
+                Yank.execute(sql, null);
+            } catch (YankSQLException e) {
+                throw new JdbcSQLException(e);
+            }
         }
     }
 
-    public void doCreateItemTable(ItemVO vo) {
+    public void doCreateItemTable(ItemVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlCreateItemTable,
                 new String[] { "#tableName#", "#dbType#", "#tablePrimaryKey#" },
                 new String[] { vo.getTableName(), vo.getDbType(), sqlTypes.get("tablePrimaryKey") });
         logger.debug("JDBC::doCreateItemTable sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public void doStoreItemValue(Item item, State itemState, ItemVO vo) {
+    public void doStoreItemValue(Item item, State itemState, ItemVO vo) throws JdbcSQLException {
         ItemVO storedVO = storeItemValueProvider(item, itemState, vo);
         String sql = StringUtilsExt.replaceArrayMerge(sqlInsertItemValue,
                 new String[] { "#tableName#", "#tablePrimaryValue#" },
                 new String[] { storedVO.getTableName(), sqlTypes.get("tablePrimaryValue") });
         Object[] params = { storedVO.getValue(), storedVO.getValue() };
         logger.debug("JDBC::doStoreItemValue sql={} value='{}'", sql, storedVO.getValue());
-        Yank.execute(sql, params);
+        try {
+            Yank.execute(sql, params);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public void doStoreItemValue(Item item, State itemState, ItemVO vo, ZonedDateTime date) {
+    public void doStoreItemValue(Item item, State itemState, ItemVO vo, ZonedDateTime date) throws JdbcSQLException {
         ItemVO storedVO = storeItemValueProvider(item, itemState, vo);
         String sql = StringUtilsExt.replaceArrayMerge(sqlInsertItemValue,
                 new String[] { "#tableName#", "#tablePrimaryValue#" }, new String[] { storedVO.getTableName(), "?" });
         java.sql.Timestamp timestamp = new java.sql.Timestamp(date.toInstant().toEpochMilli());
         Object[] params = { timestamp, storedVO.getValue(), storedVO.getValue() };
         logger.debug("JDBC::doStoreItemValue sql={} timestamp={} value='{}'", sql, timestamp, storedVO.getValue());
-        Yank.execute(sql, params);
+        try {
+            Yank.execute(sql, params);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     public List<HistoricItem> doGetHistItemFilterQuery(Item item, FilterCriteria filter, int numberDecimalcount,
-            String table, String name, ZoneId timeZone) {
+            String table, String name, ZoneId timeZone) throws JdbcSQLException {
         String sql = histItemFilterQueryProvider(filter, numberDecimalcount, table, name, timeZone);
         logger.debug("JDBC::doGetHistItemFilterQuery sql={}", sql);
-        List<Object[]> m = Yank.queryObjectArrays(sql, null);
+        List<Object[]> m;
+        try {
+            m = Yank.queryObjectArrays(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
         if (m == null) {
             logger.debug("JDBC::doGetHistItemFilterQuery Query failed. Returning an empty list.");
             return List.of();
@@ -385,18 +452,26 @@ public class JdbcBaseDAO {
                 .collect(Collectors.<HistoricItem> toList());
     }
 
-    public void doDeleteItemValues(FilterCriteria filter, String table, ZoneId timeZone) {
+    public void doDeleteItemValues(FilterCriteria filter, String table, ZoneId timeZone) throws JdbcSQLException {
         String sql = histItemFilterDeleteProvider(filter, table, timeZone);
         logger.debug("JDBC::doDeleteItemValues sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
-    public long doGetRowCount(String tableName) {
+    public long doGetRowCount(String tableName) throws JdbcSQLException {
         final String sql = StringUtilsExt.replaceArrayMerge(sqlGetRowCount, new String[] { "#tableName#" },
                 new String[] { tableName });
         logger.debug("JDBC::doGetRowCount sql={}", sql);
-        final @Nullable Long result = Yank.queryScalar(sql, Long.class, null);
-        return Objects.requireNonNullElse(result, 0L);
+        try {
+            final @Nullable Long result = Yank.queryScalar(sql, Long.class, null);
+            return Objects.requireNonNullElse(result, 0L);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcHsqldbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcHsqldbDAO.java
@@ -15,10 +15,12 @@ package org.openhab.persistence.jdbc.db;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
+import org.knowm.yank.exceptions.YankSQLException;
 import org.openhab.core.items.Item;
 import org.openhab.core.types.State;
 import org.openhab.persistence.jdbc.dto.ItemVO;
 import org.openhab.persistence.jdbc.dto.ItemsVO;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.utils.StringUtilsExt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,34 +85,46 @@ public class JdbcHsqldbDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public @Nullable Integer doPingDB() {
-        return Yank.queryScalar(sqlPingDB, Integer.class, null);
+    public @Nullable Integer doPingDB() throws JdbcSQLException {
+        try {
+            return Yank.queryScalar(sqlPingDB, Integer.class, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     @Override
-    public ItemsVO doCreateItemsTableIfNot(ItemsVO vo) {
+    public ItemsVO doCreateItemsTableIfNot(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlCreateItemsTableIfNot,
                 new String[] { "#itemsManageTable#", "#colname#", "#coltype#", "#itemsManageTable#" },
                 new String[] { vo.getItemsManageTable(), vo.getColname(), vo.getColtype(), vo.getItemsManageTable() });
         logger.debug("JDBC::doCreateItemsTableIfNot sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
         return vo;
     }
 
     @Override
-    public Long doCreateNewEntryInItemsTable(ItemsVO vo) {
+    public Long doCreateNewEntryInItemsTable(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlCreateNewEntryInItemsTable,
                 new String[] { "#itemsManageTable#", "#itemname#" },
                 new String[] { vo.getItemsManageTable(), vo.getItemName() });
         logger.debug("JDBC::doCreateNewEntryInItemsTable sql={}", sql);
-        return Yank.insert(sql, null);
+        try {
+            return Yank.insert(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /*************
      * ITEM DAOs *
      *************/
     @Override
-    public void doStoreItemValue(Item item, State itemState, ItemVO vo) {
+    public void doStoreItemValue(Item item, State itemState, ItemVO vo) throws JdbcSQLException {
         ItemVO storedVO = storeItemValueProvider(item, itemState, vo);
         String sql = StringUtilsExt.replaceArrayMerge(sqlInsertItemValue,
                 new String[] { "#tableName#", "#dbType#", "#tableName#", "#tablePrimaryValue#" },
@@ -118,7 +132,11 @@ public class JdbcHsqldbDAO extends JdbcBaseDAO {
                         sqlTypes.get("tablePrimaryValue") });
         Object[] params = { storedVO.getValue() };
         logger.debug("JDBC::doStoreItemValue sql={} value='{}'", sql, storedVO.getValue());
-        Yank.execute(sql, params);
+        try {
+            Yank.execute(sql, params);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /****************************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMariadbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMariadbDAO.java
@@ -17,6 +17,8 @@ import java.util.Objects;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
+import org.knowm.yank.exceptions.YankSQLException;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.utils.DbMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,9 +97,13 @@ public class JdbcMariadbDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public @Nullable Integer doPingDB() {
-        final @Nullable Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
-        return Objects.nonNull(result) ? result.intValue() : null;
+    public @Nullable Integer doPingDB() throws JdbcSQLException {
+        try {
+            final @Nullable Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
+            return Objects.nonNull(result) ? result.intValue() : null;
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcMysqlDAO.java
@@ -17,6 +17,8 @@ import java.util.Objects;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
+import org.knowm.yank.exceptions.YankSQLException;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.utils.DbMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,9 +100,13 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
      * ITEMS DAOs *
      **************/
     @Override
-    public @Nullable Integer doPingDB() {
-        final @Nullable Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
-        return Objects.nonNull(result) ? result.intValue() : null;
+    public @Nullable Integer doPingDB() throws JdbcSQLException {
+        try {
+            final @Nullable Long result = Yank.queryScalar(sqlPingDB, Long.class, null);
+            return Objects.nonNull(result) ? result.intValue() : null;
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /*************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcSqliteDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcSqliteDAO.java
@@ -15,10 +15,12 @@ package org.openhab.persistence.jdbc.db;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.knowm.yank.Yank;
+import org.knowm.yank.exceptions.YankSQLException;
 import org.openhab.core.items.Item;
 import org.openhab.core.types.State;
 import org.openhab.persistence.jdbc.dto.ItemVO;
 import org.openhab.persistence.jdbc.dto.ItemsVO;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.utils.StringUtilsExt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,17 +81,25 @@ public class JdbcSqliteDAO extends JdbcBaseDAO {
      **************/
 
     @Override
-    public @Nullable String doGetDB() {
-        return Yank.queryColumn(sqlGetDB, "file", String.class, null).get(0);
+    public @Nullable String doGetDB() throws JdbcSQLException {
+        try {
+            return Yank.queryColumn(sqlGetDB, "file", String.class, null).get(0);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     @Override
-    public ItemsVO doCreateItemsTableIfNot(ItemsVO vo) {
+    public ItemsVO doCreateItemsTableIfNot(ItemsVO vo) throws JdbcSQLException {
         String sql = StringUtilsExt.replaceArrayMerge(sqlCreateItemsTableIfNot,
                 new String[] { "#itemsManageTable#", "#colname#", "#coltype#" },
                 new String[] { vo.getItemsManageTable(), vo.getColname(), vo.getColtype() });
         logger.debug("JDBC::doCreateItemsTableIfNot sql={}", sql);
-        Yank.execute(sql, null);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
         return vo;
     }
 
@@ -97,14 +107,18 @@ public class JdbcSqliteDAO extends JdbcBaseDAO {
      * ITEM DAOs *
      *************/
     @Override
-    public void doStoreItemValue(Item item, State itemState, ItemVO vo) {
+    public void doStoreItemValue(Item item, State itemState, ItemVO vo) throws JdbcSQLException {
         ItemVO storedVO = storeItemValueProvider(item, itemState, vo);
         String sql = StringUtilsExt.replaceArrayMerge(sqlInsertItemValue,
                 new String[] { "#tableName#", "#dbType#", "#tablePrimaryValue#" },
                 new String[] { storedVO.getTableName(), storedVO.getDbType(), sqlTypes.get("tablePrimaryValue") });
         Object[] params = { storedVO.getValue() };
         logger.debug("JDBC::doStoreItemValue sql={} value='{}'", sql, storedVO.getValue());
-        Yank.execute(sql, params);
+        try {
+            Yank.execute(sql, params);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 
     /****************************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcTimescaledbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcTimescaledbDAO.java
@@ -16,7 +16,9 @@ import java.util.Properties;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.knowm.yank.Yank;
+import org.knowm.yank.exceptions.YankSQLException;
 import org.openhab.persistence.jdbc.dto.ItemVO;
+import org.openhab.persistence.jdbc.exceptions.JdbcSQLException;
 import org.openhab.persistence.jdbc.utils.StringUtilsExt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,11 +47,15 @@ public class JdbcTimescaledbDAO extends JdbcPostgresqlDAO {
     }
 
     @Override
-    public void doCreateItemTable(ItemVO vo) {
+    public void doCreateItemTable(ItemVO vo) throws JdbcSQLException {
         super.doCreateItemTable(vo);
         String sql = StringUtilsExt.replaceArrayMerge(this.sqlCreateHypertable, new String[] { "#tableName#" },
                 new String[] { vo.getTableName() });
         this.logger.debug("JDBC::doCreateItemTable sql={}", sql);
-        Yank.queryScalar(sql, Boolean.class, null);
+        try {
+            Yank.queryScalar(sql, Boolean.class, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
     }
 }

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/exceptions/JdbcException.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/exceptions/JdbcException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.jdbc.exceptions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Base class for JDBC exceptions.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class JdbcException extends Exception {
+
+    private static final long serialVersionUID = 1911437557128995424L;
+
+    public JdbcException(String message) {
+        super(message);
+    }
+
+    public JdbcException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/exceptions/JdbcSQLException.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/exceptions/JdbcSQLException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.jdbc.exceptions;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.knowm.yank.exceptions.YankSQLException;
+
+/**
+ * This exception wraps a {@link YankSQLException}.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class JdbcSQLException extends JdbcException {
+
+    private static final long serialVersionUID = 4562191548585905000L;
+
+    public JdbcSQLException(YankSQLException sqlException) {
+        super(Objects.requireNonNull(sqlException.getMessage()));
+    }
+}

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/utils/DbMetaData.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/utils/DbMetaData.java
@@ -42,7 +42,6 @@ public class DbMetaData {
 
     public DbMetaData() {
         HikariDataSource h = Yank.getDefaultConnectionPool();
-        // HikariDataSource h = Yank.getDataSource();
 
         DatabaseMetaData meta;
         try {


### PR DESCRIPTION
This is a continuation of #13719 with two purposes:
- Introduce abstraction by wrapping `YankSQLException` into custom exception. This way Yank can be refactored or replaced without any impact on callers.
- Make custom exception checked to enforce handling - like `SQLException`.

Related to #13718