### PR TITLE
[networkupstools] Add missing status

### DIFF
--- a/bundles/org.openhab.binding.networkupstools/src/main/resources/OH-INF/i18n/networkupstools.properties
+++ b/bundles/org.openhab.binding.networkupstools/src/main/resources/OH-INF/i18n/networkupstools.properties
@@ -86,6 +86,7 @@ channel-type.networkupstools.ups-status.state.option.OL\ CHRG = Online, charging
 channel-type.networkupstools.ups-status.state.option.OL\ LB = Online, low battery
 channel-type.networkupstools.ups-status.state.option.OL\ CHRG\ LB = Online, charging, low battery
 channel-type.networkupstools.ups-status.state.option.RB = Replace battery
+channel-type.networkupstools.ups-status.state.option.ALARM\ OL\ RB = Alarm, online, replace battery
 channel-type.networkupstools.ups-status.state.option.OVER = Overload
 channel-type.networkupstools.ups-status.state.option.TRIM = Voltage trim
 channel-type.networkupstools.ups-status.state.option.BOOST = Voltage boost

--- a/bundles/org.openhab.binding.networkupstools/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.networkupstools/src/main/resources/OH-INF/thing/channels.xml
@@ -43,6 +43,7 @@
 				<option value="OL LB">Online, low battery</option>
 				<option value="OL CHRG LB">Online, charging, low battery</option>
 				<option value="RB">Replace battery</option>
+				<option value="ALARM OL RB">Alarm, online, replace battery</option>
 				<option value="OVER">Overload</option>
 				<option value="TRIM">Voltage trim</option>
 				<option value="BOOST">Voltage boost</option>


### PR DESCRIPTION
Add state option display string for my APC UPS that is reporting an alarm indicating the battery needs replacing.

![image](https://user-images.githubusercontent.com/26532542/202059115-e4af257c-d9a9-4d1a-b1d4-9ab9c1971e57.png)
