### PR TITLE
[jdbc] Add console command for reloading index/schema

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -195,6 +195,12 @@ This happened:
 
 In other words, extracting this information from the index before removing it, can be beneficial in order to understand the issues and possible causes.
 
+#### Reload Index/Schema
+
+Manual changes in the index table, `Items`, will not be picked up automatically for performance reasons.
+The same is true when manually adding new item tables or deleting existing ones.
+After making such changes, the command `jdbc reload` can be used to reload the index.
+
 ### For Developers
 
 * Clearly separated source files for the database-specific part of openHAB logic.

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -302,7 +302,7 @@ public class JdbcMapper {
         populateItemNameToTableNameMap();
     }
 
-    private void populateItemNameToTableNameMap() throws JdbcSQLException {
+    public void populateItemNameToTableNameMap() throws JdbcSQLException {
         itemNameToTableNameMap.clear();
         if (conf.getTableUseRealCaseSensitiveItemNames()) {
             for (String itemName : getItemTables().stream().map(t -> t.getTableName()).collect(Collectors.toList())) {


### PR DESCRIPTION
Reloading can be useful after manual index/schema changes in order to refresh the internal **item name -> table name** map.

Related to #13661