### PR TITLE
[jdbc] Make itemsManageTable configurable

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -60,6 +60,7 @@ This service can be configured in the file `services/jdbc.cfg`.
 | sqltype.tablePrimaryKey     | `TIMESTAMP`                                                  |    No     | type of `time` column for newly created item tables          |
 | sqltype.tablePrimaryValue   | `NOW()`                                                      |    No     | value of `time` column for newly inserted rows               |
 | numberDecimalcount          | 3                                                            |    No     | for Itemtype "Number" default decimal digit count            |
+| itemsManageTable            | `items`                                                      |    No     | items manage table. For Migration from MySQL Persistence, set to `Items`. |
 | tableNamePrefix             | `item`                                                       |    No     | table name prefix. For Migration from MySQL Persistence, set to `Item`. |
 | tableUseRealItemNames       | `false`                                                      |    No     | table name prefix generation.  When set to `true`, real item names are used for table names and `tableNamePrefix` is ignored.  When set to `false`, the `tableNamePrefix` is used to generate table names with sequential numbers. |
 | tableCaseSensitiveItemNames | `false`                                                      |    No     | table name case. This setting is only applicable when `tableUseRealItemNames` is `true`. When set to `true`, item name case is preserved in table names and no prefix or suffix is added. When set to `false`, table names are lower cased and a numeric suffix is added. Please read [this](#case-sensitive-item-names) before enabling. |
@@ -107,6 +108,7 @@ services/jdbc.cfg
 url=jdbc:mysql://192.168.0.1:3306/testMysql
 user=test
 password=test
+itemsManageTable=Items
 tableNamePrefix=Item
 tableUseRealItemNames=false
 tableIdDigitCount=0
@@ -125,7 +127,10 @@ The item data tables include time and data values.
 The SQL data type used depends on the openHAB item type, and allows the item state to be recovered back into openHAB in the same way it was stored.
 
 With this *per-item* layout, the scalability and easy maintenance of the database is ensured, even if large amounts of data must be managed.
-To rename existing tables, use the parameters `tableUseRealItemNames` and `tableIdDigitCount` in the configuration.
+To rename existing tables, use the parameters `tableNamePrefix`, `tableUseRealItemNames`, `tableIdDigitCount` and `tableCaseSensitiveItemNames` in the configuration.
+
+Please be aware that changing the name of `itemsManageTable` is not supported by the migration.
+If this is changed, the table must be renamed manually according to new configured name.
 
 ### Number Precision
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -58,6 +58,7 @@ public class JdbcConfiguration {
     private int numberDecimalcount = 3;
     private boolean tableUseRealItemNames = false;
     private boolean tableCaseSensitiveItemNames = false;
+    private String itemsManageTable = "items";
     private String tableNamePrefix = "item";
     private int tableIdDigitCount = 4;
     private boolean rebuildTableNames = false;
@@ -144,6 +145,12 @@ public class JdbcConfiguration {
         if (et != null && !et.isBlank() && isNumericPattern.matcher(et).matches()) {
             errReconnectThreshold = Integer.parseInt(et);
             logger.debug("JDBC::updateConfig: errReconnectThreshold={}", errReconnectThreshold);
+        }
+
+        String mt = (String) configuration.get("itemsManageTable");
+        if (mt != null && !mt.isBlank()) {
+            itemsManageTable = mt;
+            logger.debug("JDBC::updateConfig: itemsManageTable={}", itemsManageTable);
         }
 
         String np = (String) configuration.get("tableNamePrefix");
@@ -348,6 +355,10 @@ public class JdbcConfiguration {
 
     public @Nullable String getServiceName() {
         return serviceName;
+    }
+
+    public String getItemsManageTable() {
+        return itemsManageTable;
     }
 
     public String getTableNamePrefix() {

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/dto/ItemsVO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/dto/ItemsVO.java
@@ -27,8 +27,8 @@ public class ItemsVO implements Serializable {
     private static final String STR_FILTER = "[^a-zA-Z0-9]";
 
     private String coltype = "VARCHAR(500)";
-    private String colname = "itemname";
-    private String itemsManageTable = "items";
+    private String colname = "ItemName";
+    private String itemsManageTable;
     private int itemId;
     private String itemName;
     private String tableName;

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/config/config.xml
@@ -134,6 +134,10 @@
 
 		<!--
 			# T A B L E O P E R A T I O N S
+			# Items Manage Table (optional, default: "items")
+			# for Migration from MYSQL-Bundle set to 'Items'.
+			#itemsManageTable=Items
+
 			# Tablename Prefix String (optional, default: "item")
 			# for Migration from MYSQL-Bundle set to 'Item'.
 			#tableNamePrefix=Item
@@ -156,6 +160,11 @@
 			# USE WITH CARE! Deactivate after Renaming is done!
 			#rebuildTableNames=true
 		-->
+		<parameter name="itemsManageTable" type="text">
+			<label>Items Manage Table</label>
+			<description><![CDATA[Items Manage Table <br>(optional, default: "items"). <br>
+			For migration from MYSQL-Bundle set to 'Items'.]]></description>
+		</parameter>
 		<parameter name="tableNamePrefix" type="text">
 			<label>Tablename Prefix String</label>
 			<description><![CDATA[Tablename prefix string <br>(optional, default: "item"). <br>


### PR DESCRIPTION
Items are by default prefixed with `item` and the items management table is named `items`.

When migrating from the MySQL Persistence Service, users are advised to use `tableNamePrefix=Item` in configuration, but it is not mentioned that they need to manually rename the items management table from `Items` to `items`. Failing to do so will result in a new empty `items` table being created alongside the existing `Items` table. This is counter-intuitive.

This pull request introduces a configuration option to set the name of the items management table, so existing `Items` table from a migration can be used as is. This eases the migration and adds more flexibility as any desired name can be configured, instead of the items management table name being hardcoded.

Fixes #9637