### PR TITLE
[mqtt.espmilighthub] Fix wrong textual example formats in readme

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -93,7 +93,7 @@ To remove a saved state from your MQTT broker that causes an entry in your INBOX
 mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' -n -r
 ```
 
-Note that the group 0 (or ALL group) is not autodiscovered as a thing and thus has to be added manually if needed (see section [Using the group 0](#using-the-group-0) for details on when and how to do this)
+Note that the group 0 (or ALL group) is not auto discovered as a thing and thus has to be added manually if needed.
 
 ## Thing Configuration
 
@@ -137,10 +137,10 @@ Suggested settings are as follows:
 
 This binding requires things to have a specific format for the unique ID, the auto discovery does this for you.
 
-If doing textual configuration you need to add the Device ID and Group ID together to create the things unique ID.
+If doing textual configuration, you need to add the Device ID and Group ID together to create the things unique ID.
 The DeviceID is different for each remote.
 The GroupID can be 0 (all channels on the remote), or 1 to 8 for each of the individual channels on the remote).
-If you do not understand this please use auto discovery to do it for you.
+If you do not understand this, please use auto discovery to do it for you.
 
 The formula is
 DeviceID + GroupID = ThingUID
@@ -171,7 +171,7 @@ Only if you want the controls do you need to link any channels and create the it
 
 ## Full Example
 
-To use these examples for textual configuration, you must already have a configured a MQTT `broker` thing and know its unique ID.
+To use these examples for textual configuration, you must already have a configured MQTT `broker` thing, and know its unique ID.
 This UID will be used in the things file and will replace the text `myBroker`.
 The first line in the things file will create a `broker` thing and this can be removed if you have already setup a broker in another file or via the UI already.
 
@@ -179,18 +179,18 @@ The first line in the things file will create a `broker` thing and this can be r
 
 ```
 Bridge mqtt:broker:myBroker [ host="localhost", secure=false, password="*******", qos=1, username="user"]
-Thing mqtt:rgb_cct:0xE6C4 "Hallway" (mqtt:broker:myBroker) @ "MQTT"
+Thing mqtt:rgb_cct:myBroker:0xE6C4 "Hallway" (mqtt:broker:myBroker) @ "MQTT"
 ```
 
 *.items
 
 ```
-Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:0xE6C4:level"}
-Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:0xE6C4:colourTemperature"}
-Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:0xE6C4:colour"}
-String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:0xE6C4:discoMode"}
-String Hallway_BulbCommand "Send Command" {channel="mqtt:rgb_cct:0xE6C4:command"}
-String Hallway_BulbMode "Bulb Mode" {channel="mqtt:rgb_cct:0xE6C4:bulbMode"}
+Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:myBroker:0xE6C4:level"}
+Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:myBroker:0xE6C4:colourTemperature"}
+Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:myBroker:0xE6C4:colour"}
+String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:myBroker:0xE6C4:discoMode"}
+String Hallway_BulbCommand "Send Command" {channel="mqtt:rgb_cct:myBroker:0xE6C4:command"}
+String Hallway_BulbMode "Bulb Mode" {channel="mqtt:rgb_cct:myBroker:0xE6C4:bulbMode"}
 
 ```
 


### PR DESCRIPTION
Fix wrong format of the textual example as it was not allowing state updates to change openHAB controls when following the old format. Reported on forum here:
https://community.openhab.org/t/mqtt-binding-with-espmilight-mostly-working-not-getting-updates-in-openhab-when-using-remote/141153/7

Signed-off-by: Matthew Skinner <matt@pcmus.com>