### PR TITLE
[jsscripting] Fix maven build

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -48,9 +48,9 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.12.0</version>
+        <version>1.12.1</version>
         <configuration>
-          <nodeVersion>v16.17.1</nodeVersion>
+          <nodeVersion>v16.17.1</nodeVersion> <!-- DO NOT DOWNGRADE: NodeJS < 16 doesn't support Apple Silicon -->
           <workingDirectory>target/js</workingDirectory>
         </configuration>
         <executions>
@@ -67,7 +67,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install ${ohjs.version} webpack webpack-cli</arguments>
+              <arguments>install ${ohjs.version} webpack@5.75.0 webpack-cli@4.10.0</arguments> <!-- webpack-cli >= 5.0.0 doesn't properly process the given entrypoint -->
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This fixes the maven build, that fails because webpack-cli version 5.0.0 doesn’t properly process the given entrypoint. Instead, webpack tries to use the entrypoint from openhab-js‘ webpack config file.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>

cc @J-N-K