### PR TITLE
[resol] Fix handling of WeekTime fields on vbus

### DIFF
--- a/bundles/org.openhab.binding.resol/pom.xml
+++ b/bundles/org.openhab.binding.resol/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>de.resol</groupId>
       <artifactId>vbus</artifactId>
-      <version>0.7.0</version>
+      <version>0.10.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
+++ b/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
@@ -48,6 +48,7 @@ import de.resol.vbus.SpecificationFile;
 import de.resol.vbus.SpecificationFile.Enum;
 import de.resol.vbus.SpecificationFile.EnumVariant;
 import de.resol.vbus.SpecificationFile.Language;
+import tech.units.indriya.AbstractUnit;
 
 /**
  * The {@link ResolThingHandler} is responsible for handling commands, which are
@@ -254,7 +255,7 @@ public class ResolThingHandler extends ResolBaseThingHandler {
                                         this.updateState(channelId, q);
                                     } catch (IllegalArgumentException e) {
                                         logger.debug("unit of '{}' unknown in openHAB", str);
-                                        QuantityType<?> q = new QuantityType<>(dd.toString(), Locale.getDefault());
+                                        QuantityType<?> q = new QuantityType<>(dd, AbstractUnit.ONE);
                                         this.updateState(channelId, q);
                                     }
                                 }

--- a/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
+++ b/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
@@ -67,7 +67,7 @@ public class ResolThingHandler extends ResolBaseThingHandler {
 
     private static final SimpleDateFormat TIME_FORMAT = new SimpleDateFormat("HH:mm");
 
-    private static final SimpleDateFormat WEEK_FORMAT = new SimpleDateFormat("E, HH:mm");
+    private static final SimpleDateFormat WEEK_FORMAT = new SimpleDateFormat("EEE,HH:mm");
 
     static {
         synchronized (DATE_FORMAT) {
@@ -158,13 +158,13 @@ public class ResolThingHandler extends ResolBaseThingHandler {
 
             Thing thing = getThing();
             switch (pfv.getPacketFieldSpec().getType()) {
-                case WeekTime:
                 case DateTime:
                     acceptedItemType = "DateTime";
                     break;
                 case Number:
                     acceptedItemType = ResolChannelTypeProvider.itemTypeForUnit(pfv.getPacketFieldSpec().getUnit());
                     break;
+                case WeekTime:
                 case Time:
                 default:
                     acceptedItemType = "String";
@@ -249,11 +249,12 @@ public class ResolThingHandler extends ResolBaseThingHandler {
                                     this.updateState(channelId, q);
                                 } else {
                                     try {
-                                        QuantityType<?> q = new QuantityType<>(str);
+                                        QuantityType<?> q = new QuantityType<>(str, Locale
+                                                .getDefault()); /* vbus library returns the value in default locale */
                                         this.updateState(channelId, q);
                                     } catch (IllegalArgumentException e) {
                                         logger.debug("unit of '{}' unknown in openHAB", str);
-                                        QuantityType<?> q = new QuantityType<>(dd.toString());
+                                        QuantityType<?> q = new QuantityType<>(dd.toString(), Locale.getDefault());
                                         this.updateState(channelId, q);
                                     }
                                 }
@@ -272,8 +273,7 @@ public class ResolThingHandler extends ResolBaseThingHandler {
                         break;
                     case WeekTime:
                         synchronized (WEEK_FORMAT) {
-                            DateTimeType d = new DateTimeType(WEEK_FORMAT.format(pfv.getRawValueDate()));
-                            this.updateState(channelId, d);
+                            this.updateState(channelId, new StringType(WEEK_FORMAT.format(pfv.getRawValueDate())));
                         }
                         break;
                     case DateTime:
@@ -287,13 +287,15 @@ public class ResolThingHandler extends ResolBaseThingHandler {
                         if (b != null) {
                             ResolBridgeHandler handler = (ResolBridgeHandler) b.getHandler();
                             String value;
+                            Locale loc;
                             if (handler != null) {
-                                value = pfv.formatTextValue(pfv.getPacketFieldSpec().getUnit(), handler.getLocale());
+                                loc = handler.getLocale();
                             } else {
-                                value = pfv.formatTextValue(pfv.getPacketFieldSpec().getUnit(), Locale.getDefault());
+                                loc = Locale.getDefault();
                             }
+                            value = pfv.formatTextValue(pfv.getPacketFieldSpec().getUnit(), loc);
                             try {
-                                QuantityType<?> q = new QuantityType<>(value);
+                                QuantityType<?> q = new QuantityType<>(value, loc);
                                 this.updateState(channelId, q);
                             } catch (IllegalArgumentException e) {
                                 this.updateState(channelId, new StringType(value));

--- a/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
+++ b/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
@@ -48,7 +48,6 @@ import de.resol.vbus.SpecificationFile;
 import de.resol.vbus.SpecificationFile.Enum;
 import de.resol.vbus.SpecificationFile.EnumVariant;
 import de.resol.vbus.SpecificationFile.Language;
-import tech.units.indriya.AbstractUnit;
 
 /**
  * The {@link ResolThingHandler} is responsible for handling commands, which are
@@ -255,7 +254,7 @@ public class ResolThingHandler extends ResolBaseThingHandler {
                                         this.updateState(channelId, q);
                                     } catch (IllegalArgumentException e) {
                                         logger.debug("unit of '{}' unknown in openHAB", str);
-                                        QuantityType<?> q = new QuantityType<>(dd, AbstractUnit.ONE);
+                                        QuantityType<?> q = new QuantityType<>(dd, Units.ONE);
                                         this.updateState(channelId, q);
                                     }
                                 }

--- a/bundles/org.openhab.binding.resol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.resol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -145,7 +145,7 @@
 	</thing-type>
 
 	<channel-type id="weektime">
-		<item-type>DateTime</item-type>
+		<item-type>String</item-type>
 		<label>Time</label>
 		<description>Time and day of week.</description>
 		<category>Time</category>


### PR DESCRIPTION
Controllers (for example the SKSR 1/2/3) on the VBUS transmitting fields of type WeekTime did not work as decribed in #13447 which is fixed by this PR.

The resol-vbus-java library used by this binding was also improved for this controller in the meantime, that's why this PR integrates an upgrade to the latest version of this lib.

A compiled version of this code change can be found [here](https://github.com/ramack/openhab-addons/blob/51dd67d764f11084cb904aeabf7a02cb52f4791e/bundles/org.openhab.binding.resol/target/org.openhab.binding.resol-3.4.0-SNAPSHOT.jar?raw=true) and @paicl01 tested it successfully.
