### PR TITLE
[jsscripting] Fix add-on name in feature/pom

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.automation.jsscripting</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: Automation :: JSScripting</name>
+  <name>openHAB Add-ons :: Bundles :: Automation :: JS Scripting</name>
 
   <properties>
     <bnd.importpackage>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.automation.jsscripting</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: Automation :: JS Scripting</name>
+  <name>openHAB Add-ons :: Bundles :: Automation :: JavaScript Scripting</name>
 
   <properties>
     <bnd.importpackage>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -3,7 +3,7 @@
 <features name="org.openhab.automation.jsscripting-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-	<feature name="openhab-automation-jsscripting" description="JS Scripting" version="${project.version}">
+	<feature name="openhab-automation-jsscripting" description="JavaScript Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -3,7 +3,7 @@
 <features name="org.openhab.automation.jsscripting-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-	<feature name="openhab-automation-jsscripting" description="JSScripting" version="${project.version}">
+	<feature name="openhab-automation-jsscripting" description="JS Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>


### PR DESCRIPTION
Working with the UI, I noticed that the JS Scripting addon there is actually called _JSScripting_ (without the space).
This PR should correct this.