### PR TITLE
[jdbc] Add console command for checking/repairing schema integrity

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -208,6 +208,12 @@ Manual changes in the index table, `Items`, will not be picked up automatically 
 The same is true when manually adding new item tables or deleting existing ones.
 After making such changes, the command `jdbc reload` can be used to reload the index.
 
+#### Check/fix Schema
+
+Use the command `jdbc schema check` to perform an integrity check of the schema.
+
+Identified issues can be fixed automatically using the command `jdbc schema fix` (all items having issues) or `jdbc schema fix <itemName>` (single item).
+
 ### For Developers
 
 * Clearly separated source files for the database-specific part of openHAB logic.

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -201,6 +201,14 @@ public class JdbcMapper {
         return vo;
     }
 
+    protected void alterTableColumn(String tableName, String columnName, String columnType, boolean nullable)
+            throws JdbcSQLException {
+        logger.debug("JDBC::alterTableColumn");
+        long timerStart = System.currentTimeMillis();
+        conf.getDBDAO().doAlterTableColumn(tableName, columnName, columnType, nullable);
+        logTime("alterTableColumn", timerStart, System.currentTimeMillis());
+    }
+
     protected void storeItemValue(Item item, State itemState, @Nullable ZonedDateTime date) throws JdbcException {
         logger.debug("JDBC::storeItemValue: item={} state={} date={}", item, itemState, date);
         String tableName = getTable(item);

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -31,6 +31,7 @@ import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceItemInfo;
 import org.openhab.core.types.State;
+import org.openhab.persistence.jdbc.internal.dto.Column;
 import org.openhab.persistence.jdbc.internal.dto.ItemVO;
 import org.openhab.persistence.jdbc.internal.dto.ItemsVO;
 import org.openhab.persistence.jdbc.internal.dto.JdbcPersistenceItemInfo;
@@ -169,6 +170,17 @@ public class JdbcMapper {
         List<ItemsVO> vol = conf.getDBDAO().doGetItemTables(isvo);
         logTime("getItemTables", timerStart, System.currentTimeMillis());
         return vol;
+    }
+
+    protected List<Column> getTableColumns(String tableName) throws JdbcSQLException {
+        logger.debug("JDBC::getTableColumns");
+        long timerStart = System.currentTimeMillis();
+        ItemsVO isvo = new ItemsVO();
+        isvo.setJdbcUriDatabaseName(conf.getDbName());
+        isvo.setTableName(tableName);
+        List<Column> is = conf.getDBDAO().doGetTableColumns(isvo);
+        logTime("getTableColumns", timerStart, System.currentTimeMillis());
+        return is;
     }
 
     /****************

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -40,6 +40,8 @@ import org.openhab.core.persistence.QueryablePersistenceService;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
+import org.openhab.persistence.jdbc.internal.db.JdbcBaseDAO;
+import org.openhab.persistence.jdbc.internal.dto.Column;
 import org.openhab.persistence.jdbc.internal.dto.ItemsVO;
 import org.openhab.persistence.jdbc.internal.exceptions.JdbcException;
 import org.openhab.persistence.jdbc.internal.exceptions.JdbcSQLException;
@@ -301,6 +303,56 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
      */
     public Collection<String> getItemNames() {
         return itemNameToTableNameMap.keySet();
+    }
+
+    /**
+     * Get a map of item names to table names.
+     */
+    public Map<String, String> getItemNameToTableNameMap() {
+        return itemNameToTableNameMap;
+    }
+
+    public Collection<String> getSchemaIssues(String tableName, String itemName) throws JdbcSQLException {
+        List<String> issues = new ArrayList<>();
+        Item item;
+        try {
+            item = itemRegistry.getItem(itemName);
+        } catch (ItemNotFoundException e) {
+            return issues;
+        }
+        JdbcBaseDAO dao = conf.getDBDAO();
+        String timeDataType = dao.sqlTypes.get("tablePrimaryKey");
+        if (timeDataType == null) {
+            return issues;
+        }
+        String valueDataType = dao.getDataType(item);
+        List<Column> columns = getTableColumns(tableName);
+        for (Column column : columns) {
+            String columnName = column.getColumnName();
+            if ("time".equalsIgnoreCase(columnName)) {
+                if (!"time".equals(columnName)) {
+                    issues.add("Column name 'time' expected, but is '" + columnName + "'");
+                }
+                if (!timeDataType.equalsIgnoreCase(column.getColumnType())) {
+                    issues.add("Column type '" + timeDataType + "' expected, but is '"
+                            + column.getColumnType().toUpperCase() + "'");
+                }
+                if (column.getIsNullable()) {
+                    issues.add("Column 'time' expected to be NOT NULL, but is nullable");
+                }
+            } else if ("value".equalsIgnoreCase(columnName)) {
+                if (!"value".equals(columnName)) {
+                    issues.add("Column name 'value' expected, but is '" + columnName + "'");
+                }
+                if (!valueDataType.equalsIgnoreCase(column.getColumnType())) {
+                    issues.add("Column type '" + valueDataType + "' expected, but is '"
+                            + column.getColumnType().toUpperCase() + "'");
+                }
+            } else {
+                issues.add("Column '" + columnName + "' not expected");
+            }
+        }
+        return issues;
     }
 
     /**

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcBaseDAO.java
@@ -94,7 +94,8 @@ public class JdbcBaseDAO {
     protected String sqlGetItemTables = "SELECT table_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema='#jdbcUriDatabaseName#' AND NOT table_name='#itemsManageTable#'";
     protected String sqlGetTableColumnTypes = "SELECT column_name, column_type, is_nullable FROM information_schema.columns WHERE table_schema='#jdbcUriDatabaseName#' AND table_name='#tableName#'";
     protected String sqlCreateItemTable = "CREATE TABLE IF NOT EXISTS #tableName# (time #tablePrimaryKey# NOT NULL, value #dbType#, PRIMARY KEY(time))";
-    protected String sqlInsertItemValue = "INSERT INTO #tableName# (TIME, VALUE) VALUES( #tablePrimaryValue#, ? ) ON DUPLICATE KEY UPDATE VALUE= ?";
+    protected String sqlAlterTableColumn = "ALTER TABLE #tableName# MODIFY COLUMN #columnName# #columnType#";
+    protected String sqlInsertItemValue = "INSERT INTO #tableName# (time, value) VALUES( #tablePrimaryValue#, ? ) ON DUPLICATE KEY UPDATE VALUE= ?";
     protected String sqlGetRowCount = "SELECT COUNT(*) FROM #tableName#";
 
     /********
@@ -409,6 +410,19 @@ public class JdbcBaseDAO {
                 new String[] { "#tableName#", "#dbType#", "#tablePrimaryKey#" },
                 new String[] { vo.getTableName(), vo.getDbType(), sqlTypes.get("tablePrimaryKey") });
         logger.debug("JDBC::doCreateItemTable sql={}", sql);
+        try {
+            Yank.execute(sql, null);
+        } catch (YankSQLException e) {
+            throw new JdbcSQLException(e);
+        }
+    }
+
+    public void doAlterTableColumn(String tableName, String columnName, String columnType, boolean nullable)
+            throws JdbcSQLException {
+        String sql = StringUtilsExt.replaceArrayMerge(sqlAlterTableColumn,
+                new String[] { "#tableName#", "#columnName#", "#columnType#" },
+                new String[] { tableName, columnName, nullable ? columnType : columnType + " NOT NULL" });
+        logger.debug("JDBC::doAlterTableColumn sql={}", sql);
         try {
             Yank.execute(sql, null);
         } catch (YankSQLException e) {

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcBaseDAO.java
@@ -741,7 +741,6 @@ public class JdbcBaseDAO {
             }
         }
         String itemType = item.getClass().getSimpleName().toUpperCase();
-        logger.debug("JDBC::getItemType: Try to use ItemType {} for Item {}", itemType, i.getName());
         if (sqlTypes.get(itemType) == null) {
             logger.warn(
                     "JDBC::getItemType: No sqlType found for ItemType {}, use ItemType for STRINGITEM as Fallback for {}",

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcDerbyDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcDerbyDAO.java
@@ -72,6 +72,7 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
         // Prevent error against duplicate time value (seldom): No powerful Merge found:
         // http://www.codeproject.com/Questions/162627/how-to-insert-new-record-in-my-table-if-not-exists
         sqlInsertItemValue = "INSERT INTO #tableName# (TIME, VALUE) VALUES( #tablePrimaryValue#, CAST( ? as #dbType#) )";
+        sqlAlterTableColumn = "ALTER TABLE #tableName# ALTER COLUMN #columnName# SET DATA TYPE #columnType#";
     }
 
     private void initSqlTypes() {

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcPostgresqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcPostgresqlDAO.java
@@ -68,6 +68,7 @@ public class JdbcPostgresqlDAO extends JdbcBaseDAO {
         // SQL_INSERT_ITEM_VALUE = "INSERT INTO #tableName# (TIME, VALUE) VALUES( NOW(), CAST( ? as #dbType#) ) ON
         // CONFLICT DO NOTHING";
         sqlInsertItemValue = "INSERT INTO #tableName# (TIME, VALUE) VALUES( #tablePrimaryValue#, CAST( ? as #dbType#) )";
+        sqlAlterTableColumn = "ALTER TABLE #tableName# ALTER COLUMN #columnName# TYPE #columnType#";
     }
 
     /**

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/dto/Column.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/dto/Column.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.jdbc.internal.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Represents an INFORMATON_SCHEMA.COLUMNS table row.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class Column {
+
+    private @Nullable String columnName;
+    private boolean isNullable;
+    private @Nullable String columnType;
+
+    public String getColumnName() {
+        String columnName = this.columnName;
+        return columnName != null ? columnName : "";
+    }
+
+    public String getColumnType() {
+        String columnType = this.columnType;
+        return columnType != null ? columnType : "";
+    }
+
+    public boolean getIsNullable() {
+        return isNullable;
+    }
+
+    public void setColumnName(String columnName) {
+        this.columnName = columnName;
+    }
+
+    public void setColumnType(String columnType) {
+        this.columnType = columnType;
+    }
+
+    public void setIsNullable(boolean isNullable) {
+        this.isNullable = isNullable;
+    }
+}


### PR DESCRIPTION
This pull request provides tools for detecting and repairing database schema inconsistencies which may have accumulated over time, when many things changed since tables were created. For example:
- Migration from MySQL persistence where `DATETIME` was used for the time column, whereas this is now `TIMESTAMP(3)`.
- Bugfixes extending or otherwise changing column types, for example #10542 and #9394.
- Manual corrections which are inconsistent with the JDBC types.

### Example

```
openhab> openhab:jdbc schema check
Table        Item         Issue
-----------  -----------  ----------------------------------------------------------------
Anyone_Home  Anyone_Home  Column name 'time' expected, but is 'Time'
Anyone_Home  Anyone_Home  Column type 'TIMESTAMP(3)' expected, but is 'DATETIME'
Anyone_Home  Anyone_Home  Column name 'value' expected, but is 'Value'
Anyone_Home  Anyone_Home  Column type 'VARCHAR(6)' expected, but is 'CHAR(3)'
openhab> openhab:jdbc schema fix
Fixed table 'Anyone_Home' for item 'Anyone_Home'
```

### Test

JAR for testing: [org.openhab.persistence.jdbc-3.4.0-SNAPSHOT.jar](https://drive.google.com/file/d/1aEq2eyimz0V4JfRqBtq98dQ1MKkLNeZy/view?usp=sharing)

Place the corresponding database driver into the addons directory. For example, download the [MySQL connector](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.30/mysql-connector-java-8.0.30.jar) and rename it to `mysql-connector-java.jar` or the [MariaDB client](https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.0.8/mariadb-java-client-3.0.8.jar) and rename it to `mariadb-java-client.jar`.

Resolves #13712