### PR TITLE
iCloud Binding - Maintainer change

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -139,7 +139,7 @@
 /bundles/org.openhab.binding.iammeter/ @lewei50
 /bundles/org.openhab.binding.iaqualink/ @digitaldan
 /bundles/org.openhab.binding.icalendar/ @daMihe
-/bundles/org.openhab.binding.icloud/ @pgfeller
+/bundles/org.openhab.binding.icloud/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.ihc/ @paulianttila
 /bundles/org.openhab.binding.innogysmarthome/ @ollie-dev
 /bundles/org.openhab.binding.insteon/ @robnielsen


### PR DESCRIPTION
# iCloud Binding - Maintainer change

Unfortunately I do not have the resources (and equipment) anymore to act as maintainer of this add-on; and therefore have to resign from this
role.

Signed-off-by: Patrik Gfeller <patrik.gfeller@gmail.com>