### PR TITLE
[ipcamera] Improve support for newer 2k+ Instar cameras

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/README.md
+++ b/bundles/org.openhab.binding.ipcamera/README.md
@@ -167,7 +167,7 @@ If you do not specify any of these, the binding will use the default which shoul
 |-|-|
 | `ipAddress`| The IP address or host name of your camera. |
 | `port`| This port will be used for HTTP calls for fetching the snapshot and any API calls. |
-| `onvifPort`| The port your camera uses for ONVIF connections. This is needed for PTZ movement, events, and the auto discovery of RTSP and snapshot URLs. |
+| `onvifPort`| The port your camera uses for ONVIF connections. This is needed for PTZ movement, events, and the auto discovery of RTSP and snapshot URLs. A value of 0 will prevent the binding from trying to connect to ONVIF. |
 | `username`| Leave blank if your camera does not use login details. |
 | `password`| Leave blank if your camera does not use login details. |
 | `onvifMediaProfile`| 0 (default) is your cameras Mainstream and the numbers above 0 are the substreams. Any auto discovered URLs will use the streams that this indicates. You can always override the URLs should you wish to use something different for one of them. |

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -422,11 +422,4 @@ public class HikvisionHandler extends ChannelDuplexHandler {
                 return;
         }
     }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> Fix never ending WARN when HIK camera does not support alarm inputs.
-=======
->>>>>>> fix spotless
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -423,7 +423,10 @@ public class HikvisionHandler extends ChannelDuplexHandler {
         }
     }
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
 >>>>>>> Fix never ending WARN when HIK camera does not support alarm inputs.
+=======
+>>>>>>> fix spotless
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -422,4 +422,8 @@ public class HikvisionHandler extends ChannelDuplexHandler {
                 return;
         }
     }
+<<<<<<< HEAD
+=======
+
+>>>>>>> Fix never ending WARN when HIK camera does not support alarm inputs.
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -185,9 +185,9 @@ public class InstarHandler extends ChannelDuplexHandler {
     }
 
     public void alarmTriggered(String alarm) {
-        ipCameraHandler.logger.debug("Alarm has been triggered:{}", alarm);
         // older cameras placed the & for the first query, whilst newer cameras do not.
         // examples are /instar?&active=6 vs /instar?active=6&object=0
+        ipCameraHandler.setChannelState(CHANNEL_LAST_EVENT_DATA, new StringType(alarm));
         String alarmCode = alarm.replaceAll(".+active=", "");
         alarmCode = alarmCode.replaceAll("&.+", "");
         String objectCode = alarm.replaceAll(".+object=", "");
@@ -213,19 +213,22 @@ public class InstarHandler extends ChannelDuplexHandler {
             default:
                 ipCameraHandler.logger.debug("Unknown alarm code:{}", alarmCode);
         }
-        switch (objectCode) {
-            case "0":
-                break;
-            case "1":// person/human
-                ipCameraHandler.motionDetected(CHANNEL_HUMAN_ALARM);
-                break;
-            case "2":// car/Vehicles
-                ipCameraHandler.motionDetected(CHANNEL_CAR_ALARM);
-                break;
-            case "3":// Animals
-            case "4":
-                ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
-                break;
+        if (!objectCode.isEmpty()) {
+            switch (objectCode) {
+                case "0":// no object
+                    break;
+                case "1":// person/human
+                    ipCameraHandler.motionDetected(CHANNEL_HUMAN_ALARM);
+                    break;
+                case "2":// car/vehicles
+                    ipCameraHandler.motionDetected(CHANNEL_CAR_ALARM);
+                    break;
+                case "3":// animals
+                case "4":
+                case "5":
+                    ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
+                    break;
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -186,24 +186,47 @@ public class InstarHandler extends ChannelDuplexHandler {
 
     public void alarmTriggered(String alarm) {
         ipCameraHandler.logger.debug("Alarm has been triggered:{}", alarm);
-        switch (alarm) {
+        String[] queries = alarm.split("&");
+        // older cameras placed the & for the first query, whilst newer cameras do not.
+        switch (queries[0]) {
             case "/instar?&active=1":// The motion area boxes 1-4
+            case "/instar?active=1":
             case "/instar?&active=2":
+            case "/instar?active=2":
             case "/instar?&active=3":
+            case "/instar?active=3":
             case "/instar?&active=4":
+            case "/instar?active=4":
                 ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
                 break;
             case "/instar?&active=5":// PIR
+            case "/instar?active=5":
                 ipCameraHandler.motionDetected(CHANNEL_PIR_ALARM);
                 break;
             case "/instar?&active=6":// Audio Alarm
+            case "/instar?active=6":
                 ipCameraHandler.audioDetected();
                 break;
             case "/instar?&active=7":// Motion Area 1
+            case "/instar?active=7":
             case "/instar?&active=8":// Motion Area 2
+            case "/instar?active=8":
             case "/instar?&active=9":// Motion Area 3
+            case "/instar?active=9":
             case "/instar?&active=10":// Motion Area 4
+            case "/instar?active=10":
                 ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
+                break;
+        }
+        switch (queries[1]) {
+            case "object=1":// person/human
+                ipCameraHandler.motionDetected(CHANNEL_HUMAN_ALARM);
+                break;
+            case "object=2":// car/Vehicles
+                ipCameraHandler.motionDetected(CHANNEL_CAR_ALARM);
+                break;
+            case "object=3":// Animals
+                ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
                 break;
         }
     }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -186,46 +186,44 @@ public class InstarHandler extends ChannelDuplexHandler {
 
     public void alarmTriggered(String alarm) {
         ipCameraHandler.logger.debug("Alarm has been triggered:{}", alarm);
-        String[] queries = alarm.split("&");
         // older cameras placed the & for the first query, whilst newer cameras do not.
-        switch (queries[0]) {
-            case "/instar?&active=1":// The motion area boxes 1-4
-            case "/instar?active=1":
-            case "/instar?&active=2":
-            case "/instar?active=2":
-            case "/instar?&active=3":
-            case "/instar?active=3":
-            case "/instar?&active=4":
-            case "/instar?active=4":
+        // examples are /instar?&active=6 vs /instar?active=6&object=0
+        String alarmCode = alarm.replaceAll(".+active=", "");
+        alarmCode = alarmCode.replaceAll("&.+", "");
+        String objectCode = alarm.replaceAll(".+object=", "");
+        switch (alarmCode) {
+            case "1":// The motion area boxes 1-4
+            case "2":
+            case "3":
+            case "4":
                 ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
                 break;
-            case "/instar?&active=5":// PIR
-            case "/instar?active=5":
+            case "5":// PIR
                 ipCameraHandler.motionDetected(CHANNEL_PIR_ALARM);
                 break;
-            case "/instar?&active=6":// Audio Alarm
-            case "/instar?active=6":
+            case "6":// Audio Alarm
                 ipCameraHandler.audioDetected();
                 break;
-            case "/instar?&active=7":// Motion Area 1
-            case "/instar?active=7":
-            case "/instar?&active=8":// Motion Area 2
-            case "/instar?active=8":
-            case "/instar?&active=9":// Motion Area 3
-            case "/instar?active=9":
-            case "/instar?&active=10":// Motion Area 4
-            case "/instar?active=10":
+            case "7":// Motion Area 1
+            case "8":// Motion Area 2
+            case "9":// Motion Area 3
+            case "10":// Motion Area 4
                 ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
                 break;
+            default:
+                ipCameraHandler.logger.debug("Unknown alarm code:{}", alarmCode);
         }
-        switch (queries[1]) {
-            case "object=1":// person/human
+        switch (objectCode) {
+            case "0":
+                break;
+            case "1":// person/human
                 ipCameraHandler.motionDetected(CHANNEL_HUMAN_ALARM);
                 break;
-            case "object=2":// car/Vehicles
+            case "2":// car/Vehicles
                 ipCameraHandler.motionDetected(CHANNEL_CAR_ALARM);
                 break;
-            case "object=3":// Animals
+            case "3":// Animals
+            case "4":
                 ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
                 break;
         }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -230,7 +230,7 @@ public class InstarHandler extends ChannelDuplexHandler {
                     ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
                     break;
                 default:
-                    ipCameraHandler.logger.debug("Unknown object detection code:{}", alarmCode);
+                    ipCameraHandler.logger.debug("Unknown object detection code:{}", objectCode);
             }
         }
     }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -204,11 +204,12 @@ public class InstarHandler extends ChannelDuplexHandler {
             case "6":// Audio Alarm
                 ipCameraHandler.audioDetected();
                 break;
-            case "7":// Motion Area 1
-            case "8":// Motion Area 2
-            case "9":// Motion Area 3
-            case "10":// Motion Area 4
+            case "7":// Motion area 1 + PIR
+            case "8":// Motion area 2 + PIR
+            case "9":// Motion area 3 + PIR
+            case "10":// Motion area 4 + PIR
                 ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
+                ipCameraHandler.motionDetected(CHANNEL_PIR_ALARM);
                 break;
             default:
                 ipCameraHandler.logger.debug("Unknown alarm code:{}", alarmCode);
@@ -228,6 +229,8 @@ public class InstarHandler extends ChannelDuplexHandler {
                 case "5":
                     ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
                     break;
+                default:
+                    ipCameraHandler.logger.debug("Unknown object detection code:{}", alarmCode);
             }
         }
     }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraBindingConstants.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraBindingConstants.java
@@ -138,4 +138,5 @@ public class IpCameraBindingConstants {
     public static final String CHANNEL_ENABLE_PRIVACY_MODE = "enablePrivacyMode";
     public static final String CHANNEL_CAR_ALARM = "carAlarm";
     public static final String CHANNEL_HUMAN_ALARM = "humanAlarm";
+    public static final String CHANNEL_ANIMAL_ALARM = "animalAlarm";
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/MyNettyAuthHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/MyNettyAuthHandler.java
@@ -74,7 +74,7 @@ public class MyNettyAuthHandler extends ChannelDuplexHandler {
     // First run it should not have authenticate as null
     // nonce is reused if authenticate is null so the NC needs to increment to allow this//
     public void processAuth(String authenticate, String httpMethod, String requestURI, boolean reSend) {
-        if (authenticate.contains("Basic realm=\"")) {
+        if (authenticate.contains("Basic realm=")) {
             if (ipCameraHandler.useDigestAuth) {
                 // Possible downgrade authenticate attack avoided.
                 return;

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1629,6 +1629,7 @@ public class IpCameraHandler extends BaseThingHandler {
                     snapshotUri = "/ISAPI/Streaming/channels/" + cameraConfig.getNvrChannel() + "01/picture";
                 }
 <<<<<<< HEAD
+<<<<<<< HEAD
                 if (lowPriorityRequests.isEmpty()) {
                     lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
                 }
@@ -1637,6 +1638,11 @@ public class IpCameraHandler extends BaseThingHandler {
                 lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
                 this.lowPriorityRequests = lowPriorityRequests;
 >>>>>>> Fix never ending WARN when HIK camera does not support alarm inputs.
+=======
+                if (lowPriorityRequests.isEmpty()) {
+                    lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
+                }
+>>>>>>> Streamline code.
                 break;
             case INSTAR_THING:
                 if (snapshotUri.isEmpty()) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1371,7 +1371,7 @@ public class IpCameraHandler extends BaseThingHandler {
             }
             return;
         }
-        if (!onvifCamera.isConnected()) {
+        if (cameraConfig.getOnvifPort() > 0 && !onvifCamera.isConnected()) {
             logger.debug("About to connect to the IP Camera using the ONVIF PORT at IP:{}:{}", cameraConfig.getIp(),
                     cameraConfig.getOnvifPort());
             onvifCamera.connect(thing.getThingTypeUID().getId().equals(ONVIF_THING));
@@ -1628,21 +1628,9 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (snapshotUri.isEmpty()) {
                     snapshotUri = "/ISAPI/Streaming/channels/" + cameraConfig.getNvrChannel() + "01/picture";
                 }
-<<<<<<< HEAD
-<<<<<<< HEAD
                 if (lowPriorityRequests.isEmpty()) {
                     lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
                 }
-=======
-                ArrayList<String> lowPriorityRequests = new ArrayList<String>(1);
-                lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
-                this.lowPriorityRequests = lowPriorityRequests;
->>>>>>> Fix never ending WARN when HIK camera does not support alarm inputs.
-=======
-                if (lowPriorityRequests.isEmpty()) {
-                    lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
-                }
->>>>>>> Streamline code.
                 break;
             case INSTAR_THING:
                 if (snapshotUri.isEmpty()) {
@@ -1651,11 +1639,18 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (mjpegUri.isEmpty()) {
                     mjpegUri = "/mjpegstream.cgi?-chn=12";
                 }
+                // Newer Instar cameras use this to setup the Alarm Server
+                sendHttpGET(
+                        "/param.cgi?cmd=setasaction&-server=1&enable=1&-interval=1&cmd=setasattr&-as_index=1&-as_server="
+                                + hostIp + "&-as_port=" + SERVLET_PORT + "&-as_path=/ipcamera/"
+                                + getThing().getUID().getId()
+                                + "/instar&-as_ssl=0&-as_insecure=0&-as_mode=0&-as_activequery=1&-as_auth=0&-as_query1=0&-as_query2=0&-as_query3=0&-as_query4=0&-as_query5=0");
+                // Older Instar cameras use this to setup the Alarm Server
                 sendHttpGET(
                         "/param.cgi?cmd=setmdalarm&-aname=server2&-switch=on&-interval=1&cmd=setalarmserverattr&-as_index=3&-as_server="
                                 + hostIp + "&-as_port=" + SERVLET_PORT + "&-as_path=/ipcamera/"
                                 + getThing().getUID().getId()
-                                + "/instar&-as_queryattr1=&-as_queryval1=&-as_queryattr2=&-as_queryval2=&-as_queryattr3=&-as_queryval3=&-as_activequery=1&-as_auth=0&-as_query1=0&-as_query2=0&-as_query3=0");
+                                + "/instar&-as_ssl=0&-as_mode=1&-as_activequery=1&-as_auth=0&-as_query1=0&-as_query2=0&-as_query3=0&-as_query4=0&-as_query5=0");
                 break;
         }
         // for poll times 9 seconds and above don't display a warning about the Image channel.
@@ -1670,7 +1665,7 @@ public class IpCameraHandler extends BaseThingHandler {
 
     private void tryConnecting() {
         if (!thing.getThingTypeUID().getId().equals(GENERIC_THING)
-                && !thing.getThingTypeUID().getId().equals(DOORBIRD_THING)) {
+                && !thing.getThingTypeUID().getId().equals(DOORBIRD_THING) && cameraConfig.getOnvifPort() > 0) {
             onvifCamera = new OnvifConnection(this, cameraConfig.getIp() + ":" + cameraConfig.getOnvifPort(),
                     cameraConfig.getUser(), cameraConfig.getPassword());
             onvifCamera.setSelectedMediaProfile(cameraConfig.getOnvifMediaProfile());

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1521,6 +1521,9 @@ public class IpCameraHandler extends BaseThingHandler {
                 }
                 noMotionDetected(CHANNEL_MOTION_ALARM);
                 noMotionDetected(CHANNEL_PIR_ALARM);
+                noMotionDetected(CHANNEL_HUMAN_ALARM);
+                noMotionDetected(CHANNEL_CAR_ALARM);
+                noMotionDetected(CHANNEL_ANIMAL_ALARM);
                 noAudioDetected();
                 break;
             case HIKVISION_THING:

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1628,9 +1628,15 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (snapshotUri.isEmpty()) {
                     snapshotUri = "/ISAPI/Streaming/channels/" + cameraConfig.getNvrChannel() + "01/picture";
                 }
+<<<<<<< HEAD
                 if (lowPriorityRequests.isEmpty()) {
                     lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
                 }
+=======
+                ArrayList<String> lowPriorityRequests = new ArrayList<String>(1);
+                lowPriorityRequests.add("/ISAPI/System/IO/inputs/" + cameraConfig.getNvrChannel() + "/status");
+                this.lowPriorityRequests = lowPriorityRequests;
+>>>>>>> Fix never ending WARN when HIK camera does not support alarm inputs.
                 break;
             case INSTAR_THING:
                 if (snapshotUri.isEmpty()) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -2002,6 +2002,9 @@
 			<channel id="lastMotionType" typeId="lastMotionType"/>
 			<channel id="ffmpegMotionControl" typeId="ffmpegMotionControl"/>
 			<channel id="ffmpegMotionAlarm" typeId="ffmpegMotionAlarm"/>
+			<channel id="carAlarm" typeId="carAlarm"/>
+			<channel id="humanAlarm" typeId="humanAlarm"/>
+			<channel id="animalAlarm" typeId="animalAlarm"/>
 			<channel id="enableMotionAlarm" typeId="enableMotionAlarm"/>
 			<channel id="motionAlarm" typeId="motionAlarm"/>
 			<channel id="externalMotion" typeId="externalMotion"/>
@@ -2516,6 +2519,14 @@
 		<item-type>Switch</item-type>
 		<label>Car Alarm</label>
 		<description>A car has triggered the Vehicle Detection.</description>
+		<category>Alarm</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="animalAlarm" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Animal Alarm</label>
+		<description>An animal has triggered the object detection.</description>
 		<category>Alarm</category>
 		<state readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -2005,6 +2005,7 @@
 			<channel id="carAlarm" typeId="carAlarm"/>
 			<channel id="humanAlarm" typeId="humanAlarm"/>
 			<channel id="animalAlarm" typeId="animalAlarm"/>
+			<channel id="lastEventData" typeId="lastEventData"/>
 			<channel id="enableMotionAlarm" typeId="enableMotionAlarm"/>
 			<channel id="motionAlarm" typeId="motionAlarm"/>
 			<channel id="externalMotion" typeId="externalMotion"/>


### PR DESCRIPTION
Changes made:
+ Add Person, Vehicle and Animal Object detection alarms for new Instar cameras that support this ability.
+ Add support for setting up the alarm server on new Instar range of cameras.
+ Add support for changes in Instar alarm codes in their newer range.
+ Add a method to stop ONVIF from connecting if a camera has an issue by setting onvifPort=0
+ Add compatability fix/work around for cameras that do not surround a realm in quotes.

Jar can be RIGHT HAND CLICKED and downloaded from:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/3.4.0-SNAPSHOT/org.openhab.binding.ipcamera-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>