### PR TITLE
[homekit] support stop for blinds

### DIFF
--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -312,8 +312,8 @@ Rollershutter window          "Window"               {homekit = "Window" [invert
 Rollershutter door            "Door"                 {homekit = "Door" [inverted=false]}
  ```
 
-HomeKit home app never sends STOP" but only the target position. 
-If you add configuration parameter "stop=true", openHAB will emulate stop and send "STOP" command to rollenshutter item if you click on the blind icon in the home app while the blind is moving.
+HomeKit home app never sends "STOP" but only the target position. 
+If you add configuration parameter "stop=true", openHAB will emulate stop and send "STOP" command to rollershutter item if you click on the blind icon in the iOS home app while the blind is moving.
 
 ```xtend
 Rollershutter window_covering "Window Rollershutter" {homekit = "WindowCovering"  [stop=true]}

--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -310,7 +310,19 @@ In case you need to disable this logic you can do it with configuration paramete
 Rollershutter window_covering "Window Rollershutter" {homekit = "WindowCovering"  [inverted=false]}
 Rollershutter window          "Window"               {homekit = "Window" [inverted=false]}
 Rollershutter door            "Door"                 {homekit = "Door" [inverted=false]}
+ ```
 
+HomeKit home app never sends STOP" but only the target position. 
+If you add configuration parameter "stop=true", openHAB will emulate stop and send "STOP" command to rollenshutter item if you click on the blind icon in the home app while the blind is moving.
+
+```xtend
+Rollershutter window_covering "Window Rollershutter" {homekit = "WindowCovering"  [stop=true]}
+ ```
+
+Some blinds devices do support "STOP" command but would stop if they receive UP/DOWN while moving om the same direction. In order to support such devices add "stopSameDirection" parameter.
+
+```xtend
+Rollershutter window_covering "Window Rollershutter" {homekit = "WindowCovering"  [stop=true, stopSameDirection=true]}
  ```
 
 Window covering can have a number of optional characteristics like horizontal & vertical tilt, obstruction status and hold position trigger.
@@ -528,7 +540,7 @@ In order to combine multiple accessories to one HomeKit accessory you need:
 e.g. configuration for a fan with light would look as follows
 
 ```xtend
-Group           FanWithLight        "Fan with Light"                           {homekit = "Fan,Light"}
+Group           FanWithLight        "Fan with Light"                           {homekit = "Fan,Lighting"}
 Switch          FanActiveStatus     "Fan Active Status"     (FanWithLight)     {homekit = "Fan.ActiveStatus"}
 Number          FanRotationSpeed    "Fan Rotation Speed"    (FanWithLight)     {homekit = "Fan.RotationSpeed"}
 Switch          Light               "Light"                 (FanWithLight)     {homekit = "Lighting.OnState"}

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -154,7 +154,8 @@ public class HomekitImpl implements Homekit, NetworkAddressChangeListener {
                 return;
             if (!oldSettings.name.equals(settings.name) || !oldSettings.pin.equals(settings.pin)
                     || !oldSettings.setupId.equals(settings.setupId)
-                    || !oldSettings.networkInterface.equals(settings.networkInterface)
+                    || (oldSettings.networkInterface != null
+                            && !oldSettings.networkInterface.equals(settings.networkInterface))
                     || oldSettings.port != settings.port || oldSettings.useOHmDNS != settings.useOHmDNS
                     || oldSettings.instances != settings.instances) {
                 // the HomeKit server settings changed. we do a complete re-init

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -57,6 +57,7 @@ public class HomekitTaggedItem {
     public final static String PRIMARY_SERVICE = "primary";
     public final static String STEP = "step";
     public final static String UNIT = "unit";
+    public final static String EMULATE_STATE = "emulateState";
 
     private static final Map<Integer, String> CREATED_ACCESSORY_IDS = new ConcurrentHashMap<>();
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -57,7 +57,8 @@ public class HomekitTaggedItem {
     public final static String PRIMARY_SERVICE = "primary";
     public final static String STEP = "step";
     public final static String UNIT = "unit";
-    public final static String EMULATE_STATE = "emulateState";
+    public final static String EMULATE_STOP_STATE = "stop";
+    public final static String EMULATE_STOP_SAME_DIRECTION = "stopSameDirection";
 
     private static final Map<Integer, String> CREATED_ACCESSORY_IDS = new ConcurrentHashMap<>();
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
@@ -56,7 +56,6 @@ abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAcces
     private final Map<PositionStateEnum, String> positionStateMapping;
     protected boolean emulateState;
     protected boolean emulateStopSameDirection;
-
     protected PositionStateEnum emulatedState = PositionStateEnum.STOPPED;
 
     public AbstractHomekitPositionAccessoryImpl(HomekitTaggedItem taggedItem,

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
@@ -32,6 +32,7 @@ import org.openhab.core.library.items.RollershutterItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StopMoveType;
+import org.openhab.core.library.types.UpDownType;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
 import org.openhab.io.homekit.internal.HomekitSettings;
@@ -54,6 +55,7 @@ abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAcces
     protected int openPosition;
     private final Map<PositionStateEnum, String> positionStateMapping;
     protected boolean emulateState;
+    protected boolean emulateStopSameDirection;
 
     protected PositionStateEnum emulatedState = PositionStateEnum.STOPPED;
 
@@ -62,7 +64,9 @@ abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAcces
             HomekitSettings settings) {
         super(taggedItem, mandatoryCharacteristics, updater, settings);
         final boolean inverted = getAccessoryConfigurationAsBoolean(HomekitTaggedItem.INVERTED, true);
-        emulateState = getAccessoryConfigurationAsBoolean(HomekitTaggedItem.EMULATE_STATE, false);
+        emulateState = getAccessoryConfigurationAsBoolean(HomekitTaggedItem.EMULATE_STOP_STATE, false);
+        emulateStopSameDirection = getAccessoryConfigurationAsBoolean(HomekitTaggedItem.EMULATE_STOP_SAME_DIRECTION,
+                false);
         closedPosition = inverted ? 0 : 100;
         openPosition = inverted ? 100 : 0;
         positionStateMapping = new EnumMap<>(PositionStateEnum.class);
@@ -90,24 +94,26 @@ abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAcces
             final Item item = taggedItem.getItem();
             final int targetPosition = convertPosition(value, openPosition);
             if (item instanceof RollershutterItem) {
-                PositionStateEnum state = emulateState ? emulatedState
-                        : getKeyFromMapping(POSITION_STATE, positionStateMapping, PositionStateEnum.STOPPED);
-                logger.info(" state {} {}", state, targetPosition);
-                if ((targetPosition == 100 && state == PositionStateEnum.DECREASING)
-                        || ((targetPosition == 0 && state == PositionStateEnum.INCREASING))) {
-                    ((RollershutterItem) item).send(StopMoveType.STOP);
-                    if (emulateState) {
-                        emulatedState = PositionStateEnum.STOPPED;
+                // HomeKit home app never sends STOP. we emulate stop if we receive 100% or 0% while the blind is moving
+                if (emulateState && (targetPosition == 100 && emulatedState == PositionStateEnum.DECREASING)
+                        || ((targetPosition == 0 && emulatedState == PositionStateEnum.INCREASING))) {
+                    if (emulateStopSameDirection) {
+                        // some blinds devices do not support "STOP" but would stop if receive UP/DOWN while moving
+                        ((RollershutterItem) item)
+                                .send(emulatedState == PositionStateEnum.INCREASING ? UpDownType.UP : UpDownType.DOWN);
+                    } else {
+                        ((RollershutterItem) item).send(StopMoveType.STOP);
                     }
+                    emulatedState = PositionStateEnum.STOPPED;
                 } else {
                     ((RollershutterItem) item).send(new PercentType(targetPosition));
                     if (emulateState) {
                         @Nullable
                         PercentType currentPosition = item.getStateAs(PercentType.class);
-                        emulatedState = currentPosition == null || currentPosition.intValue() == targetPosition ? PositionStateEnum.STOPPED
+                        emulatedState = currentPosition == null || currentPosition.intValue() == targetPosition
+                                ? PositionStateEnum.STOPPED
                                 : currentPosition.intValue() < targetPosition ? PositionStateEnum.INCREASING
                                         : PositionStateEnum.DECREASING;
-
                     }
                 }
             } else if (item instanceof DimmerItem) {


### PR DESCRIPTION
home app never sends "STOP" but always sends the target position, e.g. 100% or 0% for fully open or closed blinds. 
Rollershutter in openHAB and some device do support stop. 
this PR adds emulation of stop if user click on blind icons in the home app while blinds is moving. 
report and discussion here
https://community.openhab.org/t/oh3-rollershutter-and-apple-homekit/112376/31

this PR also fix one potential NPE and a typo in the docu "light -> lighting"

