### PR TITLE
[enocean] Fix messages with MSC RORG

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/messages/ERP1Message.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/messages/ERP1Message.java
@@ -108,11 +108,12 @@ public class ERP1Message extends BasePacket {
                     }
                     break;
                 case SIG:
+                case MSC:
                     teachIn = false;
                     senderId = Arrays.copyOfRange(payload, dataLength - 5, dataLength - 1);
                     break;
                 default:
-                    break;
+                    rorg = RORG.Unknown;
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
Setting senderId for MSC RORG and set rorg to Unknown when there is no mach with the supported(handled) RORG types.
Fixes #13786