### PR TITLE
[jdbc] Add safety valve for suspicious migrations

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -214,6 +214,12 @@ Use the command `jdbc schema check` to perform an integrity check of the schema.
 
 Identified issues can be fixed automatically using the command `jdbc schema fix` (all items having issues) or `jdbc schema fix <itemName>` (single item).
 
+Issues than can be identified and possibly fixed:
+
+- Wrong column name case (`time` and `name`).
+- Wrong column type. Before fixing this, make sure that time-zone is correctly configured.
+- Unexpected column (identify only).
+
 ### For Developers
 
 * Clearly separated source files for the database-specific part of openHAB logic.

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -322,6 +322,12 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
      */
     public Collection<String> getSchemaIssues(String tableName, String itemName) throws JdbcSQLException {
         List<String> issues = new ArrayList<>();
+
+        if (!checkDBAccessability()) {
+            logger.warn("JDBC::getSchemaIssues: database not connected");
+            return issues;
+        }
+
         Item item;
         try {
             item = itemRegistry.getItem(itemName);
@@ -375,6 +381,11 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
      * @throws JdbcSQLException on SQL errors
      */
     public boolean fixSchemaIssues(String tableName, String itemName) throws JdbcSQLException {
+        if (!checkDBAccessability()) {
+            logger.warn("JDBC::fixSchemaIssues: database not connected");
+            return false;
+        }
+
         Item item;
         try {
             item = itemRegistry.getItem(itemName);
@@ -469,6 +480,11 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
      * @throws JdbcSQLException
      */
     public boolean cleanupItem(String itemName, boolean force) throws JdbcSQLException {
+        if (!checkDBAccessability()) {
+            logger.warn("JDBC::cleanupItem: database not connected");
+            return false;
+        }
+
         String tableName = itemNameToTableNameMap.get(itemName);
         if (tableName == null) {
             return false;


### PR DESCRIPTION
This is a small follow-up to #13544 and #13737 since the combination of these features and an invalid configuration can potentially be dangerous.

Consider this case:
- **Configuration:** `itemsManageTable=items`; `tableNamePrefix=Item`; `tableUseRealItemNames=false`; `tableIdDigitCount=4`, `rebuildTableNames=true`
- **Tables:** `Items`, `Item1`, `Item4`, `Item5`

This is logically considered as a migration _from_ real names _to_ indexed scheme with prefixes and sequential numbers, since index (items manage table) is not found. As a result:
- Index table `items` is created.
- Item1 is renamed to Item0001 and indexed as item name "Item1".
- Item4 is renamed to Item0002 and indexed as item name "Item4".
- Item5 is renamed to Item0003 and indexed as item name "Item5".
- Items is renamed to Item0004 and indexed as item name "Items".

This resulting mess can be avoided with a small sanity check: If most tables start with either the configured prefix or the hardcoded default prefix "item" (case insensitive), then log an error and abort the migration. It would be very unlikely for any user to have most items named like this.