### PR TITLE
[ipcamera] Instar API updates for new 2k+ range

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -157,24 +157,26 @@ public class InstarHandler extends ChannelDuplexHandler {
                 case CHANNEL_THRESHOLD_AUDIO_ALARM:
                 case CHANNEL_ENABLE_AUDIO_ALARM:
                     ipCameraHandler.sendHttpGET("/param.cgi?cmd=getaudioalarmattr");
-                    return;
+                    break;
                 case CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT:
                     ipCameraHandler.sendHttpGET("/param.cgi?cmd=getioattr");
-                    return;
+                    break;
                 case CHANNEL_ENABLE_MOTION_ALARM:
                     if (ipCameraHandler.newInstarApi) {
                         ipCameraHandler.sendHttpGET("/param.cgi?cmd=getalarmattr");
                     } else {
                         ipCameraHandler.sendHttpGET("/cgi-bin/hi3510/param.cgi?cmd=getmdattr");
                     }
-                    return;
+                    break;
                 case CHANNEL_ENABLE_PIR_ALARM:
                     ipCameraHandler.sendHttpGET("/param.cgi?cmd=getpirattr");
+                    break;
                 case CHANNEL_AUTO_LED:
                     ipCameraHandler.sendHttpGET("/param.cgi?cmd=getinfrared");
+                    break;
                 case CHANNEL_TEXT_OVERLAY:
                     ipCameraHandler.sendHttpGET("/param.cgi?cmd=getoverlayattr&-region=1");
-                    return;
+                    break;
             }
             return;
         } // end of "REFRESH"

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -63,7 +63,7 @@ public class InstarHandler extends ChannelDuplexHandler {
             ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
             switch (requestUrl) {
                 case "/param.cgi?cmd=getinfrared":
-                    if (content.contains("var infraredstat=\"auto") || content.contains("infraredstat=\"2")) {
+                    if (content.contains("var infraredstat=\"auto") || content.contains("infraredstat=\"2\"")) {
                         ipCameraHandler.setChannelState(CHANNEL_AUTO_LED, OnOffType.ON);
                     } else {
                         ipCameraHandler.setChannelState(CHANNEL_AUTO_LED, OnOffType.OFF);
@@ -92,7 +92,7 @@ public class InstarHandler extends ChannelDuplexHandler {
                     }
                     break;
                 case "/param.cgi?cmd=getalarmattr":// Motion Alarm new
-                    if (content.contains("armed=\"1")) {
+                    if (content.contains("armed=\"1\"")) {
                         ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
                     } else {
                         ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -150,9 +150,32 @@ public class InstarHandler extends ChannelDuplexHandler {
         }
     }
 
-    // This handles the commands that come from the Openhab event bus.
+    // This handles the commands that come from the openHAB event bus.
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
+            switch (channelUID.getId()) {
+                case CHANNEL_THRESHOLD_AUDIO_ALARM:
+                case CHANNEL_ENABLE_AUDIO_ALARM:
+                    ipCameraHandler.sendHttpGET("/param.cgi?cmd=getaudioalarmattr");
+                    return;
+                case CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT:
+                    ipCameraHandler.sendHttpGET("/param.cgi?cmd=getioattr");
+                    return;
+                case CHANNEL_ENABLE_MOTION_ALARM:
+                    if (ipCameraHandler.newInstarApi) {
+                        ipCameraHandler.sendHttpGET("/param.cgi?cmd=getalarmattr");
+                    } else {
+                        ipCameraHandler.sendHttpGET("/cgi-bin/hi3510/param.cgi?cmd=getmdattr");
+                    }
+                    return;
+                case CHANNEL_ENABLE_PIR_ALARM:
+                    ipCameraHandler.sendHttpGET("/param.cgi?cmd=getpirattr");
+                case CHANNEL_AUTO_LED:
+                    ipCameraHandler.sendHttpGET("/param.cgi?cmd=getinfrared");
+                case CHANNEL_TEXT_OVERLAY:
+                    ipCameraHandler.sendHttpGET("/param.cgi?cmd=getoverlayattr&-region=1");
+                    return;
+            }
             return;
         } // end of "REFRESH"
         if (ipCameraHandler.newInstarApi) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1643,7 +1643,8 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (mjpegUri.isEmpty()) {
                     mjpegUri = "/mjpegstream.cgi?-chn=12";
                 }
-                // Newer Instar cameras use this to setup the Alarm Server
+                // Newer Instar cameras use this to setup the Alarm Server, plus it is used to work out which API is
+                // implemented based on the response to these two requests.
                 sendHttpGET(
                         "/param.cgi?cmd=setasaction&-server=1&enable=1&-interval=1&cmd=setasattr&-as_index=1&-as_server="
                                 + hostIp + "&-as_port=" + SERVLET_PORT + "&-as_path=/ipcamera/"

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -170,6 +170,7 @@ public class IpCameraHandler extends BaseThingHandler {
     private String basicAuth = "";
     public boolean useBasicAuth = false;
     public boolean useDigestAuth = false;
+    public boolean newInstarApi = false;
     public String snapshotUri = "";
     public String mjpegUri = "";
     private byte[] currentSnapshot = new byte[] { (byte) 0x00 };

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -409,7 +409,7 @@ public class OnvifConnection {
         request.headers().add("Content-Type",
                 "application/soap+xml; charset=utf-8; action=\"" + actionString + "/" + requestType + "\"");
         request.headers().add("Charset", "utf-8");
-        request.headers().set("Host", extractIPportFromUrl(xAddr));
+        request.headers().set("Host", ipAddress + ":" + onvifPort);
         request.headers().set("Connection", HttpHeaderValues.CLOSE);
         request.headers().set("Accept-Encoding", "gzip, deflate");
         String fullXml = "<s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\"" + extraEnvelope + ">"
@@ -578,8 +578,11 @@ public class OnvifConnection {
             onvifPort = Integer.parseInt(url.substring(beginIndex + 1, endIndex));
         } else {// 192.168.1.1
             ipAddress = url;
+            deviceXAddr = "http://" + ipAddress + "/onvif/device_service";
             logger.debug("No Onvif Port found when parsing:{}", url);
+            return;
         }
+        deviceXAddr = "http://" + ipAddress + ":" + onvifPort + "/onvif/device_service";
     }
 
     public void gotoPreset(int index) {


### PR DESCRIPTION
This PR contains 1 bug fix in the ONVIF connecting code that was causing issues with Instar and possibly other brands as well. The Host http header was blank.
The rest of the changes are to provide support for a newer 2k range of cameras that have a different API implemented in them.

Jar can be RIGHT HAND CLICKED and downloaded from:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/3.4.0-SNAPSHOT/org.openhab.binding.ipcamera-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>