### PR TITLE
[jsscripting] Fix memory leak that crashes openHAB

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -234,6 +234,7 @@ public class OpenhabGraalJSScriptEngine
     @Override
     public void close() {
         jsRuntimeFeatures.close();
+        delegate.close();
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -53,12 +53,12 @@ import org.slf4j.LoggerFactory;
 import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
 
 /**
- * GraalJS Script Engine implementation
+ * GraalJS ScriptEngine implementation
  *
  * @author Jonathan Gilbert - Initial contribution
  * @author Dan Cunningham - Script injections
  * @author Florian Hotze - Create lock object for multi-thread synchronization; Inject the {@link JSRuntimeFeatures}
- *         into the JS context
+ *         into the JS context; Fix memory leak caused by HostObject by making HostAccess reference static
  */
 public class OpenhabGraalJSScriptEngine
         extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<GraalJSScriptEngine> {
@@ -66,9 +66,9 @@ public class OpenhabGraalJSScriptEngine
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenhabGraalJSScriptEngine.class);
     private static final String GLOBAL_REQUIRE = "require(\"@jsscripting-globals\");";
     private static final String REQUIRE_WRAPPER_NAME = "__wraprequire__";
-    // final CommonJS search path for our library
+    /** Final CommonJS search path for our library */
     private static final Path NODE_DIR = Paths.get("node_modules");
-    // Custom translate JS Objects - > Java Objects
+    /** Provides unlimited host access as well as custom translations from JS to Java Objects */
     private static final HostAccess HOST_ACCESS = HostAccess.newBuilder(HostAccess.ALL)
             // Translate JS-Joda ZonedDateTime to java.time.ZonedDateTime
             .targetTypeMapping(Value.class, ZonedDateTime.class, (v) -> v.hasMember("withFixedOffsetZone"), v -> {
@@ -83,7 +83,7 @@ public class OpenhabGraalJSScriptEngine
                     }, HostAccess.TargetMappingPrecedence.LOW)
             .build();
 
-    // shared lock object for synchronization of multi-thread access
+    /** Shared lock object for synchronization of multi-thread access */
     private final Object lock = new Object();
     private final JSRuntimeFeatures jsRuntimeFeatures;
 


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/12577.

## Description

When a `.js` script file was changed and reloaded by openHAB, a memory leak in the JS Scripting add-on lead to an openHAB crash after some time.
This PR finally fixes the memory leak causing this.

I found the memory leak after reproducing the issue and taking several heap snapshots. Analyzation of the heap snapshots has shown, that a extremely high number of GraalJS related objects without a GC root existed in the heap. 
Looking after `OpenhabGraalJSScriptEngine` in the heap snapshot, I noticed that there were also numerous instances of the engine, which were not cleaned by GC because they were referenced by `com.oracle.truffle.host.HostObject`.

Research on the web lead me to reading https://github.com/oracle/graaljs/issues/121, where other users describe similar problems. In the issue conversation, one of the GraalJS developers said, that one should not recreate the `GraalJSScriptEngine` each time, but instead share the `Context` (reference https://github.com/oracle/graaljs/issues/121#issuecomment-880056648). If that is not possible, because other code (openhab core in our case) requires a `ScriptEngine`, `HostAccess` should not be created each time, but instead shared as a static variable (reference https://github.com/oracle/graaljs/issues/121#issuecomment-690179954).

During working on this issue, I also noticed that the `close` method of the `GraalJSScriptEngine` was never called (at least my breakpoint was never triggered), until I added a call to `close`.

## Testing

Use the reproduce script from @jlaur to verify the fix:

<details>
<summary>Create this file somewhere as `reproduce_issue_12577.sh`</summary>

```shell
#!/bin/bash
echo "Switch Issue12577" > $OPENHAB_CONF/items/issue_12577.items
i=1
while [ $i -lt 150 ]
do
    echo "Iteration ${i} starting..."
    if [ $((i % 2)) -eq 0 ]
    then
        cp test1.js "$OPENHAB_CONF/automation/js/test.js"
    else
        cp test2.js "$OPENHAB_CONF/automation/js/test.js"
    fi
    sleep 5
    ((i++))
done
```

</details>

<details>
<summary>Add these JavaScript files to the same location:</summary>

test1.js:
```javascript
const { rules, triggers } = require('openhab');

rules.JSRule({
  name: 'Reproduce jsscripting issue 1',
  description: 'Reproduce jsscripting issue',
  triggers: [triggers.ItemStateChangeTrigger('Issue12577', 'OFF', 'ON')],
  execute: data => {
    console.log('Test item triggered: 1');
  }
});
```

test2.js: 
```javascript
const { rules, triggers } = require('openhab');

rules.JSRule({
  name: 'Reproduce jsscripting issue 2',
  description: 'Reproduce jsscripting issue',
  triggers: [triggers.ItemStateChangeTrigger('Issue12577', 'ON', 'OFF')],
  execute: data => {
    console.log('Test item triggered: 2');
  }
});
```
</details>

Using this verification approach, I have confirmed that openHAB is still running without any problems after 250!! iterations of the reproduce script, my heap usage graph shows that GC works now:

![image](https://user-images.githubusercontent.com/73423173/205395213-1cba2c85-8b3f-409c-b1d2-4c9dc8645197.png)