### PR TITLE
[unifi] Migrate uptime channels to Number:Time

### DIFF
--- a/bundles/org.openhab.binding.unifi/README.md
+++ b/bundles/org.openhab.binding.unifi/README.md
@@ -161,7 +161,7 @@ The `wirelessClient` information that is retrieved is available as these channel
 | ap         | String               | Access point (AP) the client is connected to                         | Read        |
 | essid      | String               | Network name (ESSID) the client is connected to                      | Read        |
 | rssi       | Number               | Received signal strength indicator (RSSI) of the client              | Read        |
-| uptime     | Number               | Uptime of the client (in seconds)                                    | Read        |
+| uptime     | Number:Time          | Uptime of the client (in seconds)                                    | Read        |
 | lastSeen   | DateTime             | Date and Time the client was last seen                               | Read        |
 | experience | Number:Dimensionless | Overall health indication of the client (in percentage)              | Read        |
 | blocked    | Switch               | Blocked status of the client                                         | Read, Write |
@@ -181,7 +181,7 @@ The `wiredClient` information that is retrieved is available as these channels:
 | site       | String               | Site name (from the controller web UI) the client is associated with | Read        |
 | macAddress | String               | MAC address of the client                                            | Read        |
 | ipAddress  | String               | IP address of the client                                             | Read        |
-| uptime     | Number               | Uptime of the client (in seconds)                                    | Read        |
+| uptime     | Number:Time          | Uptime of the client (in seconds)                                    | Read        |
 | lastSeen   | DateTime             | Date and Time the client was last seen                               | Read        |
 | experience | Number:Dimensionless | Overall health indication of the client (in percentage)              | Read        |
 | blocked    | Switch               | Blocked status of the client                                         | Read, Write |
@@ -229,17 +229,17 @@ Replace `$user`, `$password` and `$cid` accordingly.
 items/unifi.items
 
 ```
-Switch   MatthewsPhone           "Matthew's iPhone [MAP(unifi.map):%s]"             { channel="unifi:wirelessClient:home:matthewsPhone:online" }
-String   MatthewsPhoneSite       "Matthew's iPhone: Site [%s]"                      { channel="unifi:wirelessClient:home:matthewsPhone:site" }
-String   MatthewsPhoneMAC        "Matthew's iPhone: MAC [%s]"                       { channel="unifi:wirelessClient:home:matthewsPhone:macAddress" }
-String   MatthewsPhoneIP         "Matthew's iPhone: IP [%s]"                        { channel="unifi:wirelessClient:home:matthewsPhone:ipAddress" }
-String   MatthewsPhoneAP         "Matthew's iPhone: AP [%s]"                        { channel="unifi:wirelessClient:home:matthewsPhone:ap" }
-String   MatthewsPhoneESSID      "Matthew's iPhone: ESSID [%s]"                     { channel="unifi:wirelessClient:home:matthewsPhone:essid" }
-Number   MatthewsPhoneRSSI       "Matthew's iPhone: RSSI [%d]"                      { channel="unifi:wirelessClient:home:matthewsPhone:rssi" }
-Number   MatthewsPhoneUptime     "Matthew's iPhone: Uptime [%d]"                    { channel="unifi:wirelessClient:home:matthewsPhone:uptime" }
-DateTime MatthewsPhoneLastSeen   "Matthew's iPhone: Last Seen [%1$tH:%1$tM:%1$tS]"  { channel="unifi:wirelessClient:home:matthewsPhone:lastSeen" }
-Switch   MatthewsPhoneBlocked    "Matthew's iPhone: Blocked"                        { channel="unifi:wirelessClient:home:matthewsPhone:blocked" }
-Switch   MatthewsPhoneReconnect  "Matthew's iPhone: Reconnect"                      { channel="unifi:wirelessClient:home:matthewsPhone:reconnect" }
+Switch      MatthewsPhone           "Matthew's iPhone [MAP(unifi.map):%s]"             { channel="unifi:wirelessClient:home:matthewsPhone:online" }
+String      MatthewsPhoneSite       "Matthew's iPhone: Site [%s]"                      { channel="unifi:wirelessClient:home:matthewsPhone:site" }
+String      MatthewsPhoneMAC        "Matthew's iPhone: MAC [%s]"                       { channel="unifi:wirelessClient:home:matthewsPhone:macAddress" }
+String      MatthewsPhoneIP         "Matthew's iPhone: IP [%s]"                        { channel="unifi:wirelessClient:home:matthewsPhone:ipAddress" }
+String      MatthewsPhoneAP         "Matthew's iPhone: AP [%s]"                        { channel="unifi:wirelessClient:home:matthewsPhone:ap" }
+String      MatthewsPhoneESSID      "Matthew's iPhone: ESSID [%s]"                     { channel="unifi:wirelessClient:home:matthewsPhone:essid" }
+Number      MatthewsPhoneRSSI       "Matthew's iPhone: RSSI [%d]"                      { channel="unifi:wirelessClient:home:matthewsPhone:rssi" }
+Number:Time MatthewsPhoneUptime     "Matthew's iPhone: Uptime [%1$tR]"                 { channel="unifi:wirelessClient:home:matthewsPhone:uptime" }
+DateTime    MatthewsPhoneLastSeen   "Matthew's iPhone: Last Seen [%1$tH:%1$tM:%1$tS]"  { channel="unifi:wirelessClient:home:matthewsPhone:lastSeen" }
+Switch      MatthewsPhoneBlocked    "Matthew's iPhone: Blocked"                        { channel="unifi:wirelessClient:home:matthewsPhone:blocked" }
+Switch      MatthewsPhoneReconnect  "Matthew's iPhone: Reconnect"                      { channel="unifi:wirelessClient:home:matthewsPhone:reconnect" }
 ```
 
 transform/unifi.map

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiClientThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiClientThingHandler.java
@@ -127,7 +127,7 @@ public class UniFiClientThingHandler extends UniFiBaseThingHandler<UniFiClient, 
                 break;
             case CHANNEL_UPTIME:
                 // mgb: uptime should default to 0 seconds
-                state = DecimalType.ZERO;
+                state = new QuantityType<>(0, Units.SECOND);
                 break;
             case CHANNEL_EXPERIENCE:
                 // mgb: uptime + experience should default to 0
@@ -200,7 +200,7 @@ public class UniFiClientThingHandler extends UniFiBaseThingHandler<UniFiClient, 
             // :uptime
             case CHANNEL_UPTIME:
                 if (client.getUptime() != null) {
-                    state = new DecimalType(client.getUptime());
+                    state = new QuantityType<>(client.getUptime(), Units.SECOND);
                 }
                 break;
 

--- a/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/thing/thing-types.xml
@@ -249,16 +249,18 @@
 	</channel-type>
 
 	<channel-type id="uptime">
-		<item-type>Number</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Uptime</label>
 		<description>Uptime of the client (in seconds)</description>
-		<state readOnly="true"></state>
+		<category>Time</category>
+		<state pattern="%.0f %unit%" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="lastSeen">
 		<item-type>DateTime</item-type>
 		<label>Last Seen</label>
 		<description>Timestamp of when the client was last seen</description>
+		<category>Time</category>
 		<state readOnly="true"></state>
 	</channel-type>
 


### PR DESCRIPTION
In order to fully support UoM, the uptime channel type is migrated from `Number` to `Number:Time`.

With this change, the unit "s" is automatically appended in logs etc. when not otherwise specified.

Fixes #13826