### PR TITLE
[smsmodem] Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -304,6 +304,7 @@
 /bundles/org.openhab.binding.smartmeter/ @msteigenberger
 /bundles/org.openhab.binding.smartthings/ @BobRak
 /bundles/org.openhab.binding.smhi/ @pacive
+/bundles/org.openhab.binding.smsmodem/ @dalgwen
 /bundles/org.openhab.binding.sncf/ @clinique
 /bundles/org.openhab.binding.snmp/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.solaredge/ @alexf2015


### PR DESCRIPTION
I forgot to add myself to the codeowners file, sorry.

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>