### PR TITLE
[jdbc] Fix console command 'tables' for SQLite

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcSqliteDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcSqliteDAO.java
@@ -57,6 +57,7 @@ public class JdbcSqliteDAO extends JdbcBaseDAO {
                                            // "PRAGMA SCHEMA_VERSION";
         sqlIfTableExists = "SELECT name FROM sqlite_master WHERE type='table' AND name='#searchTable#'";
         sqlCreateItemsTableIfNot = "CREATE TABLE IF NOT EXISTS #itemsManageTable# (ItemId INTEGER PRIMARY KEY AUTOINCREMENT, #colname# #coltype# NOT NULL)";
+        sqlGetItemTables = "SELECT name AS table_name FROM sqlite_master WHERE type='table' AND name NOT IN ('#itemsManageTable#','sqlite_sequence')";
         sqlInsertItemValue = "INSERT OR IGNORE INTO #tableName# (TIME, VALUE) VALUES( #tablePrimaryValue#, CAST( ? as #dbType#) )";
     }
 


### PR DESCRIPTION
Follow-up to #13662 so the console command now also supports SQLite.

See https://community.openhab.org/t/hildebrand-glowmarkt-api-binding/139091/20

Related to #13661