### PR TITLE
[groupepsa] Add missing code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -117,6 +117,7 @@
 /bundles/org.openhab.binding.gpstracker/ @gbicskei
 /bundles/org.openhab.binding.gree/ @markus7017
 /bundles/org.openhab.binding.groheondus/ @FlorianSW
+/bundles/org.openhab.binding.groupepsa/ @arjanmels
 /bundles/org.openhab.binding.guntamatic/ @MikeTheTux
 /bundles/org.openhab.binding.haassohnpelletstove/ @chingon007
 /bundles/org.openhab.binding.harmonyhub/ @digitaldan


### PR DESCRIPTION
This seems to have been forgotten as part of #10332.