### PR TITLE
[miele] Migrate time channels from DateTime to Number:Time

### DIFF
--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -126,9 +126,9 @@ Channels available for each appliance type are listed below.
 | rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number |
 | start               | DateTime             | Read       | Programmed start time of the program                                |
 | end                 | DateTime             | Read       | End time of the program (programmed or running)                     |
-| duration            | DateTime             | Read       | Duration of the program running on the appliance                    |
-| elapsed             | DateTime             | Read       | Time elapsed in the program running on the appliance                |
-| finish              | DateTime             | Read       | Time to finish the program running on the appliance                 |
+| duration            | Number:Time          | Read       | Duration of the program running on the appliance                    |
+| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                |
+| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                 |
 | door                | Contact              | Read       | Current state of the door of the appliance                          |
 | switch              | Switch               | Write      | Switch the appliance on or off                                      |
 | powerConsumption    | Number:Power         | Read       | Power consumption by the currently running program on the appliance |
@@ -239,9 +239,9 @@ Channels available for each appliance type are listed below.
 | rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number |
 | start               | DateTime             | Read       | Programmed start time of the program                                |
 | end                 | DateTime             | Read       | End time of the program (programmed or running)                     |
-| duration            | DateTime             | Read       | Duration of the program running on the appliance                    |
-| elapsed             | DateTime             | Read       | Time elapsed in the program running on the appliance                |
-| finish              | DateTime             | Read       | Time to finish the program running on the appliance                 |
+| duration            | Number:Time          | Read       | Duration of the program running on the appliance                    |
+| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                |
+| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                 |
 | target              | Number:Temperature   | Read       | Target temperature to be reached by the oven                        |
 | measured            | Number:Temperature   | Read       | Actual measured temperature in the oven                             |
 | temp1               | Number:Temperature   | Read       | Program temperature in the oven 1                                   |
@@ -282,9 +282,9 @@ See oven.
 | rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number |
 | start               | DateTime             | Read       | Programmed start time of the program                                |
 | end                 | DateTime             | Read       | End time of the program (programmed or running)                     |
-| duration            | DateTime             | Read       | Duration of the program running on the appliance                    |
-| elapsed             | DateTime             | Read       | Time elapsed in the program running on the appliance                |
-| finish              | DateTime             | Read       | Time to finish the program running on the appliance                 |
+| duration            | Number:Time          | Read       | Duration of the program running on the appliance                    |
+| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                |
+| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                 |
 | door                | Contact              | Read       | Current state of the door of the appliance                          |
 | switch              | Switch               | Write      | Switch the appliance on or off                                      |
 | step                | Number               | Read       | Current step in the program running on the appliance                |
@@ -347,9 +347,9 @@ See oven.
 | rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number |
 | start               | DateTime             | Read       | Programmed start time of the program                                |
 | end                 | DateTime             | Read       | End time of the program (programmed or running)                     |
-| duration            | DateTime             | Read       | Duration of the program running on the appliance                    |
-| elapsed             | DateTime             | Read       | Time elapsed in the program running on the appliance                |
-| finish              | DateTime             | Read       | Time to finish the program running on the appliance                 |
+| duration            | Number:Time          | Read       | Duration of the program running on the appliance                    |
+| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                |
+| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                 |
 | door                | Contact              | Read       | Current state of the door of the appliance                          |
 | switch              | Switch               | Write      | Switch the appliance on or off                                      |
 | target              | Number:Temperature   | Read       | Temperature of the selected program (10 °C = cold)                  |

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -16,10 +16,7 @@ import static java.util.Map.entry;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.lang.reflect.Method;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -32,6 +29,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 import org.openhab.core.types.UnDefType;
@@ -75,35 +73,27 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false, false),
     START_TIME("", START_CHANNEL_ID, DateTimeType.class, false, false),
     END_TIME("", END_CHANNEL_ID, DateTimeType.class, false, false),
-    DURATION("duration", "duration", DateTimeType.class, false, false) {
+    DURATION("duration", "duration", QuantityType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false, false) {
+    ELAPSED_TIME("elapsedTime", "elapsed", QuantityType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    FINISH_TIME("", FINISH_CHANNEL_ID, DateTimeType.class, false, false),
+    FINISH_TIME("", FINISH_CHANNEL_ID, QuantityType.class, false, false),
     DOOR("signalDoor", "door", OpenClosedType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -15,7 +15,6 @@ package org.openhab.binding.miele.internal.handler;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -38,6 +37,8 @@ import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -335,9 +336,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
         try {
             long minutesFromNow = Long.valueOf(value);
             if (minutesFromNow > 0) {
-                ZonedDateTime remaining = ZonedDateTime.ofInstant(Instant.ofEpochSecond(minutesFromNow * 60),
-                        ZoneId.of("UTC"));
-                updateState(channelUid, new DateTimeType(remaining.withZoneSameLocal(timeZoneProvider.getTimeZone())));
+                updateState(channelUid, new QuantityType<>(minutesFromNow, Units.MINUTE));
                 return;
             }
         } catch (NumberFormatException e) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -16,10 +16,7 @@ import static java.util.Map.entry;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.lang.reflect.Method;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -32,6 +29,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 import org.openhab.core.types.UnDefType;
@@ -70,35 +68,27 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false),
     START_TIME("", START_CHANNEL_ID, DateTimeType.class, false),
     END_TIME("", END_CHANNEL_ID, DateTimeType.class, false),
-    DURATION("duration", "duration", DateTimeType.class, false) {
+    DURATION("duration", "duration", QuantityType.class, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false) {
+    ELAPSED_TIME("elapsedTime", "elapsed", QuantityType.class, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    FINISH_TIME("", FINISH_CHANNEL_ID, DateTimeType.class, false),
+    FINISH_TIME("", FINISH_CHANNEL_ID, QuantityType.class, false),
     TARGET_TEMP("targetTemperature", "target", QuantityType.class, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
@@ -16,10 +16,7 @@ import static java.util.Map.entry;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.lang.reflect.Method;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -30,7 +27,9 @@ import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 import org.openhab.core.types.UnDefType;
@@ -75,35 +74,27 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false),
     START_TIME("", START_CHANNEL_ID, DateTimeType.class, false),
     END_TIME("", END_CHANNEL_ID, DateTimeType.class, false),
-    DURATION("duration", "duration", DateTimeType.class, false) {
+    DURATION("duration", "duration", QuantityType.class, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false) {
+    ELAPSED_TIME("elapsedTime", "elapsed", QuantityType.class, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    FINISH_TIME("", FINISH_CHANNEL_ID, DateTimeType.class, false),
+    FINISH_TIME("", FINISH_CHANNEL_ID, QuantityType.class, false),
     DRYING_STEP("dryingStep", "step", DecimalType.class, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -16,10 +16,7 @@ import static java.util.Map.entry;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.lang.reflect.Method;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -32,6 +29,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 import org.openhab.core.types.UnDefType;
@@ -76,35 +74,27 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     PROGRAM_PHASE(RAW_PHASE_PROPERTY_NAME, PHASE_CHANNEL_ID, DecimalType.class, false, false),
     START_TIME("", START_CHANNEL_ID, DateTimeType.class, false, false),
     END_TIME("", END_CHANNEL_ID, DateTimeType.class, false, false),
-    DURATION("duration", "duration", DateTimeType.class, false, false) {
+    DURATION("duration", "duration", QuantityType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s.trim()) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    ELAPSED_TIME("elapsedTime", "elapsed", DateTimeType.class, false, false) {
+    ELAPSED_TIME("elapsedTime", "elapsed", QuantityType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {
-            Date date = new Date();
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            dateFormatter.setTimeZone(TimeZone.getTimeZone("GMT+0"));
             try {
-                date.setTime(Long.valueOf(s) * 60000);
-            } catch (Exception e) {
-                date.setTime(0);
+                return new QuantityType<>(Long.valueOf(s), Units.MINUTE);
+            } catch (NumberFormatException e) {
+                return UnDefType.UNDEF;
             }
-            return getState(dateFormatter.format(date));
         }
     },
-    FINISH_TIME("", FINISH_CHANNEL_ID, DateTimeType.class, false, false),
+    FINISH_TIME("", FINISH_CHANNEL_ID, QuantityType.class, false, false),
     TARGET_TEMP("targetTemperature", "target", QuantityType.class, false, false) {
         @Override
         public State getState(String s, @Nullable DeviceMetaData dmd, MieleTranslationProvider translationProvider) {

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -70,27 +70,27 @@
 	</channel-type>
 
 	<channel-type id="duration">
-		<item-type>DateTime</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Duration</label>
 		<description>Duration of the program running on the appliance</description>
 		<category>Time</category>
-		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
+		<state readOnly="true" pattern="%1$tR"></state>
 	</channel-type>
 
 	<channel-type id="elapsed">
-		<item-type>DateTime</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Elapsed Time</label>
 		<description>Time elapsed in the program running on the appliance</description>
 		<category>Time</category>
-		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
+		<state readOnly="true" pattern="%1$tR"></state>
 	</channel-type>
 
 	<channel-type id="finish">
-		<item-type>DateTime</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Finish Time</label>
 		<description>Time to finish the program running on the appliance</description>
 		<category>Time</category>
-		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
+		<state readOnly="true" pattern="%1$tR"></state>
 	</channel-type>
 
 	<channel-type id="door">


### PR DESCRIPTION
Migrate channels **duration**, **elapsed** and **finish** from `DateTime` to `Number:Time` since they represent an amount of time, not a specific point in time.

This is a breaking change requiring UI things to be recreated and linked items for these channels to be recreated. Persistence of these channels is unlikely, but would also break. Rules would need adaptation. Therefore I will provide a note in openhab-distro. After recreation of items, the default display format is the same, so UI's should be unaffected. openhab/openhab-distro#1435 prepared.

See also #13316 where related channels were fixed to represent a point in time.

Additional details are available in the linked issue.

Fixes #13840 