### PR TITLE
[jsscripting] Refactor log formatting & Respect toString polyfills

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -18,65 +18,54 @@
   let log = createLogger();
 
   function stringify (value) {
-    try {
-      if (Java.isJavaObject(value) || value instanceof Error) {
-        return value.toString();
-      } else {
-        // special cases
-        if (value === undefined) {
-          return 'undefined';
-        }
-        if (typeof value === 'function') {
-          return '[Function]';
-        }
-        if (value instanceof RegExp) {
-          return value.toString();
-        }
-        // fallback to JSON
-        return JSON.stringify(value, null, 2);
-      }
-    } catch (e) {
-      return '[Circular: ' + e + ']';
+    if (typeof value === 'string') return value;
+    // special cases
+    if (value === undefined) {
+      return 'undefined';
     }
+    if (value === null) {
+      return 'null';
+    }
+    // JSON.stringify all objects that do not polyfill toString (some openhab-js classed provide their own toString implementation)
+    if (typeof value === 'object' && value.toString() === '[object Object]') {
+      return JSON.stringify(value, null, 2);
+    }
+    return value.toString()
   }
 
   function format (f) {
-    if (typeof f !== 'string') {
-      const objects = [];
-      for (let index = 0; index < arguments.length; index++) {
-        objects.push(stringify(arguments[index]));
-      }
-      return objects.join(' ');
-    }
-
-    if (arguments.length === 1) return f;
-
-    let i = 1;
     const args = arguments;
-    const len = args.length;
-    let str = String(f).replace(formatRegExp, function (x) {
-      if (x === '%%') return '%';
-      if (i >= len) return x;
-      switch (x) {
-        case '%s': return String(args[i++]);
-        case '%d': return Number(args[i++]);
-        case '%j':
-          try {
-            return stringify(args[i++]);
-          } catch (_) {
-            return '[Circular]';
-          }
-          // falls through
-        default:
-          return x;
-      }
-    });
-    for (let x = args[i]; i < len; x = args[++i]) {
-      if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
-        str += ' ' + x;
-      } else {
-        str += ' ' + stringify(x);
-      }
+    
+    // If there is only one argument, stringify and return it
+    if (args.length === 1) return stringify(f);
+
+    // Else if the first arg is string, do regex string formatting
+    // the number of args after the formatted string must match the number of % placeholder
+    let str;
+    let i = 0;
+    if (typeof f === 'string') {
+      str = String(f).replace(formatRegExp, function (x) {
+        if (x === '%%') return '%';
+        i = 1;
+        if (i >= args.length) return x;
+        switch (x) {
+          case '%s': return String(args[i++]);
+          case '%d': return Number(args[i++]);
+          case '%j':
+            try {
+              return stringify(args[i++]);
+            } catch (e) {
+              return '[Circular]';
+            }
+            // falls through
+          default:
+            return x;
+        }
+      });
+    }
+    // Else stringify and join all args
+    for (let x = args[i]; i < args.length; x = args[++i]) {
+      str += ' ' + stringify(x);
     }
     return str;
   }

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -34,7 +34,7 @@
       }
       return str;
     } catch (e) {
-      return 'Error: failed to stringify "' + value + '"';
+      return 'Error: failed to format log message: ' + e;
     }
   }
 
@@ -74,7 +74,7 @@
       }
       return str;
     } catch (e) {
-      return 'Error: failed to format "' + f + '"';
+      return 'Error: failed to format log message: ' + e;
     }
   }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/node_modules/@jsscripting-globals.js
@@ -18,56 +18,64 @@
   let log = createLogger();
 
   function stringify (value) {
-    if (typeof value === 'string') return value;
-    // special cases
-    if (value === undefined) {
-      return 'undefined';
+    try {
+      if (typeof value === 'string') return value;
+      // special cases
+      if (value === undefined) {
+        return 'undefined';
+      }
+      if (value === null) {
+        return 'null';
+      }
+      // JSON.stringify all objects that do not polyfill toString()
+      const str = value.toString();
+      if (typeof value === 'object' && (str === '[object Object]') || str === '[object Java]') {
+        return JSON.stringify(value, null, 2);
+      }
+      return str;
+    } catch (e) {
+      return 'Error: failed to stringify "' + value + '"';
     }
-    if (value === null) {
-      return 'null';
-    }
-    // JSON.stringify all objects that do not polyfill toString (some openhab-js classed provide their own toString implementation)
-    if (typeof value === 'object' && value.toString() === '[object Object]') {
-      return JSON.stringify(value, null, 2);
-    }
-    return value.toString()
   }
 
   function format (f) {
-    const args = arguments;
-    
-    // If there is only one argument, stringify and return it
-    if (args.length === 1) return stringify(f);
+    try {
+      const args = arguments;
 
-    // Else if the first arg is string, do regex string formatting
-    // the number of args after the formatted string must match the number of % placeholder
-    let str;
-    let i = 0;
-    if (typeof f === 'string') {
-      str = String(f).replace(formatRegExp, function (x) {
-        if (x === '%%') return '%';
-        i = 1;
-        if (i >= args.length) return x;
-        switch (x) {
-          case '%s': return String(args[i++]);
-          case '%d': return Number(args[i++]);
-          case '%j':
-            try {
-              return stringify(args[i++]);
-            } catch (e) {
-              return '[Circular]';
-            }
-            // falls through
-          default:
-            return x;
-        }
-      });
+      // If there is only one argument, stringify and return it
+      if (args.length === 1) return stringify(f);
+
+      // Else if the first arg is string, do regex string formatting
+      // the number of args after the formatted string must match the number of % placeholder
+      let str;
+      let i = 1;
+      if (typeof f === 'string') {
+        str = String(f).replace(formatRegExp, function (x) {
+          if (x === '%%') return '%';
+          if (i >= args.length) return x;
+          switch (x) {
+            case '%s': return String(args[i++]);
+            case '%d': return Number(args[i++]);
+            case '%j':
+              try {
+                return stringify(args[i++]);
+              } catch (e) {
+                return '[Circular]';
+              }
+              // falls through
+            default:
+              return x;
+          }
+        });
+      }
+      // Else stringify and join all args
+      for (let x = args[i]; i < args.length; x = args[++i]) {
+        str += ' ' + stringify(x);
+      }
+      return str;
+    } catch (e) {
+      return 'Error: failed to format "' + f + '"';
     }
-    // Else stringify and join all args
-    for (let x = args[i]; i < args.length; x = args[++i]) {
-      str += ' ' + stringify(x);
-    }
-    return str;
   }
 
   const counters = {};


### PR DESCRIPTION
## Description

Fixes a problem, where toString polyfills of objects were ignored:

- Accept `toString` polyfills on objects and do not `JSON.stringify` them (some classes in the openhab-js library will introduce toString polyfills for string serialization).
- Refactor the log message formatting to ease understanding & readibility.

## Testing

Perform various log statements to check my changes:

```javascript
var item = {
  a: 'x',
  b: 'y'
}

console.log(item);

var arr = ['hello', 'world', 5, item];

console.log(arr);

console.log(undefined, 7, null);

console.log(function () {
  console.log("Hello world")
})

console.log(new RegExp(/ab+c/, 'i'))

console.log('Hello', 'Florian', 5, arr, item)
```