### PR TITLE
[jsscripting] Add an alternative MIME type/alias

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -1,9 +1,10 @@
 Bundle-SymbolicName: ${project.artifactId}
 DynamicImport-Package: *
 Import-Package: org.openhab.core.automation.module.script,javax.management,javax.script,javax.xml.datatype,javax.xml.stream;version="[1.0,2)",org.osgi.framework;version="[1.8,2)",org.slf4j;version="[1.7,2)"
-Require-Capability: osgi.extender;
+Require-Capability: 
+    osgi.extender:=
       filter:="(osgi.extender=osgi.serviceloader.processor)",
-    osgi.serviceloader;
+    osgi.serviceloader:=
       filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)";
       cardinality:=multiple
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -40,11 +40,14 @@ import org.osgi.service.component.annotations.Reference;
 public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     private static final String CFG_INJECTION_ENABLED = "injectionEnabled";
     private static final String INJECTION_CODE = "Object.assign(this, require('openhab'));";
-    private final JSDependencyTracker jsDependencyTracker;
     private boolean injectionEnabled = true;
 
     public static final String MIME_TYPE = "application/javascript;version=ECMAScript-2021";
+    private static final String ALT_MIME_TYPE = "text/javascript;version=ECMAScript-2021";
+    private static final String ALIAS = "graaljs";
+
     private final JSScriptServiceUtil jsScriptServiceUtil;
+    private final JSDependencyTracker jsDependencyTracker;
 
     @Activate
     public GraalJSScriptEngineFactory(final @Reference JSScriptServiceUtil jsScriptServiceUtil,
@@ -68,7 +71,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
         // scriptTypes.addAll(graalJSEngineFactory.getMimeTypes());
         // scriptTypes.addAll(graalJSEngineFactory.getExtensions());
 
-        return List.of(MIME_TYPE);
+        return List.of(MIME_TYPE, ALT_MIME_TYPE, ALIAS);
     }
 
     @Override

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -179,6 +179,9 @@ public class OpenhabGraalJSScriptEngine
         }
 
         ScriptContext ctx = delegate.getContext();
+        if (ctx == null) {
+            throw new IllegalStateException("Failed to retrieve script context");
+        }
 
         // these are added post-construction, so we need to fetch them late
         this.engineIdentifier = (String) ctx.getAttribute(CONTEXT_KEY_ENGINE_IDENTIFIER);


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/2883#issuecomment-1336442359 for discussion.

The new MIME types (especially the `graaljs` alias) are introduced to enhance working with JS Scripting in the `SCRIPT` transformation profile (https://github.com/openhab/openhab-core/pull/2883, docs https://github.com/openhab/openhab-docs/pull/1940).

Furthermore, this catches a potential NPE (it occured sometimes during testing due to reloading bundles I think) which I never experienced in production.
Also, I fiexed the syntax problems in the bndtools file.

I will provide the JS Scripting add-on docs for usage of the `SCRIPT` transformation soon, they will come with the openhab-js version bump to the add-on (for the docs, see https://github.com/openhab/openhab-js/pull/190).

@J-N-K FYI
@wborn FYI, can you review and merge?

And can one of you both please have a look at my changes to `bnd.bnd` to verify that they are fine.