### PR TITLE
[jsscripting] Fix "Error removing engine" because context is already closed

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -237,7 +237,6 @@ public class OpenhabGraalJSScriptEngine
     @Override
     public void close() {
         jsRuntimeFeatures.close();
-        delegate.close();
     }
 
     /**


### PR DESCRIPTION
In recent PR #13824, I added closing the context when the engine is closed, but core seems to have problems with that.

It logs: "[ERROR] [ipt.internal.ScriptEngineManagerImpl] - Error removing ScriptEngine java.lang.IllegalStateException: The Context is already closed."

Using the reproduce strategy from #13824, I can confirm that the change of this PR does not bring back the memory leak!

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>