### PR TITLE
Upgrade commons-net to 3.9.0

### DIFF
--- a/bundles/org.openhab.binding.folderwatcher/pom.xml
+++ b/bundles/org.openhab.binding.folderwatcher/pom.xml
@@ -14,11 +14,15 @@
 
   <name>openHAB Add-ons :: Bundles :: FolderWatcher Binding</name>
 
+  <properties>
+    <dep.noembedding>commons-net</dep.noembedding>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.7.2</version>
+      <version>${commons.net.version}</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.folderwatcher/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.folderwatcher/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
 
 	<feature name="openhab-binding-folderwatcher" description="FolderWatcher Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<feature dependency="true">openhab.tp-commons-net</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.folderwatcher/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.transform.jinja/pom.xml
+++ b/bundles/org.openhab.transform.jinja/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.3</version>
+      <version>${commons.net.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -4,10 +4,10 @@
 
 	<feature name="openhab-transformation-jinja" description="Jinja Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<feature dependency="true">openhab.tp-commons-net</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true">mvn:org.jsoup/jsoup/1.15.3</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>
-		<bundle dependency="true">mvn:commons-net/commons-net/3.6</bundle>
 		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.jinja/${project.version}</bundle>
 	</feature>
 </features>

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -16,7 +16,6 @@ Fragment-Host: org.openhab.binding.ntp
 # done
 #
 -runbundles: \
-	org.apache.commons.commons-net;version='[3.7.2,3.7.3)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
@@ -71,4 +70,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.openhab.core.io.console;version='[3.4.0,3.4.1)',\
 	org.openhab.core.test;version='[3.4.0,3.4.1)',\
 	org.openhab.core.thing;version='[3.4.0,3.4.1)',\
-	org.openhab.core.thing.xml;version='[3.4.0,3.4.1)'
+	org.openhab.core.thing.xml;version='[3.4.0,3.4.1)',\
+	org.apache.commons.commons-net;version='[3.9.0,3.9.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <ohc.version>3.4.0-SNAPSHOT</ohc.version>
     <bnd.version>6.3.0</bnd.version>
-    <commons.net.version>3.7.2</commons.net.version>
+    <commons.net.version>3.9.0</commons.net.version>
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.7</jackson.version>
     <karaf.version>4.3.7</karaf.version>


### PR DESCRIPTION
Related to openhab/openhab-core#3200

Also reworks a few POMs/features so the commons-net OHC feature is used and the dependency is not embedded. 

Replaces: 

* https://github.com/openhab/openhab-addons/pull/13856
* https://github.com/openhab/openhab-addons/pull/13857