### PR TITLE
[mielecloud] Integration test fixes: remove things after each integration test

### DIFF
--- a/itests/org.openhab.binding.mielecloud.tests/src/main/java/org/openhab/binding/mielecloud/internal/handler/AbstractMieleThingHandlerTest.java
+++ b/itests/org.openhab.binding.mielecloud.tests/src/main/java/org/openhab/binding/mielecloud/internal/handler/AbstractMieleThingHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.mielecloud.internal.MieleCloudBindingConstants;
@@ -365,6 +366,12 @@ public abstract class AbstractMieleThingHandlerTest extends JavaOSGiTest {
      * @return The created {@link ThingHandler}.
      */
     protected abstract AbstractMieleThingHandler setUpThingHandler();
+
+    @AfterEach
+    public void tearDownAbstractMieleThingHandlerTest() {
+        getThingRegistry().forceRemove(getThingHandler().getThing().getUID());
+        getThingRegistry().forceRemove(getBridge().getUID());
+    }
 
     @Test
     public void testCachedStateIsQueriedOnInitialize() throws Exception {


### PR DESCRIPTION
When comparing the integration tests of the mielecloud binding to the ones of the nest binding I saw that things are removed after each integration test run. This PR adds this behavior to the mielecloud integration tests, hoping that this is a cause for them failing in the CI build. Also see #12627.