### PR TITLE
[Nanolaef] Visual State Bugfix

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/README.md
+++ b/bundles/org.openhab.binding.nanoleaf/README.md
@@ -110,6 +110,8 @@ Compare the following output with the right picture at the beginning of the arti
 The state channel shows an image of the panels on the wall.
 You have to configure things for each panel to get the correct color. 
 Since the colors of the panels can make it difficult to see the panel ids, please use the layout channel where the background color is always white to identify them.
+For state to work, you need to set static colors to your panel. 
+This is because Nanoleaf does not return updates on colors for dynamic effects and animations.
 
 ![Image](doc/NanoCanvas_rendered.jpg)
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/NanoleafBindingConstants.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/NanoleafBindingConstants.java
@@ -59,7 +59,7 @@ public class NanoleafBindingConstants {
     public static final String CHANNEL_SWIPE_EVENT_LEFT = "LEFT";
     public static final String CHANNEL_SWIPE_EVENT_RIGHT = "RIGHT";
     public static final String CHANNEL_LAYOUT = "layout";
-    public static final String CHANNEL_STATE = "state";
+    public static final String CHANNEL_VISUAL_STATE = "visualState";
 
     // List of light panel channels
     public static final String CHANNEL_PANEL_COLOR = "color";

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayout.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayout.java
@@ -60,7 +60,7 @@ public class NanoleafLayout {
 
         List<PositionDatum> positionDatums = layout.getPositionData();
         if (positionDatums == null) {
-            logger.warn("Returning no image as we dont have any position datums to render");
+            logger.warn("Returning no image as we don't have any position datums to render");
             return new byte[] {};
         }
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayout.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayout.java
@@ -31,6 +31,8 @@ import org.openhab.binding.nanoleaf.internal.model.GlobalOrientation;
 import org.openhab.binding.nanoleaf.internal.model.Layout;
 import org.openhab.binding.nanoleaf.internal.model.PanelLayout;
 import org.openhab.binding.nanoleaf.internal.model.PositionDatum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Renders the Nanoleaf layout to an image.
@@ -40,6 +42,7 @@ import org.openhab.binding.nanoleaf.internal.model.PositionDatum;
 @NonNullByDefault
 public class NanoleafLayout {
 
+    private static final Logger logger = LoggerFactory.getLogger(NanoleafLayout.class);
     private static final Color COLOR_BACKGROUND = Color.WHITE;
 
     public static byte[] render(PanelLayout panelLayout, PanelState state, LayoutSettings settings) throws IOException {
@@ -51,11 +54,13 @@ public class NanoleafLayout {
 
         Layout layout = panelLayout.getLayout();
         if (layout == null) {
+            logger.warn("Returning no image as we dont have any layout to render");
             return new byte[] {};
         }
 
         List<PositionDatum> positionDatums = layout.getPositionData();
         if (positionDatums == null) {
+            logger.warn("Returning no image as we dont have any position datums to render");
             return new byte[] {};
         }
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayout.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayout.java
@@ -54,7 +54,7 @@ public class NanoleafLayout {
 
         Layout layout = panelLayout.getLayout();
         if (layout == null) {
-            logger.warn("Returning no image as we dont have any layout to render");
+            logger.warn("Returning no image as we don't have any layout to render");
             return new byte[] {};
         }
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/PanelState.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/PanelState.java
@@ -23,6 +23,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.nanoleaf.internal.handler.NanoleafPanelHandler;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.Thing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Stores the state of the panels.
@@ -32,6 +34,7 @@ import org.openhab.core.thing.Thing;
 @NonNullByDefault
 public class PanelState {
 
+    private static final Logger logger = LoggerFactory.getLogger(PanelState.class);
     private final Map<Integer, HSBType> panelStates = new HashMap<>();
 
     public PanelState(List<Thing> panels) {
@@ -40,13 +43,26 @@ public class PanelState {
             NanoleafPanelHandler panelHandler = (NanoleafPanelHandler) panel.getHandler();
             if (panelHandler != null) {
                 HSBType c = panelHandler.getColor();
+
+                if (c == null) {
+                    logger.trace("Panel {}: Failed to get color", panelId);
+                }
+
                 HSBType color = (c == null) ? HSBType.BLACK : c;
                 panelStates.put(panelId, color);
+            } else {
+                logger.trace("Panel {}: Couldn't find handler", panelId);
             }
         }
     }
 
     public HSBType getHSBForPanel(Integer panelId) {
+        if (logger.isTraceEnabled()) {
+            if (!panelStates.containsKey(panelId)) {
+                logger.trace("Failed to get color for panel {}, falling back to black", panelId);
+            }
+        }
+
         return panelStates.getOrDefault(panelId, HSBType.BLACK);
     }
 }

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/i18n/nanoleaf.properties
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/i18n/nanoleaf.properties
@@ -40,8 +40,8 @@ channel-type.nanoleaf.swipe.label = Swipe
 channel-type.nanoleaf.swipe.description = Swipe over the panels
 channel-type.nanoleaf.layout.label = Layout
 channel-type.nanoleaf.layout.description = Layout of the panels
-channel-type.nanoleaf.state.label = State
-channel-type.nanoleaf.state.description = Current state of the panels
+channel-type.nanoleaf.state.label = Visual State
+channel-type.nanoleaf.state.description = Current visual state of the panels
 
 # error messages
 error.nanoleaf.controller.noIp = IP/host address and/or port are not configured for the controller.

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/thing/lightpanels.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/thing/lightpanels.xml
@@ -19,7 +19,7 @@
 			<channel id="rhythmMode" typeId="rhythmMode"/>
 			<channel id="swipe" typeId="swipe"/>
 			<channel id="layout" typeId="layout"/>
-			<channel id="currentState" typeId="state"/>
+			<channel id="visualState" typeId="visualState"/>
 		</channels>
 
 		<properties>
@@ -115,7 +115,7 @@
 		<description>@text/channel-type.nanoleaf.layout.description</description>
 	</channel-type>
 
-	<channel-type id="state">
+	<channel-type id="visualState">
 		<item-type>Image</item-type>
 		<label>@text/channel-type.nanoleaf.state.label</label>
 		<description>@text/channel-type.nanoleaf.state.description</description>


### PR DESCRIPTION
Fix the visual state channel name.

Also:
- Better name (from "state" to "visual state") of the (new, not released yet) channel
- Better logs which has helped us debug the problem
- Some more information on when it will work in the README

Discussed on https://community.openhab.org/t/state-and-layout-are-unreliable/141798/19

Signed-off-by: Jørgen Austvik <jaustvik@acm.org>