### PR TITLE
[ipcamera] Add a check to see if FFmpeg is frozen for mjpeg creation

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
@@ -131,7 +131,7 @@ public class Ffmpeg {
                     BufferedReader bufferedReader = new BufferedReader(errorStreamReader);
                     String line = null;
                     while ((line = bufferedReader.readLine()) != null) {
-                        logger.debug("{}", line);
+                        logger.trace("{}", line);
                         switch (format) {
                             case RTSP_ALARMS:
                                 if (line.contains("lavfi.")) {
@@ -172,8 +172,9 @@ public class Ffmpeg {
                                 } else if (line.contains("silence_end")) {
                                     ipCameraHandler.audioDetected();
                                 }
+                            case MJPEG:
                             case SNAPSHOT:
-                                notFrozen = true;// RTSP_ALARMS and SNAPSHOT both set this to true as there is no break.
+                                notFrozen = true;// RTSP_ALARMS, MJPEG and SNAPSHOT all set this to true, no break.
                                 break;
                         }
                     }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -137,6 +137,16 @@ public class InstarHandler extends ChannelDuplexHandler {
                             && content.contains("response=\"200\";")) {// new
                         ipCameraHandler.newInstarApi = true;
                         ipCameraHandler.logger.debug("Alarm server sucessfully setup for a 2k+ Instar camera");
+                        if (ipCameraHandler.cameraConfig.getFfmpegInput().isEmpty()) {
+                            ipCameraHandler.rtspUri = "rtsp://" + ipCameraHandler.cameraConfig.getIp()
+                                    + "/livestream/12";
+                        }
+                        if (ipCameraHandler.cameraConfig.getMjpegUrl().isEmpty()) {
+                            ipCameraHandler.mjpegUri = "/livestream/12?action=play&media=mjpeg";
+                        }
+                        if (ipCameraHandler.cameraConfig.getSnapshotUrl().isEmpty()) {
+                            ipCameraHandler.snapshotUri = "/snap.cgi?chn=12";
+                        }
                     } else if (requestUrl.startsWith("/param.cgi?cmd=setmdalarm&-aname=server2&-switch=on&-interval=1")
                             && content.startsWith("[Succeed]set ok")) {
                         ipCameraHandler.newInstarApi = false;

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -906,9 +906,9 @@ public class IpCameraHandler extends BaseThingHandler {
             case MJPEG:
                 if (ffmpegMjpeg == null) {
                     if (inputOptions.isEmpty()) {
-                        inputOptions = "-hide_banner -loglevel warning";
+                        inputOptions = "-hide_banner";
                     } else {
-                        inputOptions += " -hide_banner -loglevel warning";
+                        inputOptions += " -hide_banner";
                     }
                     ffmpegMjpeg = new Ffmpeg(this, format, cameraConfig.getFfmpegLocation(), inputOptions, rtspUri,
                             cameraConfig.getMjpegOptions(), "http://127.0.0.1:" + SERVLET_PORT + "/ipcamera/"
@@ -1573,6 +1573,13 @@ public class IpCameraHandler extends BaseThingHandler {
             localFfmpeg = ffmpegRtspHelper;
             if (localFfmpeg == null || !localFfmpeg.getIsAlive()) {
                 setupFfmpegFormat(FFmpegFormat.RTSP_ALARMS);
+            }
+        }
+        if (ffmpegMjpeg != null) {// check if the thread has frozen due to camera doing a soft reboot
+            localFfmpeg = ffmpegMjpeg;
+            if (localFfmpeg == null || !localFfmpeg.getIsAlive()) {
+                setupFfmpegFormat(FFmpegFormat.MJPEG);
+                logger.debug("MJPEG was not being produced by FFmpeg when it should have been, restarting FFmpeg.");
             }
         }
         if (openChannels.size() > 10) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1575,12 +1575,11 @@ public class IpCameraHandler extends BaseThingHandler {
                 setupFfmpegFormat(FFmpegFormat.RTSP_ALARMS);
             }
         }
-        if (ffmpegMjpeg != null) {// check if the thread has frozen due to camera doing a soft reboot
-            localFfmpeg = ffmpegMjpeg;
-            if (localFfmpeg == null || !localFfmpeg.getIsAlive()) {
-                setupFfmpegFormat(FFmpegFormat.MJPEG);
-                logger.debug("MJPEG was not being produced by FFmpeg when it should have been, restarting FFmpeg.");
-            }
+        // check if the thread has frozen due to camera doing a soft reboot
+        localFfmpeg = ffmpegMjpeg;
+        if (localFfmpeg != null && !localFfmpeg.getIsAlive()) {
+            logger.debug("MJPEG was not being produced by FFmpeg when it should have been, restarting FFmpeg.");
+            setupFfmpegFormat(FFmpegFormat.MJPEG);
         }
         if (openChannels.size() > 10) {
             logger.debug("There are {} open Channels being tracked.", openChannels.size());


### PR DESCRIPTION
Had a user report that a Unifi protect camera does not get detected as OFFLINE by the binding as the base station/hub/bridge stays online whilst the camera itself does a reboot. FFmpeg hangs if the stream stops midway so this fix will check if the thread is still working when it is needed. Also hard coded URLS in for newer range Instar cameras.

Reported via forum here:
https://community.openhab.org/t/ipcamera-streams-not-automatically-updating-cached/141223/15

Jar can be RIGHT HAND CLICKED and `save link as` to get around the jfrog login from:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/3.4.0-SNAPSHOT/org.openhab.binding.ipcamera-3.4.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>