### PR TITLE
[jrubyscripting] Reverses order of class imports and ScriptEngine puts calls

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
@@ -61,7 +61,8 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     private JRubyDependencyTracker jrubyDependencyTracker;
 
-    // Adds $ in front of a set of variables so that Ruby recognizes them as global variables
+    // Adds $ in front of a set of variables so that Ruby recognizes them as global
+    // variables
     private static Map.Entry<String, Object> mapGlobalPresets(Map.Entry<String, Object> entry) {
         if (Character.isLowerCase(entry.getKey().charAt(0)) && !(entry.getValue() instanceof Class)
                 && !(entry.getValue() instanceof Enum)) {
@@ -98,7 +99,8 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
 
     @Override
     public void scopeValues(ScriptEngine scriptEngine, Map<String, Object> scopeValues) {
-        // Empty comments prevent the formatter from breaking up the correct streams chaining
+        // Empty comments prevent the formatter from breaking up the correct streams
+        // chaining
         logger.debug("Scope Values: {}", scopeValues);
         Map<String, Object> filteredScopeValues = //
                 scopeValues //
@@ -113,20 +115,23 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
                         .collect(Collectors.partitioningBy(entry -> (entry.getValue() instanceof Class),
                                 Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
-        importClassesToRuby(scriptEngine, partitionedMap.getOrDefault(true, new HashMap<>()));
         super.scopeValues(scriptEngine, partitionedMap.getOrDefault(false, new HashMap<>()));
+        importClassesToRuby(scriptEngine, partitionedMap.getOrDefault(true, new HashMap<>()));
 
         Object scriptExtension = scopeValues.get("scriptExtension");
         if (scriptExtension instanceof ScriptExtensionManagerWrapper) {
             ScriptExtensionManagerWrapper wrapper = (ScriptExtensionManagerWrapper) scriptExtension;
             // we inject like this instead of using the script context, because
-            // this is executed _before_ the dependency tracker is added to the script context.
+            // this is executed _before_ the dependency tracker is added to the script
+            // context.
             // But we need this set up before we inject our requires
             scriptEngine.put("$dependencyListener", jrubyDependencyTracker.getTracker(wrapper.getScriptIdentifier()));
         }
 
-        // scopeValues is called twice. The first call only passed 'se'. The second call passed the rest of the
-        // presets, including 'ir'. We wait for the second call before running the require statements.
+        // scopeValues is called twice. The first call only passed 'se'. The second call
+        // passed the rest of the
+        // presets, including 'ir'. We wait for the second call before running the
+        // require statements.
         if (scopeValues.containsKey("ir")) {
             configuration.injectRequire(scriptEngine);
         }


### PR DESCRIPTION
This appears to fix an incompatibility introduced after M5, more details available [here](https://github.com/boc-tothefuture/openhab-jruby/pull/659).  To be honest, I am not sure why the order of these calls matter or what changed between M5 and now to make the order matter? 

Because the resolution is so unclear (at least to me) @ccutrer and @jimtng can you verify this doesn't break anything on your end? 

The other changes are from running spotless:apply
