### PR TITLE
[nanoleaf] Don't set read only temp file in test

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayoutTest.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/layout/NanoleafLayoutTest.java
@@ -18,11 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
-import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -66,14 +62,11 @@ public class NanoleafLayoutTest {
         assertNotNull(result, "Should be able to render the layout: " + fileName);
         assertTrue(result.length > 0, "Should get content back, but got " + result.length + "bytes");
 
-        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-r--r--");
-        FileAttribute<Set<PosixFilePermission>> attributes = PosixFilePermissions.asFileAttribute(permissions);
-        Path outFile = Files.createTempFile(temporaryDirectory, fileName.replace(".json", ""), ".png", attributes);
+        Path outFile = Files.createTempFile(temporaryDirectory, fileName.replace(".json", ""), ".png");
         Files.write(outFile, result);
 
         // For inspecting images on own computer
-        // Path permanentOutFile = Files.createFile(Path.of("/tmp", fileName.replace(".json", "") + ".png"),
-        // attributes);
+        // Path permanentOutFile = Files.createFile(Path.of("/tmp", fileName.replace(".json", "") + ".png"));
         // Files.write(permanentOutFile, result);
     }
 


### PR DESCRIPTION
Because it breaks windows builds

Signed-off-by: Jørgen Austvik <jaustvik@acm.org>

