### PR TITLE
[jdbc] Fix console command 'tables clean'

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -525,6 +525,7 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
                 if (!conf.getTableUseRealCaseSensitiveItemNames()) {
                     ItemsVO itemsVo = new ItemsVO();
                     itemsVo.setItemName(entry.getItemName());
+                    itemsVo.setItemsManageTable(conf.getItemsManageTable());
                     deleteItemsEntry(itemsVo);
                 }
                 itemNameToTableNameMap.remove(entry.getItemName());


### PR DESCRIPTION
`NullPointerException` was thrown because items manage table was not provided.

Regression of #13737
Fixes #13911