### PR TITLE
[Nanoleaf] Fix wrong image and website build (again)

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/README.md
+++ b/bundles/org.openhab.binding.nanoleaf/README.md
@@ -113,7 +113,7 @@ Since the colors of the panels can make it difficult to see the panel ids, pleas
 For state to work, you need to set static colors to your panel. 
 This is because Nanoleaf does not return updates on colors for dynamic effects and animations.
 
-![Image](doc/NanoCanvas_rendered.jpg)
+![Image](doc/NanoCanvas_rendered.png)
 
 ## Thing Configuration
 


### PR DESCRIPTION
next.openhab.org website isn't building because of a wrong includeded image in nanoleaf binding based on the build errors.
A quick merge would be apprecieated.

Also we should check this a bit deeper for current nanoleaf contributions.
This is the second time i have to fix a build caused from the nanonleaf readme.
(Picture uploaded as `png` but referenced as `jpg`.)

I will try to have an eye on this too but would appreciate, if @openhab/add-ons-maintainers would also do so.