### PR TITLE
[hueemulation] Fix for Alexa failing to discover all devices.

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -271,15 +271,14 @@ public class ConfigStore {
      */
     private String getHueIDPrefixFromUUID(final String uuid) {
         // Hue API example of a unique id is AA:BB:CC:DD:EE:FF:00:11-XX
-        // XX is generated from the item.
+        // 00:11-XX is generated from the item.
         String prefix = uuid;
         try {
             // Generate prefix if uuid is a randomly generated UUID
             if (UUID.fromString(uuid).version() == 4) {
                 final StringBuilder sb = new StringBuilder(23);
                 sb.append(uuid, 0, 2).append(":").append(uuid, 2, 4).append(":").append(uuid, 4, 6).append(":")
-                        .append(uuid, 6, 8).append(":").append(uuid, 9, 11).append(":").append(uuid, 11, 13).append(":")
-                        .append(uuid, 14, 16).append(":").append(uuid, 16, 18);
+                        .append(uuid, 6, 8).append(":").append(uuid, 9, 11).append(":").append(uuid, 11, 13);
                 prefix = sb.toString().toUpperCase();
             }
         } catch (final IllegalArgumentException e) {
@@ -352,14 +351,20 @@ public class ConfigStore {
      * @return The unique id
      */
     public String getHueUniqueId(final String hueId) {
-        String unique = hueId;
+        String unique;
+
         try {
-            unique = String.format("%02X", Integer.valueOf(hueId));
+            final String id = String.format("%06X", Integer.valueOf(hueId));
+            final StringBuilder sb = new StringBuilder(26);
+            sb.append(hueIDPrefix).append(":").append(id, 0, 2).append(":").append(id, 2, 4).append("-").append(id, 4,
+                    6);
+            unique = sb.toString();
         } catch (final NumberFormatException | IllegalFormatException e) {
             // Use the hueId as is
+            unique = hueIDPrefix + "-" + hueId;
         }
 
-        return hueIDPrefix + "-" + unique;
+        return unique;
     }
 
     public boolean isReady() {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -276,7 +276,7 @@ public class ConfigStore {
         try {
             // Generate prefix if uuid is a randomly generated UUID
             if (UUID.fromString(uuid).version() == 4) {
-                final StringBuilder sb = new StringBuilder(23);
+                final StringBuilder sb = new StringBuilder(17);
                 sb.append(uuid, 0, 2).append(":").append(uuid, 2, 4).append(":").append(uuid, 4, 6).append(":")
                         .append(uuid, 6, 8).append(":").append(uuid, 9, 11).append(":").append(uuid, 11, 13);
                 prefix = sb.toString().toUpperCase();

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/CommonSetup.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/CommonSetup.java
@@ -122,7 +122,7 @@ public class CommonSetup {
         } else {
             cs = new ConfigStoreWithoutMetadata(networkAddressService, configAdmin, scheduler);
         }
-        cs.activate(Collections.singletonMap("uuid", "demouuid"));
+        cs.activate(Collections.singletonMap("uuid", "a668dc9b-7172-49c3-832f-acb07dda2a20"));
         cs.switchFilter = Collections.singleton("Switchable");
         cs.whiteFilter = Collections.singleton("Switchable");
         cs.colorFilter = Collections.singleton("ColorLighting");

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
@@ -116,4 +116,36 @@ public class ItemUIDtoHueIDMappingTests {
 
         assertThat(cs.getHighestAssignedHueID(), CoreMatchers.is(1));
     }
+
+    @Test
+    public void uniqueIdForLargeHueID() {
+        ConfigStore cs = commonSetup.cs;
+        assertThat(cs.getHighestAssignedHueID(), CoreMatchers.is(1));
+
+        SwitchItem item = new SwitchItem("switch1");
+        item.setCategory("Light");
+        commonSetup.metadataRegistry.add(new Metadata(new MetadataKey(ConfigStore.METAKEY, "switch1"), "255", null));
+        itemRegistry.add(item);
+
+        String hueID = cs.mapItemUIDtoHueID(item);
+        assertThat(hueID, CoreMatchers.is("255"));
+
+        HueLightEntry device = cs.ds.lights.get(hueID);
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+        assertThat(device.uniqueid, CoreMatchers.is("A6:68:DC:9B:71:72:00:00-FF"));
+
+        item = new SwitchItem("switch2");
+        item.setCategory("Light");
+        commonSetup.metadataRegistry.add(new Metadata(new MetadataKey(ConfigStore.METAKEY, "switch2"), "256000", null));
+        itemRegistry.add(item);
+
+        hueID = cs.mapItemUIDtoHueID(item);
+        assertThat(hueID, CoreMatchers.is("256000"));
+
+        device = cs.ds.lights.get(hueID);
+        assertThat(device.item, is(item));
+        assertThat(device.state, is(instanceOf(HueStatePlug.class)));
+        assertThat(device.uniqueid, CoreMatchers.is("A6:68:DC:9B:71:72:03:E8-00"));
+    }
 }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
@@ -136,7 +136,7 @@ public class UpnpTests {
             sendSocket.receive(p);
             String received = new String(buffer);
             assertThat(received, CoreMatchers.startsWith("HTTP/1.1 200 OK"));
-            assertThat(received, CoreMatchers.containsString("hue-bridgeid: DEMOUUID"));
+            assertThat(received, CoreMatchers.containsString("hue-bridgeid: A668DC9B7172"));
         }
 
         r.dispose();


### PR DESCRIPTION
Alexa currently fails to discover devices which have an internal hue id greater than 255. This appears to be due to the value of the uniqueid which is not in the format described in the hue API when the value exceeds 255.

[Reports of issue and fix tested](https://community.openhab.org/t/oh3-hue-emulation-bug/139875)

Signed-off-by: Mike Major <mike_j_major@hotmail.com>
