### PR TITLE
[nanoleaf] Bugfix: Handle non-integer panel ids

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafPanelHandler.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafPanelHandler.java
@@ -286,7 +286,21 @@ public class NanoleafPanelHandler extends BaseThingHandler implements NanoleafPa
     }
 
     public Integer getPanelID() {
-        return (Integer) getThing().getConfiguration().get(CONFIG_PANEL_ID);
+        Object panelId = getThing().getConfiguration().get(CONFIG_PANEL_ID);
+        if (panelId instanceof Integer) {
+            return (Integer) panelId;
+        } else if (panelId instanceof Number) {
+            return ((Number) panelId).intValue();
+        } else {
+            // Fall back to parsing string representation of panel if it is not returning an integer
+            String stringPanelId = panelId.toString();
+            Integer parsedPanelId = Integer.getInteger(stringPanelId);
+            if (parsedPanelId == null) {
+                return 0;
+            } else {
+                return parsedPanelId;
+            }
+        }
     }
 
     private void setPanelColor(HSBType color) {


### PR DESCRIPTION
Panel ids are sometimes returned as BigInteger

We haven't been able to understand why this happens somewhere and somewhere not, but this is an sledgehammer attempt to fix it quickly to unblock users, and then we will try to understand it later.

Discussions:
https://community.openhab.org/t/java-lang-classcastexception-class-java-math-bigdecimal-cannot-be-cast-to-class-java-lang-integer/142035/16 https://community.openhab.org/t/nanoleaf-binding-oh3-stabilization-update/116300/61

Signed-off-by: Jørgen Austvik <jaustvik@acm.org>

