### PR TITLE
Fix Zigbee name stylization

### DIFF
--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/i18n/draytonwiser.properties
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/i18n/draytonwiser.properties
@@ -112,4 +112,4 @@ channel-type.draytonwiser.wiserBatteryLevel-channel.description = Current Batter
 channel-type.draytonwiser.wiserSignalStrength-channel.label = Signal Strength (Wiser)
 channel-type.draytonwiser.wiserSignalStrength-channel.description = The reported network signal strength
 channel-type.draytonwiser.zigbeeConnected-channel.label = Device Connected
-channel-type.draytonwiser.zigbeeConnected-channel.description = Is the device still connected to the ZigBee network
+channel-type.draytonwiser.zigbeeConnected-channel.description = Is the device still connected to the Zigbee network

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
@@ -364,7 +364,7 @@
 	<channel-type id="zigbeeConnected-channel" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Device Connected</label>
-		<description>Is the device still connected to the ZigBee network</description>
+		<description>Is the device still connected to the Zigbee network</description>
 		<state readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.hue/README.md
+++ b/bundles/org.openhab.binding.hue/README.md
@@ -8,21 +8,21 @@ The integration happens through the Hue Bridge, which acts as an IP gateway to t
 ## Supported Things
 
 The Hue Bridge is required as a "bridge" for accessing any other Hue device.
-It supports the ZigBee LightLink protocol as well as the upwards compatible ZigBee 3.0 protocol.
+It supports the Zigbee Light Link protocol as well as the upwards compatible Zigbee 3.0 protocol.
 There are two types of Hue Bridges, generally referred to as v1 (the rounded version) and v2 (the squared version).
 Only noticeable difference between the two generation of bridges is the added support for Apple HomeKit in v2.
 Both bridges are fully supported by this binding.
 
 Almost all available Hue devices are supported by this binding.
 This includes not only the "Friends of Hue", but also products like the LivingWhites adapter.
-Additionally, it is possible to use OSRAM Lightify devices as well as other ZigBee LightLink compatible products, including the IKEA TRÅDFRI lights (when updated).
-Beside bulbs and luminaires the Hue binding also supports some ZigBee sensors. Currently only Hue specific sensors are tested successfully (Hue Motion Sensor and Hue Dimmer Switch).
+Additionally, it is possible to use OSRAM Lightify devices as well as other Zigbee Light Link compatible products, including the IKEA TRÅDFRI lights (when updated).
+Beside bulbs and luminaires the Hue binding also supports some Zigbee sensors. Currently only Hue specific sensors are tested successfully (Hue Motion Sensor and Hue Dimmer Switch).
 Please note that the devices need to be registered with the Hue Bridge before it is possible for this binding to use them.
 
-The Hue binding supports all seven types of lighting devices defined for ZigBee LightLink ([see page 24, table 2](https://www.nxp.com/docs/en/user-guide/JN-UG-3091.pdf).
+The Hue binding supports all seven types of lighting devices defined for Zigbee Light Link ([see page 24, table 2](https://www.nxp.com/docs/en/user-guide/JN-UG-3091.pdf).
 These are:
 
-| Device type              | ZigBee Device ID | Thing type |
+| Device type              | Zigbee Device ID | Thing type |
 |--------------------------|------------------|------------|
 | On/Off Light             | 0x0000           | 0000       |
 | On/Off Plug-in Unit      | 0x0010           | 0010       |
@@ -46,13 +46,13 @@ The following matrix lists the capabilities (channels) for each type:
 |  0210       |    X   |            |   X   |          X        |
 |  0220       |    X   |     X      |       |          X        |
 
-Beside bulbs and luminaires the Hue binding supports some ZigBee sensors.
+Beside bulbs and luminaires the Hue binding supports some Zigbee sensors.
 Currently only Hue specific sensors are tested successfully (e.g. Hue Motion Sensor, Hue Dimmer Switch, Hue Tap, CLIP Sensor).
 The Hue Motion Sensor registers a `ZLLLightLevel` sensor (0106), a `ZLLPresence` sensor (0107) and a `ZLLTemperature` sensor (0302) in one device.
 The Hue CLIP Sensor saves scene states with status or flag for HUE rules.
-They are presented by the following ZigBee Device ID and _Thing type_:
+They are presented by the following Zigbee Device ID and _Thing type_:
 
-| Device type                 | ZigBee Device ID | Thing type     |
+| Device type                 | Zigbee Device ID | Thing type     |
 |-----------------------------|------------------|----------------|
 | Light Sensor                | 0x0106           | 0106           |
 | Occupancy Sensor            | 0x0107           | 0107           |

--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -2,14 +2,14 @@
 
 This binding integrates Miele@home appliances.
 Miele@home allows controlling Miele appliances that are equipped with special communication modules.
-There are devices that communicate through ZigBee and others that use WiFi.
+There are devices that communicate through Zigbee and others that use WiFi.
 
 See [www.miele.de](https://www.miele.de) for the list of available appliances.
 
 ## Supported Things
 
 This binding requires the XGW3000 gateway from Miele as all integration with openHAB is done through this gateway.
-While users with ZigBee-enabled Miele appliances usually own such a gateway, this is often not the case for people that have only WiFi-enabled appliances.
+While users with Zigbee-enabled Miele appliances usually own such a gateway, this is often not the case for people that have only WiFi-enabled appliances.
 
 The types of appliances that are supported by this binding are:
 

--- a/bundles/org.openhab.binding.mielecloud/README.md
+++ b/bundles/org.openhab.binding.mielecloud/README.md
@@ -7,7 +7,7 @@ The latter can be requested from the [Miele Developer Portal](https://www.miele.
 ## Supported Things
 
 Most Miele appliances that directly connect to the cloud via a Wi-Fi module are supported.
-Appliances connecting to the XGW3000 gateway via ZigBee are also supported when registered with the cloud account.
+Appliances connecting to the XGW3000 gateway via Zigbee are also supported when registered with the cloud account.
 However they might be better supported by the [gateway-based Miele binding](https://www.openhab.org/addons/bindings/miele/).
 Depending on the age of your appliance the functionality of the binding might be limited.
 Appliances from recent generations will support all functionality.

--- a/bundles/org.openhab.binding.mihome/README.md
+++ b/bundles/org.openhab.binding.mihome/README.md
@@ -1,7 +1,7 @@
 # Xiaomi Mi Smart Home Binding
 
 This binding allows your openHAB to communicate with the Xiaomi Smart Home Suite.
-It consists of devices communicating over a ZigBee network with a ZigBee - WiFi gateway.
+It consists of devices communicating over a Zigbee network with a Zigbee - WiFi gateway.
 
 The devices are very affordable and you can get them from your favourite Chinese markets like [AliExpress](https://www.aliexpress.com/) or [GearBest](https://www.gearbest.com).
 The sensors run on a coin cell battery for over a year.

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -1,16 +1,16 @@
 # OpenWebNet (BTicino/Legrand) Binding
 
-This binding integrates BTicino / Legrand MyHOME&reg; BUS and ZigBee wireless (MyHOME_Play&reg;) devices using the [OpenWebNet](https://en.wikipedia.org/wiki/OpenWebNet) protocol.
+This binding integrates BTicino / Legrand MyHOME&reg; BUS and Zigbee wireless (MyHOME_Play&reg;) devices using the [OpenWebNet](https://en.wikipedia.org/wiki/OpenWebNet) protocol.
 
 The binding supports:
 
-- both wired BUS/SCS (MyHOME) and wireless setups (MyHOME ZigBee). The two networks can be configured simultaneously
-- auto discovery of BUS/SCS IP and ZigBee USB gateways; auto discovery of devices
+- both wired BUS/SCS (MyHOME) and wireless setups (MyHOME Zigbee). The two networks can be configured simultaneously
+- auto discovery of BUS/SCS IP and Zigbee USB gateways; auto discovery of devices
 - commands from openHAB and feedback (events) from BUS/SCS and wireless network
 
 ![MyHOMEServer1 Gateway](doc/MyHOMEServer1_gateway.jpg)
 ![F454 Gateway](doc/F454_gateway.png)
-![ZigBee USB Gateway](doc/USB_gateway.jpg)
+![Zigbee USB Gateway](doc/USB_gateway.jpg)
 
 ## Supported Things
 
@@ -29,7 +29,7 @@ These gateways have been tested with the binding:
 [MH200N](https://www.homesystems-legrandgroup.com/home?p_p_id=it_smc_bticino_homesystems_search_AutocompletesearchPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_it_smc_bticino_homesystems_search_AutocompletesearchPortlet_journalArticleId=2469209&_it_smc_bticino_homesystems_search_AutocompletesearchPortlet_mvcPath=%2Fview_journal_article_content.jsp),
 [F453](https://www.homesystems-legrandgroup.com/home?p_p_id=it_smc_bticino_homesystems_search_AutocompletesearchPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_it_smc_bticino_homesystems_search_AutocompletesearchPortlet_journalArticleId=2703566&_it_smc_bticino_homesystems_search_AutocompletesearchPortlet_mvcPath=%2Fview_journal_article_content.jsp),  etc.
 
-- **ZigBee USB Gateways**, such as [BTicino 3578](https://catalogo.bticino.it/BTI-3578-IT), also known as Legrand 088328
+- **Zigbee USB Gateways**, such as [BTicino 3578](https://catalogo.bticino.it/BTI-3578-IT), also known as Legrand 088328
 
 **NOTE** The new BTicino Living Now&reg; and Livinglight Smart&reg; wireless systems are not supported by this binding as they do not use the OpenWebNet protocol.
 
@@ -49,13 +49,13 @@ The following Things and OpenWebNet `WHOs` are supported:
 | Dry Contact and IR Interfaces |    `25`     |                    `bus_dry_contact_ir`                    | Dry Contacts and IR Interfaces                                   | Successfully tested: contact interfaces F428 and 3477; IR sensors: HC/HD/HS/L/N/NT4610      |
 | Energy Management             |    `18`     |                     `bus_energy_meter`                     | Energy Management                                                | Successfully tested: F520, F521. Partially tested: F522, F523                               |
 
-### For ZigBee (Radio)
+### For Zigbee (Radio)
 
 | Category             | WHO    | Thing Type IDs                                        | Description                                                           | Status                               |
 | -------------------- | :----: | :---------------------------------------------------: | :-------------------------------------------------------------------: | ------------------------------------ |
-| Gateway Management   | `13`   | `zb_gateway`                                          | ZigBee USB Gateway (models: BTI-3578 / LG 088328)                     | Tested: BTI-3578 and LG 088328       |
-| Lighting             | `1`    | `zb_dimmer`, `zb_on_off_switch`, `zb_on_off_switch2u` | ZigBee dimmers, switches and 2-unit switches                          | Tested: BTI-4591, BTI-3584, BTI-4585 |
-| Automation           | `2`    | `zb_automation`                                       | ZigBee roller shutters                                                |                                      |
+| Gateway Management   | `13`   | `zb_gateway`                                          | Zigbee USB Gateway (models: BTI-3578 / LG 088328)                     | Tested: BTI-3578 and LG 088328       |
+| Lighting             | `1`    | `zb_dimmer`, `zb_on_off_switch`, `zb_on_off_switch2u` | Zigbee dimmers, switches and 2-unit switches                          | Tested: BTI-4591, BTI-3584, BTI-4585 |
+| Automation           | `2`    | `zb_automation`                                       | Zigbee roller shutters                                                |                                      |
 
 ## Discovery
 
@@ -78,9 +78,9 @@ Setting the parameter `discoveryByActivation=true` for a BUS gateway Thing makes
 
 If a device cannot be discovered automatically from Inbox it's always possible to add it manually, see [Configuring Devices](#configuring-devices).
 
-### ZigBee Discovery
+### Zigbee Discovery
 
-- The ZigBee USB Gateway must be inserted in one of the USB ports of the openHAB computer before a discovery is started
+- The Zigbee USB Gateway must be inserted in one of the USB ports of the openHAB computer before a discovery is started
 - _**IMPORTANT NOTE:**_ As for other openHAB bindings using the USB/serial ports, on Linux the `openhab` user must be member of the `dialout` group to be able to use USB/serial port; set the group with the following command:
 
 ```shell
@@ -88,10 +88,10 @@ sudo usermod -a -G dialout openhab
 ```
 
 - The user will need to logout and login to see the new group added. If you added your user to this group and still cannot get permission, reboot Linux to ensure the new group permission is attached to the `openhab` user.
-- Once the ZigBee USB Gateway is added and online, a second Inbox Scan will discover devices connected to it. Because of the ZigBee radio network, device discovery will take ~40-60 sec. Be patient!
-- Wireless devices must be part of the same ZigBee network of the ZigBee USB Gateway to discover them. Please refer to [this video by BTicino](https://www.youtube.com/watch?v=CoIgg_Xqhbo) to setup a ZigBee wireless network which includes the ZigBee USB Gateway
-- Only powered wireless devices part of the same ZigBee network and within radio coverage of the ZigBee USB Gateway will be discovered. Unreachable or not powered devices will be discovered as _GENERIC_ devices and cannot be controlled
-- Wireless control units cannot be discovered by the ZigBee USB Gateway and therefore are not supported
+- Once the Zigbee USB Gateway is added and online, a second Inbox Scan will discover devices connected to it. Because of the Zigbee radio network, device discovery will take ~40-60 sec. Be patient!
+- Wireless devices must be part of the same Zigbee network of the Zigbee USB Gateway to discover them. Please refer to [this video by BTicino](https://www.youtube.com/watch?v=CoIgg_Xqhbo) to setup a Zigbee wireless network which includes the Zigbee USB Gateway
+- Only powered wireless devices part of the same Zigbee network and within radio coverage of the Zigbee USB Gateway will be discovered. Unreachable or not powered devices will be discovered as _GENERIC_ devices and cannot be controlled
+- Wireless control units cannot be discovered by the Zigbee USB Gateway and therefore are not supported
 
 ## Thing Configuration
 
@@ -110,14 +110,14 @@ Configuration parameters are:
 
 Alternatively the BUS/SCS Gateway thing can be configured using the `.things` file, see `openwebnet.things` example [below](#full-example).
 
-### Configuring Wireless ZigBee USB Gateway
+### Configuring Wireless Zigbee USB Gateway
 
 Configuration parameters are:
 
-- `serialPort` : the serial port where the ZigBee USB Gateway is connected (`String`, _mandatory_)
+- `serialPort` : the serial port where the Zigbee USB Gateway is connected (`String`, _mandatory_)
   - Examples: `/dev/ttyUSB0` (Linux/RaPi), `COM3` (Windows)
 
-Alternatively the ZigBee USB Gateway thing can be configured using the `.things` file, see `openwebnet.things` example [below](#full-example).
+Alternatively the Zigbee USB Gateway thing can be configured using the `.things` file, see `openwebnet.things` example [below](#full-example).
 
 ### Configuring Devices
 
@@ -137,7 +137,7 @@ For any manually added device, you must configure:
     - energy meter F520/F521 numbered `1`: add `5` before  --> `where="51"`
     - energy meter F522/F523 numbered `4`: add `7` before and `#0` after --> `where="74#0"`
     - alarm zone `2` --> `where="2"`
-  - example for ZigBee devices: `where=765432101#9`. The ID of the device (ADDR part) is usually written in hexadecimal on the device itself, for example `ID 0074CBB1`: convert to decimal (`7654321`) and add `01#9` at the end to obtain `where=765432101#9`. For 2-unit switch devices (`zb_on_off_switch2u`), last part should be `00#9`.
+  - example for Zigbee devices: `where=765432101#9`. The ID of the device (ADDR part) is usually written in hexadecimal on the device itself, for example `ID 0074CBB1`: convert to decimal (`7654321`) and add `01#9` at the end to obtain `where=765432101#9`. For 2-unit switch devices (`zb_on_off_switch2u`), last part should be `00#9`.
 
 #### Configuring Thermo
 
@@ -210,7 +210,7 @@ OPEN command to execute: *5*8#134##
 
 | Channel Type ID (channel ID)            | Applies to Thing Type IDs                                     | Item Type     | Description                                                                                                           | Read/Write  |
 |-----------------------------------------|---------------------------------------------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------|:-----------:|
-| `switch` or `switch_01`/`02` for ZigBee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                   |     R/W     |
+| `switch` or `switch_01`/`02` for Zigbee | `bus_on_off_switch`, `zb_on_off_switch`, `zb_on_off_switch2u` | Switch        | To switch the device `ON` and `OFF`                                                                                   |     R/W     |
 | `brightness`                            | `bus_dimmer`, `zb_dimmer`                                     | Dimmer        | To adjust the brightness value (Percent, `ON`, `OFF`)                                                                 |     R/W     |
 | `shutter`                               | `bus_automation`                                              | Rollershutter | To activate roller shutters (`UP`, `DOWN`, `STOP`, Percent - [see Shutter position](#shutter-position))               |     R/W     |
 | `scenario`                              | `bus_scenario_control`                                        | String        | Trigger channel for Basic scenario events [see possible values](#scenario-channels)                                   | R (TRIGGER) |
@@ -334,7 +334,7 @@ Bridge openwebnet:bus_gateway:mybridge "MyHOMEServer1" [ host="192.168.1.35", pa
 }
 ```
 
-ZigBee USB Gateway and things configuration - for radio devices:
+Zigbee USB Gateway and things configuration - for radio devices:
 
 ```java
 Bridge openwebnet:zb_gateway:myZBgateway  [ serialPort="COM3" ] {
@@ -400,7 +400,7 @@ Switch              iAlarm_Zone_3_State         "Zone 3 state"                 (
 String              iAlarm_Zone_3_Alarm         "Zone 3 alarm"                 (gAlarm)         { channel="openwebnet:bus_alarm_zone:mybridge:Alarm_Zone_3:alarm" }
 ```
 
-Example items linked to OpenWebNet ZigBee devices:
+Example items linked to OpenWebNet Zigbee devices:
 
 ```java
 Dimmer          iDimmer             "Dimmer [%.0f %%]"                  <DimmableLight>  (gKitchen)                   [ "Lighting" ]  { channel="openwebnet:zb_dimmer:myZBgateway:myZB_dimmer:brightness" }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -44,7 +44,7 @@ public class OpenWebNetBindingConstants {
     public static final String THING_LABEL_GENERIC_DEVICE = "GENERIC Device";
     // bridges
     public static final ThingTypeUID THING_TYPE_ZB_GATEWAY = new ThingTypeUID(BINDING_ID, "zb_gateway");
-    public static final String THING_LABEL_ZB_GATEWAY = "ZigBee USB Gateway";
+    public static final String THING_LABEL_ZB_GATEWAY = "Zigbee USB Gateway";
     public static final ThingTypeUID THING_TYPE_BUS_GATEWAY = new ThingTypeUID(BINDING_ID, "bus_gateway");
     public static final String THING_LABEL_BUS_GATEWAY = "BUS Gateway";
     // other thing types
@@ -81,14 +81,14 @@ public class OpenWebNetBindingConstants {
     public static final String THING_LABEL_BUS_AUX = "Auxiliary";
     // ZIGBEE
     public static final ThingTypeUID THING_TYPE_ZB_ON_OFF_SWITCH = new ThingTypeUID(BINDING_ID, "zb_on_off_switch");
-    public static final String THING_LABEL_ZB_ON_OFF_SWITCH = "ZigBee Switch";
+    public static final String THING_LABEL_ZB_ON_OFF_SWITCH = "Zigbee Switch";
     public static final ThingTypeUID THING_TYPE_ZB_ON_OFF_SWITCH_2UNITS = new ThingTypeUID(BINDING_ID,
             "zb_on_off_switch2u");
-    public static final String THING_LABEL_ZB_ON_OFF_SWITCH_2UNITS = "ZigBee 2-units Switch";
+    public static final String THING_LABEL_ZB_ON_OFF_SWITCH_2UNITS = "Zigbee 2-units Switch";
     public static final ThingTypeUID THING_TYPE_ZB_DIMMER = new ThingTypeUID(BINDING_ID, "zb_dimmer");
-    public static final String THING_LABEL_ZB_DIMMER = "ZigBee Dimmer";
+    public static final String THING_LABEL_ZB_DIMMER = "Zigbee Dimmer";
     public static final ThingTypeUID THING_TYPE_ZB_AUTOMATION = new ThingTypeUID(BINDING_ID, "zb_automation");
-    public static final String THING_LABEL_ZB_AUTOMATION = "ZigBee Automation";
+    public static final String THING_LABEL_ZB_AUTOMATION = "Zigbee Automation";
 
     // #SUPPORTED THINGS SETS
     // ## Generic

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -206,7 +206,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
             default:
                 logger.warn("Device type {} is not supported, default to GENERIC device (WHERE={})", deviceType, where);
                 if (where instanceof WhereZigBee) {
-                    thingLabel = "ZigBee " + thingLabel;
+                    thingLabel = "Zigbee " + thingLabel;
                 }
                 if (baseMsg != null) {
                     deviceWho = baseMsg.getWho();

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
@@ -44,9 +44,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link UsbGatewayDiscoveryService} extends {@link AbstractDiscoveryService} to detect ZigBee USB gateways
+ * The {@link UsbGatewayDiscoveryService} extends {@link AbstractDiscoveryService} to detect Zigbee USB gateways
  * connected via serial port. The service will iterate over the available serial ports and open each one to test if a
- * OpenWebNet ZigBee USB gateway is connected. On successful connection, a new DiscoveryResult is created.
+ * OpenWebNet Zigbee USB gateway is connected. On successful connection, a new DiscoveryResult is created.
  *
  * @author Massimo Valla - Initial contribution
  */
@@ -74,7 +74,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
     private boolean scanning;
 
     /**
-     * Constructs a new UsbGatewayDiscoveryService with the specified ZigBee USB Bridge ThingTypeUID
+     * Constructs a new UsbGatewayDiscoveryService with the specified Zigbee USB Bridge ThingTypeUID
      */
     @Activate
     public UsbGatewayDiscoveryService(final @Reference SerialPortManager spm) {
@@ -89,7 +89,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
      */
     @Override
     protected void startScan() {
-        logger.debug("Started OpenWebNet ZigBee USB Gateway discovery scan");
+        logger.debug("Started OpenWebNet Zigbee USB Gateway discovery scan");
         removeOlderResults(getTimestampOfLastScan());
         scanning = true;
         Stream<SerialPortIdentifier> portEnum = serialPortManager.getIdentifiers();
@@ -103,7 +103,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
                         logger.debug("[{}] serial port is owned by: {}", currentScannedPortName,
                                 portIdentifier.getCurrentOwner());
                     } else {
-                        logger.debug("[{}] trying to connect to a ZigBee USB Gateway...", currentScannedPortName);
+                        logger.debug("[{}] trying to connect to a Zigbee USB Gateway...", currentScannedPortName);
                         USBGateway gw = new USBGateway(currentScannedPortName);
                         zbGateway = gw;
                         gw.subscribe(this);
@@ -117,7 +117,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
                             gw.connect();
                             portCheckLatch.await();
                         } catch (OWNException e) {
-                            logger.debug("[{}] OWNException while trying to connect to a ZigBee USB Gateway: {}",
+                            logger.debug("[{}] OWNException while trying to connect to a Zigbee USB Gateway: {}",
                                     currentScannedPortName, e.getMessage());
                             cancelConnectTimeout();
                             endGwConnection();
@@ -141,7 +141,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
         endGwConnection();
         portCheckLatch.countDown();
         super.stopScan();
-        logger.debug("Stopped OpenWebNet ZigBee USB Gateway discovery scan");
+        logger.debug("Stopped OpenWebNet Zigbee USB Gateway discovery scan");
     }
 
     /**
@@ -166,7 +166,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
     }
 
     /**
-     * Create and notify a new ZigBee USB Gateway thing has been discovered
+     * Create and notify a new Zigbee USB Gateway thing has been discovered
      */
     private void bridgeDiscovered() {
         USBGateway gw = zbGateway;
@@ -182,7 +182,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(gatewayUID).withProperties(gwProperties)
                     .withLabel(OpenWebNetBindingConstants.THING_LABEL_ZB_GATEWAY + " (" + gw.getSerialPortName() + ")")
                     .withRepresentationProperty(OpenWebNetBindingConstants.PROPERTY_ZIGBEEID).build();
-            logger.debug("--- ZigBee USB Gateway thing discovered: {} fw: {}", discoveryResult.getLabel(),
+            logger.debug("--- Zigbee USB Gateway thing discovered: {} fw: {}", discoveryResult.getLabel(),
                     gw.getFirmwareVersion());
             thingDiscovered(discoveryResult);
         }
@@ -190,7 +190,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
 
     @Override
     public void onConnected() {
-        logger.debug("[{}] found ZigBee USB Gateway", currentScannedPortName);
+        logger.debug("[{}] found Zigbee USB Gateway", currentScannedPortName);
         cancelConnectTimeout();
         bridgeDiscovered();
         endGwConnection();

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -162,14 +162,14 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     }
 
     /**
-     * Init a ZigBee gateway based on config
+     * Init a Zigbee gateway based on config
      */
     private @Nullable OpenGateway initZigBeeGateway() {
-        logger.debug("Initializing ZigBee USB Gateway");
+        logger.debug("Initializing Zigbee USB Gateway");
         OpenWebNetZigBeeBridgeConfig zbBridgeConfig = getConfigAs(OpenWebNetZigBeeBridgeConfig.class);
         String serialPort = zbBridgeConfig.getSerialPort();
         if (serialPort == null || serialPort.isEmpty()) {
-            logger.warn("Cannot connect ZigBee USB Gateway. No serial port has been provided in Bridge configuration.");
+            logger.warn("Cannot connect Zigbee USB Gateway. No serial port has been provided in Bridge configuration.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-no-serial-port");
             return null;
@@ -539,7 +539,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
             return;
         }
         if (gw instanceof USBGateway) {
-            logger.info("---- CONNECTED to ZigBee USB gateway bridge '{}' (serialPort: {})", thing.getUID(),
+            logger.info("---- CONNECTED to Zigbee USB gateway bridge '{}' (serialPort: {})", thing.getUID(),
                     ((USBGateway) gw).getSerialPortName());
         } else {
             logger.info("---- CONNECTED to BUS gateway bridge '{}' ({}:{})", thing.getUID(),

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/config/OpenWebNetZigBeeBridgeConfig.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/config/OpenWebNetZigBeeBridgeConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * ZigBee USB Bridge configuration object
+ * Zigbee USB Bridge configuration object
  *
  * @author Massimo Valla - Initial contribution
  *

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/binding/binding.xml
@@ -5,6 +5,6 @@
 
 	<name>OpenWebNet (BTicino/Legrand) Binding</name>
 	<description>The OpenWebNet Binding integrates the BTicino/Legrand 'MyHOME' connected home system using the OpenWebNet
-		protocol. It supports BUS (SCS) and ZigBee USB gateways and devices.</description>
+		protocol. It supports BUS (SCS) and Zigbee USB gateways and devices.</description>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -1,7 +1,7 @@
 # binding
 
 binding.openwebnet.name = OpenWebNet (BTicino/Legrand) Binding
-binding.openwebnet.description = The OpenWebNet Binding integrates the BTicino/Legrand 'MyHOME' connected home system using the OpenWebNet protocol. It supports BUS (SCS) and ZigBee USB gateways and devices.
+binding.openwebnet.description = The OpenWebNet Binding integrates the BTicino/Legrand 'MyHOME' connected home system using the OpenWebNet protocol. It supports BUS (SCS) and Zigbee USB gateways and devices.
 
 # thing types
 
@@ -37,16 +37,16 @@ thing-type.openwebnet.bus_thermo_zone.label = Thermo Zone
 thing-type.openwebnet.bus_thermo_zone.description = An OpenWebNet BUS/SCS configured thermo zone (managed via Central Unit or stand alone).
 thing-type.openwebnet.generic_device.label = Generic Device
 thing-type.openwebnet.generic_device.description = An OpenWebNet Generic Device.
-thing-type.openwebnet.zb_automation.label = ZigBee Automation
-thing-type.openwebnet.zb_automation.description = An OpenWebNet ZigBee automation device to control roller shutters, blinds, etc. BTicino models: xxx/yyyy/etc.
-thing-type.openwebnet.zb_dimmer.label = ZigBee Dimmer
-thing-type.openwebnet.zb_dimmer.description = An OpenWebNet ZigBee dimmer for the dimmer control of 1 light. BTicino models: 4585/4594/etc.
-thing-type.openwebnet.zb_gateway.label = ZigBee USB Gateway
-thing-type.openwebnet.zb_gateway.description = This USB gateway (BTicino/Legrand models: BTI-3578/088328) connects to a BTicino/Legrand ZigBee network and uses the OpenWebNet protocol. For more information see: https://catalogo.bticino.it/BTI-3578-IT and https://www.legrand.com/ecatalogue/088328-openweb-net-zigbee-gateway-radio-interface.html
-thing-type.openwebnet.zb_on_off_switch.label = ZigBee Switch
-thing-type.openwebnet.zb_on_off_switch.description = An OpenWebNet ZigBee switch (actuator) for the control of 1 load/light. BTicino models: 4591/3684/etc.
-thing-type.openwebnet.zb_on_off_switch2u.label = ZigBee 2-units Switch
-thing-type.openwebnet.zb_on_off_switch2u.description = An OpenWebNet ZigBee 2-units switch (actuator) for the control of 2 loads/lights. BTicino model: 4592
+thing-type.openwebnet.zb_automation.label = Zigbee Automation
+thing-type.openwebnet.zb_automation.description = An OpenWebNet Zigbee automation device to control roller shutters, blinds, etc. BTicino models: xxx/yyyy/etc.
+thing-type.openwebnet.zb_dimmer.label = Zigbee Dimmer
+thing-type.openwebnet.zb_dimmer.description = An OpenWebNet Zigbee dimmer for the dimmer control of 1 light. BTicino models: 4585/4594/etc.
+thing-type.openwebnet.zb_gateway.label = Zigbee USB Gateway
+thing-type.openwebnet.zb_gateway.description = This USB gateway (BTicino/Legrand models: BTI-3578/088328) connects to a BTicino/Legrand Zigbee network and uses the OpenWebNet protocol. For more information see: https://catalogo.bticino.it/BTI-3578-IT and https://www.legrand.com/ecatalogue/088328-openweb-net-zigbee-gateway-radio-interface.html
+thing-type.openwebnet.zb_on_off_switch.label = Zigbee Switch
+thing-type.openwebnet.zb_on_off_switch.description = An OpenWebNet Zigbee switch (actuator) for the control of 1 load/light. BTicino models: 4591/3684/etc.
+thing-type.openwebnet.zb_on_off_switch2u.label = Zigbee 2-units Switch
+thing-type.openwebnet.zb_on_off_switch2u.description = An OpenWebNet Zigbee 2-units switch (actuator) for the control of 2 loads/lights. BTicino model: 4592
 
 # thing types config
 
@@ -99,15 +99,15 @@ thing-type.config.openwebnet.generic_device.where.description = It identifies on
 thing-type.config.openwebnet.zb_automation.shutterRun.label = Shutter Run
 thing-type.config.openwebnet.zb_automation.shutterRun.description = Time (in ms) to go from max position (e.g. CLOSED) to the other position (e.g. OPEN). Example: 12000 (=12sec). Use AUTO (default) to calibrate the shutter automatically (UP->DOWN->Position%) the first time a Position command (%) is sent.
 thing-type.config.openwebnet.zb_automation.where.label = OpenWebNet Address (where)
-thing-type.config.openwebnet.zb_automation.where.description = It identifies one ZigBee device. Example: 765432101#9
+thing-type.config.openwebnet.zb_automation.where.description = It identifies one Zigbee device. Example: 765432101#9
 thing-type.config.openwebnet.zb_dimmer.where.label = OpenWebNet Address (where)
-thing-type.config.openwebnet.zb_dimmer.where.description = It identifies one ZigBee device. Example: 765432101#9
+thing-type.config.openwebnet.zb_dimmer.where.description = It identifies one Zigbee device. Example: 765432101#9
 thing-type.config.openwebnet.zb_gateway.serialPort.label = Serial Port
-thing-type.config.openwebnet.zb_gateway.serialPort.description = Serial port where the OpenWebNet ZigBee USB Gateway is connected. Example: COM3 (Win), /dev/ttyUSB0 (Linux), etc.
+thing-type.config.openwebnet.zb_gateway.serialPort.description = Serial port where the OpenWebNet Zigbee USB Gateway is connected. Example: COM3 (Win), /dev/ttyUSB0 (Linux), etc.
 thing-type.config.openwebnet.zb_on_off_switch.where.label = OpenWebNet Address (where)
-thing-type.config.openwebnet.zb_on_off_switch.where.description = It identifies one ZigBee device. Example: 765432101#9
+thing-type.config.openwebnet.zb_on_off_switch.where.description = It identifies one Zigbee device. Example: 765432101#9
 thing-type.config.openwebnet.zb_on_off_switch2u.where.label = OpenWebNet Address (where)
-thing-type.config.openwebnet.zb_on_off_switch2u.where.description = It identifies one ZigBee device. Example: 765432100#9 (use unit=00 at the end)
+thing-type.config.openwebnet.zb_on_off_switch2u.where.description = It identifies one Zigbee device. Example: 765432100#9 (use unit=00 at the end)
 
 # channel types
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBAutomation.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBAutomation.xml
@@ -10,8 +10,8 @@
 			<bridge-type-ref id="zb_gateway"/>
 		</supported-bridge-type-refs>
 
-		<label>ZigBee Automation</label>
-		<description>An OpenWebNet ZigBee automation device to control roller shutters, blinds, etc. BTicino models:
+		<label>Zigbee Automation</label>
+		<description>An OpenWebNet Zigbee automation device to control roller shutters, blinds, etc. BTicino models:
 			xxx/yyyy/etc.</description>
 
 		<channels>
@@ -38,7 +38,7 @@
 			</parameter>
 			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>
-				<description>It identifies one ZigBee device. Example: 765432101#9</description>
+				<description>It identifies one Zigbee device. Example: 765432101#9</description>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBDimmer.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBDimmer.xml
@@ -4,14 +4,14 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- Thing for ZigBee Dimmer (BTicino 4585/4594/...) -->
+	<!-- Thing for Zigbee Dimmer (BTicino 4585/4594/...) -->
 	<thing-type id="zb_dimmer">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="zb_gateway"/>
 		</supported-bridge-type-refs>
 
-		<label>ZigBee Dimmer</label>
-		<description>An OpenWebNet ZigBee dimmer for the dimmer control of 1 light. BTicino models: 4585/4594/etc.</description>
+		<label>Zigbee Dimmer</label>
+		<description>An OpenWebNet Zigbee dimmer for the dimmer control of 1 light. BTicino models: 4585/4594/etc.</description>
 
 		<channels>
 			<channel id="brightness" typeId="brightness"/>
@@ -28,7 +28,7 @@
 		<config-description>
 			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>
-				<description>It identifies one ZigBee device. Example: 765432101#9</description>
+				<description>It identifies one Zigbee device. Example: 765432101#9</description>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBGateway.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBGateway.xml
@@ -4,10 +4,10 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- OpenWebNet ZigBee USB Gateway -->
+	<!-- OpenWebNet Zigbee USB Gateway -->
 	<bridge-type id="zb_gateway">
-		<label>ZigBee USB Gateway</label>
-		<description>This USB gateway (BTicino/Legrand models: BTI-3578/088328) connects to a BTicino/Legrand ZigBee network
+		<label>Zigbee USB Gateway</label>
+		<description>This USB gateway (BTicino/Legrand models: BTI-3578/088328) connects to a BTicino/Legrand Zigbee network
 			and uses the OpenWebNet protocol. For more information see: https://catalogo.bticino.it/BTI-3578-IT and
 			https://www.legrand.com/ecatalogue/088328-openweb-net-zigbee-gateway-radio-interface.html</description>
 
@@ -24,7 +24,7 @@
 				<context>serial-port</context>
 				<limitToOptions>false</limitToOptions>
 				<label>Serial Port</label>
-				<description>Serial port where the OpenWebNet ZigBee USB Gateway is connected. Example: COM3 (Win), /dev/ttyUSB0
+				<description>Serial port where the OpenWebNet Zigbee USB Gateway is connected. Example: COM3 (Win), /dev/ttyUSB0
 					(Linux), etc.</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch.xml
@@ -10,8 +10,8 @@
 			<bridge-type-ref id="zb_gateway"/>
 		</supported-bridge-type-refs>
 
-		<label>ZigBee Switch</label>
-		<description>An OpenWebNet ZigBee switch (actuator) for the control of 1 load/light. BTicino models: 4591/3684/etc.</description>
+		<label>Zigbee Switch</label>
+		<description>An OpenWebNet Zigbee switch (actuator) for the control of 1 load/light. BTicino models: 4591/3684/etc.</description>
 
 		<channels>
 			<channel id="switch_01" typeId="switch"/>
@@ -28,7 +28,7 @@
 		<config-description>
 			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>
-				<description>It identifies one ZigBee device. Example: 765432101#9</description>
+				<description>It identifies one Zigbee device. Example: 765432101#9</description>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch2Units.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch2Units.xml
@@ -4,14 +4,14 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<!-- Thing for ZigBee OnOff Switch with 2 units (BTicino 4592) -->
+	<!-- Thing for Zigbee OnOff Switch with 2 units (BTicino 4592) -->
 	<thing-type id="zb_on_off_switch2u">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="zb_gateway"/>
 		</supported-bridge-type-refs>
 
-		<label>ZigBee 2-units Switch</label>
-		<description>An OpenWebNet ZigBee 2-units switch (actuator) for the control of 2 loads/lights. BTicino model: 4592</description>
+		<label>Zigbee 2-units Switch</label>
+		<description>An OpenWebNet Zigbee 2-units switch (actuator) for the control of 2 loads/lights. BTicino model: 4592</description>
 
 		<channels>
 			<channel id="switch_01" typeId="switch"/>
@@ -29,7 +29,7 @@
 		<config-description>
 			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>
-				<description>It identifies one ZigBee device. Example: 765432100#9 (use unit=00 at the end)</description>
+				<description>It identifies one Zigbee device. Example: 765432100#9 (use unit=00 at the end)</description>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.plugwise/README.md
+++ b/bundles/org.openhab.binding.plugwise/README.md
@@ -1,6 +1,6 @@
 # Plugwise Binding
 
-The Plugwise binding adds support to openHAB for [Plugwise](https://www.plugwise.com) ZigBee devices using the Stick.
+The Plugwise binding adds support to openHAB for [Plugwise](https://www.plugwise.com) Zigbee devices using the Stick.
 
 Users should use the Plugwise Source software to define the network, reset devices or perform firmware upgrades.
 
@@ -14,11 +14,11 @@ The binding supports the following Plugwise devices:
 | Device Type | Description                                                                              | Thing Type |
 |-------------|------------------------------------------------------------------------------------------|------------|
 | Circle      | A power outlet plug that provides energy measurement and switching control of appliances | circle     |
-| Circle+     | A special Circle that coordinates the ZigBee network and acts as network gateway         | circleplus |
+| Circle+     | A special Circle that coordinates the Zigbee network and acts as network gateway         | circleplus |
 | Scan        | A wireless motion (PIR) and light sensor                                                 | scan       |
 | Sense       | A wireless temperature and humidity sensor                                               | sense      |
 | Stealth     | A Circle with a more compact form factor that can be built-in                            | stealth    |
-| Stick       | A ZigBee USB controller that openHAB uses to communicate with the Circle+                | stick      |
+| Stick       | A Zigbee USB controller that openHAB uses to communicate with the Circle+                | stick      |
 | Switch      | A wireless wall switch                                                                   | switch     |
 
 ## Discovery
@@ -44,7 +44,7 @@ Similarly the MAC addresses of the Scan, Sense and Switch can also be obtained f
 | Configuration Parameter | Required | Default      | Description                                                                       |
 |-------------------------|----------|--------------|-----------------------------------------------------------------------------------|
 | serialPort              | X        | /dev/ttyUSB0 | The serial port of the Stick, e.g. "/dev/ttyUSB0" for Linux or "COM1" for Windows |
-| messageWaitTime         |          | 150          | The time to wait between messages sent on the ZigBee network (in ms)              |
+| messageWaitTime         |          | 150          | The time to wait between messages sent on the Zigbee network (in ms)              |
 
 To determine the serial port in Linux, insert the Stick, then execute the `dmesg` command.
 The last few lines of the output will contain the USB port of the Stick (e.g. `/dev/ttyUSB0`).
@@ -60,7 +60,7 @@ To access the serial port of the Stick on Linux, the user running openHAB needs 
 | powerStateChanging      |          | commandSwitching | Controls if the power state can be changed with commands or is always on/off (commandSwitching, alwaysOn or alwaysOff) |
 | suppliesPower           |          | false            | Enables power production measurements (true or false)                                                                  |
 | measurementInterval     |          | 60               | The energy measurement interval (in minutes) (5 to 60)                                                                 |
-| temporarilyNotInNetwork |          | false            | Stops searching for an unplugged device on the ZigBee network traffic (true or false)                                  |
+| temporarilyNotInNetwork |          | false            | Stops searching for an unplugged device on the Zigbee network traffic (true or false)                                  |
 
 ### Scan
 

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseStickHandler.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseStickHandler.java
@@ -60,8 +60,8 @@ import org.slf4j.LoggerFactory;
  * The {@link PlugwiseStickHandler} handles channel updates and commands for a Plugwise Stick device.
  * </p>
  * <p>
- * The Stick is an USB ZigBee controller that communicates with the Circle+. It is a {@link Bridge} to the devices on a
- * Plugwise ZigBee mesh network.
+ * The Stick is an USB Zigbee controller that communicates with the Circle+. It is a {@link Bridge} to the devices on a
+ * Plugwise Zigbee mesh network.
  * </p>
  *
  * @author Wouter Born, Karel Goderis - Initial contribution

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/binding/binding.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Plugwise Binding</name>
-	<description>Monitor and control Plugwise ZigBee devices using the Stick. Supported devices are the Circle, Circle+,
+	<description>Monitor and control Plugwise Zigbee devices using the Stick. Supported devices are the Circle, Circle+,
 		Scan, Sense, Stealth and Switch.</description>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/config/config.xml
@@ -13,7 +13,7 @@
 		</parameter>
 		<parameter name="messageWaitTime" type="integer" min="0" max="500" step="50">
 			<label>Message Wait Time</label>
-			<description>The time to wait between messages sent on the ZigBee network (in ms)</description>
+			<description>The time to wait between messages sent on the Zigbee network (in ms)</description>
 			<default>150</default>
 			<unitLabel>ms</unitLabel>
 		</parameter>
@@ -67,7 +67,7 @@
 		</parameter>
 		<parameter name="temporarilyNotInNetwork" type="boolean" required="false">
 			<label>Temporarily Not in Network</label>
-			<description>Stops searching for an unplugged device on the ZigBee network traffic</description>
+			<description>Stops searching for an unplugged device on the Zigbee network traffic</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/i18n/plugwise.properties
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/i18n/plugwise.properties
@@ -1,6 +1,6 @@
 # binding
 binding.plugwise.name = Plugwise Binding
-binding.plugwise.description = Monitor and control Plugwise ZigBee devices using the Stick. Supported devices are the Circle, Circle+, Scan, Sense, Stealth and Switch.
+binding.plugwise.description = Monitor and control Plugwise Zigbee devices using the Stick. Supported devices are the Circle, Circle+, Scan, Sense, Stealth and Switch.
 
 
 # bridge type configuration parameters
@@ -8,7 +8,7 @@ bridge-type.config.plugwise.stick.serialPort.label = Serial port
 bridge-type.config.plugwise.stick.serialPort.description = The serial port of the Stick, e.g. "/dev/ttyUSB0" for Linux or "COM1" for Windows
 
 bridge-type.config.plugwise.stick.messageWaitTime.label = Message wait time
-bridge-type.config.plugwise.stick.messageWaitTime.description = The time to wait between messages sent on the ZigBee network (in ms)
+bridge-type.config.plugwise.stick.messageWaitTime.description = The time to wait between messages sent on the Zigbee network (in ms)
 
 
 # thing types
@@ -16,7 +16,7 @@ thing-type.plugwise.circle.label = Plugwise Circle
 thing-type.plugwise.circle.description = A power outlet plug that provides energy measurement and switching control of appliances
 
 thing-type.plugwise.circleplus.label = Plugwise Circle+
-thing-type.plugwise.circleplus.description = A special Circle that coordinates the ZigBee network and acts as network gateway
+thing-type.plugwise.circleplus.description = A special Circle that coordinates the Zigbee network and acts as network gateway
 
 thing-type.plugwise.scan.label = Plugwise Scan
 thing-type.plugwise.scan.description = A wireless motion (PIR) and light sensor
@@ -28,7 +28,7 @@ thing-type.plugwise.stealth.label = Plugwise Stealth
 thing-type.plugwise.stealth.description = A Circle with a more compact form factor that can be built-in
 
 thing-type.plugwise.stick.label = Plugwise Stick
-thing-type.plugwise.stick.description = A ZigBee USB controller used for communicating with the Circle+
+thing-type.plugwise.stick.description = A Zigbee USB controller used for communicating with the Circle+
 
 thing-type.plugwise.switch.label = Plugwise Switch
 thing-type.plugwise.switch.description = A wireless wall switch
@@ -51,7 +51,7 @@ thing-type.config.plugwise.relay.measurementInterval.label = Measurement interva
 thing-type.config.plugwise.relay.measurementInterval.description = The energy measurement interval (in minutes)
 
 thing-type.config.plugwise.relay.temporarilyNotInNetwork.label = Temporarily not in network
-thing-type.config.plugwise.relay.temporarilyNotInNetwork.description = Stops searching for an unplugged device on the ZigBee network
+thing-type.config.plugwise.relay.temporarilyNotInNetwork.description = Stops searching for an unplugged device on the Zigbee network
 
 thing-type.config.plugwise.relay.updateConfiguration.label = Update configuration
 thing-type.config.plugwise.relay.updateConfiguration.description = Stores if the device configuration is up to date (automatically enabled/disabled)

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/thing/circleplus.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/thing/circleplus.xml
@@ -9,7 +9,7 @@
 			<bridge-type-ref id="stick"/>
 		</supported-bridge-type-refs>
 		<label>Plugwise Circle+</label>
-		<description>A special Circle that coordinates the ZigBee network and acts as network gateway</description>
+		<description>A special Circle that coordinates the Zigbee network and acts as network gateway</description>
 		<channels>
 			<channel id="clock" typeId="clock"/>
 			<channel id="energy" typeId="energy"/>

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/thing/stick.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/thing/stick.xml
@@ -6,7 +6,7 @@
 
 	<bridge-type id="stick">
 		<label>Plugwise Stick</label>
-		<description>A ZigBee USB controller used for communicating with the Circle+</description>
+		<description>A Zigbee USB controller used for communicating with the Circle+</description>
 		<representation-property>macAddress</representation-property>
 		<config-description-ref uri="bridge-type:plugwise:stick"/>
 	</bridge-type>

--- a/bundles/org.openhab.binding.plugwiseha/README.md
+++ b/bundles/org.openhab.binding.plugwiseha/README.md
@@ -1,7 +1,7 @@
 # PlugwiseHA Binding
 
 The Plugwise Home Automation binding adds support to openHAB for the [Plugwise Home Automation ecosystem](https://www.plugwise.com/en_US/adam_zone_control).
-This system is built around a gateway from Plugwise called the 'Adam' which incorporates a ZigBee controller to manage thermostatic radiator valves, room thermostats, floor heating pumps, et cetera.
+This system is built around a gateway from Plugwise called the 'Adam' which incorporates a Zigbee controller to manage thermostatic radiator valves, room thermostats, floor heating pumps, et cetera.
 
 Users can manage and control this system either via a web app or a mobile phone app developed by Plugwise.
 The (web) app allows users to define heating zone's (e.g. rooms) and add radiator valves to those rooms to manage and control their heating irrespective of other rooms.

--- a/bundles/org.openhab.binding.tacmi/README.md
+++ b/bundles/org.openhab.binding.tacmi/README.md
@@ -141,7 +141,7 @@ The behavior in detail:
 
 * `Default` (`0`): When the channel is 'read-only' the update-policy defaults to _On-Fetch_ . When the channel is linked to something that can be modified it defaults to _On-Change_ .
 * `On-Fetch` (`1`): This is the default for read-only values. This means the channel is updated every time the schema page is polled. Ideally for values you want to monitor and log into charts.
-* `On-Change` (`2`): When channel values can be changed via OH it is better to only update the channel when the value changes. The binding will cache the previous value and only send an update when it changes to the previous known value. This is especially useful if you intend to link other things (like i.e. ZigBee or Shelly switches) to the TA via OH that can be controlled by different sources. This prevents unintended toggles or even toggle-loops.
+* `On-Change` (`2`): When channel values can be changed via OH it is better to only update the channel when the value changes. The binding will cache the previous value and only send an update when it changes to the previous known value. This is especially useful if you intend to link other things (like i.e. Zigbee or Shelly switches) to the TA via OH that can be controlled by different sources. This prevents unintended toggles or even toggle-loops.
 
 ### TA C.M.I. CoE Connection
 

--- a/bundles/org.openhab.binding.tradfri/README.md
+++ b/bundles/org.openhab.binding.tradfri/README.md
@@ -10,10 +10,10 @@ The TRÅDFRI controller and sensor devices currently cannot be observed right aw
 This makes it nearly impossible to trigger events for pressed buttons.
 We only can access some static data like the present status or battery level.
 
-The thing type ids are defined according to the lighting devices defined for ZigBee LightLink ([see page 24, table 2](https://www.nxp.com/docs/en/user-guide/JN-UG-3091.pdf)).
+The thing type ids are defined according to the lighting devices defined for Zigbee Light Link ([see page 24, table 2](https://www.nxp.com/docs/en/user-guide/JN-UG-3091.pdf)).
 These are:
 
-| Device type                     | ZigBee Device ID | Thing type |
+| Device type                     | Zigbee Device ID | Thing type |
 |---------------------------------|------------------|------------|
 | Dimmable Light                  | 0x0100           | 0100       |
 | Colour Temperature Light        | 0x0220           | 0220       |

--- a/bundles/org.openhab.binding.wemo/README.md
+++ b/bundles/org.openhab.binding.wemo/README.md
@@ -1,7 +1,7 @@
 # Belkin Wemo Binding
 
 This binding integrates the [Belkin WeMo Family](https://www.belkin.com/us/Products/c/home-automation/).
-The integration happens either through the WeMo-Link bridge, which acts as an IP gateway to the ZigBee devices or through WiFi connection to standalone devices.
+The integration happens either through the WeMo-Link bridge, which acts as an IP gateway to the Zigbee devices or through WiFi connection to standalone devices.
 
 ## Supported Things
 


### PR DESCRIPTION
Name was changed some years ago from ZigBee to [Zigbee](https://en.wikipedia.org/wiki/Zigbee). Maybe it's time to adapt.

See also:
- openhab/org.openhab.binding.zigbee#785