### PR TITLE
[rrd4j] Error handling for broken rrd4j files

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -259,6 +259,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             db = getDB(itemName);
         } catch (Exception e) {
             logger.warn("Failed to open rrd4j database '{}' ({})", itemName, e.getClass().getName());
+            return List.of();
         }
         if (db == null) {
             logger.debug("Could not find item '{}' in rrd4j database", itemName);

--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -152,7 +152,12 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         }
         final String name = alias == null ? item.getName() : alias;
 
-        RrdDb db = getDB(name);
+        RrdDb db = null;
+        try {
+            db = getDB(name);
+        } catch (Exception e) {
+            logger.warn("Failed to open rrd4j database '{}' ({})", name, e.getClass().getName());
+        }
         if (db == null) {
             return;
         }
@@ -249,7 +254,12 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     public Iterable<HistoricItem> query(FilterCriteria filter) {
         String itemName = filter.getItemName();
 
-        RrdDb db = getDB(itemName);
+        RrdDb db = null;
+        try {
+            db = getDB(itemName);
+        } catch (Exception e) {
+            logger.warn("Failed to open rrd4j database '{}' ({})", itemName, e.getClass().getName());
+        }
         if (db == null) {
             logger.debug("Could not find item '{}' in rrd4j database", itemName);
             return List.of();


### PR DESCRIPTION
Catch exceptions thrown by getDB(..) and print the name of the affected database file. This allows to identify a broken rrd4j file.

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>


During testing of the M6 milestone I got stacktraces like this in my log:
```
[WARN ] [ore.internal.scheduler.SchedulerImpl] - Scheduled job '<unknown>' failed and stopped
java.lang.IndexOutOfBoundsException: null
        at java.nio.Buffer.checkIndex(Buffer.java:693) ~[?:?]
        at java.nio.DirectByteBuffer.getInt(DirectByteBuffer.java:758) ~[?:?]
        at org.rrd4j.core.ByteBufferBackend.readInt(ByteBufferBackend.java:130) ~[?:?]
        at org.rrd4j.core.RrdPrimitive.readInt(RrdPrimitive.java:38) ~[?:?]
        at org.rrd4j.core.RrdInt.get(RrdInt.java:35) ~[?:?]
        at org.rrd4j.core.Archive.<init>(Archive.java:45) ~[?:?]
        at org.rrd4j.core.RrdDb.<init>(RrdDb.java:646) ~[?:?]
        at org.rrd4j.core.RrdDb.<init>(RrdDb.java:44) ~[?:?]
        at org.rrd4j.core.RrdDb$Builder.build(RrdDb.java:94) ~[?:?]
        at org.rrd4j.core.RrdDbPool.requestRrdDb(RrdDbPool.java:420) ~[?:?]
        at org.rrd4j.core.RrdDb$Builder.build(RrdDb.java:92) ~[?:?]
        at org.openhab.persistence.rrd4j.internal.RRD4jPersistenceService.getDB(RRD4jPersistenceService.java:349) ~[?:?]
        at org.openhab.persistence.rrd4j.internal.RRD4jPersistenceService.store(RRD4jPersistenceService.java:155) ~[?:?]
        at org.openhab.core.persistence.internal.PersistItemsJob.run(PersistItemsJob.java:60) ~[?:?]
        at org.openhab.core.internal.scheduler.CronSchedulerImpl.lambda$0(CronSchedulerImpl.java:62) ~[?:?]
        at org.openhab.core.internal.scheduler.CronSchedulerImpl.lambda$1(CronSchedulerImpl.java:69) ~[?:?]
        at org.openhab.core.internal.scheduler.SchedulerImpl.lambda$12(SchedulerImpl.java:191) ~[?:?]
        at org.openhab.core.internal.scheduler.SchedulerImpl.lambda$1(SchedulerImpl.java:88) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```

This was caused by some broken RRD4J database file, but from the log it was not clear which file is causing the issue.

With the patch, it should be clearly visible.
Not sure if the message should be a WARN or an INFO.
```
 [WARN ] [d4j.internal.RRD4jPersistenceService] - Failed to open rrd4j database 'DummyUI_dummy' (java.lang.IndexOutOfBoundsException)
```