### PR TITLE
[rrd4j] Upgrade base library from 3.8.1 to 3.8.2

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/pom.xml
+++ b/bundles/org.openhab.persistence.rrd4j/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.rrd4j</groupId>
       <artifactId>rrd4j</artifactId>
-      <version>3.8.1</version>
+      <version>3.8.2</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
RRD4J base library was updated.

See changes here:
https://github.com/rrd4j/rrd4j/compare/3.8.1...3.8.2

Typically I would not recommend an update shortly before a planned release, but in this case there might be a reason to do it: The interesting part is the update of log4j from 2.17.0 to 2.19.0.
@openhab/add-ons-maintainers Can you pls check if we have a log4j problem here? Log4j 2.7.0 used by the older rrd4j 3.8.1 is affected by the known log4j issue, see https://logging.apache.org/log4j/2.x/security.html