### PR TITLE
Prevent Markdown rendering issues in Main UI

### DIFF
--- a/bundles/org.openhab.binding.weatherunderground/README.md
+++ b/bundles/org.openhab.binding.weatherunderground/README.md
@@ -1,9 +1,3 @@
----
-layout: documentation
----
-
-{% include base.html %}
-
 # WeatherUnderground Binding
 
 This binding uses the [Weather Underground service](https://www.wunderground.com/weather/api/) for providing weather information for any location worldwide.

--- a/bundles/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/org.openhab.persistence.rrd4j/README.md
@@ -260,8 +260,6 @@ Items {
 **IMPORTANT:**
 When creating a custom datasource in the `rrd4j.cfg` file the used [sample interval](#sampleinterval-sample-interval) should be 20 seconds or less in order to keep the granularity. The selection of the used strategy has no effect on the granularity.  
 
----
-
 ## Troubleshooting
 
 From time to time, you may find that if you change the Item type of a persisted data point, you may experience charting or other problems. To resolve this issue, remove the old `<item_name>`.rrd file in the `${openhab_home}/userdata/persistence/rrd4j` folder or `/var/lib/openhab/persistence/rrd4j` folder for apt-get installed openHABs.


### PR DESCRIPTION
Some add-ons use `---` separators which causes issues when rendering the documentation in Main UI.

Fixes #13953