### PR TITLE
[jsscripting] Minor fixes & improvements

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -44,9 +44,21 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     private static final String INJECTION_CODE = "Object.assign(this, require('openhab'));";
     private boolean injectionEnabled = true;
 
+    /*
+     * Whilst we run in parallel with Nashorn, we use a custom mime-type to avoid
+     * disrupting Nashorn scripts. When Nashorn is removed, we take over the standard
+     * JS runtime.
+     */
+
+    // GraalJSEngineFactory graalJSEngineFactory = new GraalJSEngineFactory();
+    //
+    // scriptTypes.addAll(graalJSEngineFactory.getMimeTypes());
+    // scriptTypes.addAll(graalJSEngineFactory.getExtensions());
+
     public static final String MIME_TYPE = "application/javascript;version=ECMAScript-2021";
     private static final String ALT_MIME_TYPE = "text/javascript;version=ECMAScript-2021";
     private static final String ALIAS = "graaljs";
+    private static final List<String> SCRIPT_TYPES = List.of(MIME_TYPE, ALT_MIME_TYPE, ALIAS);
 
     private final JSScriptServiceUtil jsScriptServiceUtil;
     private final JSDependencyTracker jsDependencyTracker;
@@ -61,19 +73,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public List<String> getScriptTypes() {
-
-        /*
-         * Whilst we run in parallel with Nashorn, we use a custom mime-type to avoid
-         * disrupting Nashorn scripts. When Nashorn is removed, we take over the standard
-         * JS runtime.
-         */
-
-        // GraalJSEngineFactory graalJSEngineFactory = new GraalJSEngineFactory();
-        //
-        // scriptTypes.addAll(graalJSEngineFactory.getMimeTypes());
-        // scriptTypes.addAll(graalJSEngineFactory.getExtensions());
-
-        return List.of(MIME_TYPE, ALT_MIME_TYPE, ALIAS);
+        return SCRIPT_TYPES;
     }
 
     @Override
@@ -83,6 +83,9 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public @Nullable ScriptEngine createScriptEngine(String scriptType) {
+        if (!SCRIPT_TYPES.contains(scriptType)) {
+            return null;
+        }
         return new DebuggingGraalScriptEngine<>(
                 new OpenhabGraalJSScriptEngine(injectionEnabled ? INJECTION_CODE : null, jsScriptServiceUtil));
     }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -178,6 +178,8 @@ public class OpenhabGraalJSScriptEngine
 
     @Override
     protected void beforeInvocation() {
+        super.beforeInvocation();
+
         lock.lock();
 
         if (initialized) {
@@ -230,8 +232,6 @@ public class OpenhabGraalJSScriptEngine
         } catch (ScriptException e) {
             LOGGER.error("Could not inject global script", e);
         }
-
-        super.beforeInvocation();
     }
 
     @Override

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -230,18 +230,20 @@ public class OpenhabGraalJSScriptEngine
         } catch (ScriptException e) {
             LOGGER.error("Could not inject global script", e);
         }
+
+        super.beforeInvocation();
     }
 
     @Override
     protected Object afterInvocation(Object obj) {
         lock.unlock();
-        return obj;
+        return super.afterInvocation(obj);
     }
 
     @Override
     protected Exception afterThrowsInvocation(Exception e) {
         lock.unlock();
-        return e;
+        return super.afterThrowsInvocation(e);
     }
 
     @Override

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable.java
@@ -54,6 +54,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
             return afterInvocation(super.eval(s, scriptContext));
         } catch (ScriptException se) {
             throw (ScriptException) afterThrowsInvocation(se);
+        } catch (Exception e) {
+            throw new UndeclaredThrowableException(afterThrowsInvocation(e)); // Wrap and rethrow other exceptions
         }
     }
 
@@ -64,6 +66,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
             return afterInvocation(super.eval(reader, scriptContext));
         } catch (ScriptException se) {
             throw (ScriptException) afterThrowsInvocation(se);
+        } catch (Exception e) {
+            throw new UndeclaredThrowableException(afterThrowsInvocation(e)); // Wrap and rethrow other exceptions
         }
     }
 
@@ -74,6 +78,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
             return afterInvocation(super.eval(s));
         } catch (ScriptException se) {
             throw (ScriptException) afterThrowsInvocation(se);
+        } catch (Exception e) {
+            throw new UndeclaredThrowableException(afterThrowsInvocation(e)); // Wrap and rethrow other exceptions
         }
     }
 
@@ -84,6 +90,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
             return afterInvocation(super.eval(reader));
         } catch (ScriptException se) {
             throw (ScriptException) afterThrowsInvocation(se);
+        } catch (Exception e) {
+            throw new UndeclaredThrowableException(afterThrowsInvocation(e)); // Wrap and rethrow other exceptions
         }
     }
 
@@ -94,6 +102,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
             return afterInvocation(super.eval(s, bindings));
         } catch (ScriptException se) {
             throw (ScriptException) afterThrowsInvocation(se);
+        } catch (Exception e) {
+            throw new UndeclaredThrowableException(afterThrowsInvocation(e)); // Wrap and rethrow other exceptions
         }
     }
 
@@ -104,6 +114,8 @@ public abstract class InvocationInterceptingScriptEngineWithInvocableAndAutoClos
             return afterInvocation(super.eval(reader, bindings));
         } catch (ScriptException se) {
             throw (ScriptException) afterThrowsInvocation(se);
+        } catch (Exception e) {
+            throw new UndeclaredThrowableException(afterThrowsInvocation(e)); // Wrap and rethrow other exceptions
         }
     }
 


### PR DESCRIPTION
Fixes #13950.

## Description

Completes a few minor improvements and fixes that were left over from #13924:

- Make sure to also unlock the `ReentrantLock` on exceptions from all synchronized `ScriptEngine` methods
- Fix the wrong implementation of `createScriptEngine`

For more details, please have a look at the commits (messages).

## Testing

This shouldn't change the behaviour of the addon, but anyway I tested this (not extensively), works fine.

@J-N-K I've fixed the `createScriptEngine` implementation.
@jpg0 I made sure that all exceptions are handled and the lock is removed. I also call the `super` methods from their overrides.