### PR TITLE
[wundergroundupdatereceiver] Prevent 😕 showing in documentation

### DIFF
--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/README.md
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/README.md
@@ -5,7 +5,7 @@ Many personal weather stations or similar devices are only capable of submitting
 This binding enables acting as a receiver of updates from devices that post measurements to https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php.
 If the hostname is configurable - as on weather stations based on the Fine Offset Electronics WH2600-IP - this is simple, otherwise you have to set up dns such that it resolves the above hostname to your server, without preventing the server from resolving the proper ip if you want to forward the request.
 
-The server thus listens at http(s)://&lt;your-openHAB-server&gt;:&lt;openHAB-port&gt;/weatherstation/updateweatherstation.php and the device needs to be pointed at this address.
+The server thus listens at `http(s)://<your-openHAB-server>:<openHAB-port>/weatherstation/updateweatherstation.php` and the device needs to be pointed at this address.
 If you can't configure the device itself to submit to an alternate hostname you would need to set up a dns server that resolves rtupdate.wunderground.com to the IP-address of your server and provide it as the DHCP dns-server to the device.
 Make sure not to use this dns server instance for any other DHCP clients.
 


### PR DESCRIPTION
A 😕 shows where it shouldn't:

![Screenshot from 2022-12-15 21-55-45](https://user-images.githubusercontent.com/12213581/207966331-177598b7-f232-4585-8071-bd8029200249.png)

See: https://www.openhab.org/addons/bindings/wundergroundupdatereceiver/

