### PR TITLE
[mapdb] Add some documentation

### DIFF
--- a/bundles/org.openhab.persistence.mapdb/README.md
+++ b/bundles/org.openhab.persistence.mapdb/README.md
@@ -1,0 +1,12 @@
+# MapDB Persistence
+
+The [MapDB](https://mapdb.org/) persistence service is based on simple key-value store that only saves the last value.
+MapDB is useful for restoring items that have the `restoreOnStartup` strategy because other persistence options have some drawbacks if only the last value is needed on restarts.
+
+Some disadvantages of other persistence services compared to MapDB are that they:
+
+* grow in time
+* require complex installs (`influxdb`, `jdbc`, `jpa`)
+* `rrd4j` cannot store all item types (only numeric types)
+
+It is only possible to query the last value and not other historic values because the MapDB persistence service can only store one value per item.


### PR DESCRIPTION
No docs showed for this add-on in Main UI because there is not even a README.md for this useful persistence service. :roll_eyes: 
It's also missing from https://www.openhab.org/addons/ which makes it also hard to discover.
These docs are based on the original OH1 documentation which did contain some info on its advantages and limitations.