### PR TITLE
[mapdb] Fix "a" typo and use "-" for bullets in docs

### DIFF
--- a/bundles/org.openhab.persistence.mapdb/README.md
+++ b/bundles/org.openhab.persistence.mapdb/README.md
@@ -1,12 +1,12 @@
 # MapDB Persistence
 
-The [MapDB](https://mapdb.org/) persistence service is based on simple key-value store that only saves the last value.
+The [MapDB](https://mapdb.org/) persistence service is based on a simple key-value store that only saves the last value.
 MapDB is useful for restoring items that have the `restoreOnStartup` strategy because other persistence options have some drawbacks if only the last value is needed on restarts.
 
 Some disadvantages of other persistence services compared to MapDB are that they:
 
-* grow in time
-* require complex installs (`influxdb`, `jdbc`, `jpa`)
-* `rrd4j` cannot store all item types (only numeric types)
+- grow in time
+- require complex installs (`influxdb`, `jdbc`, `jpa`)
+- `rrd4j` cannot store all item types (only numeric types)
 
 It is only possible to query the last value and not other historic values because the MapDB persistence service can only store one value per item.


### PR DESCRIPTION
Here are a few small documentation tweaks on top of #13964.