### PR TITLE
[bluetooth.generic] null annotations and SAT warnings

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothUnit.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothUnit.java
@@ -230,9 +230,6 @@ public enum BluetoothUnit {
         public static final Unit<ArealDensity> KILOGRAM_PER_SQUARE_METER = addUnit(
                 new ProductUnit<ArealDensity>(SIUnits.KILOGRAM.divide(SIUnits.SQUARE_METRE)));
 
-        public static final Unit<RadiationExposure> COULOMB_PER_KILOGRAM = addUnit(
-                new ProductUnit<RadiationExposure>(Units.COULOMB.divide(SIUnits.KILOGRAM)));
-
         public static final Unit<RadiationDoseAbsorptionRate> GRAY_PER_SECOND = addUnit(
                 new ProductUnit<RadiationDoseAbsorptionRate>(Units.GRAY.divide(Units.SECOND)));
 

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/CharacteristicChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/CharacteristicChannelTypeProvider.java
@@ -108,10 +108,7 @@ public class CharacteristicChannelTypeProvider implements ChannelTypeProvider {
         if (channelID.charAt(30) != '-') {
             return false;
         }
-        if (channelID.charAt(67) != '-') {
-            return false;
-        }
-        return true;
+        return !(channelID.charAt(67) != '-');
     }
 
     public ChannelTypeUID registerChannelType(String characteristicUUID, boolean advanced, boolean readOnly,
@@ -135,7 +132,7 @@ public class CharacteristicChannelTypeProvider implements ChannelTypeProvider {
             throw new IllegalStateException("Unknown field format type: " + field.getUnit());
         }
 
-        if (itemType.equals("Switch")) {
+        if ("Switch".equals(itemType)) {
             options = Collections.emptyList();
         }
 

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -202,7 +202,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
                                     .hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_BROADCAST))
                             .collect(Collectors.toUnmodifiableList());
 
-                    if (broadcastCharacteristics.size() == 0) {
+                    if (broadcastCharacteristics.isEmpty()) {
                         logger.info(
                                 "No Characteristic of service with UUID {} on {} has the broadcast property set, ignored.",
                                 uuidStr, scanNotification.getAddress());
@@ -298,7 +298,6 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
         }
 
         public void handleCommand(ChannelUID channelUID, Command command) {
-
             // Handle REFRESH
             if (command == RefreshType.REFRESH) {
                 if (canRead()) {

--- a/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/BluetoothUnitTest.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/test/java/org/openhab/binding/bluetooth/generic/internal/BluetoothUnitTest.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.binding.bluetooth.generic.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Connor Petty - Initial contribution
  *
  */
+@NonNullByDefault
 class BluetoothUnitTest {
 
     @Test


### PR DESCRIPTION
Signed-off-by: Leo Siepel [leosiepel@gmail.com](mailto:leosiepel@gmail.com)

null annotations
checkstyle.


=> would be good to remove the forbidden units package, but it depends on changes in core. I could not find if they are added yet. 
=> i see several warnings that i'm unable to fix yet (circular dependency with other classes)

Would be cool if i get some advice in how to fix those remaining issues.

Part of multiple PR's for bluetooth bundles. Can be merged independent.