### PR TITLE
[bluetooth.bluez] null annotations and checkstyle

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -131,14 +131,14 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             try {
                 dev.getAdapter().removeDevice(dev.getRawDevice());
             } catch (DBusException ex) {
-                if (ex.getMessage().contains("Does Not Exist")) {
-                    // this happens when the underlying device has already been removed
-                    // but we don't have a way to check if that is the case beforehand so
-                    // we will just eat the error here.
-                } else {
+                String exceptionMessage = ex.getMessage();
+                if (exceptionMessage == null || exceptionMessage.contains("Does Not Exist")) {
                     logger.debug("Exception occurred when trying to remove inactive device '{}': {}", address,
                             ex.getMessage());
                 }
+                // this codeblock will only be hit when the underlying device has already
+                // been removed but we don't have a way to check if that is the case beforehand
+                // so we will just eat the error here.
             } catch (RuntimeException ex) {
                 // try to catch any other exceptions
                 logger.debug("Exception occurred when trying to remove inactive device '{}': {}", address,
@@ -169,7 +169,6 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                     // Have to double check because sometimes, exception but still worked
                     logger.debug("Got a timeout - but sometimes happen. Is Connected ? {}", dev.isConnected());
                     if (Boolean.FALSE.equals(dev.isConnected())) {
-
                         notifyListeners(BluetoothEventType.CONNECTION_STATE,
                                 new BluetoothConnectionStatusNotification(ConnectionState.DISCONNECTED));
                         return false;
@@ -182,7 +181,6 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                 } catch (Exception e) {
                     logger.warn("error occured while trying to connect", e);
                 }
-
             } else {
                 logger.debug("Device was already connected");
                 // we might be stuck in another state atm so we need to trigger a connected in this case
@@ -278,9 +276,10 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             try {
                 c.startNotify();
             } catch (DBusException e) {
-                if (e.getMessage().contains("Already notifying")) {
+                String exceptionMessage = e.getMessage();
+                if (exceptionMessage != null && exceptionMessage.contains("Already notifying")) {
                     return null;
-                } else if (e.getMessage().contains("In Progress")) {
+                } else if (exceptionMessage != null && exceptionMessage.contains("In Progress")) {
                     // let's retry in half a second
                     throw new RetryException(500, TimeUnit.MILLISECONDS);
                 } else {
@@ -524,9 +523,10 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             try {
                 c.stopNotify();
             } catch (DBusException e) {
-                if (e.getMessage().contains("Already notifying")) {
+                String exceptionMessage = e.getMessage();
+                if (exceptionMessage != null && exceptionMessage.contains("Already notifying")) {
                     return null;
-                } else if (e.getMessage().contains("In Progress")) {
+                } else if (exceptionMessage != null && exceptionMessage.contains("In Progress")) {
                     // let's retry in half a second
                     throw new RetryException(500, TimeUnit.MILLISECONDS);
                 } else {

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/DeviceManagerWrapper.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/DeviceManagerWrapper.java
@@ -39,6 +39,7 @@ public class DeviceManagerWrapper {
         this.deviceManager = deviceManager;
     }
 
+    @SuppressWarnings("null")
     public synchronized Collection<BluetoothAdapter> scanForBluetoothAdapters() {
         if (deviceManager != null) {
             return deviceManager.scanForBluetoothAdapters();

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/events/ServiceDataEvent.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/events/ServiceDataEvent.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class ServiceDataEvent extends BlueZEvent {
 
-    final private Map<String, byte[]> data;
+    private final Map<String, byte[]> data;
 
     public ServiceDataEvent(String dbusPath, Map<String, byte[]> data) {
         super(dbusPath);

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/test/java/org/openhab/binding/bluetooth/bluez/internal/BlueZEventTest.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/test/java/org/openhab/binding/bluetooth/bluez/internal/BlueZEventTest.java
@@ -14,7 +14,7 @@ package org.openhab.binding.bluetooth.bluez.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.bluetooth.BluetoothAddress;
 import org.openhab.binding.bluetooth.bluez.internal.events.BlueZEvent;
@@ -25,6 +25,7 @@ import org.openhab.binding.bluetooth.bluez.internal.events.BlueZEventListener;
  * @author Benjamin Lafois - Initial Contribution
  * @author Connor Petty - Added additional test cases
  */
+@NonNullByDefault
 public class BlueZEventTest {
 
     @Test
@@ -83,7 +84,7 @@ public class BlueZEventTest {
         }
 
         @Override
-        public void dispatch(@NonNull BlueZEventListener listener) {
+        public void dispatch(BlueZEventListener listener) {
             listener.onDBusBlueZEvent(this);
         }
     }


### PR DESCRIPTION
Signed-off-by: Leo Siepel [leosiepel@gmail.com](mailto:leosiepel@gmail.com)


- null annotations
- checkstyle
- 
Part of multiple PR's for bluetooth bundles. Can me merged independent 

I see some unused methods, but not sure if they can be removed or if they are part of some (yet to be planned) overhaul/expansion.