### PR TITLE
[siemensrds] Fix missing locale in accessToken parsing

### DIFF
--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsAccessToken.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsAccessToken.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -130,9 +131,9 @@ public class RdsAccessToken {
         Date expDate = this.expDate;
         if (expDate == null) {
             try {
-                expDate = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z").parse(expires);
+                expDate = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH).parse(expires);
             } catch (ParseException e) {
-                logger.debug("isExpired: expiry date parsing exception");
+                logger.debug("isExpired: expiry date parsing exception", e);
 
                 Calendar calendar = Calendar.getInstance();
                 calendar.setTime(new Date());


### PR DESCRIPTION
The missing locale results in a test error on MacOS Ventura with german locale. The reason is that with a german locale the weekday cannot be parsed. Probably this is also the case in real life but since there is a fallback if date parsing fails.

Discovered while working on #13276 

Signed-off-by: Jan N. Klug <github@klug.nrw>
