### PR TITLE
Show add-on intros in Main UI

### DIFF
--- a/bundles/org.openhab.binding.pioneeravr/README.md
+++ b/bundles/org.openhab.binding.pioneeravr/README.md
@@ -1,5 +1,7 @@
 # Pioneer AVR Binding
 
+This binding integrates Pioneer AVRs.
+
 ## Binding configuration
 
 The binding can auto-discover the Pioneer AVRs present on your local network.

--- a/bundles/org.openhab.voice.mactts/README.md
+++ b/bundles/org.openhab.voice.mactts/README.md
@@ -1,7 +1,5 @@
 # macOS Text-to-Speech
 
-## Overview
-
 The macOS Text-to-Speech (TTS) service uses the macOS "say" command for producing spoken text.
 
 Obviously, this service only works on a host that is running macOS.

--- a/bundles/org.openhab.voice.marytts/README.md
+++ b/bundles/org.openhab.voice.marytts/README.md
@@ -1,7 +1,5 @@
 # Mary Text-to-Speech
 
-## Overview
-
 The Mary Text-to-Speech (TTS) service is a pure Java implementation of a TTS service, which uses the [MaryTTS](http://mary.dfki.de/) project of DFKI.
 
 While it provides good quality results, it must be noted that it is too heavy-weight for most embedded hardware like a Raspberry Pi. When using this service, you should be running openHAB on some real server instead.

--- a/bundles/org.openhab.voice.picotts/README.md
+++ b/bundles/org.openhab.voice.picotts/README.md
@@ -1,7 +1,5 @@
 # Pico Text-to-Speech
 
-## Overview
-
 The Pico Text-to-Speech (TTS) service uses the TTS binary from SVOX for producing spoken text.
 
 You manually need to install the pico2wave binary in order for this service to work correctly. You can,

--- a/bundles/org.openhab.voice.voicerss/README.md
+++ b/bundles/org.openhab.voice.voicerss/README.md
@@ -1,7 +1,5 @@
 # VoiceRSS Text-to-Speech
 
-## Overview
-
 VoiceRSS is an Internet based TTS service hosted at <https://api.voicerss.org>.
 You must obtain an API Key to get access to this service.
 The free version allows you to make up to 350 requests per day; for more you may need a commercial subscription.


### PR DESCRIPTION
Using these Markdown tweaks a small intro will show in Main UI instead of emptiness and a "more" button:

![Screenshot from 2022-12-17 22-29-39](https://user-images.githubusercontent.com/12213581/208266670-d10122eb-1451-4b30-82fb-b2e67f2f92d5.png)

There's also https://github.com/openhab/openhab-webui/pull/1587 for UI add-ons.
