### PR TITLE
[shelly] Fix NullPointerException

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -344,10 +344,10 @@ public class ShellyChannelDefinitions {
         }
 
         // Shelly 1/1PM and Plus 1/1PM Addon
-        addChannel(thing, add,
-                profile.settings.extSwitch != null && profile.settings.extSwitch.input0 != null
-                        && idx == getInteger(profile.settings.extSwitch.input0.relayNum),
-                CHGR_SENSOR, CHANNEL_ESENSOR_INPUT + (profile.settings.extSwitch.input0.relayNum + 1));
+        if (profile.settings.extSwitch != null && profile.settings.extSwitch.input0 != null
+                && idx == getInteger(profile.settings.extSwitch.input0.relayNum)) {
+            addChannel(thing, add, true, CHGR_SENSOR, CHANNEL_ESENSOR_INPUT + (idx + 1));
+        }
         if (profile.status.extTemperature != null) {
             addChannel(thing, add, profile.status.extTemperature.sensor1 != null, CHGR_SENSOR, CHANNEL_ESENSOR_TEMP1);
             addChannel(thing, add, profile.status.extTemperature.sensor2 != null, CHGR_SENSOR, CHANNEL_ESENSOR_TEMP2);


### PR DESCRIPTION
This is an attempt to fix the `NullPointerException` mentioned in #13961 and introduced by #13520.

This is completely untested since I do not have any Shellys or have any experience with this binding. So the fix is purely technical and based on the call stack and quick code analysis by looking at the merged PR.

However, when `profile.settings.extSwitch != null && profile.settings.extSwitch.input0 != null && idx == getInteger(profile.settings.extSwitch.input0.relayNum)` would evaluate to `false`, the next parameters for `addChannel()` won't have any significance as the method will just return:

https://github.com/openhab/openhab-addons/blob/4871d6dab197e2e6aabc3d1dfb7d5864eac1fc63/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java#L554-L583

So the fix should be safe, even if the `NullPointerException` is not root cause of the problems.

JAR for testing: [org.openhab.binding.shelly-3.4.0-SNAPSHOT.jar](https://drive.google.com/file/d/1PsNwns9rwJjeRmOEa1G_Zgk1W5Qi0KSO/view?usp=sharing)

Fixes #13961
Regression of #13520