### PR TITLE
[jsscriptingnashorn] JavaScript Scripting Nashorn Automation 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -415,6 +415,7 @@
 /bundles/org.openhab.voice.voicerss/ @JochenHiller @lolodomo
 /bundles/org.openhab.voice.voskstt/ @GiviMAD
 /bundles/org.openhab.voice.watsonstt/ @GiviMAD
+/itests/org.openhab.automation.jsscriptingnashorn.tests/ @wborn
 /itests/org.openhab.binding.astro.tests/ @gerrieg
 /itests/org.openhab.binding.avmfritz.tests/ @cweitkamp
 /itests/org.openhab.binding.feed.tests/ @svilenvul

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /bundles/org.openhab.automation.groovyscripting/ @wborn
 /bundles/org.openhab.automation.jrubyscripting/ @boc-tothefuture @ccutrer @jimtng
 /bundles/org.openhab.automation.jsscripting/ @jpg0 @florian-h05
+/bundles/org.openhab.automation.jsscriptingnashorn/ @wborn
 /bundles/org.openhab.automation.jythonscripting/ @openhab/add-ons-maintainers
 /bundles/org.openhab.automation.pidcontroller/ @fwolter
 /bundles/org.openhab.automation.pwm/ @fwolter

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -33,6 +33,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.automation.jsscriptingnashorn</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.automation.jythonscripting</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/NOTICE
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.automation.jsscriptingnashorn/README.md
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/README.md
@@ -1,0 +1,5 @@
+# JavaScript Scripting (Nashorn)
+
+This add-on allows you to use your older JavaScript (ECMAScript 5.1) rules on newer Java versions until they are migrated to JavaScript (ECMAScript 2021+).
+
+The add-on uses a standalone [Nashorn Engine](https://github.com/openjdk/nashorn) which was part of Java until it was removed in Java 15.

--- a/bundles/org.openhab.automation.jsscriptingnashorn/README.md
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/README.md
@@ -1,5 +1,49 @@
 # JavaScript Scripting (Nashorn)
 
-This add-on allows you to use your older JavaScript (ECMAScript 5.1) rules on newer Java versions until they are migrated to JavaScript (ECMAScript 2021+).
+This add-on allows you to use your older ECMAScript 5.1 code on newer Java versions until the code is migrated to ECMAScript 2021+.
+It should only be installed for providing backwards compatibility.
+When writing new code it is preferred to do this using ECMAScript 2021+ for which support is provided by installing the [JavaScript Scripting](https://www.openhab.org/addons/automation/jsscripting/) add-on.
 
-The add-on uses a standalone [Nashorn Engine](https://github.com/openjdk/nashorn) which was part of Java until it was removed in Java 15.
+This add-on uses a standalone [Nashorn Engine](https://github.com/openjdk/nashorn) to run ECMAScript 5.1 code.
+The Nashorn Engine was pre-installed in openHAB 2 and openHAB 3 because it was part of Java.
+Since Java 15 the Nashorn Engine has been removed from Java.
+
+## Creating JavaScript Scripts
+
+When this add-on is installed, JavaScript script actions will be run by this add-on and allow ECMAScript 5.1 features.
+
+Alternatively, you can create scripts in the `automation/jsr223` configuration directory.
+If you create an empty file called `test.nashornjs`, you will see a log line with information similar to:
+
+```text
+    ... [INFO ] [.a.m.s.r.i.l.ScriptFileWatcher:150  ] - Loading script 'test.nashornjs'
+```
+
+To enable debug logging, use the [console logging]({{base}}/administration/logging.html) commands to enable debug logging for the automation functionality:
+
+```text
+log:set DEBUG org.openhab.core.automation
+```
+
+For more information on the available APIs in scripts see the [JSR223 Scripting]({{base}}/configuration/jsr223.html) documentation.
+
+## Script Examples
+
+JavaScript scripts provide access to almost all the functionality in an openHAB runtime environment.
+As a simple example, the following script logs "Hello, World!".
+Note that `console.log` will usually not work since the output has no terminal to display the text.
+The openHAB server uses the [SLF4J](https://www.slf4j.org/) library for logging.
+
+```js
+var LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+
+LoggerFactory.getLogger("org.openhab.core.automation.examples").info("Hello, World!");
+```
+
+Depending on the openHAB logging configuration, you may need to prefix logger names with `org.openhab.core.automation` for them to show up in the log file (or you modify the logging configuration).
+
+The script uses the [LoggerFactory](https://www.slf4j.org/apidocs/org/slf4j/Logger.html) to obtain a named logger and then logs a message like:
+
+```text
+    ... [INFO ] [org.openhab.core.automation.examples ] - Hello, World!
+```

--- a/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.automation.jsscriptingnashorn</artifactId>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.3.0-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.automation.jsscriptingnashorn</artifactId>
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.openjdk.nashorn</groupId>
       <artifactId>nashorn-core</artifactId>
-      <version>15.3</version>
+      <version>15.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
@@ -19,7 +19,6 @@
     <asm.version>7.3.1</asm.version>
   </properties>
 
-
   <dependencies>
     <dependency>
       <groupId>org.openjdk.nashorn</groupId>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.automation.jsscriptingnashorn</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Automation :: JSScripting Nashorn</name>
+
+  <properties>
+    <bnd.importpackage>jdk.dynalink.*;resolution:=optional</bnd.importpackage>
+    <asm.version>7.3.1</asm.version>
+  </properties>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>15.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-tree</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.automation.jsscriptingnashorn</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: Automation :: JSScripting Nashorn</name>
+  <name>openHAB Add-ons :: Bundles :: Automation :: JavaScript Scripting (Nashorn)</name>
 
   <properties>
     <bnd.importpackage>jdk.dynalink.*;resolution:=optional</bnd.importpackage>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.automation.jsscriptingnashorn-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-automation-jsscriptingnashorn" description="JavaScript Scripting (Nashorn)" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscriptingnashorn/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/NashornScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/NashornScriptEngineFactory.java
@@ -38,23 +38,11 @@ import org.osgi.service.component.annotations.Component;
 @NonNullByDefault
 public class NashornScriptEngineFactory extends AbstractScriptEngineFactory {
 
-    private static final String NASHORN_ARGS = "nashorn.args";
-
     private final org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory factory = new org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory();
 
     private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(), factory.getMimeTypes())
             .flatMap(List::stream) //
             .collect(Collectors.toUnmodifiableList());
-
-    public NashornScriptEngineFactory() {
-        removeUnsupportedNashornArgs();
-    }
-
-    private void removeUnsupportedNashornArgs() {
-        String property = System.getProperty(NASHORN_ARGS, "");
-        property = property.replaceAll("--no-deprecation-warning", "").trim();
-        System.setProperty(NASHORN_ARGS, property);
-    }
 
     @Override
     public List<String> getScriptTypes() {

--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/NashornScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/NashornScriptEngineFactory.java
@@ -40,9 +40,17 @@ public class NashornScriptEngineFactory extends AbstractScriptEngineFactory {
 
     private final org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory factory = new org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory();
 
-    private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(), factory.getMimeTypes())
-            .flatMap(List::stream) //
-            .collect(Collectors.toUnmodifiableList());
+    private final List<String> scriptTypes = createScriptTypes();
+
+    private List<String> createScriptTypes() {
+        List<String> extensions = List.of("nashornjs");
+
+        String mimeTypeVersion = ";version=ECMAScript-5.1";
+        List<String> mimeTypes = factory.getMimeTypes().stream().map(mimeType -> mimeType + mimeTypeVersion)
+                .collect(Collectors.toUnmodifiableList());
+
+        return Stream.of(extensions, mimeTypes).flatMap(List::stream).collect(Collectors.toUnmodifiableList());
+    }
 
     @Override
     public List<String> getScriptTypes() {

--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/NashornScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/NashornScriptEngineFactory.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscriptingnashorn.internal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
+import org.openhab.core.automation.module.script.ScriptEngineFactory;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This is an implementation of a {@link ScriptEngineFactory} for Nashorn.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@Component(service = ScriptEngineFactory.class)
+@NonNullByDefault
+public class NashornScriptEngineFactory extends AbstractScriptEngineFactory {
+
+    private static final String NASHORN_ARGS = "nashorn.args";
+
+    private final org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory factory = new org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory();
+
+    private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(), factory.getMimeTypes())
+            .flatMap(List::stream) //
+            .collect(Collectors.toUnmodifiableList());
+
+    public NashornScriptEngineFactory() {
+        removeUnsupportedNashornArgs();
+    }
+
+    private void removeUnsupportedNashornArgs() {
+        String property = System.getProperty(NASHORN_ARGS, "");
+        property = property.replaceAll("--no-deprecation-warning", "").trim();
+        System.setProperty(NASHORN_ARGS, property);
+    }
+
+    @Override
+    public List<String> getScriptTypes() {
+        return scriptTypes;
+    }
+
+    @Override
+    public void scopeValues(ScriptEngine scriptEngine, Map<String, Object> scopeValues) {
+        Set<String> expressions = new HashSet<>();
+
+        for (Entry<String, Object> entry : scopeValues.entrySet()) {
+            scriptEngine.put(entry.getKey(), entry.getValue());
+            if (entry.getValue() instanceof Class) {
+                expressions.add(String.format("%s = %<s.static;", entry.getKey()));
+            }
+        }
+        String scriptToEval = String.join("\n", expressions);
+        try {
+            scriptEngine.eval(scriptToEval);
+        } catch (ScriptException ex) {
+            logger.error("ScriptException while importing scope: {}", ex.getMessage());
+        }
+    }
+
+    @Override
+    public @Nullable ScriptEngine createScriptEngine(String scriptType) {
+        return scriptTypes.contains(scriptType)
+                ? factory.getScriptEngine(NashornScriptEngineFactory.class.getClassLoader())
+                : null;
+    }
+}

--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/package-info.java
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/main/java/org/openhab/automation/jsscriptingnashorn/internal/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.osgi.annotation.bundle.Header(name = org.osgi.framework.Constants.DYNAMICIMPORT_PACKAGE, value = "*")
+package org.openhab.automation.jsscriptingnashorn.internal;
+
+/**
+ * Additional information for the JavaScript Scripting Nashorn package
+ *
+ * @author Wouter Born - Initial contribution
+ */

--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/test/java/org/openhab/automation/jsscriptingnashorn/NashornScriptEngineFactoryTest.java
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/test/java/org/openhab/automation/jsscriptingnashorn/NashornScriptEngineFactoryTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscriptingnashorn;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.automation.jsscriptingnashorn.internal.NashornScriptEngineFactory;
+
+/**
+ * Tests {@link NashornScriptEngineFactory}.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class NashornScriptEngineFactoryTest {
+
+    @Test
+    public void scriptTypesAreNashornSpecific() {
+        List<String> scriptTypes = new NashornScriptEngineFactory().getScriptTypes();
+
+        assertThat(scriptTypes,
+                contains("nashornjs", "application/javascript;version=ECMAScript-5.1",
+                        "application/ecmascript;version=ECMAScript-5.1", "text/javascript;version=ECMAScript-5.1",
+                        "text/ecmascript;version=ECMAScript-5.1"));
+        assertThat(scriptTypes.size(), is(5));
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -21,6 +21,7 @@
     <module>org.openhab.automation.groovyscripting</module>
     <module>org.openhab.automation.jrubyscripting</module>
     <module>org.openhab.automation.jsscripting</module>
+    <module>org.openhab.automation.jsscriptingnashorn</module>
     <module>org.openhab.automation.jythonscripting</module>
     <module>org.openhab.automation.pidcontroller</module>
     <module>org.openhab.automation.pwm</module>

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/NOTICE
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/itest.bndrun
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/itest.bndrun
@@ -1,0 +1,69 @@
+-include: ../itest-common.bndrun
+
+Bundle-SymbolicName: ${project.artifactId}
+Fragment-Host: org.openhab.automation.jsscriptingnashorn
+
+-runrequires: \
+	bnd.identity;id='org.openhab.automation.jsscriptingnashorn.tests',\
+	bnd.identity;id='org.openhab.core',\
+	bnd.identity;id='org.openhab.automation.jsscriptingnashorn'
+
+# We would like to use the "volatile" storage only
+-runblacklist: \
+	bnd.identity;id='org.openhab.core.storage.json'
+
+#
+# done
+#
+-runbundles: \
+	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
+	org.osgi.service.event;version='[1.4.0,1.4.1)',\
+	org.hamcrest;version='[2.2.0,2.2.1)',\
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.jsr-305;version='[3.0.2,3.0.3)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)',\
+	si-units;version='[2.1.0,2.1.1)',\
+	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
+	junit-jupiter-api;version='[5.8.1,5.8.2)',\
+	junit-jupiter-engine;version='[5.8.1,5.8.2)',\
+	junit-platform-commons;version='[1.8.1,1.8.2)',\
+	junit-platform-engine;version='[1.8.1,1.8.2)',\
+	junit-platform-launcher;version='[1.8.1,1.8.2)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	org.eclipse.jetty.http;version='[9.4.46,9.4.47)',\
+	org.eclipse.jetty.io;version='[9.4.46,9.4.47)',\
+	org.eclipse.jetty.security;version='[9.4.46,9.4.47)',\
+	org.eclipse.jetty.server;version='[9.4.46,9.4.47)',\
+	org.eclipse.jetty.servlet;version='[9.4.46,9.4.47)',\
+	org.eclipse.jetty.util;version='[9.4.46,9.4.47)',\
+	org.eclipse.jetty.util.ajax;version='[9.4.46,9.4.47)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.16,2.0.17)',\
+	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
+	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
+	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
+	org.openhab.core;version='[4.0.0,4.0.1)',\
+	org.openhab.core.config.core;version='[4.0.0,4.0.1)',\
+	org.openhab.core.test;version='[4.0.0,4.0.1)',\
+	com.google.gson;version='[2.9.1,2.9.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.openhab.automation.jsscriptingnashorn;version='[4.0.0,4.0.1)',\
+	org.openhab.automation.jsscriptingnashorn.tests;version='[4.0.0,4.0.1)',\
+	org.openhab.core.automation;version='[4.0.0,4.0.1)',\
+	org.openhab.core.automation.module.script;version='[4.0.0,4.0.1)',\
+	org.openhab.core.ephemeris;version='[4.0.0,4.0.1)',\
+	org.openhab.core.io.console;version='[4.0.0,4.0.1)',\
+	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
+	org.openhab.core.transform;version='[4.0.0,4.0.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/pom.xml
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.itests</groupId>
+    <artifactId>org.openhab.addons.reactor.itests</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.automation.jsscriptingnashorn.tests</artifactId>
+
+  <name>openHAB Add-ons :: Integration Tests :: JavaScript Scripting (Nashorn)</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.automation.jsscriptingnashorn</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/src/main/java/org/openhab/automation/jsscriptingnashorn/ScriptScopeOSGiTest.java
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/src/main/java/org/openhab/automation/jsscriptingnashorn/ScriptScopeOSGiTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscriptingnashorn;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.module.script.ScriptEngineContainer;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.test.java.JavaOSGiTest;
+
+/**
+ * This tests the script modules using the Nashorn scripting engine.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@NonNullByDefault
+public class ScriptScopeOSGiTest extends JavaOSGiTest {
+
+    private @NonNullByDefault({}) ScriptEngine engine;
+
+    private final String path = "OH-INF/automation/jsr223/";
+    private final String workingFile = "scopeWorking.nashornjs";
+    private final String failureFile = "scopeFailure.nashornjs";
+
+    @BeforeEach
+    public void init() {
+        ScriptEngineManager scriptManager = getService(ScriptEngineManager.class);
+        ScriptEngineContainer container = scriptManager.createScriptEngine("nashornjs", "myJSEngine");
+        engine = container.getScriptEngine();
+    }
+
+    @Test
+    public void testScopeDefinesItemTypes() throws ScriptException, IOException {
+        URL url = bundleContext.getBundle().getResource(path + workingFile);
+        engine.eval(new InputStreamReader(url.openStream()));
+    }
+
+    @Test
+    public void testScopeDoesNotDefineFoobar() throws ScriptException, IOException {
+        URL url = bundleContext.getBundle().getResource(path + failureFile);
+        assertThrows(ScriptException.class, () -> engine.eval(new InputStreamReader(url.openStream())));
+    }
+}

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/src/main/resources/OH-INF/automation/jsr223/scopeFailure.nashornjs
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/src/main/resources/OH-INF/automation/jsr223/scopeFailure.nashornjs
@@ -1,0 +1,5 @@
+'use strict';
+
+if(FOOBAR === undefined  && UnDefType.FOOBAR === undefined) {
+    throw "FOOBAR and UnDefType.FOOBAR not defined";
+}

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/src/main/resources/OH-INF/automation/jsr223/scopeWorking.nashornjs
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/src/main/resources/OH-INF/automation/jsr223/scopeWorking.nashornjs
@@ -1,0 +1,194 @@
+'use strict';
+
+if(State === undefined) {
+    throw "State not defined";
+}
+
+if(Command === undefined) {
+    throw "Command not defined";
+}
+
+if(URLEncoder === undefined) {
+    throw "URLEncoder not defined";
+}
+
+if(File === undefined) {
+    throw "File not defined";
+}
+
+if(Files === undefined) {
+    throw "Files not defined";
+}
+
+if(Path === undefined) {
+    throw "Path not defined";
+}
+
+if(Paths === undefined) {
+    throw "Paths not defined";
+}
+
+//types
+if(IncreaseDecreaseType === undefined) {
+    throw "IncreaseDecreaseType not defined";
+}
+
+if(DECREASE === undefined) {
+    throw "DECREASE not defined";
+}
+
+if(INCREASE === undefined) {
+    throw "INCREASE not defined";
+}
+
+if(OnOffType === undefined) {
+    throw "OnOffType not defined";
+}
+
+if(ON === undefined) {
+    throw "OFF not defined";
+}
+
+if(OpenClosedType === undefined) {
+    throw "OpenClosedType not defined";
+}
+
+if(CLOSED === undefined) {
+    throw "CLOSED not defined";
+}
+
+if(OPEN === undefined) {
+    throw "OPEN not defined";
+}
+
+if(StopMoveType === undefined) {
+    throw "StopMoveType not defined";
+}
+
+if(MOVE === undefined) {
+    throw "MOVE not defined";
+}
+
+if(STOP === undefined) {
+    throw "STOP not defined";
+}
+
+if(UpDownType === undefined) {
+    throw "UpDownType not defined";
+}
+
+if(DOWN === undefined) {
+    throw "DOWN not defined";
+}
+
+if(UP === undefined) {
+    throw "UP not defined";
+}
+
+if(UnDefType === undefined) {
+    throw "UnDefType not defined";
+}
+
+if(NULL === undefined) {
+    throw "NULL not defined";
+}
+
+if(NextPreviousType === undefined) {
+    throw "NextPreviousType not defined";
+}
+
+if(NEXT === undefined) {
+    throw "NEXT not defined";
+}
+
+if(PREVIOUS === undefined) {
+    throw "PREVIOUS not defined";
+}
+
+if(PlayPauseType === undefined) {
+    throw "PlayPauseType not defined";
+}
+
+if(PLAY === undefined) {
+    throw "PLAY not defined";
+}
+
+if(PAUSE === undefined) {
+    throw "PAUSE not defined";
+}
+
+if(RewindFastforwardType === undefined) {
+    throw "RewindFastforwardType not defined";
+}
+
+if(REWIND === undefined) {
+    throw "REWIND not defined";
+}
+
+if(FASTFORWARD === undefined) {
+    throw "FASTFORWARD not defined";
+}
+
+if(QuantityType === undefined) {
+    throw "QuantityType not defined";
+}
+
+if(StringListType === undefined) {
+    throw "StringListType not defined";
+}
+
+if(RawType === undefined) {
+    throw "RawType not defined";
+}
+
+if(DateTimeType === undefined) {
+    throw "DateTimeType not defined";
+}
+
+if(DecimalType === undefined) {
+    throw "DecimalType not defined";
+}
+
+if(DateTimeType === undefined) {
+    throw "DateTimeType not defined";
+}
+
+if(HSBType === undefined) {
+    throw "HSBType not defined";
+}
+
+if(PercentType === undefined) {
+    throw "PercentType not defined";
+}
+
+if(PointType === undefined) {
+    throw "PointType not defined";
+}
+
+if(StringType === undefined) {
+    throw "StringType not defined";
+}
+
+if(items === undefined) {
+    throw "items not defined";
+}
+
+if(ir === undefined) {
+    throw "ir not defined";
+}
+
+if(itemRegistry === undefined) {
+    throw "itemRegistry not defined";
+}
+
+if(things === undefined) {
+    throw "things not defined";
+}
+
+if(events === undefined) {
+    throw "events not defined";
+}
+
+if(rules === undefined) {
+    throw "rules not defined";
+}

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -17,6 +17,7 @@
   <name>openHAB Add-ons :: Integration Tests</name>
 
   <modules>
+    <module>org.openhab.automation.jsscriptingnashorn.tests</module>
     <module>org.openhab.binding.astro.tests</module>
     <module>org.openhab.binding.avmfritz.tests</module>
     <module>org.openhab.binding.feed.tests</module>


### PR DESCRIPTION
This add-on allows you to use your older ECMAScript 5.1 code on newer Java versions until the code is migrated to ECMAScript 2021+. It should only be installed for providing backwards compatibility. When writing new code it is preferred to do this using ECMAScript 2021+ for which support is provided by installing the [JavaScript Scripting](https://www.openhab.org/addons/automation/jsscripting/) add-on.

This add-on uses a standalone [Nashorn Engine](https://github.com/openjdk/nashorn) to run ECMAScript 5.1 code. The Nashorn Engine was pre-installed in openHAB 2 and openHAB 3 because it was part of Java. Since Java 15 the Nashorn Engine has been removed from Java.

---

This PR is based on the [JavaScript Scripting (Nashorn) Marketplace add-on](https://community.openhab.org/t/javascript-scripting-nashorn/134770?u=wborn).

---

To do:

* [x] Add more documentation
* [x] Update MIME types
* [x] Add more tests