### PR TITLE
[knx] Upgrade Calimero library to release 2.5.1

### DIFF
--- a/bundles/org.openhab.binding.knx/pom.xml
+++ b/bundles/org.openhab.binding.knx/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-core</artifactId>
-      <version>2.5</version>
+      <version>2.5.1</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-device</artifactId>
-      <version>2.5</version>
+      <version>2.5.1</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-rxtx</artifactId>
-      <version>2.5</version>
+      <version>2.5.1</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -166,9 +166,8 @@ class KNXCoreTypeMapperTest {
 
         assertEquals("42.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("42 s"), "13.100"));
 
-        // DPTs 13.1200 and 13.1201 not available in Calimero 2.5, fix once we update
-        assertNotEquals("42.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("42 l"), "13.1200"));
-        assertNotEquals("42.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("42 m³"), "13.1201"));
+        assertEquals("42.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("42 l"), "13.1200"));
+        assertEquals("42.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("42 m³"), "13.1201"));
     }
 
     @Test
@@ -258,9 +257,8 @@ class KNXCoreTypeMapperTest {
         assertEquals("1.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("1 J"), "14.079"));
         assertEquals("1.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("1 VA"), "14.080"));
 
-        // DPTs 14.1200 and 14.1201 not available in Calimero 2.5, fix once we update
-        assertNotEquals("1.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("1 m³/h"), "14.1200"));
-        assertNotEquals("1.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("1 l/s"), "14.1201"));
+        assertEquals("1.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("1 m³/h"), "14.1200"));
+        assertEquals("1.0", new KNXCoreTypeMapper().toDPTValue(new QuantityType<>("1 l/s"), "14.1201"));
     }
 
     @Test


### PR DESCRIPTION
Calimero 2.5.1 was recently released and brings a few fixes needed for further development of KNX data secure feature.