### PR TITLE
[hdpowerview] Remove deprecated scene channels

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewHubHandler.java
@@ -50,7 +50,6 @@ import org.openhab.binding.hdpowerview.internal.exceptions.HubException;
 import org.openhab.binding.hdpowerview.internal.exceptions.HubInvalidResponseException;
 import org.openhab.binding.hdpowerview.internal.exceptions.HubMaintenanceException;
 import org.openhab.binding.hdpowerview.internal.exceptions.HubProcessingException;
-import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -63,7 +62,6 @@ import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.openhab.core.thing.binding.ThingHandler;
-import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
@@ -100,7 +98,6 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
     private List<SceneCollection> sceneCollectionCache = new CopyOnWriteArrayList<>();
     private List<ScheduledEvent> scheduledEventCache = new CopyOnWriteArrayList<>();
     private Instant userDataUpdated = Instant.MIN;
-    private Boolean deprecatedChannelsCreated = false;
 
     private final ChannelTypeUID sceneChannelTypeUID = new ChannelTypeUID(HDPowerViewBindingConstants.BINDING_ID,
             HDPowerViewBindingConstants.CHANNELTYPE_SCENE_ACTIVATE);
@@ -181,7 +178,6 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
         sceneCache.clear();
         sceneCollectionCache.clear();
         scheduledEventCache.clear();
-        deprecatedChannelsCreated = false;
     }
 
     public HDPowerViewWebTargets getWebTargets() {
@@ -481,50 +477,7 @@ public class HDPowerViewHubHandler extends BaseBridgeHandler {
 
         updateThing(editThing().withChannels(channelBuilder.build()).build());
 
-        createDeprecatedSceneChannels(scenes);
-
         return scenes;
-    }
-
-    /**
-     * Create backwards compatible scene channels if any items configured before release 3.2
-     * are still linked. Users should have a reasonable amount of time to migrate to the new
-     * scene channels that are connected to a channel group.
-     */
-    private void createDeprecatedSceneChannels(List<Scene> scenes) {
-        if (deprecatedChannelsCreated) {
-            // Only do this once.
-            return;
-        }
-        ChannelGroupUID channelGroupUid = new ChannelGroupUID(thing.getUID(),
-                HDPowerViewBindingConstants.CHANNEL_GROUP_SCENES);
-        for (Scene scene : scenes) {
-            String channelId = Integer.toString(scene.id);
-            ChannelUID newChannelUid = new ChannelUID(channelGroupUid, channelId);
-            ChannelUID deprecatedChannelUid = new ChannelUID(getThing().getUID(), channelId);
-            String description = translationProvider.getText("dynamic-channel.scene-activate.deprecated.description",
-                    scene.getName());
-            Channel channel = ChannelBuilder.create(deprecatedChannelUid, CoreItemFactory.SWITCH)
-                    .withType(sceneChannelTypeUID).withLabel(scene.getName()).withDescription(description).build();
-            logger.debug("Creating deprecated channel '{}' ('{}') to probe for linked items", deprecatedChannelUid,
-                    scene.getName());
-            updateThing(editThing().withChannel(channel).build());
-            if (this.isLinked(deprecatedChannelUid) && !this.isLinked(newChannelUid)) {
-                logger.warn("Created deprecated channel '{}' ('{}'), please link items to '{}' instead",
-                        deprecatedChannelUid, scene.getName(), newChannelUid);
-            } else {
-                if (this.isLinked(newChannelUid)) {
-                    logger.debug("Removing deprecated channel '{}' ('{}') since new channel '{}' is linked",
-                            deprecatedChannelUid, scene.getName(), newChannelUid);
-
-                } else {
-                    logger.debug("Removing deprecated channel '{}' ('{}') since it has no linked items",
-                            deprecatedChannelUid, scene.getName());
-                }
-                updateThing(editThing().withoutChannel(deprecatedChannelUid).build());
-            }
-        }
-        deprecatedChannelsCreated = true;
     }
 
     private List<SceneCollection> fetchSceneCollections()

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/i18n/hdpowerview.properties
@@ -73,7 +73,6 @@ offline.gone.shade-unknown-to-hub = Shade is unknown to Hub
 # dynamic channels
 
 dynamic-channel.scene-activate.description = Activates the scene ''{0}''
-dynamic-channel.scene-activate.deprecated.description = DEPRECATED: Activates the scene ''{0}''
 dynamic-channel.scene-group-activate.description = Activates the scene group ''{0}''
 dynamic-channel.automation-enabled.description = Enables/disables the automation ''{0}''
 dynamic-channel.automation-enabled.label = {0}, {1}, {2}


### PR DESCRIPTION
Related to #11637 after the introduction of scene groups and automations in addition to scenes. This required the use of channel groups for separating these three groups of dynamic channels.

Channel names before release 3.2:
- **Scene:** `1`

Channel names from release 3.2:
- **Scene:** `scenes#1`
- **Scene Group:** `sceneGroups#1`
- **Automation:** `automations#1`