### PR TITLE
[fineoffsetweatherstation] Fix QuantityType for rain-rate

### DIFF
--- a/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/README.md
@@ -75,7 +75,11 @@ In this case you have to configure a service to which the data is sent.
 Please try if here the [IPObserver binding](https://www.openhab.org/addons/bindings/ipobserver/) offers an alternative.
 Known weather stations not compatible with this binding:
 
-- [WH3000](https://community.openhab.org/t/fine-offset-weather-station-binding-beta-and-discussion/134167/52?u=andy2003)
+- [WH3000](https://community.openhab.org/t/fine-offset-weather-station-binding-beta-and-discussion/134167/52)
+- [Ecowitt HP2564C](https://community.openhab.org/t/fine-offset-weather-station-binding-discussion/134167/134)
+
+If your gateway does not support reading out live-data, a second gateway can be used to read out the sensors for openHAB.
+[This approach has been tested by a community member](https://community.openhab.org/t/fine-offset-weather-station-binding-discussion/134167/151).
 
 ## Discovery
 
@@ -156,126 +160,126 @@ Valid sensors:
 
 ### `gateway` Channels
 
-| Channel                               | Type                          | Read/Write | Description                                    |
-|---------------------------------------|-------------------------------|------------|------------------------------------------------|
-| temperature-indoor                    | Number:Temperature            | R          | Indoor Temperature                             |
-| temperature-outdoor                   | Number:Temperature            | R          | Outdoor Temperature                            |
-| temperature-dew-point                 | Number:Temperature            | R          | Dew Point                                      |
-| temperature-wind-chill                | Number:Temperature            | R          | Perceived Temperature                          |
-| temperature-heat-index                | Number:Temperature            | R          | Heat Index                                     |
-| humidity-indoor                       | Number:Dimensionless          | R          | Humidity Inside                                |
-| humidity-outdoor                      | Number:Dimensionless          | R          | Humidity Outside                               |
-| pressure-absolute                     | Number:Pressure               | R          | Absolute Pressure                              |
-| pressure-relative                     | Number:Pressure               | R          | Relative Pressure                              |
-| direction-wind                        | Number:Angle                  | R          | Wind Direction                                 |
-| speed-wind                            | Number:Speed                  | R          | Wind Speed                                     |
-| speed-gust                            | Number:Speed                  | R          | Gust Speed                                     |
-| rain-event                            | Number:Length                 | R          | Amount of Rainfall At the last Rain            |
-| rain-rate                             | Number:VolumetricFlowRate     | R          | Rainfall Rate                                  |
-| rain-hour                             | Number:Length                 | R          | Rainfall Current Hour                          |
-| rain-day                              | Number:Length                 | R          | Rainfall Today                                 |
-| rain-week                             | Number:Length                 | R          | Rainfall this Week                             |
-| rain-month                            | Number:Length                 | R          | Rainfall this Month                            |
-| rain-year                             | Number:Length                 | R          | Rainfall this Year                             |
-| rain-total                            | Number:Length                 | R          | Rainfall Total                                 |
-| illumination                          | Number:Illuminance            | R          | Light Intensity                                |
-| irradiation-uv                        | Number:Intensity              | R          | UV Irradiation                                 |
-| uv-index                              | Number:Dimensionless          | R          | UV Index                                       |
-| wind-max-day                          | Number:Speed                  | R          | Maximum Wind Speed Today                       |
-| temperature-channel-1                 | Number:Temperature            | R          | Temperature Channel 1                          |
-| temperature-channel-2                 | Number:Temperature            | R          | Temperature Channel 2                          |
-| temperature-channel-3                 | Number:Temperature            | R          | Temperature Channel 3                          |
-| temperature-channel-4                 | Number:Temperature            | R          | Temperature Channel 4                          |
-| temperature-channel-5                 | Number:Temperature            | R          | Temperature Channel 5                          |
-| temperature-channel-6                 | Number:Temperature            | R          | Temperature Channel 6                          |
-| temperature-channel-7                 | Number:Temperature            | R          | Temperature Channel 7                          |
-| temperature-channel-8                 | Number:Temperature            | R          | Temperature Channel 8                          |
-| humidity-channel-1                    | Number:Dimensionless          | R          | Humidity Channel 1                             |
-| humidity-channel-2                    | Number:Dimensionless          | R          | Humidity Channel 2                             |
-| humidity-channel-3                    | Number:Dimensionless          | R          | Humidity Channel 3                             |
-| humidity-channel-4                    | Number:Dimensionless          | R          | Humidity Channel 4                             |
-| humidity-channel-5                    | Number:Dimensionless          | R          | Humidity Channel 5                             |
-| humidity-channel-6                    | Number:Dimensionless          | R          | Humidity Channel 6                             |
-| humidity-channel-7                    | Number:Dimensionless          | R          | Humidity Channel 7                             |
-| humidity-channel-8                    | Number:Dimensionless          | R          | Humidity Channel 8                             |
-| temperature-soil-channel-1            | Number:Temperature            | R          | Soil Temperature Channel 1                     |
-| temperature-soil-channel-2            | Number:Temperature            | R          | Soil Temperature Channel 2                     |
-| temperature-soil-channel-3            | Number:Temperature            | R          | Soil Temperature Channel 3                     |
-| temperature-soil-channel-4            | Number:Temperature            | R          | Soil Temperature Channel 4                     |
-| temperature-soil-channel-5            | Number:Temperature            | R          | Soil Temperature Channel 5                     |
-| temperature-soil-channel-6            | Number:Temperature            | R          | Soil Temperature Channel 6                     |
-| temperature-soil-channel-7            | Number:Temperature            | R          | Soil Temperature Channel 7                     |
-| temperature-soil-channel-8            | Number:Temperature            | R          | Soil Temperature Channel 8                     |
-| temperature-soil-channel-9            | Number:Temperature            | R          | Soil Temperature Channel 9                     |
-| temperature-soil-channel-10           | Number:Temperature            | R          | Soil Temperature Channel 10                    |
-| temperature-soil-channel-11           | Number:Temperature            | R          | Soil Temperature Channel 11                    |
-| temperature-soil-channel-12           | Number:Temperature            | R          | Soil Temperature Channel 12                    |
-| temperature-soil-channel-13           | Number:Temperature            | R          | Soil Temperature Channel 13                    |
-| temperature-soil-channel-14           | Number:Temperature            | R          | Soil Temperature Channel 14                    |
-| temperature-soil-channel-15           | Number:Temperature            | R          | Soil Temperature Channel 15                    |
-| temperature-soil-channel-16           | Number:Temperature            | R          | Soil Temperature Channel 16                    |
-| moisture-soil-channel-1               | Number:Dimensionless          | R          | Soil Moisture Channel 1                        |
-| moisture-soil-channel-2               | Number:Dimensionless          | R          | Soil Moisture Channel 2                        |
-| moisture-soil-channel-3               | Number:Dimensionless          | R          | Soil Moisture Channel 3                        |
-| moisture-soil-channel-4               | Number:Dimensionless          | R          | soil Moisture Channel 4                        |
-| moisture-soil-channel-5               | Number:Dimensionless          | R          | Soil Moisture Channel 5                        |
-| moisture-soil-channel-6               | Number:Dimensionless          | R          | Soil Moisture Channel 6                        |
-| moisture-soil-channel-7               | Number:Dimensionless          | R          | Soil Moisture Channel 7                        |
-| moisture-soil-channel-8               | Number:Dimensionless          | R          | Soil Moisture Channel 8                        |
-| moisture-soil-channel-9               | Number:Dimensionless          | R          | Soil Moisture Channel 9                        |
-| moisture-soil-channel-10              | Number:Dimensionless          | R          | Soil Moisture Channel 10                       |
-| moisture-soil-channel-11              | Number:Dimensionless          | R          | Soil Moisture Channel 11                       |
-| moisture-soil-channel-12              | Number:Dimensionless          | R          | Soil Moisture Channel 12                       |
-| moisture-soil-channel-13              | Number:Dimensionless          | R          | soil Moisture Channel 13                       |
-| moisture-soil-channel-14              | Number:Dimensionless          | R          | Soil Moisture Channel 14                       |
-| moisture-soil-channel-15              | Number:Dimensionless          | R          | Soil Moisture Channel 15                       |
-| moisture-soil-channel-16              | Number:Dimensionless          | R          | Soil Moisture Channel 16                       |
-| air-quality-24-hour-average-channel-1 | Number:Density                | R          | PM2.5 Air Quality 24 Hour Average Channel 1    |
-| air-quality-24-hour-average-channel-2 | Number:Density                | R          | PM2.5 Air Quality 24 Hour Average Channel 2    |
-| air-quality-24-hour-average-channel-3 | Number:Density                | R          | PM2.5 Air Quality 24 Hour Average Channel 3    |
-| air-quality-24-hour-average-channel-4 | Number:Density                | R          | PM2.5 Air Quality 24 Hour Average Channel 4    |
-| air-quality-channel-1                 | Number:Density                | R          | PM2.5 Air Quality Channel 1                    |
-| air-quality-channel-2                 | Number:Density                | R          | PM2.5 Air Quality Channel 2                    |
-| air-quality-channel-3                 | Number:Density                | R          | PM2.5 Air Quality Channel 3                    |
-| air-quality-channel-4                 | Number:Density                | R          | PM2.5 Air Quality Channel 4                    |
-| water-leak-channel-1                  | Switch                        | R          | Water Leak Detection Channel 1                 |
-| water-leak-channel-2                  | Switch                        | R          | Water Leak Detection Channel 2                 |
-| water-leak-channel-3                  | Switch                        | R          | Water Leak Detection Channel 3                 |
-| water-leak-channel-4                  | Switch                        | R          | Water Leak Detection Channel 4                 |
-| lightning-distance                    | Number:Length                 | R          | Lightning Distance                             |
-| lightning-time                        | DateTime                      | R          | Time of last Lightning Strike                  |
-| lightning-counter                     | Number                        | R          | Lightning Strikes Today                        |
-| temperature-external-channel-1        | Number:Temperature            | R          | External Temperature Sensor Channel 1          |
-| temperature-external-channel-2        | Number:Temperature            | R          | External Temperature Sensor Channel 2          |
-| temperature-external-channel-3        | Number:Temperature            | R          | External Temperature Sensor Channel 3          |
-| temperature-external-channel-4        | Number:Temperature            | R          | External Temperature Sensor Channel 4          |
-| temperature-external-channel-5        | Number:Temperature            | R          | External Temperature Sensor Channel 5          |
-| temperature-external-channel-6        | Number:Temperature            | R          | External Temperature Sensor Channel 6          |
-| temperature-external-channel-7        | Number:Temperature            | R          | External Temperature Sensor Channel 7          |
-| temperature-external-channel-8        | Number:Temperature            | R          | External Temperature Sensor Channel 8          |
-| sensor-co2-temperature                | Number:Temperature            | R          | Temperature (CO2-Sensor)                       |
-| sensor-co2-humidity                   | Number:Dimensionless          | R          | Humidity (CO2-Sensor)                          |
-| sensor-co2-pm10                       | Number:Density                | R          | PM10 Air Quality (CO2-Sensor)                  |
-| sensor-co2-pm10-24-hour-average       | Number:Density                | R          | PM10 Air Quality 24 Hour Average (CO2-Sensor)  |
-| sensor-co2-pm25                       | Number:Density                | R          | PM2.5 Air Quality (CO2-Sensor)                 |
-| sensor-co2-pm25-24-hour-average       | Number:Density                | R          | PM2.5 Air Quality 24 Hour Average (CO2-Sensor) |
-| sensor-co2-co2                        | Number:Dimensionless          | R          | CO2                                            |
-| sensor-co2-co2-24-hour-average        | Number:Dimensionless          | R          | CO2 24 Hour Average                            |
-| leaf-wetness-channel-1                | Number:Dimensionless          | R          | Leaf Moisture Channel 1                        |  
-| leaf-wetness-channel-2                | Number:Dimensionless          | R          | Leaf Moisture Channel 2                        |
-| leaf-wetness-channel-3                | Number:Dimensionless          | R          | Leaf Moisture Channel 3                        |
-| leaf-wetness-channel-4                | Number:Dimensionless          | R          | Leaf Moisture Channel 4                        |
-| leaf-wetness-channel-5                | Number:Dimensionless          | R          | Leaf Moisture Channel 5                        |
-| leaf-wetness-channel-6                | Number:Dimensionless          | R          | Leaf Moisture Channel 6                        |
-| leaf-wetness-channel-7                | Number:Dimensionless          | R          | Leaf Moisture Channel 7                        |
-| leaf-wetness-channel-8                | Number:Dimensionless          | R          | Leaf Moisture Channel 8                        |
-| piezo-rain-rate                       | Number:VolumetricFlowRate     | R          | Piezo - Rainfall Rate                          |
-| piezo-rain-event                      | Number:Length                 | R          | Piezo - Amount of Rainfall At the last Rain    |
-| piezo-rain-hour                       | Number:Length                 | R          | Piezo - Rainfall Current Hour                  |
-| piezo-rain-day                        | Number:Length                 | R          | Piezo - Rainfall Today                         |
-| piezo-rain-week                       | Number:Length                 | R          | Piezo - Rainfall this Week                     |
-| piezo-rain-month                      | Number:Length                 | R          | Piezo - Rainfall this Month                    |
-| piezo-rain-year                       | Number:Length                 | R          | Piezo - Rainfall this Year                     |
+| Channel                               | Type                 | Read/Write | Description                                    |
+|---------------------------------------|----------------------|------------|------------------------------------------------|
+| temperature-indoor                    | Number:Temperature   | R          | Indoor Temperature                             |
+| temperature-outdoor                   | Number:Temperature   | R          | Outdoor Temperature                            |
+| temperature-dew-point                 | Number:Temperature   | R          | Dew Point                                      |
+| temperature-wind-chill                | Number:Temperature   | R          | Perceived Temperature                          |
+| temperature-heat-index                | Number:Temperature   | R          | Heat Index                                     |
+| humidity-indoor                       | Number:Dimensionless | R          | Humidity Inside                                |
+| humidity-outdoor                      | Number:Dimensionless | R          | Humidity Outside                               |
+| pressure-absolute                     | Number:Pressure      | R          | Absolute Pressure                              |
+| pressure-relative                     | Number:Pressure      | R          | Relative Pressure                              |
+| direction-wind                        | Number:Angle         | R          | Wind Direction                                 |
+| speed-wind                            | Number:Speed         | R          | Wind Speed                                     |
+| speed-gust                            | Number:Speed         | R          | Gust Speed                                     |
+| rain-event                            | Number:Length        | R          | Amount of Rainfall At the last Rain            |
+| rain-rate                             | Number:Speed         | R          | Rainfall Rate                                  |
+| rain-hour                             | Number:Length        | R          | Rainfall Current Hour                          |
+| rain-day                              | Number:Length        | R          | Rainfall Today                                 |
+| rain-week                             | Number:Length        | R          | Rainfall this Week                             |
+| rain-month                            | Number:Length        | R          | Rainfall this Month                            |
+| rain-year                             | Number:Length        | R          | Rainfall this Year                             |
+| rain-total                            | Number:Length        | R          | Rainfall Total                                 |
+| illumination                          | Number:Illuminance   | R          | Light Intensity                                |
+| irradiation-uv                        | Number:Intensity     | R          | UV Irradiation                                 |
+| uv-index                              | Number:Dimensionless | R          | UV Index                                       |
+| wind-max-day                          | Number:Speed         | R          | Maximum Wind Speed Today                       |
+| temperature-channel-1                 | Number:Temperature   | R          | Temperature Channel 1                          |
+| temperature-channel-2                 | Number:Temperature   | R          | Temperature Channel 2                          |
+| temperature-channel-3                 | Number:Temperature   | R          | Temperature Channel 3                          |
+| temperature-channel-4                 | Number:Temperature   | R          | Temperature Channel 4                          |
+| temperature-channel-5                 | Number:Temperature   | R          | Temperature Channel 5                          |
+| temperature-channel-6                 | Number:Temperature   | R          | Temperature Channel 6                          |
+| temperature-channel-7                 | Number:Temperature   | R          | Temperature Channel 7                          |
+| temperature-channel-8                 | Number:Temperature   | R          | Temperature Channel 8                          |
+| humidity-channel-1                    | Number:Dimensionless | R          | Humidity Channel 1                             |
+| humidity-channel-2                    | Number:Dimensionless | R          | Humidity Channel 2                             |
+| humidity-channel-3                    | Number:Dimensionless | R          | Humidity Channel 3                             |
+| humidity-channel-4                    | Number:Dimensionless | R          | Humidity Channel 4                             |
+| humidity-channel-5                    | Number:Dimensionless | R          | Humidity Channel 5                             |
+| humidity-channel-6                    | Number:Dimensionless | R          | Humidity Channel 6                             |
+| humidity-channel-7                    | Number:Dimensionless | R          | Humidity Channel 7                             |
+| humidity-channel-8                    | Number:Dimensionless | R          | Humidity Channel 8                             |
+| temperature-soil-channel-1            | Number:Temperature   | R          | Soil Temperature Channel 1                     |
+| temperature-soil-channel-2            | Number:Temperature   | R          | Soil Temperature Channel 2                     |
+| temperature-soil-channel-3            | Number:Temperature   | R          | Soil Temperature Channel 3                     |
+| temperature-soil-channel-4            | Number:Temperature   | R          | Soil Temperature Channel 4                     |
+| temperature-soil-channel-5            | Number:Temperature   | R          | Soil Temperature Channel 5                     |
+| temperature-soil-channel-6            | Number:Temperature   | R          | Soil Temperature Channel 6                     |
+| temperature-soil-channel-7            | Number:Temperature   | R          | Soil Temperature Channel 7                     |
+| temperature-soil-channel-8            | Number:Temperature   | R          | Soil Temperature Channel 8                     |
+| temperature-soil-channel-9            | Number:Temperature   | R          | Soil Temperature Channel 9                     |
+| temperature-soil-channel-10           | Number:Temperature   | R          | Soil Temperature Channel 10                    |
+| temperature-soil-channel-11           | Number:Temperature   | R          | Soil Temperature Channel 11                    |
+| temperature-soil-channel-12           | Number:Temperature   | R          | Soil Temperature Channel 12                    |
+| temperature-soil-channel-13           | Number:Temperature   | R          | Soil Temperature Channel 13                    |
+| temperature-soil-channel-14           | Number:Temperature   | R          | Soil Temperature Channel 14                    |
+| temperature-soil-channel-15           | Number:Temperature   | R          | Soil Temperature Channel 15                    |
+| temperature-soil-channel-16           | Number:Temperature   | R          | Soil Temperature Channel 16                    |
+| moisture-soil-channel-1               | Number:Dimensionless | R          | Soil Moisture Channel 1                        |
+| moisture-soil-channel-2               | Number:Dimensionless | R          | Soil Moisture Channel 2                        |
+| moisture-soil-channel-3               | Number:Dimensionless | R          | Soil Moisture Channel 3                        |
+| moisture-soil-channel-4               | Number:Dimensionless | R          | soil Moisture Channel 4                        |
+| moisture-soil-channel-5               | Number:Dimensionless | R          | Soil Moisture Channel 5                        |
+| moisture-soil-channel-6               | Number:Dimensionless | R          | Soil Moisture Channel 6                        |
+| moisture-soil-channel-7               | Number:Dimensionless | R          | Soil Moisture Channel 7                        |
+| moisture-soil-channel-8               | Number:Dimensionless | R          | Soil Moisture Channel 8                        |
+| moisture-soil-channel-9               | Number:Dimensionless | R          | Soil Moisture Channel 9                        |
+| moisture-soil-channel-10              | Number:Dimensionless | R          | Soil Moisture Channel 10                       |
+| moisture-soil-channel-11              | Number:Dimensionless | R          | Soil Moisture Channel 11                       |
+| moisture-soil-channel-12              | Number:Dimensionless | R          | Soil Moisture Channel 12                       |
+| moisture-soil-channel-13              | Number:Dimensionless | R          | soil Moisture Channel 13                       |
+| moisture-soil-channel-14              | Number:Dimensionless | R          | Soil Moisture Channel 14                       |
+| moisture-soil-channel-15              | Number:Dimensionless | R          | Soil Moisture Channel 15                       |
+| moisture-soil-channel-16              | Number:Dimensionless | R          | Soil Moisture Channel 16                       |
+| air-quality-24-hour-average-channel-1 | Number:Density       | R          | PM2.5 Air Quality 24 Hour Average Channel 1    |
+| air-quality-24-hour-average-channel-2 | Number:Density       | R          | PM2.5 Air Quality 24 Hour Average Channel 2    |
+| air-quality-24-hour-average-channel-3 | Number:Density       | R          | PM2.5 Air Quality 24 Hour Average Channel 3    |
+| air-quality-24-hour-average-channel-4 | Number:Density       | R          | PM2.5 Air Quality 24 Hour Average Channel 4    |
+| air-quality-channel-1                 | Number:Density       | R          | PM2.5 Air Quality Channel 1                    |
+| air-quality-channel-2                 | Number:Density       | R          | PM2.5 Air Quality Channel 2                    |
+| air-quality-channel-3                 | Number:Density       | R          | PM2.5 Air Quality Channel 3                    |
+| air-quality-channel-4                 | Number:Density       | R          | PM2.5 Air Quality Channel 4                    |
+| water-leak-channel-1                  | Switch               | R          | Water Leak Detection Channel 1                 |
+| water-leak-channel-2                  | Switch               | R          | Water Leak Detection Channel 2                 |
+| water-leak-channel-3                  | Switch               | R          | Water Leak Detection Channel 3                 |
+| water-leak-channel-4                  | Switch               | R          | Water Leak Detection Channel 4                 |
+| lightning-distance                    | Number:Length        | R          | Lightning Distance                             |
+| lightning-time                        | DateTime             | R          | Time of last Lightning Strike                  |
+| lightning-counter                     | Number               | R          | Lightning Strikes Today                        |
+| temperature-external-channel-1        | Number:Temperature   | R          | External Temperature Sensor Channel 1          |
+| temperature-external-channel-2        | Number:Temperature   | R          | External Temperature Sensor Channel 2          |
+| temperature-external-channel-3        | Number:Temperature   | R          | External Temperature Sensor Channel 3          |
+| temperature-external-channel-4        | Number:Temperature   | R          | External Temperature Sensor Channel 4          |
+| temperature-external-channel-5        | Number:Temperature   | R          | External Temperature Sensor Channel 5          |
+| temperature-external-channel-6        | Number:Temperature   | R          | External Temperature Sensor Channel 6          |
+| temperature-external-channel-7        | Number:Temperature   | R          | External Temperature Sensor Channel 7          |
+| temperature-external-channel-8        | Number:Temperature   | R          | External Temperature Sensor Channel 8          |
+| sensor-co2-temperature                | Number:Temperature   | R          | Temperature (CO2-Sensor)                       |
+| sensor-co2-humidity                   | Number:Dimensionless | R          | Humidity (CO2-Sensor)                          |
+| sensor-co2-pm10                       | Number:Density       | R          | PM10 Air Quality (CO2-Sensor)                  |
+| sensor-co2-pm10-24-hour-average       | Number:Density       | R          | PM10 Air Quality 24 Hour Average (CO2-Sensor)  |
+| sensor-co2-pm25                       | Number:Density       | R          | PM2.5 Air Quality (CO2-Sensor)                 |
+| sensor-co2-pm25-24-hour-average       | Number:Density       | R          | PM2.5 Air Quality 24 Hour Average (CO2-Sensor) |
+| sensor-co2-co2                        | Number:Dimensionless | R          | CO2                                            |
+| sensor-co2-co2-24-hour-average        | Number:Dimensionless | R          | CO2 24 Hour Average                            |
+| leaf-wetness-channel-1                | Number:Dimensionless | R          | Leaf Moisture Channel 1                        |  
+| leaf-wetness-channel-2                | Number:Dimensionless | R          | Leaf Moisture Channel 2                        |
+| leaf-wetness-channel-3                | Number:Dimensionless | R          | Leaf Moisture Channel 3                        |
+| leaf-wetness-channel-4                | Number:Dimensionless | R          | Leaf Moisture Channel 4                        |
+| leaf-wetness-channel-5                | Number:Dimensionless | R          | Leaf Moisture Channel 5                        |
+| leaf-wetness-channel-6                | Number:Dimensionless | R          | Leaf Moisture Channel 6                        |
+| leaf-wetness-channel-7                | Number:Dimensionless | R          | Leaf Moisture Channel 7                        |
+| leaf-wetness-channel-8                | Number:Dimensionless | R          | Leaf Moisture Channel 8                        |
+| piezo-rain-rate                       | Number:Speed         | R          | Piezo - Rainfall Rate                          |
+| piezo-rain-event                      | Number:Length        | R          | Piezo - Amount of Rainfall At the last Rain    |
+| piezo-rain-hour                       | Number:Length        | R          | Piezo - Rainfall Current Hour                  |
+| piezo-rain-day                        | Number:Length        | R          | Piezo - Rainfall Today                         |
+| piezo-rain-week                       | Number:Length        | R          | Piezo - Rainfall this Week                     |
+| piezo-rain-month                      | Number:Length        | R          | Piezo - Rainfall this Month                    |
+| piezo-rain-year                       | Number:Length        | R          | Piezo - Rainfall this Year                     |
 
 NOTE: Not every gateway provides all available data, even if they are displayed in the WS-View app.
 Especially the channels `temperature-dew-point` or `temperature-wind-chill` are derived from other measured values.
@@ -333,7 +337,7 @@ Number:Illuminance        weather_illumination         "Light intensity"        
 Number:Intensity          weather_irradiation_uv       "UV radiation"                        <Sun>         (gOutdoor) ["Measurement", "Light"]        { channel="fineoffsetweatherstation:gateway:3906700515:irradiation-uv" }
 Number:Dimensionless      weather_uv_index             "UV Index"                            <Sun>         (gOutdoor) ["Measurement", "Light"]        { channel="fineoffsetweatherstation:gateway:3906700515:uv-index" }
 Number:Speed              weather_max_day              "Maximum wind speed today"            <Wind>        (gOutdoor) ["Measurement", "Wind"]         { channel="fineoffsetweatherstation:gateway:3906700515:wind-max-day" }
-Number:VolumetricFlowRate weather_rain_rate            "Rainfall rate"                       <Rain>        (gOutdoor) ["Measurement", "Rain"]         { channel="fineoffsetweatherstation:gateway:3906700515:rain-rate" }
+Number:Speed              weather_rain_rate            "Rainfall rate"                       <Rain>        (gOutdoor) ["Measurement", "Rain"]         { channel="fineoffsetweatherstation:gateway:3906700515:rain-rate" }
 Number:Length             weather_rain_day             "Rainfall today"                      <Rain>        (gOutdoor) ["Measurement", "Rain"]         { channel="fineoffsetweatherstation:gateway:3906700515:rain-day" }
 Number:Length             weather_rain_week            "Rainfall this week"                  <Rain>        (gOutdoor) ["Measurement", "Rain"]         { channel="fineoffsetweatherstation:gateway:3906700515:rain-week" }
 Number:Length             weather_rain_month           "Rainfall this month"                 <Rain>        (gOutdoor) ["Measurement", "Rain"]         { channel="fineoffsetweatherstation:gateway:3906700515:rain-month" }

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
@@ -108,7 +108,7 @@
 	</channel-type>
 
 	<channel-type id="rain-rate">
-		<item-type>Number:VolumetricFlowRate</item-type>
+		<item-type>Number:Speed</item-type>
 		<label>Rain Rate</label>
 		<category>Rain</category>
 		<tags>


### PR DESCRIPTION
A community member realized, that the used unit for rain-rate was wrong (https://community.openhab.org/t/fine-offset-weather-station-binding-discussion/134167/153) Rain rate is measured in mm/h and so it is not a `VolumetricFlowRate` but a `Speed`.

Additionally, I added some details to the doc.