### PR TITLE
[knx] Replace gnu.io dependency with serial transport

### DIFF
--- a/bundles/org.openhab.binding.knx/pom.xml
+++ b/bundles/org.openhab.binding.knx/pom.xml
@@ -43,18 +43,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.github.calimero</groupId>
-      <artifactId>calimero-rxtx</artifactId>
-      <version>2.5.1</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <build>

--- a/bundles/org.openhab.binding.knx/pom.xml
+++ b/bundles/org.openhab.binding.knx/pom.xml
@@ -20,6 +20,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <version>${bnd.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-core</artifactId>
       <version>2.5.1</version>
@@ -48,6 +54,23 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <configuration>
+            <bnd><![CDATA[${oh.bndDefaults}
+Require-Capability:
+    osgi.extender:=
+      filter:="(osgi.extender=osgi.serviceloader.processor)",
+    osgi.serviceloader:=
+      filter:="(osgi.serviceloader=tuwien.auto.calimero.serial.spi.SerialCom)";
+      cardinality:=multiple
+SPI-Provider: tuwien.auto.calimero.serial.spi.SerialCom
+SPI-Consumer: java.util.ServiceLoader#load(java.lang.Class[tuwien.auto.calimero.serial.spi.SerialCom])
+            ]]>
+            </bnd>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>

--- a/bundles/org.openhab.binding.knx/pom.xml
+++ b/bundles/org.openhab.binding.knx/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: KNX Binding</name>
 
   <properties>
-    <bnd.importpackage>gnu.io;version="[3.12,6)",javax.microedition.io.*;resolution:="optional",javax.usb.*;resolution:="optional",org.usb4java.*;resolution:="optional"</bnd.importpackage>
+    <bnd.importpackage>javax.microedition.io.*;resolution:="optional",javax.usb.*;resolution:="optional",org.usb4java.*;resolution:="optional"</bnd.importpackage>
   </properties>
 
   <dependencies>

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/client/SerialTransportAdapter.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/client/SerialTransportAdapter.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.knx.internal.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.io.transport.serial.PortInUseException;
+import org.openhab.core.io.transport.serial.SerialPort;
+import org.openhab.core.io.transport.serial.SerialPortIdentifier;
+import org.openhab.core.io.transport.serial.SerialPortManager;
+import org.openhab.core.io.transport.serial.UnsupportedCommOperationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tuwien.auto.calimero.KNXException;
+import tuwien.auto.calimero.serial.spi.SerialCom;
+
+/**
+ * The {@link SerialTransportAdapter} provides org.openhab.core.io.transport.serial
+ * services to the Calimero library.
+ *
+ * @author Holger Friedrich - Initial contribution
+ */
+@NonNullByDefault
+public class SerialTransportAdapter implements SerialCom {
+    private static final int OPEN_TIMEOUT_MS = 200;
+    private static final int RECEIVE_TIMEOUT_MS = 5;
+    private static final int RECEIVE_THRESHOLD = 1024;
+    private static final int BAUDRATE = 19200;
+
+    private Logger logger = LoggerFactory.getLogger(SerialTransportAdapter.class);
+    @Nullable
+    private static SerialPortManager serialPortManager = null;
+    @Nullable
+    private SerialPort serialPort = null;
+
+    public static void setSerialPortManager(SerialPortManager serialPortManager) {
+        SerialTransportAdapter.serialPortManager = serialPortManager;
+    }
+
+    public SerialTransportAdapter() {
+    }
+
+    @Override
+    public void open(@Nullable String portId) throws IOException, KNXException {
+        if (portId == null) {
+            throw new IOException("Port not available");
+        }
+        logger = LoggerFactory.getLogger("SerialTransportAdapter:" + portId);
+
+        final @Nullable SerialPortManager tmpSerialPortManager = serialPortManager;
+        if (tmpSerialPortManager == null) {
+            throw new IOException("PortManager not available");
+        }
+        try {
+            SerialPortIdentifier portIdentifier = tmpSerialPortManager.getIdentifier(portId);
+            if (portIdentifier != null) {
+                logger.trace("Trying to open port {}", portId);
+                SerialPort serialPort = portIdentifier.open(this.getClass().getName(), OPEN_TIMEOUT_MS);
+                // apply default settings for com port, may be overwritten by caller
+                serialPort.setSerialPortParams(BAUDRATE, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
+                        SerialPort.PARITY_EVEN);
+                serialPort.enableReceiveThreshold(RECEIVE_THRESHOLD);
+                serialPort.enableReceiveTimeout(RECEIVE_TIMEOUT_MS);
+                this.serialPort = serialPort;
+
+                // Notification / event listeners are available and may be used to log/trace com failures
+                // serialPort.notifyOnDataAvailable(true);
+                logger.trace("Port opened successfully");
+            } else {
+                logger.info("Port {} not available", portId);
+                throw new IOException("Port " + portId + " not available");
+            }
+        } catch (PortInUseException e) {
+            logger.info("Port {} already in use", portId);
+            throw new IOException("Port " + portId + " already in use", e);
+        } catch (UnsupportedCommOperationException e) {
+            logger.info("Port {} unsupported com operation", portId);
+            throw new IOException("Port " + portId + " unsupported com operation", e);
+        }
+    }
+
+    // SerialCom extends AutoCloseable, close() throws Exception
+    @Override
+    public void close() {
+        logger.trace("Closing serial port");
+        final @Nullable SerialPort tmpSerialPort = serialPort;
+        if (tmpSerialPort != null) {
+            tmpSerialPort.close();
+            serialPort = null;
+        }
+    }
+
+    @Override
+    public @Nullable InputStream inputStream() {
+        final @Nullable SerialPort tmpSerialPort = serialPort;
+        if (tmpSerialPort != null) {
+            try {
+                return tmpSerialPort.getInputStream();
+            } catch (IOException e) {
+                logger.info("Cannot open input stream");
+            }
+        }
+        // should not throw, create a dummy return value
+        byte buf[] = {};
+        return new ByteArrayInputStream(buf);
+    }
+
+    @Override
+    public @Nullable OutputStream outputStream() {
+        final @Nullable SerialPort tmpSerialPort = serialPort;
+        if (tmpSerialPort != null) {
+            try {
+                return tmpSerialPort.getOutputStream();
+            } catch (IOException e) {
+                logger.info("Cannot open output stream");
+            }
+        }
+        // should not throw, create a dummy return value
+        return new ByteArrayOutputStream(0);
+    }
+
+    // disable NonNullByDefault for this function, legacy interface List<String>
+    @NonNullByDefault({})
+    @Override
+    public List<String> portIdentifiers() {
+        final @Nullable SerialPortManager tmpSerialPortManager = serialPortManager;
+        if (tmpSerialPortManager == null) {
+            return Collections.emptyList();
+        }
+        return tmpSerialPortManager.getIdentifiers().map(SerialPortIdentifier::getName).collect(Collectors.toList());
+    }
+
+    @Override
+    public int baudRate() throws IOException {
+        final @Nullable SerialPort tmpSerialPort = serialPort;
+        if (tmpSerialPort == null) {
+            throw new IOException("Port not available");
+        }
+        return tmpSerialPort.getBaudRate();
+    }
+
+    @Override
+    public void setSerialPortParams(final int baudrate, final int databits, @Nullable StopBits stopbits,
+            @Nullable Parity parity) throws IOException {
+        final @Nullable SerialPort tmpSerialPort = serialPort;
+        if (tmpSerialPort == null) {
+            throw new IOException("Port not available");
+        }
+        if ((stopbits == null) || (parity == null)) {
+            throw new IOException("Invalid parameters");
+        }
+        try {
+            tmpSerialPort.setSerialPortParams(baudrate, databits, stopbits.value(), parity.value());
+        } catch (final UnsupportedCommOperationException e) {
+            throw new IOException("Setting serial port parameters for " + tmpSerialPort.getName() + " failed", e);
+        }
+    }
+
+    @Override
+    public void setFlowControlMode(@Nullable FlowControl mode) throws IOException {
+        final @Nullable SerialPort tmpSerialPort = serialPort;
+        if (tmpSerialPort == null) {
+            throw new IOException("Port not available");
+        }
+        if (mode == null) {
+            throw new IOException("Invalid parameters");
+        }
+        if (mode == FlowControl.None) {
+            try {
+                tmpSerialPort.setFlowControlMode(SerialPort.FLOWCONTROL_NONE);
+            } catch (final UnsupportedCommOperationException e) {
+                throw new IOException("Setting flow control parameters for " + tmpSerialPort.getName() + " failed", e);
+            }
+        } else {
+            logger.warn("Unknown FlowControl mode {}", mode);
+            throw new IOException("Invalid flow mode");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/client/SerialTransportAdapter.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/client/SerialTransportAdapter.java
@@ -31,15 +31,24 @@ import org.openhab.core.io.transport.serial.UnsupportedCommOperationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import tuwien.auto.calimero.KNXException;
 import tuwien.auto.calimero.serial.spi.SerialCom;
 
 /**
  * The {@link SerialTransportAdapter} provides org.openhab.core.io.transport.serial
  * services to the Calimero library.
- *
+ * 
+ * @ServiceProvider annotation (biz.aQute.bnd.annotation) automatically creates the file
+ *                  /META-INF/services/tuwien.auto.calimero.serial.spi.SerialCom
+ *                  to register SerialTransportAdapter to the service loader.
+ *                  Additional attributes for SerialTansportAdapter can be specified as well, e.g.
+ *                  attribute = { "position=1" }
+ *                  and will be part of MANIFEST.MF
+ * 
  * @author Holger Friedrich - Initial contribution
  */
+@ServiceProvider(value = SerialCom.class)
 @NonNullByDefault
 public class SerialTransportAdapter implements SerialCom {
     private static final int OPEN_TIMEOUT_MS = 200;

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/factory/KNXHandlerFactory.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/factory/KNXHandlerFactory.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.knx.internal.client.SerialTransportAdapter;
 import org.openhab.binding.knx.internal.handler.DeviceThingHandler;
 import org.openhab.binding.knx.internal.handler.IPBridgeThingHandler;
 import org.openhab.binding.knx.internal.handler.SerialBridgeThingHandler;
@@ -61,6 +62,7 @@ public class KNXHandlerFactory extends BaseThingHandlerFactory {
             final @Reference LocaleProvider localeProvider, final @Reference SerialPortManager serialPortManager) {
         KNXTranslationProvider.I18N.setProvider(localeProvider, translationProvider);
         this.serialPortManager = serialPortManager;
+        SerialTransportAdapter.setSerialPortManager(serialPortManager);
     }
 
     @Override

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/factory/KNXHandlerFactory.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/factory/KNXHandlerFactory.java
@@ -26,6 +26,7 @@ import org.openhab.binding.knx.internal.i18n.KNXTranslationProvider;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
@@ -53,11 +54,13 @@ public class KNXHandlerFactory extends BaseThingHandlerFactory {
 
     @Nullable
     private NetworkAddressService networkAddressService;
+    private final SerialPortManager serialPortManager;
 
     @Activate
     public KNXHandlerFactory(final @Reference TranslationProvider translationProvider,
-            final @Reference LocaleProvider localeProvider) {
+            final @Reference LocaleProvider localeProvider, final @Reference SerialPortManager serialPortManager) {
         KNXTranslationProvider.I18N.setProvider(localeProvider, translationProvider);
+        this.serialPortManager = serialPortManager;
     }
 
     @Override
@@ -87,7 +90,7 @@ public class KNXHandlerFactory extends BaseThingHandlerFactory {
         if (thing.getThingTypeUID().equals(THING_TYPE_IP_BRIDGE)) {
             return new IPBridgeThingHandler((Bridge) thing, networkAddressService);
         } else if (thing.getThingTypeUID().equals(THING_TYPE_SERIAL_BRIDGE)) {
-            return new SerialBridgeThingHandler((Bridge) thing);
+            return new SerialBridgeThingHandler((Bridge) thing, serialPortManager);
         } else if (thing.getThingTypeUID().equals(THING_TYPE_DEVICE)) {
             return new DeviceThingHandler(thing);
         }

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/SerialBridgeThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/SerialBridgeThingHandler.java
@@ -20,6 +20,7 @@ import org.openhab.binding.knx.internal.client.KNXClient;
 import org.openhab.binding.knx.internal.client.NoOpClient;
 import org.openhab.binding.knx.internal.client.SerialClient;
 import org.openhab.binding.knx.internal.config.SerialBridgeConfiguration;
+import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingStatus;
 import org.slf4j.Logger;
@@ -42,8 +43,11 @@ public class SerialBridgeThingHandler extends KNXBridgeBaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(SerialBridgeThingHandler.class);
 
-    public SerialBridgeThingHandler(Bridge bridge) {
+    private final SerialPortManager serialPortManager;
+
+    public SerialBridgeThingHandler(Bridge bridge, final SerialPortManager serialPortManager) {
         super(bridge);
+        this.serialPortManager = serialPortManager;
     }
 
     @Override
@@ -53,7 +57,7 @@ public class SerialBridgeThingHandler extends KNXBridgeBaseThingHandler {
         SerialBridgeConfiguration config = getConfigAs(SerialBridgeConfiguration.class);
         client = new SerialClient(config.getAutoReconnectPeriod(), thing.getUID(), config.getResponseTimeout(),
                 config.getReadingPause(), config.getReadRetriesLimit(), getScheduler(), config.getSerialPort(),
-                config.useCemi(), this);
+                config.useCemi(), serialPortManager, this);
 
         updateStatus(ThingStatus.UNKNOWN);
         // delay actual initialization, allow for longer runtime of actual initialization

--- a/bundles/org.openhab.binding.knx/src/main/resources/META-INF/services/tuwien.auto.calimero.serial.spi.SerialCom
+++ b/bundles/org.openhab.binding.knx/src/main/resources/META-INF/services/tuwien.auto.calimero.serial.spi.SerialCom
@@ -1,1 +1,0 @@
-org.openhab.binding.knx.internal.client.SerialTransportAdapter

--- a/bundles/org.openhab.binding.knx/src/main/resources/META-INF/services/tuwien.auto.calimero.serial.spi.SerialCom
+++ b/bundles/org.openhab.binding.knx/src/main/resources/META-INF/services/tuwien.auto.calimero.serial.spi.SerialCom
@@ -1,0 +1,1 @@
+org.openhab.binding.knx.internal.client.SerialTransportAdapter


### PR DESCRIPTION
~This is still work in progress.~
The goal is to remove dependency on  gnu.io.rxtx and to user openHAB SerialTransport.

Two steps are necessary:
* remove our code in the KNX binding (easy, only used to show available com ports)
* remove the transitive dependency imported with the Calimero library.

Calimero introduced a new way to handle pluggable serial transport classes via the java.util.ServiceLoader in release 2.5.1.
This is in principle working and I was able to connect to our serial communication classes,
~*but* Serviceloader fails once we reload the KNX plugin. I could not get this fixed, so right now openHAB needs a restart to reload the KNX plugin! Any suggestions welcome....~

Calimero seems to change the interface again, after 2.5.1 ~this was removed. I need to have a look how to proceed.~