### PR TITLE
[unifi] Fix PoE bug with combination of other data/ports

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/UniFiControllerRequest.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/UniFiControllerRequest.java
@@ -124,14 +124,14 @@ class UniFiControllerRequest<T> {
     }
 
     public @Nullable T execute() throws UniFiException {
-        T result = null;
+        T result = (T) null;
         final String json = getContent();
         // mgb: only try and unmarshall non-void result types
         if (!Void.class.equals(resultType)) {
             final JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();
 
             if (jsonObject.has(PROPERTY_DATA) && jsonObject.get(PROPERTY_DATA).isJsonArray()) {
-                result = gson.fromJson(jsonObject.getAsJsonArray(PROPERTY_DATA), resultType);
+                result = (T) gson.fromJson(jsonObject.getAsJsonArray(PROPERTY_DATA), resultType);
             }
         }
         return result;

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/cache/UniFiCache.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/cache/UniFiCache.java
@@ -106,7 +106,9 @@ abstract class UniFiCache<T extends @Nullable HasId> {
             logger.debug("Put #{} entries in {}: {}", values.length, getClass().getSimpleName(),
                     lazyFormatAsList(values));
             for (final T value : values) {
-                put(value.getId(), value);
+                if (value != null) {
+                    put(value.getId(), value);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/cache/UniFiDeviceCache.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/cache/UniFiDeviceCache.java
@@ -38,7 +38,8 @@ class UniFiDeviceCache extends UniFiCache<UniFiDevice> {
         switch (prefix) {
             case MAC:
                 return device.getMac();
+            default:
+                return null;
         }
-        return null;
     }
 }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UnfiPortOverrideJsonObject.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UnfiPortOverrideJsonObject.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.unifi.internal.api.dto;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -22,7 +21,7 @@ import com.google.gson.JsonObject;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
-public class UnfiPortOverrideJsonElement {
+public class UnfiPortOverrideJsonObject {
 
     private static final String PORT_IDX = "port_idx";
     private static final String PORT_CONF_ID = "port_conf_id";
@@ -30,12 +29,16 @@ public class UnfiPortOverrideJsonElement {
 
     private final JsonObject jsonObject;
 
-    public UnfiPortOverrideJsonElement(final JsonElement element) {
-        this.jsonObject = element.getAsJsonObject();
+    public UnfiPortOverrideJsonObject(final JsonObject Object) {
+        this.jsonObject = Object.getAsJsonObject();
     }
 
     public JsonObject getJsonObject() {
         return jsonObject;
+    }
+
+    public static boolean hasPortIdx(final JsonObject jsonObject) {
+        return jsonObject.has(PORT_IDX);
     }
 
     public int getPortIdx() {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiDevice.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiDevice.java
@@ -15,7 +15,7 @@ package org.openhab.binding.unifi.internal.api.dto;
 import org.openhab.binding.unifi.internal.api.cache.UniFiControllerCache;
 import org.openhab.binding.unifi.internal.api.util.UniFiTidyLowerCaseStringDeserializer;
 
-import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
@@ -44,7 +44,7 @@ public class UniFiDevice implements HasId {
 
     private UniFiPortTable[] portTable;
 
-    private JsonElement[] portOverrides;
+    private JsonObject[] portOverrides;
 
     public UniFiDevice(final UniFiControllerCache cache) {
         this.cache = cache;
@@ -75,7 +75,7 @@ public class UniFiDevice implements HasId {
         return portTable;
     }
 
-    public JsonElement[] getPortOverrides() {
+    public JsonObject[] getPortOverrides() {
         return portOverrides;
     }
 

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiPortTuple.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiPortTuple.java
@@ -14,7 +14,7 @@ package org.openhab.binding.unifi.internal.api.dto;
 
 /**
  * Tuple to store both the {@link UniFiPortTable}, which contains the all information related to the port,
- * and the {@link UnfiPortOverrideJsonElement}, which contains the raw json data of the port override.
+ * and the {@link UnfiPortOverrideJsonObject}, which contains the raw json data of the port override.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
@@ -24,7 +24,7 @@ public class UniFiPortTuple {
 
     private UniFiPortTable table;
 
-    private UnfiPortOverrideJsonElement jsonElement;
+    private UnfiPortOverrideJsonObject jsonElement;
 
     public UniFiDevice getDevice() {
         return device;
@@ -46,11 +46,11 @@ public class UniFiPortTuple {
         this.table = table;
     }
 
-    public UnfiPortOverrideJsonElement getJsonElement() {
+    public UnfiPortOverrideJsonObject getJsonElement() {
         return jsonElement;
     }
 
-    public void setJsonElement(final UnfiPortOverrideJsonElement jsonElement) {
+    public void setJsonElement(final UnfiPortOverrideJsonObject jsonElement) {
         this.jsonElement = jsonElement;
     }
 }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiSwitchPorts.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiSwitchPorts.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.unifi.internal.api.dto;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Data object to keep track of all port data, including all port_override data (both for ports and additional data) on
+ * a switch device.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+@NonNullByDefault
+public class UniFiSwitchPorts {
+
+    /**
+     * Port data grouped by port id.
+     */
+    private final Map<Integer, UniFiPortTuple> ports = new HashMap<>();
+    /**
+     * Additional none port specific override data. Keep track to send to device when updating override data.
+     */
+    private final Set<JsonObject> otherOverrides = new HashSet<>();
+
+    /**
+     * Return port data for the given port
+     *
+     * @param portIdx port to get the data for
+     * @return Return port data for the given port
+     */
+    public @Nullable UniFiPortTuple getPort(final int portIdx) {
+        return ports.get(portIdx);
+    }
+
+    /**
+     * Return port data for the given port or if none exists set a new data object and return it.
+     *
+     * @param portIdx port to get the data for
+     * @return Return port data for the given port or if none exists set a new data object and return it.
+     */
+    public UniFiPortTuple computeIfAbsent(final int portIdx) {
+        final UniFiPortTuple tuple = ports.computeIfAbsent(portIdx, t -> new UniFiPortTuple());
+        if (tuple == null) {
+            // This should never happen because ports can never contain a null value, and computeIfAbsent should never
+            // return null. However to satisfy the compiler a check for null was added.
+            throw new IllegalStateException("UniFiPortTuple is null for portIdx " + portIdx);
+        }
+        return tuple;
+    }
+
+    /**
+     * @return Returns the list of PoE Ports.
+     */
+    public List<UniFiPortTuple> getPoePorts() {
+        return ports.values().stream().filter(e -> e.getTable().isPortPoe()).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the override data as list with json objects after calling the updateMethod on the data for the given
+     * portIdx.
+     * The update method changes the data in the internal structure.
+     *
+     * @param portIdx port to call updateMethod for
+     * @param updateMethod method to call to update data for a specific port
+     * @return Returns a list of json objects of all override data
+     */
+    public List<JsonObject> updatedList(final int portIdx, final Consumer<UnfiPortOverrideJsonObject> updateMethod) {
+        @SuppressWarnings("null")
+        final List<UnfiPortOverrideJsonObject> updatedList = ports.entrySet().stream()
+                .map(e -> e.getValue().getJsonElement()).filter(Objects::nonNull).collect(Collectors.toList());
+
+        updatedList.stream().filter(p -> p.getPortIdx() == portIdx).findAny().ifPresent(updateMethod::accept);
+
+        return Stream
+                .concat(otherOverrides.stream(), updatedList.stream().map(UnfiPortOverrideJsonObject::getJsonObject))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Set the port override object. If it's for a specific port set bind it to the port data, otherwise store it as
+     * generic data.
+     *
+     * @param jsonObject json object to set
+     */
+    public void setOverride(final JsonObject jsonObject) {
+        if (UnfiPortOverrideJsonObject.hasPortIdx(jsonObject)) {
+            final UnfiPortOverrideJsonObject po = new UnfiPortOverrideJsonObject(jsonObject);
+            final UniFiPortTuple tuple = ports.get(po.getPortIdx());
+
+            if (tuple == null) {
+                otherOverrides.add(jsonObject);
+            } else {
+                tuple.setJsonElement(po);
+            }
+        } else {
+            otherOverrides.add(jsonObject);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/util/UnfiPortOverrideJsonElementDeserializer.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/util/UnfiPortOverrideJsonElementDeserializer.java
@@ -15,22 +15,22 @@ package org.openhab.binding.unifi.internal.api.util;
 import java.lang.reflect.Type;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.unifi.internal.api.dto.UnfiPortOverrideJsonElement;
+import org.openhab.binding.unifi.internal.api.dto.UnfiPortOverrideJsonObject;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 /**
- * Serializer for {@link UnfiPortOverrideJsonElement}. Returns the content of the jsonObject in the class.
+ * Serializer for {@link UnfiPortOverrideJsonObject}. Returns the content of the jsonObject in the class.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
 @NonNullByDefault
-public class UnfiPortOverrideJsonElementDeserializer implements JsonSerializer<UnfiPortOverrideJsonElement> {
+public class UnfiPortOverrideJsonElementDeserializer implements JsonSerializer<UnfiPortOverrideJsonObject> {
 
     @Override
-    public JsonElement serialize(final UnfiPortOverrideJsonElement src, final Type typeOfSrc,
+    public JsonElement serialize(final UnfiPortOverrideJsonObject src, final Type typeOfSrc,
             final JsonSerializationContext context) {
         return src.getJsonObject();
     }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiBaseThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiBaseThingHandler.java
@@ -61,6 +61,7 @@ public abstract class UniFiBaseThingHandler<E, C> extends BaseThingHandler {
             return;
         }
         // mgb: derive the config class from the generic type
+        @SuppressWarnings("null")
         final Class<?> clazz = (Class<?>) (((ParameterizedType) getClass().getGenericSuperclass())
                 .getActualTypeArguments()[1]);
         final C config = (C) getConfigAs(clazz);
@@ -99,7 +100,7 @@ public abstract class UniFiBaseThingHandler<E, C> extends BaseThingHandler {
         logger.debug("Handling command = {} for channel = {}", command, channelUID);
         // mgb: only handle commands if we're ONLINE
         if (getThing().getStatus() == ONLINE) {
-            final E entity = getEntity();
+            final @Nullable E entity = getEntity();
             final UniFiController controller = getController();
 
             if (command == REFRESH) {
@@ -128,13 +129,13 @@ public abstract class UniFiBaseThingHandler<E, C> extends BaseThingHandler {
     protected final void refresh() {
         // mgb: only refresh if we're ONLINE
         if (getThing().getStatus() == ONLINE) {
-            final E entity = getEntity();
+            final @Nullable E entity = getEntity();
 
             getThing().getChannels().forEach(channel -> updateState(entity, channel.getUID()));
         }
     }
 
-    private void updateState(final E entity, final ChannelUID channelUID) {
+    private void updateState(final @Nullable E entity, final ChannelUID channelUID) {
         final String channelId = channelUID.getId();
         final State state = Optional.ofNullable(entity).map(e -> getChannelState(e, channelId))
                 .orElseGet(() -> getDefaultState(channelId));

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiControllerThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiControllerThingHandler.java
@@ -39,6 +39,7 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.openhab.core.types.Command;
@@ -107,13 +108,15 @@ public class UniFiControllerThingHandler extends BaseBridgeHandler {
     @Override
     public void dispose() {
         cancelRefreshJob();
+        final UniFiController controller = this.controller;
+
         if (controller != null) {
             try {
                 controller.stop();
             } catch (final UniFiException e) {
                 // mgb: nop as we're in dispose
             }
-            controller = null;
+            this.controller = null;
         }
     }
 
@@ -188,8 +191,10 @@ public class UniFiControllerThingHandler extends BaseBridgeHandler {
             uc.refresh();
             // mgb: then refresh all the client things
             getThing().getThings().forEach((thing) -> {
-                if (thing.getHandler() instanceof UniFiBaseThingHandler) {
-                    ((UniFiBaseThingHandler) thing.getHandler()).refresh();
+                final ThingHandler handler = thing.getHandler();
+
+                if (handler instanceof UniFiBaseThingHandler) {
+                    ((UniFiBaseThingHandler<?, ?>) handler).refresh();
                 }
             });
         }

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiThingDiscoveryService.java
@@ -21,7 +21,6 @@ import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER
 import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER_WIFI_NAME;
 
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -34,6 +33,7 @@ import org.openhab.binding.unifi.internal.api.cache.UniFiControllerCache;
 import org.openhab.binding.unifi.internal.api.dto.UniFiClient;
 import org.openhab.binding.unifi.internal.api.dto.UniFiPortTuple;
 import org.openhab.binding.unifi.internal.api.dto.UniFiSite;
+import org.openhab.binding.unifi.internal.api.dto.UniFiSwitchPorts;
 import org.openhab.binding.unifi.internal.api.dto.UniFiWlan;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -161,9 +161,8 @@ public class UniFiThingDiscoveryService extends AbstractDiscoveryService
     }
 
     private void discoverPoePorts(final UniFiControllerCache cache, final ThingUID bridgeUID) {
-        for (final Map<Integer, UniFiPortTuple> uc : cache.getSwitchPorts()) {
-            for (final Entry<Integer, UniFiPortTuple> sp : uc.entrySet()) {
-                final UniFiPortTuple pt = sp.getValue();
+        for (final UniFiSwitchPorts uc : cache.getSwitchPorts()) {
+            for (final UniFiPortTuple pt : uc.getPoePorts()) {
                 final String deviceMac = pt.getDevice().getMac();
                 final String id = deviceMac.replace(":", "") + "_" + pt.getPortIdx();
                 final ThingUID thingUID = new ThingUID(UniFiBindingConstants.THING_TYPE_POE_PORT, bridgeUID, id);

--- a/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/i18n/unifi.properties
+++ b/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/i18n/unifi.properties
@@ -127,7 +127,7 @@ channel-type.unifi.wpaMode.description = WPA Mode of the Wi-Fi network
 channel-type.config.unifi.poeEnable.mode.label = On Mode
 channel-type.config.unifi.poeEnable.mode.description = The value to set when setting PoE on.
 channel-type.config.unifi.poeEnable.mode.option.auto = Auto
-channel-type.config.unifi.poeEnable.mode.option.pasv24v = 24V
+channel-type.config.unifi.poeEnable.mode.option.pasv24 = 24V
 channel-type.config.unifi.poeEnable.mode.option.passthrough = Passthrough
 
 # status messages


### PR DESCRIPTION
- It seems to throw an exception when updating internal cache. It can happen if you have a switch that has both PoE ports and other PoE ports or data in the port override.
- Fixed logout, should be POST instead of GET.
- Fixed typo in channel-type.config.unifi.poeEnable.mode.option.pasv24 should be without appending v.
- Removed compiler warnings.
