### PR TITLE
[rrd4j] Improve logging of exceptions thrown by getDB

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -156,7 +156,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         try {
             db = getDB(name);
         } catch (Exception e) {
-            logger.warn("Failed to open rrd4j database '{}' ({})", name, e.getClass().getName());
+            logger.warn("Failed to open rrd4j database '{}' to store data ({})", name, e.toString());
         }
         if (db == null) {
             return;
@@ -258,7 +258,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         try {
             db = getDB(itemName);
         } catch (Exception e) {
-            logger.warn("Failed to open rrd4j database '{}' ({})", itemName, e.getClass().getName());
+            logger.warn("Failed to open rrd4j database '{}' for querying ({})", itemName, e.toString());
             return List.of();
         }
         if (db == null) {


### PR DESCRIPTION
I have seen a discussion about warning messages from rrd4j in the 3.4 release discussion thread.
https://community.openhab.org/t/openhab-3-4-release-discussion/142257/130

The current log may look like this:
> Failed to open rrd4j database ‘...’ (java.lang.IllegalStateException)

This not really helpful for identifying the root cause, as rrd4j library uses ```llegalStateException``` at many different places, but with specific error messages.

So we should make use of the method ```getMessage()```. ```toString()``` will actually print class name and message (if available).
This will it make easier to understand issues being reported.
(should IMHO also be cherry picked for potential 3.4.x patch release)