### PR TITLE
[shelly] TRV: Add selectedProfile state option "Disabled" and made it selectable

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -351,8 +351,8 @@ public class ShellyDeviceProfile {
 
     public String getValueProfile(int valveId, int profileId) {
         int id = profileId;
-        if (id <= 0 && settings.thermostats != null) {
-            id = settings.thermostats.get(0).profile;
+        if (id <= 0 || id > 5) {
+            id = 0;
         }
         return "" + id;
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -602,6 +602,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             String channelId = mkChannelId(CHANNEL_GROUP_CONTROL, CHANNEL_CONTROL_PROFILE);
             logger.debug("{}: Adding TRV profile names to channel description: {}", thingName, profileNames);
             channelDefinitions.clearStateOptions(channelId);
+            channelDefinitions.addStateOption(channelId, "0",
+                    "0: " + messages.get("channel-type.shelly.controlProfile.disabled"));
             int fid = 1;
             for (String name : profileNames) {
                 channelDefinitions.addStateOption(channelId, "" + fid, fid + ": " + name);

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -419,6 +419,7 @@ channel-type.shelly.controlMode.state.option.manual = Manual
 channel-type.shelly.controlMode.state.option.automatic = Automatic
 channel-type.shelly.controlProfile.label = Selected Profile
 channel-type.shelly.controlProfile.description = Id of the selected Profile configured in the Shelly App
+channel-type.shelly.controlProfile.disabled = Disabled
 channel-type.shelly.controlSchedule.label = Schedule Active
 channel-type.shelly.controlSchedule.description = ON: A scheduled program is active
 channel-type.shelly.boostControl.label = Boost Mode

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly_de.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly_de.properties
@@ -395,6 +395,7 @@ channel-type.shelly.controlMode.state.option.manual = Manuell
 channel-type.shelly.controlMode.state.option.automatic = Automatisch
 channel-type.shelly.controlProfile.label = Ausgewähltes Profil
 channel-type.shelly.controlProfile.description = Ausgewähltes Profil (wird in der Shelly App konfiguriert)
+channel-type.shelly.controlProfile.disabled = Deaktiviert
 channel-type.shelly.controlSchedule.label = Zeitplan aktiv
 channel-type.shelly.controlSchedule.description = ON\: Ein Zeitplan ist aktiv
 channel-type.shelly.boostControl.label = Boost-Modus


### PR DESCRIPTION
The selectedProfile did not have 0:Disabled in its state options and even if adding it manually, it could not be selected. Now the behaviour of the selectedProfile channel matches the profile selection on the device itself, as well as the documentation of the shelly binding.

Fixes https://github.com/openhab/openhab-addons/issues/14069

