### PR TITLE
Update i18n command version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In some cases the command does not work, and requires the full plug-in name.
 In that case use:
 
 ```shell
-mvn org.openhab.core.tools:i18n-maven-plugin:3.3.0:generate-default-translations
+mvn org.openhab.core.tools:i18n-maven-plugin:3.4.0:generate-default-translations
 ```
 
 


### PR DESCRIPTION
update i18n example command line to ```3.4.0```

For me it makes more sense to use the stable version ```3.4.0```, even if we are on snapshot.
```4.0.0-SNAPSHOT``` would work as well, but always fetch a lot of artifacts.