### PR TITLE
[dbquery] Upgrade Gson to 2.9.1

### DIFF
--- a/bundles/org.openhab.binding.dbquery/pom.xml
+++ b/bundles/org.openhab.binding.dbquery/pom.xml
@@ -45,7 +45,7 @@
     <dependency> <!-- also used for querydb library -->
       <artifactId>gson</artifactId>
       <groupId>com.google.code.gson</groupId>
-      <version>2.8.9</version>
+      <version>2.9.1</version>
     </dependency>
     <dependency>
       <artifactId>gson-fire</artifactId>


### PR DESCRIPTION
Related to #14088
Triggered by openhab/openhab-core#2994 (where Gson was upgraded to 2.9.1)
Previous upgrade: #12798

JAR for testing: [org.openhab.binding.dbquery-4.0.0-SNAPSHOT.jar](https://drive.google.com/file/d/1kGMMl0ogFpqUTMoapzB9lFfA_aHEsVmA/view?usp=sharing)
(I have not been able to test this myself)