### PR TITLE
[influxdb] Upgrade Gson to 2.9.1

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <artifactId>gson</artifactId>
       <groupId>com.google.code.gson</groupId>
-      <version>2.8.9</version>
+      <version>2.9.1</version>
     </dependency>
     <dependency>
       <artifactId>gson-fire</artifactId>


### PR DESCRIPTION
Related to #14088
Triggered by openhab/openhab-core#2994 (where Gson was upgraded to 2.9.1)
Previous upgrade: #12772

JAR for testing: [org.openhab.persistence.influxdb-4.0.0-SNAPSHOT.jar](https://drive.google.com/file/d/1j8avqdE3sWtfXoq-n0Nus1NLZvk53PwF/view?usp=sharing)
(I have not been able to test this myself)