### PR TITLE
[watsonstt] Upgrade Gson to 2.9.1

### DIFF
--- a/bundles/org.openhab.voice.watsonstt/pom.xml
+++ b/bundles/org.openhab.voice.watsonstt/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version>
+      <version>2.9.1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Related to #14088
Triggered by openhab/openhab-core#2994 (where Gson was upgraded to 2.9.1)

JAR for testing: [org.openhab.voice.watsonstt-4.0.0-SNAPSHOT.jar](https://drive.google.com/file/d/1lhTouRY6mKC19BNcJLBTsSRd78oDdOuK/view?usp=sharing)
(I have not been able to test this myself)