### PR TITLE
[bluetooth.generic] Upgrade Gson to 2.9.1

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Related to #14088
Triggered by openhab/openhab-core#2994 (where Gson was upgraded to 2.9.1)

JAR for testing: [org.openhab.binding.bluetooth.generic-4.0.0-SNAPSHOT.jar](https://drive.google.com/file/d/17JRGVtrmlAbVdi69tCplgGRB-UUxkcd_/view?usp=sharing)
(I have not been able to test this myself)