### PR TITLE
[jsscripting] Upgrade to ECMAScript 2022 & Dependency improvements

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -121,7 +121,6 @@
       <artifactId>js-scriptengine</artifactId>
       <version>${graal.version}</version>
     </dependency>
-    <!-- org.graalvm.js/js-launcher is GraalVM's JavaScript command line interpreter and not required here -->
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
@@ -138,7 +137,6 @@
       <version>${graal.version}</version>
     </dependency>
     <!-- GraalJS changelog says that com.ibm.icu/icu4j is not required for GraalJS >= 22.0.0 as it moved to org.graalvm.truffle;
-      but GraalJS >= 22.2.0 requires it -->
-    <!-- org.ow2.asm is not required as compile dependency for GraalJS >= 20.3.0 -->
+      but GraalJS >= 22.2.0 requires it, so we'll need to add it when we upgrade -->
   </dependencies>
 </project>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -23,7 +23,6 @@
       !jdk.vm.ci.services
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 -->
-    <asm.version>6.2.1</asm.version>
     <oh.version>${project.version}</oh.version>
     <ohjs.version>openhab@3.1.2</ohjs.version>
   </properties>
@@ -143,32 +142,6 @@
       <version>${graal.version}</version>
     </dependency>
     <!-- com.ibm.icu.icu4j/69.1 is not required on GraalJS >= 22.0.0 as it moved to org.graalvm.truffle -->
-
-    <!-- include as version required is older than OH provides -->
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-commons</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-tree</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-util</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-analysis</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
+    <!-- org.ow2.asm is not required as compile dependency anymore for GraalJS >= 20.3.0 -->
   </dependencies>
 </project>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -121,11 +121,7 @@
       <artifactId>js-scriptengine</artifactId>
       <version>${graal.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.graalvm.js</groupId>
-      <artifactId>js-launcher</artifactId>
-      <version>${graal.version}</version>
-    </dependency>
+    <!-- org.graalvm.js/js-launcher is GraalJS's command line interpreter and not required here -->
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -22,7 +22,7 @@
       !jdk.internal.reflect.*,
       !jdk.vm.ci.services
     </bnd.importpackage>
-    <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 -->
+    <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
     <ohjs.version>openhab@3.1.2</ohjs.version>
   </properties>
@@ -121,7 +121,7 @@
       <artifactId>js-scriptengine</artifactId>
       <version>${graal.version}</version>
     </dependency>
-    <!-- org.graalvm.js/js-launcher is GraalJS's command line interpreter and not required here -->
+    <!-- org.graalvm.js/js-launcher is GraalVM's JavaScript command line interpreter and not required here -->
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
@@ -137,7 +137,13 @@
       <artifactId>js</artifactId>
       <version>${graal.version}</version>
     </dependency>
-    <!-- com.ibm.icu.icu4j/69.1 is not required on GraalJS >= 22.0.0 as it moved to org.graalvm.truffle -->
-    <!-- org.ow2.asm is not required as compile dependency anymore for GraalJS >= 20.3.0 -->
+    <!-- GraalJS changelog says that com.ibm.icu/icu4j is not required for GraalJS >= 22.0.0 as it moved to org.graalvm.truffle;
+      but GraalJS >= 22.2.0 requires it -->
+    <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>71.1</version>
+    </dependency>
+    <!-- org.ow2.asm is not required as compile dependency for GraalJS >= 20.3.0 -->
   </dependencies>
 </project>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -139,11 +139,6 @@
     </dependency>
     <!-- GraalJS changelog says that com.ibm.icu/icu4j is not required for GraalJS >= 22.0.0 as it moved to org.graalvm.truffle;
       but GraalJS >= 22.2.0 requires it -->
-    <dependency>
-      <groupId>com.ibm.icu</groupId>
-      <artifactId>icu4j</artifactId>
-      <version>71.1</version>
-    </dependency>
     <!-- org.ow2.asm is not required as compile dependency for GraalJS >= 20.3.0 -->
   </dependencies>
 </project>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -113,10 +113,12 @@ public class OpenhabGraalJSScriptEngine
                         .build(),
                 Context.newBuilder("js").allowExperimentalOptions(true).allowAllAccess(true)
                         .allowHostAccess(HOST_ACCESS).option("js.commonjs-require-cwd", JSDependencyTracker.LIB_PATH)
-                        .option("js.nashorn-compat", "true") // to ease migration
-                        .option("js.ecmascript-version", "2021") // nashorn compat will enforce es5 compatibility, we
-                                                                 // want ecma2021
-                        .option("js.commonjs-require", "true") // enable CommonJS module support
+                        .option("js.nashorn-compat", "false") // Disable Nashorn compat mode as it's functionality
+                                                              // shouldn't be used (openhab-js does not use it), see
+                                                              // https://www.graalvm.org/22.3/reference-manual/js/NashornMigrationGuide/
+                        .option("js.ecmascript-version", "2022") // If Nashorn compat is enabled, it will enforce ES5
+                                                                 // compatibility, we want ECMA2022
+                        .option("js.commonjs-require", "true") // Enable CommonJS module support
                         .hostClassLoader(getClass().getClassLoader())
                         .fileSystem(new DelegatingFileSystem(FileSystems.getDefault().provider()) {
                             @Override

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -113,9 +113,9 @@ public class OpenhabGraalJSScriptEngine
                         .build(),
                 Context.newBuilder("js").allowExperimentalOptions(true).allowAllAccess(true)
                         .allowHostAccess(HOST_ACCESS).option("js.commonjs-require-cwd", JSDependencyTracker.LIB_PATH)
-                        .option("js.nashorn-compat", "false") // Disable Nashorn compat mode as it's functionality
-                                                              // shouldn't be used (openhab-js does not use it), see
-                                                              // https://www.graalvm.org/22.3/reference-manual/js/NashornMigrationGuide/
+                        .option("js.nashorn-compat", "true") // Enable Nashorn compat mode as openhab-js relies on
+                                                             // accessors, see
+                                                             // https://github.com/oracle/graaljs/blob/master/docs/user/NashornMigrationGuide.md#accessors
                         .option("js.ecmascript-version", "2022") // If Nashorn compat is enabled, it will enforce ES5
                                                                  // compatibility, we want ECMA2022
                         .option("js.commonjs-require", "true") // Enable CommonJS module support


### PR DESCRIPTION
## Description

- Remove `org.ow2.asm` from dependency, as it is not required by GraalJS since 20.3.0
- Remove `org.graalvm.js`/js-launcher dependency, as we don't need the JavaScript command line interpreter
- ~Disable Nashorn compatiblity mode as it's additional functionality is not used by openhab-js and very unlikely used by any user.~ Don't disable Nashorn compat mode as the library relies on some Nashorn accessors: https://github.com/oracle/graaljs/blob/master/docs/user/NashornMigrationGuide.md#accessors.
- **Enable new ECMAScript-2022 features like private properties for classes**

**Note: I also wanted to upgrade to GraalJS 22.3.0, but it is failing with the same error message as on OpenJDK 11 on armv7l, so we cannot upgrade :cry:** 

## Testing

I have tested this change on these system/JDK combinations and it works on both of them:

x86_64: `Linux fedora 6.0.15-200.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Wed Dec 21 18:46:09 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux` with 
```
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment GraalVM CE 22.3.0 (build 17.0.5+8-jvmci-22.3-b08)
OpenJDK 64-Bit Server VM GraalVM CE 22.3.0 (build 17.0.5+8-jvmci-22.3-b08, mixed mode, sharing)
```
and
```
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment (Red_Hat-17.0.5.0.8-3.fc36) (build 17.0.5+8)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.5.0.8-3.fc36) (build 17.0.5+8, mixed mode, sharing)
```

Raspberry Pi 3B+: `Linux homeberrypi 5.10.103-v7+ #1529 SMP Tue Mar 8 12:21:37 GMT 2022 armv7l GNU/Linux` with
```
openjdk 17.0.5 2022-10-18
OpenJDK Runtime Environment Zulu17.38+21-CA (build 17.0.5+8)
OpenJDK Server VM Zulu17.38+21-CA (build 17.0.5+8, mixed mode)
```