### PR TITLE
[mqtt] Fix shutdownRetain default value

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/thing/thing-types.xml
@@ -157,7 +157,7 @@
 			<parameter name="shutdownRetain" type="boolean">
 				<label>Shutdown Message Retain</label>
 				<description>True if the shutdown message should be retained (defaults to true)</description>
-				<default>false</default>
+				<default>true</default>
 				<advanced>true</advanced>
 			</parameter>
 


### PR DESCRIPTION
The documentation and java code set the default for `shutdownRetain` to true, but the thing-types.xml sets it to false. I came across a bug when I didn't specify `shutdownRetain` in my mqtt bridge config, and it appears to have been set to false, when I expected it to default to true. This resulted in an unexpected behaviour.

The workaround is to explicitly set `shutdownRetain` to true in the thing config, until this PR is merged.