### PR TITLE
[bondhome] Fix fatal Null Pointer errors

### DIFF
--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/BondException.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/BondException.java
@@ -21,6 +21,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class BondException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private boolean wasBridgeSetOffline;
 
     public BondException(String message) {

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BPUPListener.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BPUPListener.java
@@ -130,9 +130,11 @@ public class BPUPListener implements Runnable {
                 sock.receive(inPacket);
                 BPUPUpdate response = transformUpdatePacket(inPacket);
                 if (response != null) {
-                    if (!response.bondId.equalsIgnoreCase(bridgeHandler.getBridgeId())) {
+                    @Nullable
+                    String bondId = response.bondId;
+                    if (bondId == null || !bondId.equalsIgnoreCase(bridgeHandler.getBridgeId())) {
                         logger.warn("Response isn't from expected Bridge!  Expected: {}  Got: {}",
-                                bridgeHandler.getBridgeId(), response.bondId);
+                                bridgeHandler.getBridgeId(), bondId);
                     } else {
                         bridgeHandler.setBridgeOnline(inPacket.getAddress().getHostAddress());
                         numberOfKeepAliveTimeouts = 0;

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BPUPUpdate.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BPUPUpdate.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.api;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDevice.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDevice.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.api;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceProperties.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceProperties.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.api;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceState.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceState.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.api;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceType.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceType.java
@@ -35,6 +35,7 @@ public enum BondDeviceType {
     FIREPLACE(THING_TYPE_BOND_FIREPLACE),
     @SerializedName("GX")
     GENERIC_DEVICE(THING_TYPE_BOND_GENERIC);
+    // TODO: add Light ("LT") type
 
     private ThingTypeUID deviceTypeUid;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHash.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHash.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.api;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -90,12 +90,10 @@ public class BondHttpApi {
      * @throws BondException
      */
     public List<String> getDevices() throws BondException {
-
         List<String> list = new ArrayList<>();
         String json = request("/v2/devices/");
         try {
-            JsonParser parser = new JsonParser();
-            JsonElement element = parser.parse(json);
+            JsonElement element = JsonParser.parseString(json);
             JsonObject obj = element.getAsJsonObject();
             Set<Map.Entry<String, JsonElement>> entries = obj.entrySet();
             for (Map.Entry<String, JsonElement> entry : entries) {

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -252,7 +252,7 @@ public class BondHttpApi {
                     logger.debug("Repeated Bond API calls to {} failed.", uri);
                     bridgeHandler.setBridgeOffline(ThingStatusDetail.COMMUNICATION_ERROR,
                             "@text/offline.comm-error.api-call-failed");
-                    throw new BondException("@text/offline.conf-error.api-call-failed", true);
+                    throw new BondException("@text/offline.comm-error.api-call-failed", true);
                 }
             }
         } while (true);

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondSysVersion.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondSysVersion.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.api;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/config/BondBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/config/BondBridgeConfiguration.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.bondhome.internal.config;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link BondBridgeConfiguration} class contains fields mapping thing
@@ -29,15 +26,19 @@ public class BondBridgeConfiguration {
     /**
      * Configuration for a Bond Bridge
      */
-    public @Nullable String serialNumber;
-    public @Nullable String localToken;
-    public @Nullable String ipAddress;
+    public String serialNumber = "";
+    public String localToken = "";
+    public String ipAddress = "";
 
-    public @Nullable String getIpAddress() {
+    public String getIpAddress() {
         return ipAddress;
     }
 
     public void setIpAddress(String ipAddress) {
         this.ipAddress = ipAddress;
+    }
+
+    public boolean isValid() {
+        return !(serialNumber.isEmpty() || localToken.isEmpty() || ipAddress.isEmpty());
     }
 }

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/config/BondDeviceConfiguration.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/config/BondDeviceConfiguration.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.bondhome.internal.config;
 
-import static org.openhab.binding.bondhome.internal.BondHomeBindingConstants.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
@@ -94,7 +94,7 @@ public class BondDiscoveryService extends AbstractDiscoveryService implements Th
                 for (final String deviceId : deviceList) {
                     BondDevice thisDevice = api.getDevice(deviceId);
                     String deviceName;
-                    if (thisDevice != null && (deviceName = thisDevice.name) != null) {
+                    if (thisDevice != null && thisDevice.type != null && (deviceName = thisDevice.name) != null) {
                         final ThingUID deviceUid = new ThingUID(thisDevice.type.getThingTypeUID(), bridgeUid, deviceId);
                         final DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(deviceUid)
                                 .withBridge(bridgeUid).withLabel(thisDevice.name)

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
@@ -59,9 +59,11 @@ public class BondDiscoveryService extends AbstractDiscoveryService implements Th
     @Override
     public void setThingHandler(@Nullable ThingHandler handler) {
         if (handler instanceof BondBridgeHandler) {
-            bridgeHandler = (BondBridgeHandler) handler;
-            bridgeHandler.setDiscoveryService(this);
-            api = bridgeHandler.getBridgeAPI();
+            @Nullable
+            BondBridgeHandler localHandler = (BondBridgeHandler) handler;
+            bridgeHandler = localHandler;
+            localHandler.setDiscoveryService(this);
+            api = localHandler.getBridgeAPI();
         }
     }
 
@@ -94,7 +96,7 @@ public class BondDiscoveryService extends AbstractDiscoveryService implements Th
                 for (final String deviceId : deviceList) {
                     BondDevice thisDevice = api.getDevice(deviceId);
                     String deviceName;
-                    if (thisDevice != null && thisDevice.type != null && (deviceName = thisDevice.name) != null) {
+                    if (thisDevice.type != null && (deviceName = thisDevice.name) != null) {
                         final ThingUID deviceUid = new ThingUID(thisDevice.type.getThingTypeUID(), bridgeUid, deviceId);
                         final DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(deviceUid)
                                 .withBridge(bridgeUid).withLabel(thisDevice.name)

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
@@ -554,10 +554,12 @@ public class BondDeviceHandler extends BaseThingHandler {
         Set<String> availableChannelIds = new HashSet<>();
 
         for (BondDeviceAction action : currentActions) {
-            String actionType = action.getChannelTypeId();
-            if (actionType != null) {
-                availableChannelIds.add(actionType);
-                logger.trace(" Action: {}, Relevant Channel Type Id: {}", action.getActionId(), actionType);
+            if (action != null) {
+                String actionType = action.getChannelTypeId();
+                if (actionType != null) {
+                    availableChannelIds.add(actionType);
+                    logger.trace(" Action: {}, Relevant Channel Type Id: {}", action.getActionId(), actionType);
+                }
             }
         }
         // Remove power channels if we have a dimmer channel for them;
@@ -625,7 +627,7 @@ public class BondDeviceHandler extends BaseThingHandler {
             BondDeviceProperties devProperties = this.deviceProperties;
             if (devProperties != null) {
                 double maxSpeed = devProperties.maxSpeed;
-                value = (int) (((double) updateState.speed / maxSpeed) * 100);
+                value = (int) ((updateState.speed / maxSpeed) * 100);
                 logger.trace("Raw fan speed: {}, Percent: {}", updateState.speed, value);
             } else if (updateState.speed != 0 && this.getThing().getThingTypeUID().equals(THING_TYPE_BOND_FAN)) {
                 logger.info("Unable to convert fan speed to a percent for {}!", this.getThing().getLabel());

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
@@ -627,7 +627,7 @@ public class BondDeviceHandler extends BaseThingHandler {
             BondDeviceProperties devProperties = this.deviceProperties;
             if (devProperties != null) {
                 double maxSpeed = devProperties.maxSpeed;
-                value = (int) ((updateState.speed / maxSpeed) * 100);
+                value = (int) (((double) updateState.speed / maxSpeed) * 100);
                 logger.trace("Raw fan speed: {}, Percent: {}", updateState.speed, value);
             } else if (updateState.speed != 0 && this.getThing().getThingTypeUID().equals(THING_TYPE_BOND_FAN)) {
                 logger.info("Unable to convert fan speed to a percent for {}!", this.getThing().getLabel());

--- a/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/i18n/bondhome.properties
+++ b/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/i18n/bondhome.properties
@@ -82,7 +82,7 @@ channel-type.bondhome.timerChannelType.description = Starts a timer for s second
 
 # thing status descriptions
 
-offline.comm-error.api-call-failed = Bond API call to {} failed: {}
+offline.comm-error.api-call-failed = Bond API call failed.
 offline.comm-error.device-not-found = No Bond device found with the given device id.
 offline.comm-error.no-api = Bond Bridge API not available.
 offline.comm-error.no-response = No response received!


### PR DESCRIPTION
I just got a bond bridge today. I tried to use the binding and ran into several fatal errors that stopped the binding from functioning:

1. When I changed the IP of the bridge the binding would fail connecting to the old address. An error in the translation file caused an exception when calling setBridgeOffline(),
2. In my bridge, I set up a 'Light' aka 'LT' item and this is apparently not supported by BondDeviceType. This caused the discovery service to fail when the BondDevice with a null 'type' was encountered.
3. The list of actions in one or more BondDevice objects contained null entries that would cause an NPE in deleteExtraChannels()