### PR TITLE
[bondhome] Fix fatal Null Pointer errors

### DIFF
--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceType.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceType.java
@@ -35,6 +35,7 @@ public enum BondDeviceType {
     FIREPLACE(THING_TYPE_BOND_FIREPLACE),
     @SerializedName("GX")
     GENERIC_DEVICE(THING_TYPE_BOND_GENERIC);
+    // TODO: add Light ("LT") type
 
     private ThingTypeUID deviceTypeUid;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -250,7 +250,7 @@ public class BondHttpApi {
                     logger.debug("Repeated Bond API calls to {} failed.", uri);
                     bridgeHandler.setBridgeOffline(ThingStatusDetail.COMMUNICATION_ERROR,
                             "@text/offline.comm-error.api-call-failed");
-                    throw new BondException("@text/offline.conf-error.api-call-failed", true);
+                    throw new BondException("@text/offline.comm-error.api-call-failed", true);
                 }
             }
         } while (true);

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -120,7 +120,9 @@ public class BondHttpApi {
         String json = request("/v2/devices/" + deviceId);
         logger.trace("BondHome device info : {}", json);
         try {
-            return Objects.requireNonNull(gson.fromJson(json, BondDevice.class));
+            BondDevice device = Objects.requireNonNull(gson.fromJson(json, BondDevice.class));
+            device.actions.removeIf(Objects::isNull);
+            return device;
         } catch (JsonParseException e) {
             logger.debug("Could not parse device {}'s JSON '{}'", deviceId, json, e);
             throw new BondException("@text/offline.comm-error.unparseable-response");

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
@@ -96,7 +96,7 @@ public class BondDiscoveryService extends AbstractDiscoveryService implements Th
                 for (final String deviceId : deviceList) {
                     BondDevice thisDevice = api.getDevice(deviceId);
                     String deviceName;
-                    if ((deviceName = thisDevice.name) != null) {
+                    if (thisDevice.type != null && (deviceName = thisDevice.name) != null) {
                         final ThingUID deviceUid = new ThingUID(thisDevice.type.getThingTypeUID(), bridgeUid, deviceId);
                         final DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(deviceUid)
                                 .withBridge(bridgeUid).withLabel(thisDevice.name)

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
@@ -554,12 +554,10 @@ public class BondDeviceHandler extends BaseThingHandler {
         Set<String> availableChannelIds = new HashSet<>();
 
         for (BondDeviceAction action : currentActions) {
-            if (action != null) {
-                String actionType = action.getChannelTypeId();
-                if (actionType != null) {
-                    availableChannelIds.add(actionType);
-                    logger.trace(" Action: {}, Relevant Channel Type Id: {}", action.getActionId(), actionType);
-                }
+            String actionType = action.getChannelTypeId();
+            if (actionType != null) {
+                availableChannelIds.add(actionType);
+                logger.trace(" Action: {}, Relevant Channel Type Id: {}", action.getActionId(), actionType);
             }
         }
         // Remove power channels if we have a dimmer channel for them;
@@ -627,7 +625,7 @@ public class BondDeviceHandler extends BaseThingHandler {
             BondDeviceProperties devProperties = this.deviceProperties;
             if (devProperties != null) {
                 double maxSpeed = devProperties.maxSpeed;
-                value = (int) (((double) updateState.speed / maxSpeed) * 100);
+                value = (int) ((updateState.speed / maxSpeed) * 100);
                 logger.trace("Raw fan speed: {}, Percent: {}", updateState.speed, value);
             } else if (updateState.speed != 0 && this.getThing().getThingTypeUID().equals(THING_TYPE_BOND_FAN)) {
                 logger.info("Unable to convert fan speed to a percent for {}!", this.getThing().getLabel());

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
@@ -625,7 +625,7 @@ public class BondDeviceHandler extends BaseThingHandler {
             BondDeviceProperties devProperties = this.deviceProperties;
             if (devProperties != null) {
                 double maxSpeed = devProperties.maxSpeed;
-                value = (int) ((updateState.speed / maxSpeed) * 100);
+                value = (int) (((double) updateState.speed / maxSpeed) * 100);
                 logger.trace("Raw fan speed: {}, Percent: {}", updateState.speed, value);
             } else if (updateState.speed != 0 && this.getThing().getThingTypeUID().equals(THING_TYPE_BOND_FAN)) {
                 logger.info("Unable to convert fan speed to a percent for {}!", this.getThing().getLabel());

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
@@ -554,10 +554,12 @@ public class BondDeviceHandler extends BaseThingHandler {
         Set<String> availableChannelIds = new HashSet<>();
 
         for (BondDeviceAction action : currentActions) {
-            String actionType = action.getChannelTypeId();
-            if (actionType != null) {
-                availableChannelIds.add(actionType);
-                logger.trace(" Action: {}, Relevant Channel Type Id: {}", action.getActionId(), actionType);
+            if (action != null) {
+                String actionType = action.getChannelTypeId();
+                if (actionType != null) {
+                    availableChannelIds.add(actionType);
+                    logger.trace(" Action: {}, Relevant Channel Type Id: {}", action.getActionId(), actionType);
+                }
             }
         }
         // Remove power channels if we have a dimmer channel for them;
@@ -625,7 +627,7 @@ public class BondDeviceHandler extends BaseThingHandler {
             BondDeviceProperties devProperties = this.deviceProperties;
             if (devProperties != null) {
                 double maxSpeed = devProperties.maxSpeed;
-                value = (int) (((double) updateState.speed / maxSpeed) * 100);
+                value = (int) ((updateState.speed / maxSpeed) * 100);
                 logger.trace("Raw fan speed: {}, Percent: {}", updateState.speed, value);
             } else if (updateState.speed != 0 && this.getThing().getThingTypeUID().equals(THING_TYPE_BOND_FAN)) {
                 logger.info("Unable to convert fan speed to a percent for {}!", this.getThing().getLabel());

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondDeviceHandler.java
@@ -627,7 +627,7 @@ public class BondDeviceHandler extends BaseThingHandler {
             BondDeviceProperties devProperties = this.deviceProperties;
             if (devProperties != null) {
                 double maxSpeed = devProperties.maxSpeed;
-                value = (int) ((updateState.speed / maxSpeed) * 100);
+                value = (int) (((double) updateState.speed / maxSpeed) * 100);
                 logger.trace("Raw fan speed: {}, Percent: {}", updateState.speed, value);
             } else if (updateState.speed != 0 && this.getThing().getThingTypeUID().equals(THING_TYPE_BOND_FAN)) {
                 logger.info("Unable to convert fan speed to a percent for {}!", this.getThing().getLabel());

--- a/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/i18n/bondhome.properties
+++ b/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/i18n/bondhome.properties
@@ -82,7 +82,7 @@ channel-type.bondhome.timerChannelType.description = Starts a timer for s second
 
 # thing status descriptions
 
-offline.comm-error.api-call-failed = Bond API call to {} failed: {}
+offline.comm-error.api-call-failed = Bond API call failed.
 offline.comm-error.device-not-found = No Bond device found with the given device id.
 offline.comm-error.no-api = Bond Bridge API not available.
 offline.comm-error.no-response = No response received!


### PR DESCRIPTION
I just got a bond bridge today. I tried to use the binding and ran into several fatal errors that stopped the binding from functioning:

1. When I changed the IP of the bridge the binding would fail connecting to the old address. An error in the translation file caused an exception when calling setBridgeOffline(),
2. In my bridge, I set up a 'Light' aka 'LT' item and this is apparently not supported by BondDeviceType. This caused the discovery service to fail when the BondDevice with a null 'type' was encountered.
3. The list of actions in one or more BondDevice objects contained null entries that would cause an NPE in deleteExtraChannels()

