### PR TITLE
[chromecast] Fix constant disconnections

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/discovery/ChromecastDiscoveryParticipant.java
@@ -14,6 +14,7 @@ package org.openhab.binding.chromecast.internal.discovery;
 
 import static org.openhab.binding.chromecast.internal.ChromecastBindingConstants.*;
 
+import java.net.Inet4Address;
 import java.util.Dictionary;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +90,11 @@ public class ChromecastDiscoveryParticipant implements MDNSDiscoveryParticipant 
         if (isAutoDiscoveryEnabled) {
             ThingUID uid = getThingUID(service);
             if (uid != null) {
-                String host = service.getHostAddresses()[0];
+                Inet4Address[] addresses = service.getInet4Addresses();
+                if (addresses.length == 0) {
+                    return null;
+                }
+                String host = addresses[0].getHostAddress();
                 int port = service.getPort();
                 logger.debug("Chromecast Found: {} {}", host, port);
                 String id = service.getPropertyString(PROPERTY_DEVICE_ID);


### PR DESCRIPTION
When ipv6 is configured on the network, Chromecast devices will randomly return ipv4 and/or multiple ipv6 addresses during mdns discovery. As a result of this, the discovered ip address keeps changing which would trigger a thingUpdated call which will then call dispose/initialize, causing the thing to go offline/online.

I'm experiencing this issue and it's also reported in https://community.openhab.org/t/openhab-3-4-release-discussion/142257/98 

