### PR TITLE
[daikin] Add support for Alira X

### DIFF
--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
@@ -46,6 +46,7 @@ public class ControlInfo {
     /* Not supported by all units. Sets the target humidity for dehumidifying. */
     public Optional<Integer> targetHumidity = Optional.empty();
     public AdvancedMode advancedMode = AdvancedMode.UNKNOWN;
+    public boolean separatedDirectionParams = false;
 
     private ControlInfo() {
     }
@@ -69,6 +70,7 @@ public class ControlInfo {
                     .flatMap(value -> InfoParser.parseInt(value)).map(value -> FanMovement.fromValue(value))
                     .orElse(FanMovement.STOPPED);
         } else {
+            info.separatedDirectionParams = true;
             String ud = responseMap.get("f_dir_ud");
             String lr = responseMap.get("f_dir_lr");
             if (ud != null && lr != null) {
@@ -90,12 +92,16 @@ public class ControlInfo {
         params.put("pow", power ? "1" : "0");
         params.put("mode", Integer.toString(mode.getValue()));
         params.put("f_rate", fanSpeed.getValue());
-        params.put("f_dir", Integer.toString(fanMovement.getValue()));
-        params.put("f_dir_lr",
-                fanMovement == FanMovement.VERTICAL || fanMovement == FanMovement.VERTICAL_AND_HORIZONTAL ? "S" : "0");
-        params.put("f_dir_ud",
-                fanMovement == FanMovement.HORIZONTAL || fanMovement == FanMovement.VERTICAL_AND_HORIZONTAL ? "S"
-                        : "0");
+        if (separatedDirectionParams) {
+            params.put("f_dir_lr",
+                    fanMovement == FanMovement.VERTICAL || fanMovement == FanMovement.VERTICAL_AND_HORIZONTAL ? "S"
+                            : "0");
+            params.put("f_dir_ud",
+                    fanMovement == FanMovement.HORIZONTAL || fanMovement == FanMovement.VERTICAL_AND_HORIZONTAL ? "S"
+                            : "0");
+        } else {
+            params.put("f_dir", Integer.toString(fanMovement.getValue()));
+        }
         params.put("stemp", temp.orElse(20.0).toString());
         params.put("shum", targetHumidity.map(value -> value.toString()).orElse(""));
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/InfoParser.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/InfoParser.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class InfoParser {
-    private static final Logger logger = LoggerFactory.getLogger(InfoParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfoParser.class);
 
     private InfoParser() {
     }
@@ -93,7 +93,7 @@ public class InfoParser {
         try {
             return URLDecoder.decode(value, StandardCharsets.UTF_8.toString());
         } catch (UnsupportedEncodingException e) {
-            logger.warn("Unsupported encoding error in '{}'", value, e);
+            LOGGER.warn("Unsupported encoding error in '{}'", value, e);
             return value;
         }
     }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/InfoParser.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/InfoParser.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.daikin.internal.api.Enums.FanMovement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +95,21 @@ public class InfoParser {
         } catch (UnsupportedEncodingException e) {
             logger.warn("Unsupported encoding error in '{}'", value, e);
             return value;
+        }
+    }
+
+    /**
+     * This method combines different direction parameters to one.
+     * 
+     * @param ud up/ down value S or 0
+     * @param lr left/ right value S or 0
+     * @return combined int value based on {@link FanMovement} enum
+     */
+    public static int parseSpecial(String ud, String lr) {
+        if ("S".equals(ud)) {
+            return "S".equals(lr) ? FanMovement.VERTICAL_AND_HORIZONTAL.getValue() : FanMovement.VERTICAL.getValue();
+        } else {
+            return "S".equals(lr) ? FanMovement.HORIZONTAL.getValue() : FanMovement.STOPPED.getValue();
         }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/InfoParser.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/InfoParser.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.daikin.internal.api.Enums.FanMovement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,21 +94,6 @@ public class InfoParser {
         } catch (UnsupportedEncodingException e) {
             LOGGER.warn("Unsupported encoding error in '{}'", value, e);
             return value;
-        }
-    }
-
-    /**
-     * This method combines different direction parameters to one.
-     * 
-     * @param ud up/ down value S or 0
-     * @param lr left/ right value S or 0
-     * @return combined int value based on {@link FanMovement} enum
-     */
-    public static int parseSpecial(String ud, String lr) {
-        if ("S".equals(ud)) {
-            return "S".equals(lr) ? FanMovement.VERTICAL_AND_HORIZONTAL.getValue() : FanMovement.VERTICAL.getValue();
-        } else {
-            return "S".equals(lr) ? FanMovement.HORIZONTAL.getValue() : FanMovement.STOPPED.getValue();
         }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
@@ -64,23 +64,8 @@ public class AirbaseControlInfo {
         boolean fAuto = "1".equals(responseMap.getOrDefault("f_auto", "0"));
         boolean fAirside = "1".equals(responseMap.getOrDefault("f_airside", "0"));
         info.fanSpeed = AirbaseFanSpeed.fromValue(fRate, fAuto, fAirside);
-
-        // determine if device has combined direction (f_dir) or seperated directions (f_dir_ud/f_dir_lr)
-        if (response.contains("f_dir=")) {
-            info.fanMovement = Optional.ofNullable(responseMap.get("f_dir"))
-                    .flatMap(value -> InfoParser.parseInt(value)).map(value -> AirbaseFanMovement.fromValue(value))
-                    .orElse(AirbaseFanMovement.STOPPED);
-        } else {
-            String ud = responseMap.get("f_dir_ud");
-            String lr = responseMap.get("f_dir_lr");
-            if (ud != null && lr != null) {
-                int combinedValue = InfoParser.parseSpecial(ud, lr);
-                info.fanMovement = AirbaseFanMovement.fromValue(combinedValue);
-            } else {
-                info.fanMovement = AirbaseFanMovement.UNKNOWN;
-            }
-        }
-
+        info.fanMovement = Optional.ofNullable(responseMap.get("f_dir")).flatMap(value -> InfoParser.parseInt(value))
+                .map(value -> AirbaseFanMovement.fromValue(value)).orElse(AirbaseFanMovement.STOPPED);
         info.targetHumidity = Optional.ofNullable(responseMap.get("shum")).flatMap(value -> InfoParser.parseInt(value));
         return info;
     }
@@ -93,8 +78,6 @@ public class AirbaseControlInfo {
         params.put("f_auto", fanSpeed.getAuto() ? "1" : "0");
         params.put("f_airside", fanSpeed.getAirside() ? "1" : "0");
         params.put("f_dir", Integer.toString(fanMovement.getValue()));
-        params.put("f_dir_lr", fanMovement.getValue() == 1 || fanMovement.getValue() == 3 ? "S" : "0");
-        params.put("f_dir_ud", fanMovement.getValue() == 2 || fanMovement.getValue() == 3 ? "S" : "0");
         params.put("stemp", temp.orElse(20.0).toString());
         params.put("shum", targetHumidity.map(value -> value.toString()).orElse(""));
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
@@ -59,11 +59,11 @@ public class AirbaseControlInfo {
         info.mode = Optional.ofNullable(responseMap.get("mode")).flatMap(value -> InfoParser.parseInt(value))
                 .map(value -> AirbaseMode.fromValue(value)).orElse(AirbaseMode.AUTO);
         info.temp = Optional.ofNullable(responseMap.get("stemp")).flatMap(value -> InfoParser.parseDouble(value));
-        int f_rate = Optional.ofNullable(responseMap.get("f_rate")).flatMap(value -> InfoParser.parseInt(value))
+        int fRate = Optional.ofNullable(responseMap.get("f_rate")).flatMap(value -> InfoParser.parseInt(value))
                 .orElse(1);
-        boolean f_auto = "1".equals(responseMap.getOrDefault("f_auto", "0"));
-        boolean f_airside = "1".equals(responseMap.getOrDefault("f_airside", "0"));
-        info.fanSpeed = AirbaseFanSpeed.fromValue(f_rate, f_auto, f_airside);
+        boolean fAuto = "1".equals(responseMap.getOrDefault("f_auto", "0"));
+        boolean fAirside = "1".equals(responseMap.getOrDefault("f_airside", "0"));
+        info.fanSpeed = AirbaseFanSpeed.fromValue(fRate, fAuto, fAirside);
 
         // determine if device has combined direction (f_dir) or seperated directions (f_dir_ud/f_dir_lr)
         if (response.contains("f_dir=")) {
@@ -71,8 +71,8 @@ public class AirbaseControlInfo {
                     .flatMap(value -> InfoParser.parseInt(value)).map(value -> AirbaseFanMovement.fromValue(value))
                     .orElse(AirbaseFanMovement.STOPPED);
         } else {
-            var ud = responseMap.get("f_dir_ud");
-            var lr = responseMap.get("f_dir_lr");
+            String ud = responseMap.get("f_dir_ud");
+            String lr = responseMap.get("f_dir_lr");
             if (ud != null && lr != null) {
                 int combinedValue = InfoParser.parseSpecial(ud, lr);
                 info.fanMovement = AirbaseFanMovement.fromValue(combinedValue);

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseModelInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseModelInfo.java
@@ -35,7 +35,7 @@ public class AirbaseModelInfo {
     public String ret = "";
     public int zonespresent;
     public int commonzone;
-    public int frate_steps; // fan rate steps
+    public int fRateSteps;
     public EnumSet<AirbaseFeature> features;
 
     private AirbaseModelInfo() {
@@ -53,7 +53,7 @@ public class AirbaseModelInfo {
                 .orElse(0);
         info.commonzone = Optional.ofNullable(responseMap.get("en_common_zone"))
                 .flatMap(value -> InfoParser.parseInt(value)).orElse(0);
-        info.frate_steps = Optional.ofNullable(responseMap.get("frate_steps"))
+        info.fRateSteps = Optional.ofNullable(responseMap.get("frate_steps"))
                 .flatMap(value -> InfoParser.parseInt(value)).orElse(1);
         for (AirbaseFeature f : AirbaseFeature.values()) {
             if ("1".equals(responseMap.get(f.getValue()))) {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseModelInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseModelInfo.java
@@ -35,7 +35,7 @@ public class AirbaseModelInfo {
     public String ret = "";
     public int zonespresent;
     public int commonzone;
-    public int fRateSteps;
+    public int fRateSteps; // fan rate steps
     public EnumSet<AirbaseFeature> features;
 
     private AirbaseModelInfo() {

--- a/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/AirbaseControlInfoTest.java
+++ b/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/AirbaseControlInfoTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.daikin.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseControlInfo;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanMovement;
+
+/**
+ * This class provides tests for deconz lights
+ *
+ * @author Leo Siepel - Initial contribution
+ *
+ */
+
+@NonNullByDefault
+public class AirbaseControlInfoTest {
+
+    @BeforeEach
+    public void initialize() {
+    }
+
+    @Test
+    public void seperateUpAndDown() {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.VERTICAL, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void seperateLeftAndRightTest() {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.HORIZONTAL, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void seperateStoppedTest() {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.STOPPED, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void seperateThreeDimensionalTest() {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.VERTICAL_AND_HORIZONTAL, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void combinedUpAndDown() {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=1,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.VERTICAL, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void combinedLeftAndRightTest() throws IOException {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=2,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.HORIZONTAL, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void combinedStoppedTest() throws IOException {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.STOPPED, airBaseInfo.fanMovement);
+    }
+
+    @Test
+    public void combinedThreeDimensionalTest() throws IOException {
+        // arrange
+        String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=3,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
+
+        // act
+        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+
+        // assert
+        assertEquals(AirbaseFanMovement.VERTICAL_AND_HORIZONTAL, airBaseInfo.fanMovement);
+    }
+}

--- a/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/ControlInfoTest.java
+++ b/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/ControlInfoTest.java
@@ -19,8 +19,7 @@ import java.io.IOException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openhab.binding.daikin.internal.api.airbase.AirbaseControlInfo;
-import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanMovement;
+import org.openhab.binding.daikin.internal.api.Enums.FanMovement;
 
 /**
  * This class provides tests for deconz lights
@@ -30,7 +29,7 @@ import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanMo
  */
 
 @NonNullByDefault
-public class AirbaseControlInfoTest {
+public class ControlInfoTest {
 
     @BeforeEach
     public void initialize() {
@@ -42,10 +41,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.VERTICAL, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.VERTICAL, Info.fanMovement);
     }
 
     @Test
@@ -54,10 +53,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.HORIZONTAL, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.HORIZONTAL, Info.fanMovement);
     }
 
     @Test
@@ -66,10 +65,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.STOPPED, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.STOPPED, Info.fanMovement);
     }
 
     @Test
@@ -78,10 +77,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.VERTICAL_AND_HORIZONTAL, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.VERTICAL_AND_HORIZONTAL, Info.fanMovement);
     }
 
     @Test
@@ -90,10 +89,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=1,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.VERTICAL, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.VERTICAL, Info.fanMovement);
     }
 
     @Test
@@ -102,10 +101,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=2,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.HORIZONTAL, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.HORIZONTAL, Info.fanMovement);
     }
 
     @Test
@@ -114,10 +113,10 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.STOPPED, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.STOPPED, Info.fanMovement);
     }
 
     @Test
@@ -126,9 +125,9 @@ public class AirbaseControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=3,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        AirbaseControlInfo airBaseInfo = AirbaseControlInfo.parse(incomingMessage);
+        ControlInfo Info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(AirbaseFanMovement.VERTICAL_AND_HORIZONTAL, airBaseInfo.fanMovement);
+        assertEquals(FanMovement.VERTICAL_AND_HORIZONTAL, Info.fanMovement);
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/ControlInfoTest.java
+++ b/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/ControlInfoTest.java
@@ -41,10 +41,10 @@ public class ControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.VERTICAL, Info.fanMovement);
+        assertEquals(FanMovement.VERTICAL, info.fanMovement);
     }
 
     @Test
@@ -53,10 +53,10 @@ public class ControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.HORIZONTAL, Info.fanMovement);
+        assertEquals(FanMovement.HORIZONTAL, info.fanMovement);
     }
 
     @Test
@@ -65,22 +65,22 @@ public class ControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.STOPPED, Info.fanMovement);
+        assertEquals(FanMovement.STOPPED, info.fanMovement);
     }
 
     @Test
-    public void separateThreeDimensionalTest() {
+    public void separateTwoDimensionalTest() {
         // arrange
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.VERTICAL_AND_HORIZONTAL, Info.fanMovement);
+        assertEquals(FanMovement.VERTICAL_AND_HORIZONTAL, info.fanMovement);
     }
 
     @Test
@@ -89,10 +89,10 @@ public class ControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=1,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.VERTICAL, Info.fanMovement);
+        assertEquals(FanMovement.VERTICAL, info.fanMovement);
     }
 
     @Test
@@ -101,10 +101,10 @@ public class ControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=2,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.HORIZONTAL, Info.fanMovement);
+        assertEquals(FanMovement.HORIZONTAL, info.fanMovement);
     }
 
     @Test
@@ -113,21 +113,21 @@ public class ControlInfoTest {
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.STOPPED, Info.fanMovement);
+        assertEquals(FanMovement.STOPPED, info.fanMovement);
     }
 
     @Test
-    public void combinedThreeDimensionalTest() throws IOException {
+    public void combinedTwoDimensionalTest() throws IOException {
         // arrange
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir=3,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
 
         // act
-        ControlInfo Info = ControlInfo.parse(incomingMessage);
+        ControlInfo info = ControlInfo.parse(incomingMessage);
 
         // assert
-        assertEquals(FanMovement.VERTICAL_AND_HORIZONTAL, Info.fanMovement);
+        assertEquals(FanMovement.VERTICAL_AND_HORIZONTAL, info.fanMovement);
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/ControlInfoTest.java
+++ b/bundles/org.openhab.binding.daikin/src/test/java/org/openhab/binding/daikin/internal/api/ControlInfoTest.java
@@ -36,7 +36,7 @@ public class ControlInfoTest {
     }
 
     @Test
-    public void seperateUpAndDown() {
+    public void separateUpAndDown() {
         // arrange
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=S0,ndfd4=00,ndfd6=00,ndfdh=00";
 
@@ -48,7 +48,7 @@ public class ControlInfoTest {
     }
 
     @Test
-    public void seperateLeftAndRightTest() {
+    public void separateLeftAndRightTest() {
         // arrange
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=0S,ndfd4=00,ndfd6=00,ndfdh=00";
 
@@ -60,7 +60,7 @@ public class ControlInfoTest {
     }
 
     @Test
-    public void seperateStoppedTest() {
+    public void separateStoppedTest() {
         // arrange
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=0,f_dir_lr=0,ndfd1=00,ndfd2=00,ndfd3=00,ndfd4=00,ndfd6=00,ndfdh=00";
 
@@ -72,7 +72,7 @@ public class ControlInfoTest {
     }
 
     @Test
-    public void seperateThreeDimensionalTest() {
+    public void separateThreeDimensionalTest() {
         // arrange
         String incomingMessage = "ret=OK,pow=0,mode=3,stemp=21.0,shum=0,adv=13,dt1=21.0,dt2=M,dt3=21.0,dt4=25.0,dh1=0,dh2=0,dh3=0,dh4=0,dhh=0,alert=16,f_rate=3,dfr1=A,dfr2=A,dfr3=3,dfr4=A,dfr6=A,dfrh=0,f_dir_ud=S,f_dir_lr=S,ndfd1=00,ndfd2=00,ndfd3=SS,ndfd4=00,ndfd6=00,ndfdh=00";
 


### PR DESCRIPTION
Adds support for the Alira X and maybe more devices.

Before  devices reported the fan movement in an API parameter `f_dir` that holds combined values for horizontal/vertical moment. This changes alse supports devices that have this movement parameter split into `f_dir_lr` (horizontal) and `f_dir_ud` (vertial).
I added several tests to the parsing of both seperated and combined parameters.

Also fix some very minor checkstyle while at it.
Create a jar for testing on 3.4.0: https://1drv.ms/u/s!AnMcxmvEeupwjp1-KSBYK96ylDpC7A?e=7nxdWo 