### PR TITLE
[jsscripting] Improve performance & reduce memory usage

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -71,7 +71,7 @@ public class OpenhabGraalJSScriptEngine
     private static final String REQUIRE_WRAPPER_NAME = "__wraprequire__";
     /** Final CommonJS search path for our library */
     private static final Path NODE_DIR = Paths.get("node_modules");
-    /** Shared Polyglot {@link Engine} across all instances of {@link OpenhabGraalJSScriptEngine} for performance and memory improvements */
+    /** Shared Polyglot {@link Engine} across all instances of {@link OpenhabGraalJSScriptEngine} */
     private static final Engine ENGINE = Engine.newBuilder().allowExperimentalOptions(true)
             .option("engine.WarnInterpreterOnly", "false").build();
     /** Provides unlimited host access as well as custom translations from JS to Java Objects */
@@ -229,7 +229,9 @@ public class OpenhabGraalJSScriptEngine
         initialized = true;
 
         try {
+            LOGGER.debug("Evaluating global script...");
             eval(globalScript);
+            LOGGER.debug("Successfully initialized GraalJS script engine.");
         } catch (ScriptException e) {
             LOGGER.error("Could not inject global script", e);
         }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -71,6 +71,9 @@ public class OpenhabGraalJSScriptEngine
     private static final String REQUIRE_WRAPPER_NAME = "__wraprequire__";
     /** Final CommonJS search path for our library */
     private static final Path NODE_DIR = Paths.get("node_modules");
+    /** Shared Polyglot {@link Engine} across all instances of {@link OpenhabGraalJSScriptEngine} for performance and memory improvements */
+    private static final Engine ENGINE = Engine.newBuilder().allowExperimentalOptions(true)
+            .option("engine.WarnInterpreterOnly", "false").build();
     /** Provides unlimited host access as well as custom translations from JS to Java Objects */
     private static final HostAccess HOST_ACCESS = HostAccess.newBuilder(HostAccess.ALL)
             // Translate JS-Joda ZonedDateTime to java.time.ZonedDateTime
@@ -108,9 +111,7 @@ public class OpenhabGraalJSScriptEngine
 
         LOGGER.debug("Initializing GraalJS script engine...");
 
-        delegate = GraalJSScriptEngine.create(
-                Engine.newBuilder().allowExperimentalOptions(true).option("engine.WarnInterpreterOnly", "false")
-                        .build(),
+        delegate = GraalJSScriptEngine.create(ENGINE,
                 Context.newBuilder("js").allowExperimentalOptions(true).allowAllAccess(true)
                         .allowHostAccess(HOST_ACCESS).option("js.commonjs-require-cwd", JSDependencyTracker.LIB_PATH)
                         .option("js.nashorn-compat", "true") // to ease migration


### PR DESCRIPTION
## Description

### Improve performance

Performance is improved by caching parts of the global code that is injected into each new script, see https://github.com/openhab/openhab-addons/pull/14113/commits/e4c95471fba2416a2c3da8b4f07640638048c9cf.
Currently, only the `@jsscripting-globals.js` is cached, but if you disable the injection of globals into UI scripts inside the UI's settings, you can see the effect of this code caching: scripts are extremely fast evaluated, even on my Pi 3 the evaluation time is nearly zero.

For some background, see:
- https://www.graalvm.org/22.0/reference-manual/embed-languages/#code-caching-across-multiple-contexts
- https://www.graalvm.org/sdk/javadoc/

I would like to also cache the library code, but I am not sure how to do this while keeping the ability to reload the library during runtime of the addon. Since this will be a larger change, I won’t do this in this PR.

### Reduce memory usage

This is mainly done by sharing one `org.graalvm.polyglot.Engine` across all `OpenhabGraalJSScriptEngine`s, see https://github.com/openhab/openhab-addons/pull/14113/commits/a86e32a0dd7cd5af44f0879cdf23e7d83ac4d731.

Also see https://github.com/oracle/graaljs/issues/121#issuecomment-880056648, it is not required to have one engine per GraalJSScriptEngine.

This results in the following: With 5 GraalJS UI scripts, heap usage is now below 100 MB. Before this change, it was over 100 MB.

## Concerns One Can Have

- Multi-threaded access problems: This is no problem with the current changes, see the conversation below with my test script.
- Memory leak: As far as I can see from my heap dumps, the current changes do not lead to any memory leak.

Current changes refers to what changed until commit https://github.com/openhab/openhab-addons/pull/14113/commits/e4c95471fba2416a2c3da8b4f07640638048c9cf.


@digitaldan This might be interesting for you and I’d like to get your review here.