### PR TITLE
[groovyscripting] Update Groovy to 4.0.7

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/README.md
+++ b/bundles/org.openhab.automation.groovyscripting/README.md
@@ -1,6 +1,6 @@
 # Groovy Scripting
 
-This add-on provides support for [Groovy](https://groovy-lang.org/) 3.0.13 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
+This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.7 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
 
 ## Creating Groovy Scripts
 

--- a/bundles/org.openhab.automation.groovyscripting/pom.xml
+++ b/bundles/org.openhab.automation.groovyscripting/pom.xml
@@ -16,19 +16,25 @@
 
   <properties>
     <bnd.importpackage>com.ibm.icu.*;resolution:=optional,groovy.runtime.metaclass;resolution:=optional,groovyjarjarantlr4.stringtemplate;resolution:=optional,org.abego.treelayout.*;resolution:=optional,org.apache.ivy.*;resolution:=optional,org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
-    <groovy.version>3.0.13</groovy.version>
+    <groovy.version>4.0.7</groovy.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy</artifactId>
       <version>${groovy.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-jsr223</artifactId>
+      <version>${groovy.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy-xml</artifactId>
       <version>${groovy.version}</version>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
Updates Groovy from 3.0.13 to 4.0.7.

For Groovy 4.0 release notes, see:

https://groovy-lang.org/releasenotes/groovy-4.0.html#releasenotes