### PR TITLE
Update Jackson version to 2.14.1

### DIFF
--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -95,7 +95,6 @@ Import-Package: \
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
-	jakarta.ws.rs-api;version='[2.1.6,2.1.7)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.openhab.binding.mqtt;version='[4.0.0,4.0.1)',\
 	org.openhab.binding.mqtt.generic;version='[4.0.0,4.0.1)',\

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -95,7 +95,6 @@ Import-Package: \
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
-	jakarta.ws.rs-api;version='[2.1.6,2.1.7)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.openhab.binding.mqtt;version='[4.0.0,4.0.1)',\
 	org.openhab.binding.mqtt.generic;version='[4.0.0,4.0.1)',\

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -45,7 +45,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	com.fasterxml.woodstox.woodstox-core;version='[6.2.6,6.2.7)',\
 	org.apache.cxf.cxf-core;version='[3.4.5,3.4.6)',\
 	org.apache.cxf.cxf-rt-frontend-jaxrs;version='[3.4.5,3.4.6)',\
 	org.apache.cxf.cxf-rt-rs-client;version='[3.4.5,3.4.6)',\
@@ -107,4 +106,5 @@ Fragment-Host: org.openhab.binding.nest
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	org.openhab.core.thing.xml;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)',\
+	com.fasterxml.woodstox.woodstox-core;version='[6.4.0,6.4.1)'

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <bnd.version>6.4.0</bnd.version>
     <commons.net.version>3.9.0</commons.net.version>
     <eea.version>2.2.1</eea.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
     <karaf.version>4.3.7</karaf.version>
     <netty.version>4.1.72.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>


### PR DESCRIPTION
This is the version used in the feature provided by openhab-core.

Depends on openhab/openhab-core#3284