### PR TITLE
[tesla] Synchronize access to account to avoid concurrency issues

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
@@ -818,31 +818,34 @@ public class TeslaVehicleHandler extends BaseThingHandler {
         if (authHeader != null) {
             try {
                 // get a list of vehicles
-                Response response = account.vehiclesTarget.request(MediaType.APPLICATION_JSON_TYPE)
-                        .header("Authorization", authHeader).get();
+                synchronized (account.vehiclesTarget) {
+                    Response response = account.vehiclesTarget.request(MediaType.APPLICATION_JSON_TYPE)
+                            .header("Authorization", authHeader).get();
 
-                logger.debug("Querying the vehicle, response : {}, {}", response.getStatus(),
-                        response.getStatusInfo().getReasonPhrase());
+                    logger.debug("Querying the vehicle, response : {}, {}", response.getStatus(),
+                            response.getStatusInfo().getReasonPhrase());
 
-                if (!checkResponse(response, true)) {
-                    logger.debug("An error occurred while querying the vehicle");
-                    return null;
-                }
-
-                JsonObject jsonObject = JsonParser.parseString(response.readEntity(String.class)).getAsJsonObject();
-                Vehicle[] vehicleArray = gson.fromJson(jsonObject.getAsJsonArray("response"), Vehicle[].class);
-
-                for (Vehicle vehicle : vehicleArray) {
-                    logger.debug("Querying the vehicle: VIN {}", vehicle.vin);
-                    if (vehicle.vin.equals(getConfig().get(VIN))) {
-                        vehicleJSON = gson.toJson(vehicle);
-                        parseAndUpdate("queryVehicle", null, vehicleJSON);
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Vehicle is id {}/vehicle_id {}/tokens {}", vehicle.id, vehicle.vehicle_id,
-                                    vehicle.tokens);
-                        }
-                        return vehicle;
+                    if (!checkResponse(response, true)) {
+                        logger.debug("An error occurred while querying the vehicle");
+                        return null;
                     }
+
+                    JsonObject jsonObject = JsonParser.parseString(response.readEntity(String.class)).getAsJsonObject();
+                    Vehicle[] vehicleArray = gson.fromJson(jsonObject.getAsJsonArray("response"), Vehicle[].class);
+
+                    for (Vehicle vehicle : vehicleArray) {
+                        logger.debug("Querying the vehicle: VIN {}", vehicle.vin);
+                        if (vehicle.vin.equals(getConfig().get(VIN))) {
+                            vehicleJSON = gson.toJson(vehicle);
+                            parseAndUpdate("queryVehicle", null, vehicleJSON);
+                            if (logger.isTraceEnabled()) {
+                                logger.trace("Vehicle is id {}/vehicle_id {}/tokens {}", vehicle.id, vehicle.vehicle_id,
+                                        vehicle.tokens);
+                            }
+                            return vehicle;
+                        }
+                    }
+
                 }
             } catch (ProcessingException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());


### PR DESCRIPTION
When an account contains multiple vehicles, the handler tries to query them concurrently - which results in an exception since the `vehiclesTarget` does not support concurrent executions.

Signed-off-by: Kai Kreuzer <kai@openhab.org>