### PR TITLE
[jsscripting] Cache openhab-js injection to improve performance

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -24,7 +24,7 @@
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@3.1.2</ohjs.version>
+    <ohjs.version>openhab@3.2.1</ohjs.version>
   </properties>
 
   <build>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -45,7 +45,7 @@ import com.oracle.truffle.js.scriptengine.GraalJSEngineFactory;
 @NonNullByDefault
 public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     private static final String CFG_INJECTION_ENABLED = "injectionEnabled";
-    private static final String INJECTION_CODE = "Object.assign(this, require('openhab'));";
+    private static final String CFG_INTERNAL_LIBRARY_ENABLED = "internalLibraryEnabled";
 
     private static final GraalJSEngineFactory factory = new GraalJSEngineFactory();
 
@@ -61,6 +61,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     }
 
     private boolean injectionEnabled = true;
+    private boolean internalLibraryEnabled = true;
 
     private final JSScriptServiceUtil jsScriptServiceUtil;
     private final JSDependencyTracker jsDependencyTracker;
@@ -89,7 +90,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
             return null;
         }
         return new DebuggingGraalScriptEngine<>(
-                new OpenhabGraalJSScriptEngine(injectionEnabled ? INJECTION_CODE : null, jsScriptServiceUtil));
+                new OpenhabGraalJSScriptEngine(injectionEnabled, internalLibraryEnabled, jsScriptServiceUtil));
     }
 
     @Override
@@ -100,6 +101,8 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     @Modified
     protected void modified(Map<String, ?> config) {
         Object injectionEnabled = config.get(CFG_INJECTION_ENABLED);
-        this.injectionEnabled = injectionEnabled == null || (Boolean) injectionEnabled;
+        this.injectionEnabled = injectionEnabled == null || (boolean) injectionEnabled;
+        Object internalLibraryEnabled = config.get(CFG_INTERNAL_LIBRARY_ENABLED);
+        this.internalLibraryEnabled = internalLibraryEnabled == null || (boolean) internalLibraryEnabled;
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -45,7 +45,7 @@ import com.oracle.truffle.js.scriptengine.GraalJSEngineFactory;
 @NonNullByDefault
 public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     private static final String CFG_INJECTION_ENABLED = "injectionEnabled";
-    private static final String CFG_INTERNAL_LIBRARY_ENABLED = "internalLibraryEnabled";
+    private static final String CFG_USE_INCLUDED_LIBRARY = "useIncludedLibrary";
 
     private static final GraalJSEngineFactory factory = new GraalJSEngineFactory();
 
@@ -61,7 +61,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     }
 
     private boolean injectionEnabled = true;
-    private boolean internalLibraryEnabled = true;
+    private boolean useIncludedLibrary = true;
 
     private final JSScriptServiceUtil jsScriptServiceUtil;
     private final JSDependencyTracker jsDependencyTracker;
@@ -90,7 +90,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
             return null;
         }
         return new DebuggingGraalScriptEngine<>(
-                new OpenhabGraalJSScriptEngine(injectionEnabled, internalLibraryEnabled, jsScriptServiceUtil));
+                new OpenhabGraalJSScriptEngine(injectionEnabled, useIncludedLibrary, jsScriptServiceUtil));
     }
 
     @Override
@@ -102,7 +102,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
     protected void modified(Map<String, ?> config) {
         Object injectionEnabled = config.get(CFG_INJECTION_ENABLED);
         this.injectionEnabled = injectionEnabled == null || (boolean) injectionEnabled;
-        Object internalLibraryEnabled = config.get(CFG_INTERNAL_LIBRARY_ENABLED);
-        this.internalLibraryEnabled = internalLibraryEnabled == null || (boolean) internalLibraryEnabled;
+        Object useIncludedLibrary = config.get(CFG_USE_INCLUDED_LIBRARY);
+        this.useIncludedLibrary = useIncludedLibrary == null || (boolean) useIncludedLibrary;
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -125,17 +125,17 @@ public class OpenhabGraalJSScriptEngine
 
     private boolean initialized = false;
     private final boolean injectionEnabled;
-    private final boolean internalLibraryEnabled;
+    private final boolean useIncludedLibrary;
 
     /**
      * Creates an implementation of ScriptEngine (& Invocable), wrapping the contained engine, that tracks the script
      * lifecycle and provides hooks for scripts to do so too.
      */
-    public OpenhabGraalJSScriptEngine(boolean injectionEnabled, boolean internalLibraryEnabled,
+    public OpenhabGraalJSScriptEngine(boolean injectionEnabled, boolean useIncludedLibrary,
             JSScriptServiceUtil jsScriptServiceUtil) {
         super(null); // delegate depends on fields not yet initialised, so we cannot set it immediately
         this.injectionEnabled = injectionEnabled;
-        this.internalLibraryEnabled = internalLibraryEnabled;
+        this.useIncludedLibrary = useIncludedLibrary;
         this.jsRuntimeFeatures = jsScriptServiceUtil.getJSRuntimeFeatures(lock);
 
         LOGGER.debug("Initializing GraalJS script engine...");
@@ -264,7 +264,7 @@ public class OpenhabGraalJSScriptEngine
             LOGGER.debug("Evaluating cached global script...");
             delegate.getPolyglotContext().eval(GLOBAL_SOURCE);
             if (this.injectionEnabled) {
-                if (this.internalLibraryEnabled) {
+                if (this.useIncludedLibrary) {
                     LOGGER.debug("Evaluating cached openhab-js injection...");
                     delegate.getPolyglotContext().eval(OPENHAB_JS_SOURCE);
                 } else {

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -64,7 +64,7 @@ import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
  * @author Dan Cunningham - Script injections
  * @author Florian Hotze - Create lock object for multi-thread synchronization; Inject the {@link JSRuntimeFeatures}
  *         into the JS context; Fix memory leak caused by HostObject by making HostAccess reference static; Switch to
- *         {@link Lock} for multi-thread synchronization
+ *         {@link Lock} for multi-thread synchronization; globals & openhab-js injection code caching
  */
 public class OpenhabGraalJSScriptEngine
         extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<GraalJSScriptEngine> {

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/ScriptExtensionModuleProvider.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/ScriptExtensionModuleProvider.java
@@ -27,7 +27,7 @@ import org.openhab.core.automation.module.script.ScriptExtensionAccessor;
 import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedAutomationManager;
 
 /**
- * Class providing script extensions via CommonJS modules.
+ * Class providing script extensions via CommonJS modules (with module name `@runtime`).
  *
  * @author Jonathan Gilbert - Initial contribution
  * @author Florian Hotze - Pass in lock object for multi-thread synchronization; Switch to {@link Lock} for multi-thread

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -18,14 +18,14 @@
 			<default>true</default>
 		</parameter>
 		<parameter name="internalLibraryEnabled" type="boolean" required="true">
-			<label>Use Internal Library</label>
+			<label>Use Included openHAB JavaScript Library</label>
 			<description><![CDATA[
-			Use the addon-included and cached openHAB JavaScript library for optimal performance.<br>
-			Disable this option to allow loading the library from the disk instead, but be aware that this increases script loading times especially on less powerful systems.
+			Use the included openHAB JavaScript library for optimal performance.<br>
+			Disable this option to allow loading the library from the local user configuration directory "automation/js/node_modules". Using a user provided version of the library may increase script loading times, especially on less powerful systems.
 			]]></description>
 			<options>
-				<option value="true">Use Internal Library</option>
-				<option value="false">Do Not Use Internal Library</option>
+				<option value="true">Use Included Library</option>
+				<option value="false">Do Not Use Included Library</option>
 			</options>
 			<default>true</default>
 		</parameter>

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -7,12 +7,25 @@
 	<config-description uri="automation:jsscripting">
 		<parameter name="injectionEnabled" type="boolean" required="true">
 			<label>Use Built-in Global Variables</label>
-			<description><![CDATA[ Import all variables from the OH scripting library into all rules for common services like items, things, actions, log, etc... <br>
-			If disabled, the OH scripting library can be imported manually using "<i>require('openhab')</i>"
+			<description><![CDATA[
+			Import all variables from the openHAB JavaScript library into all rules for common services like items, things, actions, log, etc... <br>
+			If disabled, the openHAB JavaScript library can be imported manually using "<i>require('openhab')</i>"
 			]]></description>
 			<options>
 				<option value="true">Use Built-in Variables</option>
 				<option value="false">Do Not Use Built-in Variables</option>
+			</options>
+			<default>true</default>
+		</parameter>
+		<parameter name="internalLibraryEnabled" type="boolean" required="true">
+			<label>Use Internal Library</label>
+			<description><![CDATA[
+			Use the addon-included and cached openHAB JavaScript library for optimal performance.<br>
+			Disable this option to allow loading the library from the disk instead, but be aware that this increases script loading times especially on less powerful systems.
+			]]></description>
+			<options>
+				<option value="true">Use Internal Library</option>
+				<option value="false">Do Not Use Internal Library</option>
 			</options>
 			<default>true</default>
 		</parameter>

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/config/config.xml
@@ -17,7 +17,7 @@
 			</options>
 			<default>true</default>
 		</parameter>
-		<parameter name="internalLibraryEnabled" type="boolean" required="true">
+		<parameter name="useIncludedLibrary" type="boolean" required="true">
 			<label>Use Included openHAB JavaScript Library</label>
 			<description><![CDATA[
 			Use the included openHAB JavaScript library for optimal performance.<br>

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
@@ -1,7 +1,11 @@
 automation.config.jsscripting.injectionEnabled.label = Use Built-in Global Variables
-automation.config.jsscripting.injectionEnabled.description = Import all variables from the OH scripting library into all rules for common services like items, things, actions, log, etc... <br> If disabled, the OH scripting library can be imported manually using "<i>require('openhab')</i>"
+automation.config.jsscripting.injectionEnabled.description = Import all variables from the openHAB JavaScript library into all rules for common services like items, things, actions, log, etc... <br> If disabled, the openHAB JavaScript library can be imported manually using "<i>require('openhab')</i>"
 automation.config.jsscripting.injectionEnabled.option.true = Use Built-in Variables
 automation.config.jsscripting.injectionEnabled.option.false = Do Not Use Built-in Variables
+automation.config.jsscripting.internalLibraryEnabled.label = Use Included openHAB JavaScript Library
+automation.config.jsscripting.internalLibraryEnabled.description = Use the included openHAB JavaScript library for optimal performance.<br> Disable this option to allow loading the library from the local user configuration directory "automation/js/node_modules". Using a user provided version of the library may increase script loading times, especially on less powerful systems.
+automation.config.jsscripting.internalLibraryEnabled.option.true = Use Included Library
+automation.config.jsscripting.internalLibraryEnabled.option.false = Do Not Use Included Library
 
 # service
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
@@ -2,6 +2,11 @@ automation.config.jsscripting.injectionEnabled.label = Use Built-in Global Varia
 automation.config.jsscripting.injectionEnabled.description = Import all variables from the openHAB JavaScript library into all rules for common services like items, things, actions, log, etc... <br> If disabled, the openHAB JavaScript library can be imported manually using "<i>require('openhab')</i>"
 automation.config.jsscripting.injectionEnabled.option.true = Use Built-in Variables
 automation.config.jsscripting.injectionEnabled.option.false = Do Not Use Built-in Variables
+automation.config.jsscripting.useIncludedLibrary.label = Use Included openHAB JavaScript Library
+automation.config.jsscripting.useIncludedLibrary.description = Use the included openHAB JavaScript library for optimal performance.<br> Disable this option to allow loading the library from the local user configuration directory "automation/js/node_modules". Using a user provided version of the library may increase script loading times, especially on less powerful systems.
+automation.config.jsscripting.useIncludedLibrary.option.true = Use Included Library
+automation.config.jsscripting.useIncludedLibrary.option.false = Do Not Use Included Library
+
 automation.config.jsscripting.internalLibraryEnabled.label = Use Included openHAB JavaScript Library
 automation.config.jsscripting.internalLibraryEnabled.description = Use the included openHAB JavaScript library for optimal performance.<br> Disable this option to allow loading the library from the local user configuration directory "automation/js/node_modules". Using a user provided version of the library may increase script loading times, especially on less powerful systems.
 automation.config.jsscripting.internalLibraryEnabled.option.true = Use Included Library

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/i18n/jsscripting.properties
@@ -7,11 +7,6 @@ automation.config.jsscripting.useIncludedLibrary.description = Use the included 
 automation.config.jsscripting.useIncludedLibrary.option.true = Use Included Library
 automation.config.jsscripting.useIncludedLibrary.option.false = Do Not Use Included Library
 
-automation.config.jsscripting.internalLibraryEnabled.label = Use Included openHAB JavaScript Library
-automation.config.jsscripting.internalLibraryEnabled.description = Use the included openHAB JavaScript library for optimal performance.<br> Disable this option to allow loading the library from the local user configuration directory "automation/js/node_modules". Using a user provided version of the library may increase script loading times, especially on less powerful systems.
-automation.config.jsscripting.internalLibraryEnabled.option.true = Use Included Library
-automation.config.jsscripting.internalLibraryEnabled.option.false = Do Not Use Included Library
-
 # service
 
 service.automation.jsscripting.label = JavaScript Scripting


### PR DESCRIPTION
For previous discussion see #14113.

## Description

This PR extends the code caching to the version of the openHAB JavaScript library (openhab-js) that is included in the JS Scripting addon.
A new configuration option is introduced to allow the user to disable usage of the internal openhab-js library and instead load it from the file system.

~**Note: I am currently not super happy with the description and the label of that new configuration option, I would like to get some feedback on them.**~

Code caching of the openhab-js injection brings great performance improvements as the evaluation of the pretty large openhab-js codebase takes some time. 

Note: it is not possible to cache the `Object.assign(this, require("openhab");` therefore I had to take the way of creating an injection script at openhab-js.

I've performed a few test runs on my dev system (that is quite powerful, AMD Ryzen 7) and here are the results:

- openhab-js injection without caching: about 1 second
- openhab-js injection with code caching: between 100 and 200 milliseconds

On my Raspberry Pi 3 (Debian 10 Buster), caching makes a even larger difference:

- openhab-js injection without caching: about 13 seconds
- openhab-js injection with code caching: about 2 seconds

Note that evaluation of the cached version takes a bit longer than usual after the first start of the addon -- the code needs to be evaluated once before it is cached.

## To Do

- [x] Regenerate default translations
- [x] Maybe improve the label and description of the new configuration option

Ping @digitaldan @jlaur 