### PR TITLE
[ism8] Fix SAT warnings

### DIFF
--- a/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/DataPointBool.java
+++ b/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/DataPointBool.java
@@ -55,7 +55,7 @@ public class DataPointBool extends DataPointBase<@Nullable Boolean> {
     @Override
     protected byte[] convertWriteValue(Object value) {
         String valueText = value.toString().toLowerCase();
-        if (valueText.equalsIgnoreCase("true") || valueText.equalsIgnoreCase("1")) {
+        if ("true".equalsIgnoreCase(valueText) || "1".equalsIgnoreCase(valueText)) {
             this.setValue(true);
             return new byte[] { 0x01 };
         }

--- a/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/DataPointLongValue.java
+++ b/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/DataPointLongValue.java
@@ -33,7 +33,7 @@ public class DataPointLongValue extends DataPointBase<@Nullable Double> {
     public DataPointLongValue(int id, String knxDataType, String description) {
         super(id, knxDataType, description);
 
-        if (knxDataType.equals("13.002")) {
+        if ("13.002".equals(knxDataType)) {
             this.setUnit("m³/h");
             this.factor = 0.0001f;
             this.outputFormat = "%.1f";

--- a/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/DataPointValue.java
+++ b/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/DataPointValue.java
@@ -33,15 +33,15 @@ public class DataPointValue extends DataPointBase<@Nullable Double> {
     public DataPointValue(int id, String knxDataType, String description) {
         super(id, knxDataType, description);
         this.factor = 0.0f;
-        if (knxDataType.equals("9.001")) {
+        if ("9.001".equals(knxDataType)) {
             this.setUnit("°C");
             this.factor = 0.01f;
             this.outputFormat = "%.1f";
-        } else if (knxDataType.equals("9.002")) {
+        } else if ("9.002".equals(knxDataType)) {
             this.setUnit("°K");
             this.factor = 0.01f;
             this.outputFormat = "%.1f";
-        } else if (knxDataType.equals("9.006")) {
+        } else if ("9.006".equals(knxDataType)) {
             this.setUnit("Bar");
             this.factor = 0.0000001f;
             this.outputFormat = "%.2f";

--- a/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/KnxNetFrame.java
+++ b/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/server/KnxNetFrame.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class KnxNetFrame {
-    public static byte[] KNX_HEADER = new byte[6];
-    public static byte[] CONNECTION_HEADER = new byte[4];
+    public static final byte[] KNX_HEADER = new byte[6];
+    public static final byte[] CONNECTION_HEADER = new byte[4];
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KnxNetFrame.class);
     private ArrayList<SetDatapointValueMessage> valueMessages = new ArrayList<SetDatapointValueMessage>();


### PR DESCRIPTION
Reduce number of warnings, mainly using ```"constant".equals(var)``` instead of ```var.equals("constant")```. This is considered to be better, as "constant".equals(null) is null-safe and always returns false. (Though it should not make a difference, we have the annotation ```NonNullByDefault``` in place for the parameters).

Adding ```final``` makes the tool recognize the byte Arrays as constants (though it is not really a constant, but constant ref to a modifiable buffer). 