### PR TITLE
[jsscripting] Fix regressions from #14135 & Log stack on `IllegalArgumentException`

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/README.md
+++ b/bundles/org.openhab.automation.jsscripting/README.md
@@ -1,6 +1,6 @@
 # JavaScript Scripting
 
-This add-on provides support for JavaScript (ECMAScript 2021+) that can be used as a scripting language within automation rules.
+This add-on provides support for JavaScript (ECMAScript 2022+) that can be used as a scripting language within automation rules.
 
 Also included is [openhab-js](https://github.com/openhab/openhab-js/), a fairly high-level ES6 library to support automation in openHAB. It provides convenient access
 to common openHAB functionality within rules including items, things, actions, logging and more.

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -24,7 +24,7 @@
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@3.2.1</ohjs.version>
+    <ohjs.version>openhab@3.2.3</ohjs.version>
   </properties>
 
   <build>
@@ -66,11 +66,23 @@
               <goal>npm</goal>
             </goals>
             <configuration>
+              <!--suppress UnresolvedMavenProperty -->
               <arguments>install ${ohjs.version} webpack@5.75.0 webpack-cli@4.10.0</arguments> <!-- webpack-cli >= 5.0.0 doesn't properly process the given entrypoint -->
             </configuration>
           </execution>
           <execution>
-            <id>npx webpack</id>
+            <id>npx webpack (openhab-js globals injection)</id>
+            <goals>
+              <goal>npx</goal>
+            </goals>
+            <configuration>
+              <!--suppress UnresolvedMavenProperty -->
+              <arguments>webpack -c ./node_modules/openhab/@globals-webpack.config.js --entry
+                ./node_modules/openhab/@openhab-globals.js -o ./dist</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npx webpack (openhab-js)</id>
             <goals>
               <goal>npx</goal>
             </goals>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -24,7 +24,7 @@
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@3.2.3</ohjs.version>
+    <ohjs.version>openhab@3.2.4</ohjs.version>
   </properties>
 
   <build>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
@@ -39,6 +39,9 @@ class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoClosea
     @Override
     public Exception afterThrowsInvocation(Exception e) {
         Throwable cause = e.getCause();
+        if (cause instanceof IllegalArgumentException) {
+            STACK_LOGGER.error("Failed to execute script:", e);
+        }
         if (cause instanceof PolyglotException) {
             STACK_LOGGER.error("Failed to execute script:", cause);
         }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -71,7 +71,6 @@ public class OpenhabGraalJSScriptEngine
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenhabGraalJSScriptEngine.class);
     private static Source GLOBAL_SOURCE;
-
     static {
         try {
             GLOBAL_SOURCE = Source.newBuilder("js", getFileAsReader("node_modules/@jsscripting-globals.js"),
@@ -82,7 +81,6 @@ public class OpenhabGraalJSScriptEngine
     }
 
     private static Source OPENHAB_JS_SOURCE;
-
     static {
         try {
             OPENHAB_JS_SOURCE = Source
@@ -92,7 +90,7 @@ public class OpenhabGraalJSScriptEngine
             throw new RuntimeException("Failed to load @openhab-globals.js", e);
         }
     }
-    private static String OPENHAB_JS_INJECTION_CODE = "Object.assign(this, require('openhab'));";
+    private static final String OPENHAB_JS_INJECTION_CODE = "Object.assign(this, require('openhab'));";
 
     private static final String REQUIRE_WRAPPER_NAME = "__wraprequire__";
     /** Final CommonJS search path for our library */


### PR DESCRIPTION
## Descriptiob

- Fixes the regression from https://github.com/openhab/openhab-addons/pull/14135#issuecomment-1369231126, that `require('openhab');` does not work anymore when it is not installed in node_modules
- Fixes the cached openhab-js injection: did not work because of wrong webpack commandline args in the pom (wrong entrypoint)
- Log a stacktrace on a `IllegalArgumentException` to allow the user to find the line of JS code where he passed a wrong argument

@digitaldan This is the fix.