### PR TITLE
[bondhome] Implement missing 'Light' device type

### DIFF
--- a/bundles/org.openhab.binding.bondhome/README.md
+++ b/bundles/org.openhab.binding.bondhome/README.md
@@ -12,6 +12,7 @@ The easiest way is to open the Bond Home app on your mobile device, tap on your 
 | bondFan          | An RF or IR remote controlled ceiling fan with or without a light |
 | bondFireplace    | An RF or IR remote controlled fireplace with or without a fan     |
 | bondGenericThing | A generic RF or IR remote controlled device                       |
+| bondLight        | An RF or IR remote controlled light                               |
 | bondShades       | An RF or IR remote controlled motorized shade                     |
 
 ## Discovery
@@ -102,4 +103,5 @@ Switch GreatFan_Switch "Great Room Fan" { channel="bondhome:bondFan:BD123456:0d1
 Dimmer GreatFan_Dimmer "Great Room Fan" { channel="bondhome:bondFan:BD123456:0d11f00:fan#speed" }
 String GreatFan_Rotation "Great Room Fan Rotation" { channel="bondhome:bondFan:BD123456:0d11f00:fan#direction" }
 Switch GreatFanLight_Switch "Great Room Fan Light" { channel="bondhome:bondFan:BD123456:0d11f00:light#power" }
+Switch RF_Outlet_Lamp "Remote Control Outlet" { channel="bondhome:bondLight:BD123456:ce1fe38:light#power" }
 ```

--- a/bundles/org.openhab.binding.bondhome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bondhome/src/main/feature/feature.xml
@@ -2,7 +2,7 @@
 <features name="org.openhab.binding.bondhome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-	<feature name="openhab-binding-bondhome" description="BondHome Binding" version="${project.version}">
+	<feature name="openhab-binding-bondhome" description="Bond Home Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bondhome/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/BondHomeBindingConstants.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/BondHomeBindingConstants.java
@@ -36,12 +36,13 @@ public class BondHomeBindingConstants {
     public static final ThingTypeUID THING_TYPE_BOND_SHADES = new ThingTypeUID(BINDING_ID, "bondShades");
     public static final ThingTypeUID THING_TYPE_BOND_FIREPLACE = new ThingTypeUID(BINDING_ID, "bondFireplace");
     public static final ThingTypeUID THING_TYPE_BOND_GENERIC = new ThingTypeUID(BINDING_ID, "bondGenericThing");
+    public static final ThingTypeUID THING_TYPE_BOND_LIGHT = new ThingTypeUID(BINDING_ID, "bondLight");
 
     /**
      * The supported thing types.
      */
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BOND_FAN, THING_TYPE_BOND_SHADES,
-            THING_TYPE_BOND_FIREPLACE, THING_TYPE_BOND_GENERIC);
+            THING_TYPE_BOND_FIREPLACE, THING_TYPE_BOND_GENERIC, THING_TYPE_BOND_LIGHT);
 
     public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES = Set.of(THING_TYPE_BOND_BRIDGE);
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceType.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceType.java
@@ -34,8 +34,9 @@ public enum BondDeviceType {
     @SerializedName("FP")
     FIREPLACE(THING_TYPE_BOND_FIREPLACE),
     @SerializedName("GX")
-    GENERIC_DEVICE(THING_TYPE_BOND_GENERIC);
-    // TODO: add Light ("LT") type
+    GENERIC_DEVICE(THING_TYPE_BOND_GENERIC),
+    @SerializedName("LT")
+    LIGHT(THING_TYPE_BOND_LIGHT);
 
     private ThingTypeUID deviceTypeUid;
 

--- a/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/binding/binding.xml
@@ -4,7 +4,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Bond Home Binding</name>
-	<description>This is the binding for the Bond Bridge for Ceiling Fans and and other RF devices.</description>
-	<author>Sara Geleskie Damiano</author>
+	<description>This is the binding for the Bond Bridge for Ceiling Fans and other RF devices.</description>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/i18n/bondhome.properties
+++ b/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/i18n/bondhome.properties
@@ -1,7 +1,7 @@
 # binding
 
 binding.bondhome.name = Bond Home Binding
-binding.bondhome.description = This is the binding for the Bond Bridge for Ceiling Fans and and other RF devices.
+binding.bondhome.description = This is the binding for the Bond Bridge for Ceiling Fans and other RF devices.
 
 # thing types
 
@@ -13,6 +13,8 @@ thing-type.bondhome.bondFireplace.label = Bond Home Fireplace
 thing-type.bondhome.bondFireplace.description = An RF or IR remote controlled fireplace with or without a fan
 thing-type.bondhome.bondGenericThing.label = Bond Home Generic Remote
 thing-type.bondhome.bondGenericThing.description = A generic RF or IR remote controlled device
+thing-type.bondhome.bondLight.label = Bond Home Light
+thing-type.bondhome.bondLight.description = An RF or IR remote controlled light
 thing-type.bondhome.bondShades.label = Bond Home Motorized Shades
 thing-type.bondhome.bondShades.description = An RF or IR remote controlled motorized shade
 

--- a/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/thing/Light.xml
+++ b/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/thing/Light.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="bondhome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- A Light Thing -->
+	<thing-type id="bondLight">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bondBridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Bond Home Light</label>
+		<description>An RF or IR remote controlled light</description>
+
+		<channel-groups>
+			<channel-group id="light" typeId="lightChannelGroup"/>
+		</channel-groups>
+
+		<representation-property>deviceId</representation-property>
+
+		<config-description-ref uri="thing-type:bondhome:bonddevice"/>
+
+	</thing-type>
+
+</thing:thing-descriptions>


### PR DESCRIPTION
Follow up to #14103 

Implement the missing device type for 'Light' in BondDeviceType and add the appropriate thing definition.