### PR TITLE
[mail] Make actions names for DSL rules consistent with documentation

### DIFF
--- a/bundles/org.openhab.binding.mail/README.md
+++ b/bundles/org.openhab.binding.mail/README.md
@@ -89,11 +89,11 @@ This binding includes rule actions for sending email.
 Six different actions available:
 
 - `boolean success = sendMail(String recipient, String subject, String text)`
-- `boolean success = sendMailWithAttachment(String recipient, String subject, String text, String URL)`
-- `boolean success = sendMailWithAttachments(String recipient, String subject, String text, List<String> URL)`
+- `boolean success = sendMailWithAttachment(String recipient, String subject, String text, String url)`
+- `boolean success = sendMailWithAttachments(String recipient, String subject, String text, List<String> urlList)`
 - `boolean success = sendHtmlMail(String recipient, String subject, String htmlContent)`
-- `boolean success = sendHtmlMailWithAttachment(String recipient, String subject, String htmlContent, String URL)`
-- `boolean success = sendHtmlMailWithAttachments(String recipient, String subject, String htmlContent, List<String> URL)`
+- `boolean success = sendHtmlMailWithAttachment(String recipient, String subject, String htmlContent, String url)`
+- `boolean success = sendHtmlMailWithAttachments(String recipient, String subject, String htmlContent, List<String> urlList)`
 
 The `sendMail(...)` send a plain text mail (with attachments if supplied).
 The `sendHtmlMail(...)` send a HTML mail (with attachments if supplied).

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
@@ -60,10 +60,10 @@ public class SendMailActions implements ThingActions {
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean sendMailWithAttachment(
             @ActionInput(name = "recipient") @Nullable String recipient,
             @ActionInput(name = "subject") @Nullable String subject, @ActionInput(name = "text") @Nullable String text,
-            @ActionInput(name = "url") @Nullable String urlString) {
+            @ActionInput(name = "url") @Nullable String url) {
         List<String> urlList = new ArrayList<>();
-        if (urlString != null) {
-            urlList.add(urlString);
+        if (url != null) {
+            urlList.add(url);
         }
         return sendMailWithAttachments(recipient, subject, text, urlList);
     }
@@ -72,7 +72,7 @@ public class SendMailActions implements ThingActions {
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean sendMailWithAttachments(
             @ActionInput(name = "recipient") @Nullable String recipient,
             @ActionInput(name = "subject") @Nullable String subject, @ActionInput(name = "text") @Nullable String text,
-            @ActionInput(name = "urlList") @Nullable List<String> urlStringList) {
+            @ActionInput(name = "urlList") @Nullable List<String> urlList) {
         if (recipient == null) {
             logger.warn("Cannot send mail as recipient is missing.");
             return false;
@@ -87,8 +87,8 @@ public class SendMailActions implements ThingActions {
             if (text != null && !text.isEmpty()) {
                 builder.withText(text);
             }
-            if (urlStringList != null) {
-                for (String urlString : urlStringList) {
+            if (urlList != null) {
+                for (String urlString : urlList) {
                     builder.withURLAttachment(urlString);
                 }
             }
@@ -114,27 +114,27 @@ public class SendMailActions implements ThingActions {
     }
 
     public static boolean sendMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String text, @Nullable String urlString) {
-        return SendMailActions.sendMailWithAttachment(actions, recipient, subject, text, urlString);
+            @Nullable String text, @Nullable String url) {
+        return SendMailActions.sendMailWithAttachment(actions, recipient, subject, text, url);
     }
 
     public static boolean sendMailWithAttachment(ThingActions actions, @Nullable String recipient,
-            @Nullable String subject, @Nullable String text, @Nullable String urlString) {
+            @Nullable String subject, @Nullable String text, @Nullable String url) {
         List<String> urlList = new ArrayList<>();
-        if (urlString != null) {
-            urlList.add(urlString);
+        if (url != null) {
+            urlList.add(url);
         }
         return SendMailActions.sendMailWithAttachments(actions, recipient, subject, text, urlList);
     }
 
     public static boolean sendMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String text, @Nullable List<String> urlStringList) {
-        return SendMailActions.sendMailWithAttachments(actions, recipient, subject, text, urlStringList);
+            @Nullable String text, @Nullable List<String> urlList) {
+        return SendMailActions.sendMailWithAttachments(actions, recipient, subject, text, urlList);
     }
 
     public static boolean sendMailWithAttachments(ThingActions actions, @Nullable String recipient,
-            @Nullable String subject, @Nullable String text, @Nullable List<String> urlStringList) {
-        return ((SendMailActions) actions).sendMailWithAttachments(recipient, subject, text, urlStringList);
+            @Nullable String subject, @Nullable String text, @Nullable List<String> urlList) {
+        return ((SendMailActions) actions).sendMailWithAttachments(recipient, subject, text, urlList);
     }
 
     @RuleAction(label = "@text/sendHTMLMessageActionLabel", description = "@text/sendHTMLMessageActionDescription")
@@ -150,10 +150,10 @@ public class SendMailActions implements ThingActions {
             @ActionInput(name = "recipient") @Nullable String recipient,
             @ActionInput(name = "subject") @Nullable String subject,
             @ActionInput(name = "htmlContent") @Nullable String htmlContent,
-            @ActionInput(name = "url") @Nullable String urlString) {
+            @ActionInput(name = "url") @Nullable String url) {
         List<String> urlList = new ArrayList<>();
-        if (urlString != null) {
-            urlList.add(urlString);
+        if (url != null) {
+            urlList.add(url);
         }
         return sendHtmlMailWithAttachments(recipient, subject, htmlContent, urlList);
     }
@@ -163,7 +163,7 @@ public class SendMailActions implements ThingActions {
             @ActionInput(name = "recipient") @Nullable String recipient,
             @ActionInput(name = "subject") @Nullable String subject,
             @ActionInput(name = "htmlContent") @Nullable String htmlContent,
-            @ActionInput(name = "urlList") @Nullable List<String> urlStringList) {
+            @ActionInput(name = "urlList") @Nullable List<String> urlList) {
         if (recipient == null) {
             logger.warn("Cannot send mail as recipient is missing.");
             return false;
@@ -178,8 +178,8 @@ public class SendMailActions implements ThingActions {
             if (htmlContent != null && !htmlContent.isEmpty()) {
                 builder.withHtml(htmlContent);
             }
-            if (urlStringList != null) {
-                for (String urlString : urlStringList) {
+            if (urlList != null) {
+                for (String urlString : urlList) {
                     builder.withURLAttachment(urlString);
                 }
             }
@@ -205,27 +205,27 @@ public class SendMailActions implements ThingActions {
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String htmlContent, @Nullable String urlString) {
-        return SendMailActions.sendHtmlMailWithAttachment(actions, recipient, subject, htmlContent, urlString);
+            @Nullable String htmlContent, @Nullable String url) {
+        return SendMailActions.sendHtmlMailWithAttachment(actions, recipient, subject, htmlContent, url);
     }
 
     public static boolean sendHtmlMailWithAttachment(ThingActions actions, @Nullable String recipient,
-            @Nullable String subject, @Nullable String htmlContent, @Nullable String urlString) {
+            @Nullable String subject, @Nullable String htmlContent, @Nullable String url) {
         List<String> urlList = new ArrayList<>();
-        if (urlString != null) {
-            urlList.add(urlString);
+        if (url != null) {
+            urlList.add(url);
         }
         return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, htmlContent, urlList);
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String htmlContent, @Nullable List<String> urlStringList) {
-        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, htmlContent, urlStringList);
+            @Nullable String htmlContent, @Nullable List<String> urlList) {
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, htmlContent, urlList);
     }
 
     public static boolean sendHtmlMailWithAttachments(ThingActions actions, @Nullable String recipient,
-            @Nullable String subject, @Nullable String htmlContent, @Nullable List<String> urlStringList) {
-        return ((SendMailActions) actions).sendHtmlMailWithAttachments(recipient, subject, htmlContent, urlStringList);
+            @Nullable String subject, @Nullable String htmlContent, @Nullable List<String> urlList) {
+        return ((SendMailActions) actions).sendHtmlMailWithAttachments(recipient, subject, htmlContent, urlList);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
@@ -141,26 +141,28 @@ public class SendMailActions implements ThingActions {
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean sendHtmlMail(
             @ActionInput(name = "recipient") @Nullable String recipient,
             @ActionInput(name = "subject") @Nullable String subject,
-            @ActionInput(name = "html") @Nullable String html) {
-        return sendHtmlMailWithAttachments(recipient, subject, html, List.of());
+            @ActionInput(name = "htmlContent") @Nullable String htmlContent) {
+        return sendHtmlMailWithAttachments(recipient, subject, htmlContent, List.of());
     }
 
     @RuleAction(label = "@text/sendHTMLAttachmentMessageActionLabel", description = "@text/sendHTMLAttachmentMessageActionDescription")
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean sendHtmlMailWithAttachment(
             @ActionInput(name = "recipient") @Nullable String recipient,
-            @ActionInput(name = "subject") @Nullable String subject, @ActionInput(name = "html") @Nullable String html,
+            @ActionInput(name = "subject") @Nullable String subject,
+            @ActionInput(name = "htmlContent") @Nullable String htmlContent,
             @ActionInput(name = "url") @Nullable String urlString) {
         List<String> urlList = new ArrayList<>();
         if (urlString != null) {
             urlList.add(urlString);
         }
-        return sendHtmlMailWithAttachments(recipient, subject, html, urlList);
+        return sendHtmlMailWithAttachments(recipient, subject, htmlContent, urlList);
     }
 
     @RuleAction(label = "@text/sendHTMLAttachmentsMessageActionLabel", description = "@text/sendHTMLAttachmentsMessageActionDescription")
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean sendHtmlMailWithAttachments(
             @ActionInput(name = "recipient") @Nullable String recipient,
-            @ActionInput(name = "subject") @Nullable String subject, @ActionInput(name = "html") @Nullable String html,
+            @ActionInput(name = "subject") @Nullable String subject,
+            @ActionInput(name = "htmlContent") @Nullable String htmlContent,
             @ActionInput(name = "urlList") @Nullable List<String> urlStringList) {
         if (recipient == null) {
             logger.warn("Cannot send mail as recipient is missing.");
@@ -173,8 +175,8 @@ public class SendMailActions implements ThingActions {
             if (subject != null && !subject.isEmpty()) {
                 builder.withSubject(subject);
             }
-            if (html != null && !html.isEmpty()) {
-                builder.withHtml(html);
+            if (htmlContent != null && !htmlContent.isEmpty()) {
+                builder.withHtml(htmlContent);
             }
             if (urlStringList != null) {
                 for (String urlString : urlStringList) {
@@ -198,32 +200,32 @@ public class SendMailActions implements ThingActions {
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String html) {
-        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, html, List.of());
+            @Nullable String htmlContent) {
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, htmlContent, List.of());
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String html, @Nullable String urlString) {
-        return SendMailActions.sendHtmlMailWithAttachment(actions, recipient, subject, html, urlString);
+            @Nullable String htmlContent, @Nullable String urlString) {
+        return SendMailActions.sendHtmlMailWithAttachment(actions, recipient, subject, htmlContent, urlString);
     }
 
     public static boolean sendHtmlMailWithAttachment(ThingActions actions, @Nullable String recipient,
-            @Nullable String subject, @Nullable String html, @Nullable String urlString) {
+            @Nullable String subject, @Nullable String htmlContent, @Nullable String urlString) {
         List<String> urlList = new ArrayList<>();
         if (urlString != null) {
             urlList.add(urlString);
         }
-        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, html, urlList);
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, htmlContent, urlList);
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
-            @Nullable String html, @Nullable List<String> urlStringList) {
-        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, html, urlStringList);
+            @Nullable String htmlContent, @Nullable List<String> urlStringList) {
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, htmlContent, urlStringList);
     }
 
     public static boolean sendHtmlMailWithAttachments(ThingActions actions, @Nullable String recipient,
-            @Nullable String subject, @Nullable String html, @Nullable List<String> urlStringList) {
-        return ((SendMailActions) actions).sendHtmlMailWithAttachments(recipient, subject, html, urlStringList);
+            @Nullable String subject, @Nullable String htmlContent, @Nullable List<String> urlStringList) {
+        return ((SendMailActions) actions).sendHtmlMailWithAttachments(recipient, subject, htmlContent, urlStringList);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
@@ -110,20 +110,30 @@ public class SendMailActions implements ThingActions {
 
     public static boolean sendMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
             @Nullable String text) {
-        return SendMailActions.sendMail(actions, recipient, subject, text, List.of());
+        return SendMailActions.sendMailWithAttachments(actions, recipient, subject, text, List.of());
     }
 
     public static boolean sendMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
             @Nullable String text, @Nullable String urlString) {
+        return SendMailActions.sendMailWithAttachment(actions, recipient, subject, text, urlString);
+    }
+
+    public static boolean sendMailWithAttachment(ThingActions actions, @Nullable String recipient,
+            @Nullable String subject, @Nullable String text, @Nullable String urlString) {
         List<String> urlList = new ArrayList<>();
         if (urlString != null) {
             urlList.add(urlString);
         }
-        return SendMailActions.sendMail(actions, recipient, subject, text, urlList);
+        return SendMailActions.sendMailWithAttachments(actions, recipient, subject, text, urlList);
     }
 
     public static boolean sendMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
             @Nullable String text, @Nullable List<String> urlStringList) {
+        return SendMailActions.sendMailWithAttachments(actions, recipient, subject, text, urlStringList);
+    }
+
+    public static boolean sendMailWithAttachments(ThingActions actions, @Nullable String recipient,
+            @Nullable String subject, @Nullable String text, @Nullable List<String> urlStringList) {
         return ((SendMailActions) actions).sendMailWithAttachments(recipient, subject, text, urlStringList);
     }
 
@@ -189,20 +199,30 @@ public class SendMailActions implements ThingActions {
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
             @Nullable String html) {
-        return SendMailActions.sendHtmlMail(actions, recipient, subject, html, List.of());
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, html, List.of());
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
             @Nullable String html, @Nullable String urlString) {
+        return SendMailActions.sendHtmlMailWithAttachment(actions, recipient, subject, html, urlString);
+    }
+
+    public static boolean sendHtmlMailWithAttachment(ThingActions actions, @Nullable String recipient,
+            @Nullable String subject, @Nullable String html, @Nullable String urlString) {
         List<String> urlList = new ArrayList<>();
         if (urlString != null) {
             urlList.add(urlString);
         }
-        return SendMailActions.sendHtmlMail(actions, recipient, subject, html, urlList);
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, html, urlList);
     }
 
     public static boolean sendHtmlMail(ThingActions actions, @Nullable String recipient, @Nullable String subject,
             @Nullable String html, @Nullable List<String> urlStringList) {
+        return SendMailActions.sendHtmlMailWithAttachments(actions, recipient, subject, html, urlStringList);
+    }
+
+    public static boolean sendHtmlMailWithAttachments(ThingActions actions, @Nullable String recipient,
+            @Nullable String subject, @Nullable String html, @Nullable List<String> urlStringList) {
         return ((SendMailActions) actions).sendHtmlMailWithAttachments(recipient, subject, html, urlStringList);
     }
 


### PR DESCRIPTION
Keep old names for backward compatibility (DSL rule).
Actions names are now consistent over all rule engines.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>