### PR TITLE
[chromecast] Fix thing go offline after stop command

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
@@ -52,7 +52,7 @@ public class ChromecastAudioSink {
             // in case the audioStream is null, this should be interpreted as a request to end any currently playing
             // stream.
             logger.trace("Stop currently playing stream.");
-            commander.handleStop(OnOffType.ON);
+            commander.handleCloseApp(OnOffType.ON);
         } else {
             final String url;
             if (audioStream instanceof URLAudioStream) {

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -238,7 +238,7 @@ public class ChromecastCommander {
             }
             statusUpdater.updateStatus(ThingStatus.ONLINE);
         } catch (final IOException e) {
-            logger.info("Failed starting app: {}. Message: {}", appId, e.getMessage());
+            logger.warn("Failed starting app: {}. Message: {}", appId, e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -70,7 +70,7 @@ public class ChromecastCommander {
                 handleControl(command);
                 break;
             case CHANNEL_STOP:
-                handleStop(command);
+                handleCloseApp(command);
                 break;
             case CHANNEL_VOLUME:
                 handleVolume(command);
@@ -117,12 +117,18 @@ public class ChromecastCommander {
                 if (mediaStatus != null && mediaStatus.playerState == MediaStatus.PlayerState.IDLE
                         && mediaStatus.idleReason != null
                         && mediaStatus.idleReason != MediaStatus.IdleReason.INTERRUPTED) {
-                    stopMediaPlayerApp();
+                    closeApp(MEDIA_PLAYER);
                 }
             }
         } catch (IOException ex) {
             logger.debug("Failed to request media status with a running app: {}", ex.getMessage());
             // We were just able to request status, so let's not put the device OFFLINE.
+        }
+    }
+
+    public void handleCloseApp(final Command command) {
+        if (command == OnOffType.ON) {
+            closeApp(MEDIA_PLAYER);
         }
     }
 
@@ -163,7 +169,6 @@ public class ChromecastCommander {
             if (command instanceof NextPreviousType) {
                 // Next is implemented by seeking to the end of the current media
                 if (command == NextPreviousType.NEXT) {
-
                     Double duration = statusUpdater.getLastDuration();
                     if (duration != null) {
                         chromeCast.seek(duration.doubleValue() - 5);
@@ -179,18 +184,6 @@ public class ChromecastCommander {
         } catch (final IOException e) {
             logger.debug("{} command failed: {}", command, e.getMessage());
             statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, e.getMessage());
-        }
-    }
-
-    public void handleStop(final Command command) {
-        if (command == OnOffType.ON) {
-            try {
-                chromeCast.stopApp();
-                statusUpdater.updateStatus(ThingStatus.ONLINE);
-            } catch (final IOException ex) {
-                logger.debug("{} command failed: {}", command, ex.getMessage());
-                statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, ex.getMessage());
-            }
         }
     }
 
@@ -229,24 +222,56 @@ public class ChromecastCommander {
         }
     }
 
-    public void playMedia(@Nullable String title, @Nullable String url, @Nullable String mimeType) {
+    public void startApp(@Nullable String appId) {
+        if (appId == null) {
+            return;
+        }
         try {
-            if (chromeCast.isAppAvailable(MEDIA_PLAYER)) {
-                if (!chromeCast.isAppRunning(MEDIA_PLAYER)) {
-                    final Application app = chromeCast.launchApp(MEDIA_PLAYER);
+            if (chromeCast.isAppAvailable(appId)) {
+                if (!chromeCast.isAppRunning(appId)) {
+                    final Application app = chromeCast.launchApp(appId);
                     statusUpdater.setAppSessionId(app.sessionId);
-                    logger.debug("Application launched: {}", app);
+                    logger.debug("Application launched: {}", appId);
                 }
-                if (url != null) {
-                    // If the current track is paused, launching a new request results in nothing happening, therefore
-                    // resume current track.
-                    MediaStatus ms = chromeCast.getMediaStatus();
-                    if (ms != null && MediaStatus.PlayerState.PAUSED == ms.playerState && url.equals(ms.media.url)) {
-                        logger.debug("Current stream paused, resuming");
-                        chromeCast.play();
-                    } else {
-                        chromeCast.load(title, null, url, mimeType);
-                    }
+            } else {
+                logger.warn("Failed starting app, app probably not installed. Appid: {}", appId);
+            }
+            statusUpdater.updateStatus(ThingStatus.ONLINE);
+        } catch (final IOException e) {
+            logger.info("Failed starting app: {}. Message: {}", appId, e.getMessage());
+        }
+    }
+
+    public void closeApp(@Nullable String appId) {
+        if (appId == null) {
+            return;
+        }
+
+        try {
+            if (chromeCast.isAppRunning(appId)) {
+                Application app = chromeCast.getRunningApp();
+                if (app.id.equals(appId) && app.sessionId.equals(statusUpdater.getAppSessionId())) {
+                    chromeCast.stopApp();
+                    logger.debug("Application closed: {}", appId);
+                }
+            }
+        } catch (final IOException e) {
+            logger.debug("Failed stopping media player app: {} with message: {}", appId, e.getMessage());
+        }
+    }
+
+    public void playMedia(@Nullable String title, @Nullable String url, @Nullable String mimeType) {
+        startApp(MEDIA_PLAYER);
+        try {
+            if (url != null && chromeCast.isAppRunning(MEDIA_PLAYER)) {
+                // If the current track is paused, launching a new request results in nothing happening, therefore
+                // resume current track.
+                MediaStatus ms = chromeCast.getMediaStatus();
+                if (ms != null && MediaStatus.PlayerState.PAUSED == ms.playerState && url.equals(ms.media.url)) {
+                    logger.debug("Current stream paused, resuming");
+                    chromeCast.play();
+                } else {
+                    chromeCast.load(title, null, url, mimeType);
                 }
             } else {
                 logger.warn("Missing media player app - cannot process media.");
@@ -255,18 +280,6 @@ public class ChromecastCommander {
         } catch (final IOException e) {
             logger.debug("Failed playing media: {}", e.getMessage());
             statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, e.getMessage());
-        }
-    }
-
-    private void stopMediaPlayerApp() {
-        try {
-            Application app = chromeCast.getRunningApp();
-            if (app.id.equals(MEDIA_PLAYER) && app.sessionId.equals(statusUpdater.getAppSessionId())) {
-                chromeCast.stopApp();
-                logger.debug("Media player app stopped");
-            }
-        } catch (final IOException e) {
-            logger.debug("Failed stopping media player app", e);
         }
     }
 }

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastCommander.java
@@ -278,8 +278,13 @@ public class ChromecastCommander {
             }
             statusUpdater.updateStatus(ThingStatus.ONLINE);
         } catch (final IOException e) {
-            logger.debug("Failed playing media: {}", e.getMessage());
-            statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR, e.getMessage());
+            if ("Unable to load media".equals(e.getMessage())) {
+                logger.warn("Unable to load media: {}", url);
+            } else {
+                logger.debug("Failed playing media: {}", e.getMessage());
+                statusUpdater.updateStatus(ThingStatus.OFFLINE, COMMUNICATION_ERROR,
+                        "IOException while trying to play media: " + e.getMessage());
+            }
         }
     }
 }

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastEventReceiver.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastEventReceiver.java
@@ -56,6 +56,8 @@ public class ChromecastEventReceiver implements ChromeCastSpontaneousEventListen
 
     @Override
     public void spontaneousEventReceived(final @NonNullByDefault({}) ChromeCastSpontaneousEvent event) {
+        logger.trace("Received an {} event (class={})", event.getType(), event.getData());
+
         switch (event.getType()) {
             case CLOSE:
                 statusUpdater.updateMediaStatus(null);
@@ -65,6 +67,9 @@ public class ChromecastEventReceiver implements ChromeCastSpontaneousEventListen
                 break;
             case STATUS:
                 statusUpdater.processStatusUpdate(event.getData(Status.class));
+                break;
+            case APPEVENT:
+                logger.debug("Received an 'APPEVENT' event, ignoring");
                 break;
             case UNKNOWN:
                 logger.debug("Received an 'UNKNOWN' event (class={})", event.getType().getDataClass());


### PR DESCRIPTION
Signed-off-by: lsiepel <leosiepel@gmail.com>

When the app running on the ChromeCast was stopped by switching the ON/OFF stop channel, the binding tried to stop the app without checking if it actually runs. Because the app wasn;t running, it gives an error and the thing goes offline.
This PR adds a check, and also restructured the class a bit.

Also when a command was givfen to play media by URL, but the URL was invalid or could not be loaded by the ChromeCast, the thing went offline for ~10 seconds. That mechanism is also change so that the Thing only goes offline when there is an actuall IOException, in other case it logs a warning about unplayable url.

3.4.1 Test JAR is here: https://1drv.ms/u/s!AnMcxmvEeupwjp4ILqWfPxAy7qJh4g?e=43fQde

Fixes: https://github.com/openhab/openhab-addons/issues/9591 (tested and confirmed)