### PR TITLE
[hueemulation] Fix tests after core change

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/mocks/DummyMetadataRegistry.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/mocks/DummyMetadataRegistry.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -93,6 +94,12 @@ public class DummyMetadataRegistry implements MetadataRegistry {
     @Override
     public boolean isInternalNamespace(String namespace) {
         return false;
+    }
+
+    @Override
+    public Collection<String> getAllNamespaces(String itemname) {
+        return stream().map(Metadata::getUID).filter(key -> key.getItemName().equals(itemname))
+                .map(MetadataKey::getNamespace).collect(Collectors.toSet());
     }
 
     @Override


### PR DESCRIPTION
Fixes #14153.
This fixes the Hue Emulation tests (and in consequence the full addons build) after core change https://github.com/openhab/openhab-core/pull/3298.

For the implementation used in the test, just have a look at the linked core PR.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>

/cc @jlaur 