### PR TITLE
[sonos] Correct identification of tuneIn started from Alexa

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -93,7 +93,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     private static final String RADIO_URI = "x-sonosapi-radio:";
     private static final String RADIO_MP3_URI = "x-rincon-mp3radio:";
     private static final String RADIOAPP_URI = "x-sonosapi-hls:radioapp_";
-    private static final String OPML_TUNE = "http://opml.radiotime.com/Tune.ashx";
+    private static final String OPML_TUNE = "://opml.radiotime.com/Tune.ashx";
     private static final String FILE_URI = "x-file-cifs:";
     private static final String SPDIF = ":spdif";
     private static final String TUNEIN_URI = "x-sonosapi-stream:s%s?sid=%s&flags=32";


### PR DESCRIPTION
Contained URL is now HTTPS instead of HTTP before.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>