### PR TITLE
Exclude 3rdparty directories from license header generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,7 @@ Import-Package: \\
               <include>**/features/**/header.xml</include>
             </includes>
             <excludes>
+              <exclude>**/3rdparty/**</exclude>
               <exclude>target/**</exclude>
               <exclude>**/pom.xml</exclude>
               <exclude>_*.java</exclude>


### PR DESCRIPTION
Related to #14154, see https://github.com/openhab/openhab-addons/pull/14154#issuecomment-1371319055