### PR TITLE
[homekit] properly expose services from dummy accessories

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/DummyHomekitAccessory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/DummyHomekitAccessory.java
@@ -14,6 +14,7 @@ package org.openhab.io.homekit.internal.accessories;
 
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -160,5 +161,10 @@ public class DummyHomekitAccessory implements HomekitAccessory {
     @Override
     public CompletableFuture<String> getFirmwareRevision() {
         return CompletableFuture.completedFuture("none");
+    }
+
+    @Override
+    public Collection<Service> getServices() {
+        return services;
     }
 }


### PR DESCRIPTION
lol I'm surprised they've worked as well as they have in the past. basically only the AccessoryInformationService was getting exposed before, accidentally. now we really do publish the full set of original characteristics, just with dummy values.