### PR TITLE
[ecobee] Fix issue with UTC and local dates

### DIFF
--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
@@ -402,11 +402,12 @@ public class EcobeeBindingConstants {
     public static final HouseDetailsDTO EMPTY_HOUSEDETAILS = new HouseDetailsDTO();
     public static final ManagementDTO EMPTY_MANAGEMENT = new ManagementDTO();
     public static final TechnicianDTO EMPTY_TECHNICIAN = new TechnicianDTO();
-    public static final List<RemoteSensorDTO> EMPTY_SENSORS = Collections.<RemoteSensorDTO> emptyList();
-    public static final List<ThermostatDTO> EMPTY_THERMOSTATS = Collections.<ThermostatDTO> emptyList();
+    public static final List<RemoteSensorDTO> EMPTY_SENSORS = Collections.<RemoteSensorDTO>emptyList();
+    public static final List<ThermostatDTO> EMPTY_THERMOSTATS = Collections.<ThermostatDTO>emptyList();
 
     public static final String ECOBEE_BASE_URL = "https://api.ecobee.com/";
     public static final String ECOBEE_AUTHORIZE_URL = ECOBEE_BASE_URL + "authorize";
     public static final String ECOBEE_TOKEN_URL = ECOBEE_BASE_URL + "token";
     public static final String ECOBEE_SCOPE = "smartWrite";
+    public static final String ECOBEE_DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 }

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
@@ -402,8 +402,8 @@ public class EcobeeBindingConstants {
     public static final HouseDetailsDTO EMPTY_HOUSEDETAILS = new HouseDetailsDTO();
     public static final ManagementDTO EMPTY_MANAGEMENT = new ManagementDTO();
     public static final TechnicianDTO EMPTY_TECHNICIAN = new TechnicianDTO();
-    public static final List<RemoteSensorDTO> EMPTY_SENSORS = Collections.<RemoteSensorDTO>emptyList();
-    public static final List<ThermostatDTO> EMPTY_THERMOSTATS = Collections.<ThermostatDTO>emptyList();
+    public static final List<RemoteSensorDTO> EMPTY_SENSORS = Collections.<RemoteSensorDTO> emptyList();
+    public static final List<ThermostatDTO> EMPTY_THERMOSTATS = Collections.<ThermostatDTO> emptyList();
 
     public static final String ECOBEE_BASE_URL = "https://api.ecobee.com/";
     public static final String ECOBEE_AUTHORIZE_URL = ECOBEE_BASE_URL + "authorize";

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -32,6 +33,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.ecobee.internal.dto.AbstractResponseDTO;
 import org.openhab.binding.ecobee.internal.dto.SelectionDTO;
 import org.openhab.binding.ecobee.internal.dto.SelectionType;
+import org.openhab.binding.ecobee.internal.dto.thermostat.DateDeserializer;
 import org.openhab.binding.ecobee.internal.dto.thermostat.ThermostatDTO;
 import org.openhab.binding.ecobee.internal.dto.thermostat.ThermostatRequestDTO;
 import org.openhab.binding.ecobee.internal.dto.thermostat.ThermostatResponseDTO;
@@ -66,7 +68,7 @@ import com.google.gson.JsonSyntaxException;
 @NonNullByDefault
 public class EcobeeApi implements AccessTokenRefreshListener {
 
-    private static final Gson GSON = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss")
+    private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Date.class, new DateDeserializer())
             .registerTypeAdapter(RevisionDTO.class, new RevisionDTODeserializer())
             .registerTypeAdapter(RunningDTO.class, new RunningDTODeserializer()).create();
 

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -33,7 +33,8 @@ import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.ecobee.internal.dto.AbstractResponseDTO;
 import org.openhab.binding.ecobee.internal.dto.SelectionDTO;
 import org.openhab.binding.ecobee.internal.dto.SelectionType;
-import org.openhab.binding.ecobee.internal.dto.thermostat.DateDeserializer;
+import org.openhab.binding.ecobee.internal.dto.thermostat.InstantDeserializer;
+import org.openhab.binding.ecobee.internal.dto.thermostat.LocalDateTimeDeserializer;
 import org.openhab.binding.ecobee.internal.dto.thermostat.ThermostatDTO;
 import org.openhab.binding.ecobee.internal.dto.thermostat.ThermostatRequestDTO;
 import org.openhab.binding.ecobee.internal.dto.thermostat.ThermostatResponseDTO;
@@ -68,7 +69,8 @@ import com.google.gson.JsonSyntaxException;
 @NonNullByDefault
 public class EcobeeApi implements AccessTokenRefreshListener {
 
-    private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Date.class, new DateDeserializer())
+    private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantDeserializer())
+            .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeDeserializer())
             .registerTypeAdapter(RevisionDTO.class, new RevisionDTODeserializer())
             .registerTypeAdapter(RunningDTO.class, new RunningDTODeserializer()).create();
 

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/DateDeserializer.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/DateDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/DateDeserializer.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/DateDeserializer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecobee.internal.dto.thermostat;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * The {@link DateDeserializer} is responsible for handling the UTC dates returned from
+ * the Ecobee API service.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+@NonNullByDefault
+public class DateDeserializer implements JsonDeserializer<Date> {
+
+    @Override
+    public @Nullable Date deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2)
+            throws JsonParseException {
+        String date = element.getAsString();
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        try {
+            return formatter.parse(date);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/InstantDeserializer.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/InstantDeserializer.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ecobee.internal.dto.thermostat;
+
+import static org.openhab.binding.ecobee.internal.EcobeeBindingConstants.ECOBEE_DATETIME_FORMAT;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * The {@link InstantDeserializer} is responsible for handling the UTC dates returned from
+ * the Ecobee API service.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+@NonNullByDefault
+public class InstantDeserializer implements JsonDeserializer<Instant> {
+
+    @Override
+    public @Nullable Instant deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2)
+            throws JsonParseException {
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ECOBEE_DATETIME_FORMAT);
+            LocalDateTime localDateTime = formatter.parse(element.getAsString(), LocalDateTime::from);
+            return localDateTime.toInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/LocalDateTimeDeserializer.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/LocalDateTimeDeserializer.java
@@ -12,11 +12,12 @@
  */
 package org.openhab.binding.ecobee.internal.dto.thermostat;
 
+import static org.openhab.binding.ecobee.internal.EcobeeBindingConstants.ECOBEE_DATETIME_FORMAT;
+
 import java.lang.reflect.Type;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -27,23 +28,21 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 /**
- * The {@link DateDeserializer} is responsible for handling the UTC dates returned from
+ * The {@link LocalDateTimeDeserializer} is responsible for handling the local dates returned from
  * the Ecobee API service.
  *
  * @author Mark Hilbush - Initial contribution
  */
 @NonNullByDefault
-public class DateDeserializer implements JsonDeserializer<Date> {
+public class LocalDateTimeDeserializer implements JsonDeserializer<LocalDateTime> {
 
     @Override
-    public @Nullable Date deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2)
+    public @Nullable LocalDateTime deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2)
             throws JsonParseException {
-        String date = element.getAsString();
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         try {
-            return formatter.parse(date);
-        } catch (ParseException e) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ECOBEE_DATETIME_FORMAT);
+            return formatter.parse(element.getAsString(), LocalDateTime::from);
+        } catch (DateTimeParseException e) {
             return null;
         }
     }

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/RuntimeDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/RuntimeDTO.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ecobee.internal.dto.thermostat;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -48,29 +48,29 @@ public class RuntimeDTO {
      * The UTC date/time stamp of when the thermostat first connected
      * to the ecobee server.
      */
-    public Date firstConnected;
+    public Instant firstConnected;
 
     /*
      * The last recorded connection date and time.
      */
-    public Date connectDateTime;
+    public Instant connectDateTime;
 
     /*
      * The last recorded disconnection date and time.
      */
-    public Date disconnectDateTime;
+    public Instant disconnectDateTime;
 
     /*
      * The UTC date/time stamp of when the thermostat was updated.
      * Format: YYYY-MM-DD HH:MM:SS
      */
-    public Date lastModified;
+    public Instant lastModified;
 
     /*
      * The UTC date/time stamp of when the thermostat last posted its
      * runtime information. Format: YYYY-MM-DD HH:MM:SS
      */
-    public Date lastStatusModified;
+    public Instant lastStatusModified;
 
     /*
      * The UTC date of the last runtime reading. Format: YYYY-MM-DD

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/ThermostatDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/ThermostatDTO.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.binding.ecobee.internal.dto.thermostat;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -64,12 +65,12 @@ public class ThermostatDTO {
     /*
      * The last modified date time for the thermostat configuration.
      */
-    public Date lastModified;
+    public Instant lastModified;
 
     /*
      * The current time in the thermostat's time zone.
      */
-    public String thermostatTime;
+    public LocalDateTime thermostatTime;
 
     /*
      * The current time in UTC.

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/ThermostatDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/ThermostatDTO.java
@@ -69,7 +69,7 @@ public class ThermostatDTO {
     /*
      * The current time in the thermostat's time zone.
      */
-    public Date thermostatTime;
+    public String thermostatTime;
 
     /*
      * The current time in UTC.

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/WeatherDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/WeatherDTO.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ecobee.internal.dto.thermostat;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -25,7 +25,7 @@ public class WeatherDTO {
     /*
      * The time stamp in UTC of the weather forecast
      */
-    public Date timestamp;
+    public Instant timestamp;
 
     /*
      * The weather station identifier

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/WeatherForecastDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/WeatherForecastDTO.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.ecobee.internal.dto.thermostat;
 
+import java.time.LocalDateTime;
+
 /**
  * The {@link WeatherForecastDTO} contains the weather forecast information for
  * the thermostat. The first forecast is the most accurate, later forecasts
@@ -31,7 +33,7 @@ public class WeatherForecastDTO {
     /*
      * The time stamp of the weather forecast in the thermostat's time zone.
      */
-    public String dateTime;
+    public LocalDateTime dateTime;
 
     /*
      * A text value representing the current weather condition.

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/WeatherForecastDTO.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/dto/thermostat/WeatherForecastDTO.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.ecobee.internal.dto.thermostat;
 
-import java.util.Date;
-
 /**
  * The {@link WeatherForecastDTO} contains the weather forecast information for
  * the thermostat. The first forecast is the most accurate, later forecasts
@@ -31,9 +29,9 @@ public class WeatherForecastDTO {
     public Integer weatherSymbol;
 
     /*
-     * The time stamp of the weather forecast.
+     * The time stamp of the weather forecast in the thermostat's time zone.
      */
-    public Date dateTime;
+    public String dateTime;
 
     /*
      * A text value representing the current weather condition.

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
@@ -370,7 +370,7 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
         updateChannel(grp + CH_MODEL_NUMBER, EcobeeUtils.undefOrString(thermostat.modelNumber));
         updateChannel(grp + CH_BRAND, EcobeeUtils.undefOrString(thermostat.brand));
         updateChannel(grp + CH_FEATURES, EcobeeUtils.undefOrString(thermostat.features));
-        updateChannel(grp + CH_LAST_MODIFIED, EcobeeUtils.undefOrDate(thermostat.lastModified));
+        updateChannel(grp + CH_LAST_MODIFIED, EcobeeUtils.undefOrDate(thermostat.lastModified, timeZoneProvider));
         updateChannel(grp + CH_THERMOSTAT_TIME, EcobeeUtils.undefOrDate(thermostat.thermostatTime, timeZoneProvider));
     }
 
@@ -386,11 +386,13 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
         final String grp = CHGRP_RUNTIME + "#";
         updateChannel(grp + CH_RUNTIME_REV, EcobeeUtils.undefOrString(runtime.runtimeRev));
         updateChannel(grp + CH_CONNECTED, EcobeeUtils.undefOrOnOff(runtime.connected));
-        updateChannel(grp + CH_FIRST_CONNECTED, EcobeeUtils.undefOrDate(runtime.firstConnected));
-        updateChannel(grp + CH_CONNECT_DATE_TIME, EcobeeUtils.undefOrDate(runtime.connectDateTime));
-        updateChannel(grp + CH_DISCONNECT_DATE_TIME, EcobeeUtils.undefOrDate(runtime.disconnectDateTime));
-        updateChannel(grp + CH_RT_LAST_MODIFIED, EcobeeUtils.undefOrDate(runtime.lastModified));
-        updateChannel(grp + CH_RT_LAST_STATUS_MODIFIED, EcobeeUtils.undefOrDate(runtime.lastStatusModified));
+        updateChannel(grp + CH_FIRST_CONNECTED, EcobeeUtils.undefOrDate(runtime.firstConnected, timeZoneProvider));
+        updateChannel(grp + CH_CONNECT_DATE_TIME, EcobeeUtils.undefOrDate(runtime.connectDateTime, timeZoneProvider));
+        updateChannel(grp + CH_DISCONNECT_DATE_TIME,
+                EcobeeUtils.undefOrDate(runtime.disconnectDateTime, timeZoneProvider));
+        updateChannel(grp + CH_RT_LAST_MODIFIED, EcobeeUtils.undefOrDate(runtime.lastModified, timeZoneProvider));
+        updateChannel(grp + CH_RT_LAST_STATUS_MODIFIED,
+                EcobeeUtils.undefOrDate(runtime.lastStatusModified, timeZoneProvider));
         updateChannel(grp + CH_RUNTIME_DATE, EcobeeUtils.undefOrString(runtime.runtimeDate));
         updateChannel(grp + CH_RUNTIME_INTERVAL, EcobeeUtils.undefOrDecimal(runtime.runtimeInterval));
         updateChannel(grp + CH_ACTUAL_TEMPERATURE, EcobeeUtils.undefOrTemperature(runtime.actualTemperature));
@@ -661,7 +663,7 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
         }
         final String weatherGrp = CHGRP_WEATHER + "#";
 
-        updateChannel(weatherGrp + CH_WEATHER_TIMESTAMP, EcobeeUtils.undefOrDate(weather.timestamp));
+        updateChannel(weatherGrp + CH_WEATHER_TIMESTAMP, EcobeeUtils.undefOrDate(weather.timestamp, timeZoneProvider));
         updateChannel(weatherGrp + CH_WEATHER_WEATHER_STATION, EcobeeUtils.undefOrString(weather.weatherStation));
 
         for (int index = 0; index < weather.forecasts.size(); index++) {

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
@@ -371,7 +371,8 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
         updateChannel(grp + CH_BRAND, EcobeeUtils.undefOrString(thermostat.brand));
         updateChannel(grp + CH_FEATURES, EcobeeUtils.undefOrString(thermostat.features));
         updateChannel(grp + CH_LAST_MODIFIED, EcobeeUtils.undefOrDate(thermostat.lastModified, timeZoneProvider));
-        updateChannel(grp + CH_THERMOSTAT_TIME, EcobeeUtils.undefOrDate(thermostat.thermostatTime, timeZoneProvider));
+        updateChannel(grp + CH_THERMOSTAT_TIME,
+                EcobeeUtils.undefOrLocalDate(thermostat.thermostatTime, timeZoneProvider));
     }
 
     private void updateEquipmentStatus(ThermostatDTO thermostat) {
@@ -673,7 +674,7 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
                 updateChannel(grp + CH_FORECAST_WEATHER_SYMBOL_TEXT,
                         EcobeeUtils.undefOrString(symbolMap.get(forecast.weatherSymbol)));
                 updateChannel(grp + CH_FORECAST_DATE_TIME,
-                        EcobeeUtils.undefOrDate(forecast.dateTime, timeZoneProvider));
+                        EcobeeUtils.undefOrLocalDate(forecast.dateTime, timeZoneProvider));
                 updateChannel(grp + CH_FORECAST_CONDITION, EcobeeUtils.undefOrString(forecast.condition));
                 updateChannel(grp + CH_FORECAST_TEMPERATURE, EcobeeUtils.undefOrTemperature(forecast.temperature));
                 updateChannel(grp + CH_FORECAST_PRESSURE,

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeThermostatBridgeHandler.java
@@ -370,9 +370,8 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
         updateChannel(grp + CH_MODEL_NUMBER, EcobeeUtils.undefOrString(thermostat.modelNumber));
         updateChannel(grp + CH_BRAND, EcobeeUtils.undefOrString(thermostat.brand));
         updateChannel(grp + CH_FEATURES, EcobeeUtils.undefOrString(thermostat.features));
-        updateChannel(grp + CH_LAST_MODIFIED, EcobeeUtils.undefOrDate(thermostat.lastModified, timeZoneProvider));
-        updateChannel(grp + CH_THERMOSTAT_TIME,
-                EcobeeUtils.undefOrLocalDate(thermostat.thermostatTime, timeZoneProvider));
+        updateChannel(grp + CH_LAST_MODIFIED, EcobeeUtils.undefOrDate(thermostat.lastModified));
+        updateChannel(grp + CH_THERMOSTAT_TIME, EcobeeUtils.undefOrDate(thermostat.thermostatTime, timeZoneProvider));
     }
 
     private void updateEquipmentStatus(ThermostatDTO thermostat) {
@@ -387,13 +386,11 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
         final String grp = CHGRP_RUNTIME + "#";
         updateChannel(grp + CH_RUNTIME_REV, EcobeeUtils.undefOrString(runtime.runtimeRev));
         updateChannel(grp + CH_CONNECTED, EcobeeUtils.undefOrOnOff(runtime.connected));
-        updateChannel(grp + CH_FIRST_CONNECTED, EcobeeUtils.undefOrDate(runtime.firstConnected, timeZoneProvider));
-        updateChannel(grp + CH_CONNECT_DATE_TIME, EcobeeUtils.undefOrDate(runtime.connectDateTime, timeZoneProvider));
-        updateChannel(grp + CH_DISCONNECT_DATE_TIME,
-                EcobeeUtils.undefOrDate(runtime.disconnectDateTime, timeZoneProvider));
-        updateChannel(grp + CH_RT_LAST_MODIFIED, EcobeeUtils.undefOrDate(runtime.lastModified, timeZoneProvider));
-        updateChannel(grp + CH_RT_LAST_STATUS_MODIFIED,
-                EcobeeUtils.undefOrDate(runtime.lastStatusModified, timeZoneProvider));
+        updateChannel(grp + CH_FIRST_CONNECTED, EcobeeUtils.undefOrDate(runtime.firstConnected));
+        updateChannel(grp + CH_CONNECT_DATE_TIME, EcobeeUtils.undefOrDate(runtime.connectDateTime));
+        updateChannel(grp + CH_DISCONNECT_DATE_TIME, EcobeeUtils.undefOrDate(runtime.disconnectDateTime));
+        updateChannel(grp + CH_RT_LAST_MODIFIED, EcobeeUtils.undefOrDate(runtime.lastModified));
+        updateChannel(grp + CH_RT_LAST_STATUS_MODIFIED, EcobeeUtils.undefOrDate(runtime.lastStatusModified));
         updateChannel(grp + CH_RUNTIME_DATE, EcobeeUtils.undefOrString(runtime.runtimeDate));
         updateChannel(grp + CH_RUNTIME_INTERVAL, EcobeeUtils.undefOrDecimal(runtime.runtimeInterval));
         updateChannel(grp + CH_ACTUAL_TEMPERATURE, EcobeeUtils.undefOrTemperature(runtime.actualTemperature));
@@ -663,7 +660,8 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
             return;
         }
         final String weatherGrp = CHGRP_WEATHER + "#";
-        updateChannel(weatherGrp + CH_WEATHER_TIMESTAMP, EcobeeUtils.undefOrDate(weather.timestamp, timeZoneProvider));
+
+        updateChannel(weatherGrp + CH_WEATHER_TIMESTAMP, EcobeeUtils.undefOrDate(weather.timestamp));
         updateChannel(weatherGrp + CH_WEATHER_WEATHER_STATION, EcobeeUtils.undefOrString(weather.weatherStation));
 
         for (int index = 0; index < weather.forecasts.size(); index++) {
@@ -674,7 +672,7 @@ public class EcobeeThermostatBridgeHandler extends BaseBridgeHandler {
                 updateChannel(grp + CH_FORECAST_WEATHER_SYMBOL_TEXT,
                         EcobeeUtils.undefOrString(symbolMap.get(forecast.weatherSymbol)));
                 updateChannel(grp + CH_FORECAST_DATE_TIME,
-                        EcobeeUtils.undefOrLocalDate(forecast.dateTime, timeZoneProvider));
+                        EcobeeUtils.undefOrDate(forecast.dateTime, timeZoneProvider));
                 updateChannel(grp + CH_FORECAST_CONDITION, EcobeeUtils.undefOrString(forecast.condition));
                 updateChannel(grp + CH_FORECAST_TEMPERATURE, EcobeeUtils.undefOrTemperature(forecast.temperature));
                 updateChannel(grp + CH_FORECAST_PRESSURE,

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.binding.ecobee.internal.handler;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import javax.measure.Unit;
@@ -85,6 +87,20 @@ public final class EcobeeUtils {
 
     public static State undefOrPoint(@Nullable String value) {
         return value == null ? UnDefType.UNDEF : new PointType(value);
+    }
+
+    public static State undefOrLocalDate(@Nullable String date, TimeZoneProvider timeZoneProvider) {
+        if (date == null) {
+            return UnDefType.UNDEF;
+        }
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                    .withZone(timeZoneProvider.getTimeZone());
+            ZonedDateTime zoned = ZonedDateTime.parse(date, formatter);
+            return new DateTimeType(zoned);
+        } catch (DateTimeException e) {
+            return UnDefType.UNDEF;
+        }
     }
 
     public static State undefOrDate(@Nullable Date date, TimeZoneProvider timeZoneProvider) {

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
@@ -14,7 +14,6 @@ package org.openhab.binding.ecobee.internal.handler;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import javax.measure.Unit;
@@ -89,8 +88,9 @@ public final class EcobeeUtils {
         return value == null ? UnDefType.UNDEF : new PointType(value);
     }
 
-    public static State undefOrDate(@Nullable Instant instant) {
-        return instant == null ? UnDefType.UNDEF : new DateTimeType(ZonedDateTime.ofInstant(instant, ZoneId.of("UTC")));
+    public static State undefOrDate(@Nullable Instant instant, TimeZoneProvider timeZoneProvider) {
+        return instant == null ? UnDefType.UNDEF
+                : new DateTimeType(ZonedDateTime.ofInstant(instant, timeZoneProvider.getTimeZone()));
     }
 
     public static State undefOrDate(@Nullable LocalDateTime ldt, TimeZoneProvider timeZoneProvider) {

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.ecobee.internal.handler;
 
-import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 import javax.measure.Unit;
 import javax.measure.quantity.Temperature;
@@ -89,23 +89,12 @@ public final class EcobeeUtils {
         return value == null ? UnDefType.UNDEF : new PointType(value);
     }
 
-    public static State undefOrLocalDate(@Nullable String date, TimeZoneProvider timeZoneProvider) {
-        if (date == null) {
-            return UnDefType.UNDEF;
-        }
-        try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-                    .withZone(timeZoneProvider.getTimeZone());
-            ZonedDateTime zoned = ZonedDateTime.parse(date, formatter);
-            return new DateTimeType(zoned);
-        } catch (DateTimeException e) {
-            return UnDefType.UNDEF;
-        }
+    public static State undefOrDate(@Nullable Instant instant) {
+        return instant == null ? UnDefType.UNDEF : new DateTimeType(ZonedDateTime.ofInstant(instant, ZoneId.of("UTC")));
     }
 
-    public static State undefOrDate(@Nullable Date date, TimeZoneProvider timeZoneProvider) {
-        return date == null ? UnDefType.UNDEF
-                : new DateTimeType(ZonedDateTime.ofInstant(date.toInstant(), timeZoneProvider.getTimeZone()));
+    public static State undefOrDate(@Nullable LocalDateTime ldt, TimeZoneProvider timeZoneProvider) {
+        return ldt == null ? UnDefType.UNDEF : new DateTimeType(ldt.atZone(timeZoneProvider.getTimeZone()));
     }
 
     private static boolean isUnknown(Number value) {


### PR DESCRIPTION
The Ecobee API returns all date/time fields formatted as "yyyy-MM-dd HH:mm:ss". Most of those date/times are in UTC time, however a couple are in local time. This PR correctly handles both cases by:

- introducing a Gson DateDeserializer that handles the dates when they're in UTC time
- introduces a new method that handles the dates when they're in local time

Reference: https://community.openhab.org/t/ecobee-binding-v2/97733/225

Signed-off-by: Mark Hilbush [mark@hilbush.com](mailto:mark@hilbush.com)
