### PR TITLE
Fix incorrectly formatted license headers

### DIFF
--- a/bundles/org.openhab.binding.mycroft/src/main/java/org/openhab/binding/mycroft/internal/MycroftHandlerFactory.java
+++ b/bundles/org.openhab.binding.mycroft/src/main/java/org/openhab/binding/mycroft/internal/MycroftHandlerFactory.java
@@ -9,8 +9,6 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * @author Gwendal Roulleau - Initial contribution
  */
 package org.openhab.binding.mycroft.internal;
 

--- a/bundles/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/handler/TypicalCommonMethods.java
+++ b/bundles/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/handler/TypicalCommonMethods.java
@@ -9,12 +9,6 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
-=======
- * Copyright (c) 2014-2019 by the respective copyright holders.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.souliss.internal.handler;
 


### PR DESCRIPTION
Fix incorrectly formatted license headers detected by `mvn license:format`.

Related to #14154