### PR TITLE
Update MapDB and use mmap on 64-bit platforms

### DIFF
--- a/bundles/org.openhab.persistence.mapdb/pom.xml
+++ b/bundles/org.openhab.persistence.mapdb/pom.xml
@@ -15,14 +15,66 @@
   <name>openHAB Add-ons :: Bundles :: Persistence Service :: MapDB</name>
 
   <properties>
-    <bnd.importpackage>org.openhab.core.library.types</bnd.importpackage>
+    <bnd.importpackage>!android.*,!com.google.*,!com.mysql.jdbc,!com.sun.*,!io.opencensus.*,!libcore.*,!org.antlr.*,!org.apache.log.*,!org.checkerframework.*,!org.joda.*,!org.jspecify.*,"sun.*,org.openhab.core.library.types</bnd.importpackage>
   </properties>
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-osgi-bundle</artifactId>
+      <version>1.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>net.jpountz.lz4</groupId>
+      <artifactId>lz4</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections</artifactId>
+      <version>10.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections-api</artifactId>
+      <version>10.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>failureaccess</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>2.0.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mapdb</groupId>
+      <artifactId>elsa</artifactId>
+      <version>3.0.0-M7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.mapdb</groupId>
       <artifactId>mapdb</artifactId>
-      <version>1.0.9</version>
+      <version>3.0.9</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This updates MapDB to the latest version. Doing so will break compatibility with the previous version and it will not be possible to load previous databases. A new major version number of openHAB seems like a good idea to do this.

Using mmap will increase performance on supported platforms. We might suffer from the file descriptor leak from http://bugs.java.com/view_bug.do?bug_id=4724038 but as we don't open/close the file often it shouldn't be an issue.