### PR TITLE
Fix Markdown warnings in README.md

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/README.md
+++ b/bundles/org.openhab.automation.jrubyscripting/README.md
@@ -111,6 +111,7 @@ end
 ```
 
 #### weather.items
+
 ```Xtend
 Number:Angle Exterior_WindDirection "Wind Direction [SCRIPT(rb:compass.script):%s]" <wind>
 ```

--- a/bundles/org.openhab.binding.amazondashbutton/README.md
+++ b/bundles/org.openhab.binding.amazondashbutton/README.md
@@ -128,8 +128,8 @@ For manual definition of a `dashbutton` Thing the MAC address can either be take
 ## Channels
 
 - **press:** Trigger channel for recognizing presses on the Amazon Dash Button.
-A trigger channel can directly be used in a rule, check the "Full Example" section for one example.
-Dispatches a `PRESSED` event when a button is pressed.
+  A trigger channel can directly be used in a rule, check the "Full Example" section for one example.
+  Dispatches a `PRESSED` event when a button is pressed.
 
 The trigger channel `press` is of type `system.rawbutton` to allow the usage of the `rawbutton-toggle-switch` profile.
 

--- a/bundles/org.openhab.binding.digitalstrom/README.md
+++ b/bundles/org.openhab.binding.digitalstrom/README.md
@@ -380,8 +380,8 @@ _Generally:_
 
 - The digitalSTROM-Server only informs the binding about scene-commands. So if you set the output value of devices e.g. through  the dSS-App, the binding will not be informed about the changes and you have to send a "refresh-command" to update the channel.
 - If you press a physical switch at your digitalSTROM-installation and the called scene-value is not red out yet, it can take a bit time to read it out and change the state of the channel.
-It the scene-value is red out, the state will change immediately.
-See also _General-Informations/digitalSTROM-Scenes_.
+  It the scene-value is red out, the state will change immediately.
+  See also _General-Informations/digitalSTROM-Scenes_.
 
 _Channels with accepted command type increase and decrease:_
 

--- a/bundles/org.openhab.binding.dwdunwetter/README.md
+++ b/bundles/org.openhab.binding.dwdunwetter/README.md
@@ -18,6 +18,7 @@ Each Thing provides one or more warnings for a city.
 | warningCount | 1       | No       | Number of warnings to provide.                                                                                                             |
 
 ### Cell ID
+
 <!-- See page 10-13 (in German) of https://www.dwd.de/DE/wetter/warnungen_aktuell/objekt_einbindung/einbindung_karten_geodienste.pdf?__blob=publicationFile&v=14 for Cell ID documentation. -->
 Use [this list](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.csv) of valid IDs, please notice that **only IDs starting with an eight (8) and nine digits are supported** by this binding.
 Exeception for Berlin, where the ID of the city's districts are used. Those start with a seven (7).

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -176,9 +176,9 @@ If set to true, devices are automatically factory reset when their corresponding
 Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false! (default = false)
 
 - **bufferSize**
-If a large number of devices are connected to the gateway, the default buffersize of 2048 kB may be too small for communication with the gateway.
-In this case, e.g. the discovery fails.
-With this setting the buffer size can be adjusted. The value is specified in kB.
+  If a large number of devices are connected to the gateway, the default buffersize of 2048 kB may be too small for communication with the gateway.
+  In this case, e.g. the discovery fails.
+  With this setting the buffer size can be adjusted. The value is specified in kB.
 
 The syntax for a bridge is:
 

--- a/bundles/org.openhab.binding.mihome/README.md
+++ b/bundles/org.openhab.binding.mihome/README.md
@@ -543,7 +543,7 @@ In case you want to check if the communication between the machine and the gatew
 - make sure you have **netcat** installed
 - Enter ```netcat -ukl 9898```
 - At least every 10 seconds you should see a message coming in from the gateway which looks like
-```{"cmd":"heartbeat","model":"gateway","sid":"`xxx","short_id":"0","token":"xxx","data":"{\"ip\":\"`xxx\"}"}```
+  ```{"cmd":"heartbeat","model":"gateway","sid":"`xxx","short_id":"0","token":"xxx","data":"{\"ip\":\"`xxx\"}"}```
 
 #### Multiple network interfaces
 

--- a/bundles/org.openhab.binding.modbus/README.md
+++ b/bundles/org.openhab.binding.modbus/README.md
@@ -1038,8 +1038,8 @@ Devices may respond with an error or no error but invalid register data so this 
 Turn your poller thing into multiple things to cover smaller ranges to work around this problem.
 
 - there's potentially many more or less weird inconsistencies with some devices.
-If you fail to read a register or you only ever get invalid values (such as 00 or FF bytes), try with various poller lengths such as the exact length of a register in question or twice the amount.
-In extreme cases you might even need more than a poller for a single register so you have two or more poller with two or more data things and need to combine these into another item using a rule.
+  If you fail to read a register or you only ever get invalid values (such as 00 or FF bytes), try with various poller lengths such as the exact length of a register in question or twice the amount.
+  In extreme cases you might even need more than a poller for a single register so you have two or more poller with two or more data things and need to combine these into another item using a rule.
 
 ## Changes From Modbus 1.x Binding
 

--- a/bundles/org.openhab.binding.nibeuplink/README.md
+++ b/bundles/org.openhab.binding.nibeuplink/README.md
@@ -58,8 +58,8 @@ Setting less than 60 seconds does not make any sense as the heat pump only provi
 (default = 60)
 
 - **houseKeepingInterval**  
-interval (seconds) in which list of "dead channels" (channels that do not return any data or invalid data) should be purged (default = 3600).
-Usually this settings should not be changed.
+  interval (seconds) in which list of "dead channels" (channels that do not return any data or invalid data) should be purged (default = 3600).
+  Usually this settings should not be changed.
 
 ### Examples
 

--- a/bundles/org.openhab.binding.powermax/README.md
+++ b/bundles/org.openhab.binding.powermax/README.md
@@ -82,7 +82,7 @@ Some notes:
 - On Linux, you may get an error stating the serial port cannot be opened when the Powermax binding tries to load.
 You can get around this by adding the `openhab` user to the `dialout` group like this: `usermod -a -G dialout openhab`.
 - Also on Linux you may have issues with the USB if using two serial USB devices e.g. Powermax and RFXcom.
-See the [general documentation about serial port configuration](/docs/administration/serial.html) for more on symlinking the USB ports.
+  See the [general documentation about serial port configuration](/docs/administration/serial.html) for more on symlinking the USB ports.
 
 ### X10 device
 

--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -930,8 +930,8 @@ You can do this using RFXmngr, or you can do this using openhab:
     ```
 
 1. Activate the device and look at the pulses that are set.
-Look for a higher value in the pulses, that is likely to be a gap for a repeat.
-Take the pulses from before the gap. Make sure there are an even number, and if not, drop a 0 on the end.
+  Look for a higher value in the pulses, that is likely to be a gap for a repeat.
+  Take the pulses from before the gap. Make sure there are an even number, and if not, drop a 0 on the end.
 
 Now you have the pulses, set up a send device:
 

--- a/bundles/org.openhab.binding.russound/README.md
+++ b/bundles/org.openhab.binding.russound/README.md
@@ -81,7 +81,7 @@ The following channels are supported for each bridge/thing
 #### Notes
 
 - The JSON will look like: `[{"id":1, "name":"XXX"},...]`.
-The controller channel will contain up to 6 controllers and the sources will contain up to 8 sources (depending on how the system is configured).
+  The controller channel will contain up to 6 controllers and the sources will contain up to 8 sources (depending on how the system is configured).
 
 ### Russound Source (please see source cross-reference below for what is supported by which sources)
 

--- a/bundles/org.openhab.binding.solaredge/README.md
+++ b/bundles/org.openhab.binding.solaredge/README.md
@@ -54,8 +54,8 @@ interval (minutes) in which live data values are retrieved from Solaredge.
 Setting less than 10 minutes is only allowed when using private API. (default = 10)
 
 - **aggregateDataPollingInterval** (optional)  
-interval (minutes) in which aggregate data values are retrieved from Solaredge.
-Setting less than 60 is only allowed when using private API. (default = 60)
+  interval (minutes) in which aggregate data values are retrieved from Solaredge.
+  Setting less than 60 is only allowed when using private API. (default = 60)
 
 ## Channels
 

--- a/bundles/org.openhab.binding.sonyaudio/README.md
+++ b/bundles/org.openhab.binding.sonyaudio/README.md
@@ -5,6 +5,7 @@ This binding integrates the [Sony Audio Control API](https://developer.sony.com/
 ## Supported Things
 
 For the moment the devices that are supported by this binding are
+
 - STR-DN1080
 - HT-CT800
 - SRS-ZR5

--- a/bundles/org.openhab.binding.tacmi/README.md
+++ b/bundles/org.openhab.binding.tacmi/README.md
@@ -8,10 +8,12 @@ These modes are:
 
 
 Via a "Schema API Page"
+
   * Read values from output nodes
   * Change values for controllable nodes
 
 CoE (CAN over Ethernet) Connection
+
   * Receive data from analog CAN-outputs defined in TAPPS2
   * Receive data from digital CAN-outputs defined in TAPPS2
   * Send ON/OFF to digital CAN-inputs defined in TAPPS2

--- a/bundles/org.openhab.binding.teleinfo/README.md
+++ b/bundles/org.openhab.binding.teleinfo/README.md
@@ -153,6 +153,7 @@ The following channels are available on all Linky telemeters in standard TIC mod
 #### Three phase only channels
 
 These channels are available on the following telemeters:
+
 * lstm_electricitymeter
 * lsmt_prod_electricitymeter
 
@@ -171,6 +172,7 @@ These channels are available on the following telemeters:
 #### Producer only channels
 
 These channels are available on the following telemeters:
+
 * lsmm_prod_electricitymeter
 * lsmt_prod_electricitymeter
 

--- a/bundles/org.openhab.binding.velux/README.md
+++ b/bundles/org.openhab.binding.velux/README.md
@@ -111,10 +111,10 @@ Notes:
 For an example, see the Thing definition for 'Bathroom_Roof_Window' below.
 
 2. Somfy devices do not provide a valid serial number to the Velux KLF200 Bridge.
-For such devices you have to enter the special all-zero serial number 00:00:00:00:00:00:00:00 in the `serial` parameter.
-This special serial number complies with the serial number validation checks, but also makes the binding use the `name` parameter value instead of the `serial` parameter value when it communicates with the KLF Bridge.
-The `name` parameter must therefore contain the name that you gave to the actuator when you first registered it in the KLF200 Bridge.
-For an example, see the Thing definition for 'Living_Room_Awning' below.
+  For such devices you have to enter the special all-zero serial number 00:00:00:00:00:00:00:00 in the `serial` parameter.
+  This special serial number complies with the serial number validation checks, but also makes the binding use the `name` parameter value instead of the `serial` parameter value when it communicates with the KLF Bridge.
+  The `name` parameter must therefore contain the name that you gave to the actuator when you first registered it in the KLF200 Bridge.
+  For an example, see the Thing definition for 'Living_Room_Awning' below.
 
 ### Thing Configuration for "scene"
 

--- a/bundles/org.openhab.binding.wolfsmartset/README.md
+++ b/bundles/org.openhab.binding.wolfsmartset/README.md
@@ -80,6 +80,7 @@ Bridge wolfsmartset:account:account "Wolf Smartset Account" [ username="User", p
     }
 }
 ````
+
 _You need to use the corrosponding systemId and unitId returned by the discovery_
 
 ### Items

--- a/bundles/org.openhab.binding.yamahareceiver/README.md
+++ b/bundles/org.openhab.binding.yamahareceiver/README.md
@@ -205,6 +205,7 @@ String      Yamaha_Input_Ex
 The synthetic `Yamaha_Input_Ex` will be calculated by a rule (see below) and will drive sitemap visibility (see below).
 
 Rules:
+
 ```
 rule "Yamaha_Input_Ex"
 when
@@ -237,6 +238,7 @@ Notice how we have two preset mappings that each is meant for FM and DAB+ bands 
 Enabling detailed logging may help troubleshoot your configuration (or trace bugs in the binding itself). 
 
 Add the following lines to the logger configuration file (`userdata\etc\org.ops4j.pax.logging.cfg`):
+
 ```
 log4j2.logger.yamaha.name = org.openhab.binding.yamahareceiver
 log4j2.logger.yamaha.level = TRACE

--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -1012,9 +1012,9 @@ Try again.
 Save the settings, then re-open the settings so as to refresh the QR code.
 Re-add the device.
 * Remove HomeKit state in `${OPENHAB_USERDATA}/jsondb/homekit.json`, and HomeKit config in `${OPENHAB_USERDATA}/config/org/openhab/homekit.config`.
-Restart openHAB.
-Reboot iPhone.
-Try again.
+  Restart openHAB.
+  Reboot iPhone.
+  Try again.
 
 ### A stale HomeKit accessory will not go away after deleting the related item.
 

--- a/bundles/org.openhab.transform.jinja/README.md
+++ b/bundles/org.openhab.transform.jinja/README.md
@@ -33,6 +33,7 @@ the template
 extracts the string `4.7`.
 
 #### Outgoing data
+
 The JINJA transformation can be used to publish simple JSON strings through, for example, the HTTP Binding's `commandTransformation` parameter.
 
 Say we have a String Item which holds the following value:
@@ -52,6 +53,7 @@ will send the following string out of openHAB
 ```json
 {"msgtype":"m.text", "body":"This is my string"}
 ```
+
 `{{value}}` will be replaced by whatever the value of your Item is.
 
 Note that if using \*.things files you must escape quotation marks, for example:

--- a/bundles/org.openhab.transform.regex/README.md
+++ b/bundles/org.openhab.transform.regex/README.md
@@ -45,6 +45,7 @@ Number  Temperature "Temperature [%.1f °C]"
 ```
 
 The regex pattern is is defined as follows
+
 * `.*` match any character, zero and unlimited times
 * `=` match the equal sign literally, used to find the position
 *  `()` capture group match 

--- a/bundles/org.openhab.transform.scale/README.md
+++ b/bundles/org.openhab.transform.scale/README.md
@@ -22,26 +22,32 @@ These expressions are evaluated from top to bottom.
 The first range that includes the value is selected.
 
 ## Special entries
+
 Some special entries can be used in the scale file.
 
 ### Catchall Entry
+
 `[..]=Catchall`
 
 This entry will match all numeric values not met by a previous range. Obviously, this one should be put at the very end of the scale definition file.
 
 ### Not A Number
+
 Scale transform is designed to work with numeric or quantity states. When the value presented to scale transform does not match this (most of the time with NULL or UNDEF states) it will not be handled and a warning is raised in the openhab.log . This case can be smoothly avoided with a 
 
 `NaN=Non Numeric State presented`
 
 ### Formatting output
+
 At last, Scale transform can take care of formatting an output with this entry :
 
 `format=%label% (%value%) !`
 
 Where : 
+
 - `%label%` will be replaced by transformed value and 
 - `%value%` is the numeric value presen
+
 ## Example
 
 The following example shows how to break down numeric UV values into fixed UV index categories.

--- a/bundles/org.openhab.transform.xpath/README.md
+++ b/bundles/org.openhab.transform.xpath/README.md
@@ -47,10 +47,12 @@ Given a retrieved XML (e.g. from an HIK Vision device with the namespace `xmlns=
 A simple xpath query to fetch the Azimut value does not work as it does not address the namespace.
 
 There are two ways to address the namespace.
+
 * Simple path which may not work in complex XML.
 * With full qualified path.
-* 
-The XPath 
+
+The XPath
+
 * `[name()='PTZStatus']/*[name()='AbsoluteHigh']/*[name()='azimuth']/`
 * `/*[local-name()='PTZStatus' and namespace-uri()='http://www.hikvision.com/ver20/XMLSchema']/*[local-name()='AbsoluteHigh' and namespace-uri()='http://www.hikvision.com/ver20/XMLSchema']/*[local-name()='azimuth' and namespace-uri()='http://www.hikvision.com/ver20/XMLSchema']`
 

--- a/bundles/org.openhab.voice.googlestt/README.md
+++ b/bundles/org.openhab.voice.googlestt/README.md
@@ -27,12 +27,12 @@ Using your favorite configuration UI to edit **Settings / Other Services - Googl
 * **Client Id** - Google Cloud Platform OAuth 2.0-Client Id.
 * **Client Secret** - Google Cloud Platform OAuth 2.0-Client Secret.
 * **Authorization Code** - This code is used once for retrieving the Google Cloud Platform access and refresh tokens.
-**Please go to your browser ...**
-[https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/cloud-platform&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<clientId>](https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/cloud-platform&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<clientId>) (replace `<clientId>` by your Client Id)
-**... to generate an authorization code and paste it here**.
-After your browser has been redirected to https://www.google.com, the authorization code will be set in the browser URL as value of the "code" URL query parameter.
-After initial authorization, this code is not needed anymore.
-It is recommended to clear this configuration parameter afterwards.
+  **Please go to your browser ...**
+  [https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/cloud-platform&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<clientId>](https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/cloud-platform&access_type=offline&prompt=consent&include_granted_scopes=true&response_type=code&redirect_uri=https://www.google.com&client_id=<clientId>) (replace `<clientId>` by your Client Id)
+  **... to generate an authorization code and paste it here**.
+  After your browser has been redirected to https://www.google.com, the authorization code will be set in the browser URL as value of the "code" URL query parameter.
+  After initial authorization, this code is not needed anymore.
+  It is recommended to clear this configuration parameter afterwards.
 
 ### Speech to Text Configuration
 


### PR DESCRIPTION
Reduce number of SAT warnings in README.md files, see global analysis report.
Targets "checkstyle" "MarkdownCheck", previously showing 45 findings.