### PR TITLE
[homematic] Fix updating enum config values

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
@@ -601,8 +601,10 @@ public class HomematicThingHandler extends BaseThingHandler {
                                     } else if (dp.isFloatType()) {
                                         newValue = decimal.doubleValue();
                                     }
+                                } else if (newValue instanceof String && dp.isEnumType()) {
+                                    newValue = dp.getOptionIndex((String) newValue);
                                 }
-                                if (!Objects.equals(dp.isEnumType() ? dp.getOptionValue() : dp.getValue(), newValue)) {
+                                if (!Objects.equals(dp.getValue(), newValue)) {
                                     sendDatapoint(dp, new HmDatapointConfig(), newValue);
                                 }
                             }


### PR DESCRIPTION
When changing an enum value in the configuration, we used the wrong data type: while the value in the OH config is a string (the 'option value' - see HomematicThingHandler::getValueForConfiguration), internally we use an integer (the 'option index'), so we have to do the option value -> option index conversion when applying the new value. This especially was a problem for HM-MOD-EM-8 devices, which check the CHANNEL_FUNCTION enum value as part of their initialization routine. When disabling/enabling them after changing the CHANNEL_FUNCTION enum value, they went offline, because their initialization failed due to a NumberFormatException (via
HomematicThingHandler::doInitializeInBackground -> HmChannel::checkForChannelFunctionChange ->
HmChannel::getCurrentFunction)
