### PR TITLE
[jeelink] Fixed wrong TX22 rain value

### DIFF
--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
@@ -21,12 +21,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.ReadingPublisher;
 import org.openhab.binding.jeelink.internal.RollingAveragePublisher;
 import org.openhab.binding.jeelink.internal.RollingReadingAverage;
 import org.openhab.binding.jeelink.internal.config.LaCrosseTemperatureSensorConfig;
+import org.openhab.binding.jeelink.internal.util.StringUtils;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorHandler.java
@@ -18,10 +18,10 @@ import static org.openhab.core.library.unit.MetricPrefix.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.ReadingPublisher;
+import org.openhab.binding.jeelink.internal.util.StringUtils;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22ReadingConverter.java
@@ -83,7 +83,7 @@ public class Tx22ReadingConverter implements JeeLinkReadingConverter<Tx22Reading
                 Integer humidity = "255".equals(matcher.group(5)) ? null : Integer.parseInt(matcher.group(5));
 
                 Integer rain = "255".equals(matcher.group(6)) ? null
-                        : (Integer.parseInt(matcher.group(6)) * 256 + Integer.parseInt(matcher.group(7))) * 2;
+                        : (int) ((Integer.parseInt(matcher.group(6)) * 256 + Integer.parseInt(matcher.group(7))) * 0.5);
 
                 Float windDirection = "255".equals(matcher.group(8)) ? null
                         : (Integer.parseInt(matcher.group(8)) * 256 + Integer.parseInt(matcher.group(9))) / 10f;

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/util/StringUtils.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/util/StringUtils.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.util;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+@NonNullByDefault
+public final class StringUtils {
+
+    /**
+     * <p>
+     * Capitalizes a String changing the first character to title case.
+     * No other characters are changed.
+     * </p>
+     *
+     * <pre>
+     * StringUtils.capitalize(null)  = null
+     * StringUtils.capitalize("")    = ""
+     * StringUtils.capitalize("cat") = "Cat"
+     * StringUtils.capitalize("cAt") = "CAt"
+     * StringUtils.capitalize("'cat'") = "'cat'"
+     * </pre>
+     *
+     * @param val the String to capitalize, may not be null
+     * @return the capitalized String
+     */
+    public static String capitalize(String val) {
+        if (val.length() == 0) {
+            return val;
+        }
+        return val.substring(0, 1).toUpperCase() + val.substring(1);
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/util/StringUtils.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/util/StringUtils.java
@@ -14,6 +14,11 @@ package org.openhab.binding.jeelink.internal.util;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
+/**
+ * Utility class for strings
+ *
+ * @author Leo Siepel - Initial contribution
+ */
 @NonNullByDefault
 public final class StringUtils {
 


### PR DESCRIPTION
- Fixes the rain channel having a wrong value (divide instead of multiply)
- Removes dependency of apache.commons.

Allready tested openHAB 3.4.2 jar here: https://1drv.ms/u/s!AnMcxmvEeupwjqVCE_YtH3yeZG5hXA?e=a1d7Hv

Fixes: https://github.com/openhab/openhab-addons/issues/10358