### PR TITLE
[velux] Do not use new API on Somfy devices

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/ChannelActuatorPosition.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/ChannelActuatorPosition.java
@@ -95,10 +95,18 @@ final class ChannelActuatorPosition extends ChannelHandlerTemplate {
                 break;
             }
 
+            final VeluxExistingProducts existingProducts = thisBridgeHandler.existingProducts();
+
             GetProduct bcp = null;
             switch (channelId) {
                 case CHANNEL_ACTUATOR_POSITION:
                 case CHANNEL_ACTUATOR_STATE:
+                    // apparently Somfy products do not to support new API; so use older API instead
+                    if (existingProducts.get(veluxActuator.getProductBridgeIndex()).isSomfyProduct()) {
+                        bcp = thisBridgeHandler.thisBridge.bridgeAPI().getProduct();
+                        break;
+                    }
+                    // fall through
                 case CHANNEL_VANE_POSITION:
                     bcp = thisBridgeHandler.thisBridge.bridgeAPI().getProductStatus();
                 default:
@@ -118,7 +126,6 @@ final class ChannelActuatorPosition extends ChannelHandlerTemplate {
 
             VeluxProduct newProduct = bcp.getProduct();
             ProductBridgeIndex productBridgeIndex = newProduct.getBridgeProductIndex();
-            VeluxExistingProducts existingProducts = thisBridgeHandler.existingProducts();
             VeluxProduct existingProduct = existingProducts.get(productBridgeIndex);
             ProductState productState = newProduct.getProductState();
             switch (productState) {

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxProductPosition.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxProductPosition.java
@@ -140,7 +140,7 @@ public class VeluxProductPosition {
     }
 
     public static boolean isUnknownOrValid(int position) {
-        return (position == VeluxProductPosition.VPP_UNKNOWN) || isValid(position);
+        return (position == VeluxProductPosition.VPP_VELUX_UNKNOWN) || isValid(position);
     }
 
     /**


### PR DESCRIPTION
In #13212 we implemented the new API calls, but it seems that Somfy devices do not support use of this new API.

So this PR reverts to the old API calls for Somfy devices

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
