### PR TITLE
[mqtt] fix thread concurrency issue with type provider

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
@@ -14,10 +14,10 @@ package org.openhab.binding.mqtt.generic;
 
 import java.net.URI;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -53,9 +53,9 @@ import org.osgi.service.component.annotations.Reference;
 public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupTypeProvider, ChannelTypeProvider {
     private final ThingTypeRegistry typeRegistry;
 
-    private final Map<ChannelTypeUID, ChannelType> types = new HashMap<>();
-    private final Map<ChannelGroupTypeUID, ChannelGroupType> groups = new HashMap<>();
-    private final Map<ThingTypeUID, ThingType> things = new HashMap<>();
+    private final Map<ChannelTypeUID, ChannelType> types = new ConcurrentHashMap<>();
+    private final Map<ChannelGroupTypeUID, ChannelGroupType> groups = new ConcurrentHashMap<>();
+    private final Map<ThingTypeUID, ThingType> things = new ConcurrentHashMap<>();
 
     @Activate
     public MqttChannelTypeProvider(@Reference ThingTypeRegistry typeRegistry) {


### PR DESCRIPTION
I was getting the following errors in my log every time I tried to open a thing in MainUI shortly after booting:

```
2023-01-10 18:47:37.961 [ERROR] [internal.JSONResponseExceptionMapper] - Unexpected exception occurred while processing REST request.
java.lang.ArrayIndexOutOfBoundsException: Index 4052 out of bounds for length 4052
        at java.util.HashMap.valuesToArray(HashMap.java:973) ~[?:?]
        at java.util.HashMap$Values.toArray(HashMap.java:1050) ~[?:?]
        at java.util.ArrayList.addAll(ArrayList.java:670) ~[?:?]
        at org.openhab.core.thing.type.ChannelTypeRegistry.getChannelTypes(ChannelTypeRegistry.java:57) ~[?:?]
```

I was able to track it down to the MqttChannelTypeProvider. I presume that some component is just spamming a discover topic with the same config over and over, so the `types` field keeps getting updated from another thread while we're trying to copy the array over, and I happen to have a _lot_ of channel types coming from MQTT. Switching to a thread safe data structure resolved the issue for me.