### PR TITLE
[mqtt.homeassistant] Mark disabled by default components as advanced channels

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -232,6 +232,11 @@ public class ComponentChannel {
                             .withCommandTopic(commandTopic).makeTrigger(trigger).withFormatter(format).build(),
                     channelUID, valueState, channelStateUpdateListener, commandFilter);
 
+            // disabled by default components should always show up as advanced
+            if (!component.isEnabledByDefault()) {
+                isAdvanced = true;
+            }
+
             if (this.trigger) {
                 type = ChannelTypeBuilder.trigger(channelTypeUID, label)
                         .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL))

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -239,4 +239,8 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     public TransformationServiceProvider getTransformationServiceProvider() {
         return componentConfiguration.getTransformationServiceProvider();
     }
+
+    public boolean isEnabledByDefault() {
+        return channelConfiguration.isEnabledByDefault();
+    }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -127,9 +127,6 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
         @SerializedName("docked_topic")
         protected @Nullable String dockedTopic;
 
-        @SerializedName("enabled_by_default")
-        protected @Nullable Boolean enabledByDefault = true;
-
         @SerializedName("error_template")
         protected @Nullable String errorTemplate;
         @SerializedName("error_topic")

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/config/dto/AbstractChannelConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/config/dto/AbstractChannelConfiguration.java
@@ -55,6 +55,9 @@ public abstract class AbstractChannelConfiguration {
     @SerializedName("availability_template")
     protected @Nullable String availabilityTemplate;
 
+    @SerializedName("enabled_by_default")
+    protected boolean enabledByDefault = true;
+
     /**
      * A list of MQTT topics subscribed to receive availability (online/offline) updates. Must not be used together with
      * availability_topic
@@ -166,6 +169,10 @@ public abstract class AbstractChannelConfiguration {
     @Nullable
     public String getAvailabilityTemplate() {
         return availabilityTemplate;
+    }
+
+    public boolean isEnabledByDefault() {
+        return enabledByDefault;
     }
 
     @Nullable


### PR DESCRIPTION
openHAB doesn't have the concept of "enabled by default", since _everything_ is technically "disabled" until you link it to an item. It seems devices use disabled by default on less common entities, such as zigbee2mqtt marking a binary_sensor as a "backup" method to an update entity for when an update is available, or a sensor as a "backup" method to a select entity. So in that case, just hiding these channels unless the user clicks "Show Advanced" seems to map best.
