### PR TITLE
[evcc] Adjust to breaking API change & Add new channel

### DIFF
--- a/bundles/org.openhab.binding.evcc/README.md
+++ b/bundles/org.openhab.binding.evcc/README.md
@@ -1,6 +1,9 @@
 # evcc Binding
 
 This binding integrates [evcc - electric vehicle charging control](https://evcc.io), a project that provides a control center for electric vehicle charging.
+The binding requires evcc [version 0.111.0](https://github.com/evcc-io/evcc/releases/tag/0.111.0) or newer and is tested with this version.
+
+You can easily install and upgrade evcc on openHABian using `sudo openhabian-config`.
 
 evcc controls your wallbox(es) with multiple charging modes and allows you to charge your ev with your photovoltaik's excess current.
 To provide an intelligent charging control, evcc supports over 30 wallboxes and over 20 energy meters/home energy management systems from many manufacturers as well as electric vehicles from over 20 car manufacturers.

--- a/bundles/org.openhab.binding.evcc/README.md
+++ b/bundles/org.openhab.binding.evcc/README.md
@@ -37,6 +37,7 @@ Please note that some of them are only available when evcc is properly configure
 
 | Channel                    | Type                 | Read/Write | Description                                                                                                  |
 |----------------------------|----------------------|------------|--------------------------------------------------------------------------------------------------------------|
+| general#batteryCapacity    | Number:Energy        | R          | Capacity of (home) battery.                                                                                  |
 | general#batteryPower       | Number:Power         | R          | Current power from battery.                                                                                  |
 | general#batterySoC         | Number:Dimensionless | R          | Current State of Charge of battery.                                                                          |
 | general#batteryPrioritySoC | Number:Dimensionless | R          | State of State of Charge for which the battery has priority over charging the ev when charging mode is "pv". |
@@ -91,42 +92,43 @@ Thing evcc:device:demo "evcc Demo" [url="https://demo.evcc.io", refreshInterval=
 
 ```java
 // General
-Number:Power              evcc_demo_batteryPower                           "Battery Power [%.1f kW]"                         <energy>          {channel="evcc:device:demo:general#batteryPower"}
-Number:Dimensionless      evcc_demo_batterySoC                             "Battery SoC [%d %%]"                             <batterylevel>    {channel="evcc:device:demo:general#batterySoC"}
-Number:Dimensionless      evcc_demo_batteryPrioritySoC                     "Battery Priority SoC [%d %%]"                    <batterylevel>    {channel="evcc:device:demo:general#batteryPrioritySoC"}
-Number:Power              evcc_demo_gridPower                              "Grid Power [%.1f kW]"                            <energy>          {channel="evcc:device:demo:general#gridPower"}
-Number:Power              evcc_demo_homePower                              "Home Power [%.1f kW]"                            <energy>          {channel="evcc:device:demo:general#homePower"}
-Number:Power              evcc_demo_pvPower                                "PV Power [%.1f kW]"                              <energy>          {channel="evcc:device:demo:general#pvPower"}
+Number:General            evcc_batteryCapacity                        "Battery Capacity [%.0f kWH]"                     <energy>          {channel="evcc:device:demo:general#batteryCapacity"}
+Number:Power              evcc_batteryPower                           "Battery Power [%.1f kW]"                         <energy>          {channel="evcc:device:demo:general#batteryPower"}
+Number:Dimensionless      evcc_batterySoC                             "Battery SoC [%d %%]"                             <batterylevel>    {channel="evcc:device:demo:general#batterySoC"}
+Number:Dimensionless      evcc_batteryPrioritySoC                     "Battery Priority SoC [%d %%]"                    <batterylevel>    {channel="evcc:device:demo:general#batteryPrioritySoC"}
+Number:Power              evcc_gridPower                              "Grid Power [%.1f kW]"                            <energy>          {channel="evcc:device:demo:general#gridPower"}
+Number:Power              evcc_homePower                              "Home Power [%.1f kW]"                            <energy>          {channel="evcc:device:demo:general#homePower"}
+Number:Power              evcc_pvPower                                "PV Power [%.1f kW]"                              <energy>          {channel="evcc:device:demo:general#pvPower"}
 
 // Loadpoint
-Number                    evcc_demo_loadpoint0_activePhases                "Active Phases [%d]"                                                {channel="evcc:device:demo:loadpoint0#activePhases"}
-Number:ElectricCurrent    evcc_demo_loadpoint0_chargeCurrent               "Charging current [%.0f A]"                       <energy>          {channel="evcc:device:demo:loadpoint0#chargeCurrent"}
-Number:Time               evcc_demo_loadpoint0_chargeDuration              "Charging duration [%1$tH:%1$tM]"                 <time>            {channel="evcc:device:demo:loadpoint0#chargeDuration"}
-Number:Time               evcc_demo_loadpoint0_chargeRemainingDuration     "Charging remaining duration [%1$tH:%1$tM]"       <time>            {channel="evcc:device:demo:loadpoint0#chargeRemainingDuration"}
-Number:Energy             evcc_demo_loadpoint0_chargeRemainingEnergy       "Charging remaining energy [%.1f kWh]"            <energy>          {channel="evcc:device:demo:loadpoint0#chargeRemainingEnergy"}
-Number:Power              evcc_demo_loadpoint0_chargePower                 "Charging power [%.1f kW]"                        <energy>          {channel="evcc:device:demo:loadpoint0#chargePower"}
-Number:Energy             evcc_demo_loadpoint0_chargedEnergy               "Charged energy [%.1f kWh]"                       <energy>          {channel="evcc:device:demo:loadpoint0#chargedEnergy"}
-Switch                    evcc_demo_loadpoint0_charging                    "Currently charging [%s]"                         <battery>         {channel="evcc:device:demo:loadpoint0#charging"}
-Switch                    evcc_demo_loadpoint0_enabled                     "Charging enabled [%s]"                           <switch>          {channel="evcc:device:demo:loadpoint0#enabled"}
-Switch                    evcc_demo_loadpoint0_hasVehicle                  "Vehicle configured [%s]"                         <switch>          {channel="evcc:device:demo:loadpoint0#hasVehicle"}
-Number:ElectricCurrent    evcc_demo_loadpoint0_maxCurrent                  "Maximum current [%.0f A]"                        <energy>          {channel="evcc:device:demo:loadpoint0#maxCurrent"}
-Number:ElectricCurrent    evcc_demo_loadpoint0_minCurrent                  "Minimum current [%.0f A]"                        <energy>          {channel="evcc:device:demo:loadpoint0#minCurrent"}
-Number:Dimensionless      evcc_demo_loadpoint0_minSoC                      "Minimum SoC [%d %%]"                             <batterylevel>    {channel="evcc:device:demo:loadpoint0#minSoC"}
-String                    evcc_demo_loadpoint0_mode                        "Mode [%s]"                                                         {channel="evcc:device:demo:loadpoint0#mode"}
-Number                    evcc_demo_loadpoint0_phases                      "Enabled phases [%d]"                                               {channel="evcc:device:demo:loadpoint0#phases"}
-Number:Dimensionless      evcc_demo_loadpoint0_targetSoC                   "Target SoC [%d %%]"                              <batterylevel>    {channel="evcc:device:demo:loadpoint0#targetSoC"}
-DateTime                  evcc_demo_loadpoint0_targetTime                  "Target time [%1$td.%1$tm.%1$tY, %1$tH:%1$tM]"    <time>            {channel="evcc:device:demo:loadpoint0#targetTime"}
-Switch                    evcc_demo_loadpoint0_targetTimeEnabled           "Target time enabled [%s]"                        <switch>          {channel="evcc:device:demo:loadpoint0#targetTimeEnabled"}
-String                    evcc_demo_loadpoint0_title                       "Loadpoint title [%s]"                            <text>            {channel="evcc:device:demo:loadpoint0#title"}
+Number                    evcc_loadpoint0_activePhases                "Active Phases [%d]"                                                {channel="evcc:device:demo:loadpoint0#activePhases"}
+Number:ElectricCurrent    evcc_loadpoint0_chargeCurrent               "Charging current [%.0f A]"                       <energy>          {channel="evcc:device:demo:loadpoint0#chargeCurrent"}
+Number:Time               evcc_loadpoint0_chargeDuration              "Charging duration [%1$tH:%1$tM]"                 <time>            {channel="evcc:device:demo:loadpoint0#chargeDuration"}
+Number:Time               evcc_loadpoint0_chargeRemainingDuration     "Charging remaining duration [%1$tH:%1$tM]"       <time>            {channel="evcc:device:demo:loadpoint0#chargeRemainingDuration"}
+Number:Energy             evcc_loadpoint0_chargeRemainingEnergy       "Charging remaining energy [%.1f kWh]"            <energy>          {channel="evcc:device:demo:loadpoint0#chargeRemainingEnergy"}
+Number:Power              evcc_loadpoint0_chargePower                 "Charging power [%.1f kW]"                        <energy>          {channel="evcc:device:demo:loadpoint0#chargePower"}
+Number:Energy             evcc_loadpoint0_chargedEnergy               "Charged energy [%.1f kWh]"                       <energy>          {channel="evcc:device:demo:loadpoint0#chargedEnergy"}
+Switch                    evcc_loadpoint0_charging                    "Currently charging [%s]"                         <battery>         {channel="evcc:device:demo:loadpoint0#charging"}
+Switch                    evcc_loadpoint0_enabled                     "Charging enabled [%s]"                           <switch>          {channel="evcc:device:demo:loadpoint0#enabled"}
+Switch                    evcc_loadpoint0_hasVehicle                  "Vehicle configured [%s]"                         <switch>          {channel="evcc:device:demo:loadpoint0#hasVehicle"}
+Number:ElectricCurrent    evcc_loadpoint0_maxCurrent                  "Maximum current [%.0f A]"                        <energy>          {channel="evcc:device:demo:loadpoint0#maxCurrent"}
+Number:ElectricCurrent    evcc_loadpoint0_minCurrent                  "Minimum current [%.0f A]"                        <energy>          {channel="evcc:device:demo:loadpoint0#minCurrent"}
+Number:Dimensionless      evcc_loadpoint0_minSoC                      "Minimum SoC [%d %%]"                             <batterylevel>    {channel="evcc:device:demo:loadpoint0#minSoC"}
+String                    evcc_loadpoint0_mode                        "Mode [%s]"                                                         {channel="evcc:device:demo:loadpoint0#mode"}
+Number                    evcc_loadpoint0_phases                      "Enabled phases [%d]"                                               {channel="evcc:device:demo:loadpoint0#phases"}
+Number:Dimensionless      evcc_loadpoint0_targetSoC                   "Target SoC [%d %%]"                              <batterylevel>    {channel="evcc:device:demo:loadpoint0#targetSoC"}
+DateTime                  evcc_loadpoint0_targetTime                  "Target time [%1$td.%1$tm.%1$tY, %1$tH:%1$tM]"    <time>            {channel="evcc:device:demo:loadpoint0#targetTime"}
+Switch                    evcc_loadpoint0_targetTimeEnabled           "Target time enabled [%s]"                        <switch>          {channel="evcc:device:demo:loadpoint0#targetTimeEnabled"}
+String                    evcc_loadpoint0_title                       "Loadpoint title [%s]"                            <text>            {channel="evcc:device:demo:loadpoint0#title"}
 // Vehicle on loadpoint
-Switch                    evcc_demo_loadpoint0_vehicleConnected            "Vehicle connected [%s]"                          <switch>          {channel="evcc:device:demo:loadpoint0#vehicleConnected"}
-Number:Time               evcc_demo_loadpoint0_vehicleConnectedDuration    "Vehicle connected duration [%.1f h]"             <time>            {channel="evcc:device:demo:loadpoint0#vehicleConnectedDuration"}
-Number:Energy             evcc_demo_loadpoint0_vehicleCapacity             "Vehicle capacity [%.0f kWH]"                     <batterylevel>    {channel="evcc:device:demo:loadpoint0#vehicleCapacity"}
-Number:Length             evcc_demo_loadpoint0_vehicleOdometer             "Vehicle odometer [%.1f km]"                                        {channel="evcc:device:demo:loadpoint0#vehicleOdometer"}
-Switch                    evcc_demo_loadpoint0_vehiclePresent              "Vehicle present [%s]"                            <switch>          {channel="evcc:device:demo:loadpoint0#vehiclePresent"}
-Number:Length             evcc_demo_loadpoint0_vehicleRange                "Vehicle Range [%.0f km]"                                           {channel="evcc:device:demo:loadpoint0#vehicleRange"}
-Number:Dimensionless      evcc_demo_loadpoint0_vehicleSoC                  "Vehicle SoC [%d %%]"                             <batterylevel>    {channel="evcc:device:demo:loadpoint0#vehicleSoC"}
-String                    evcc_demo_loadpoint0_vehicleName                 "Vehicle name [%s]"                               <text>            {channel="evcc:device:demo:loadpoint0#vehicleTitle"}
+Switch                    evcc_loadpoint0_vehicleConnected            "Vehicle connected [%s]"                          <switch>          {channel="evcc:device:demo:loadpoint0#vehicleConnected"}
+Number:Time               evcc_loadpoint0_vehicleConnectedDuration    "Vehicle connected duration [%.1f h]"             <time>            {channel="evcc:device:demo:loadpoint0#vehicleConnectedDuration"}
+Number:Energy             evcc_loadpoint0_vehicleCapacity             "Vehicle capacity [%.0f kWH]"                     <batterylevel>    {channel="evcc:device:demo:loadpoint0#vehicleCapacity"}
+Number:Length             evcc_loadpoint0_vehicleOdometer             "Vehicle odometer [%.1f km]"                                        {channel="evcc:device:demo:loadpoint0#vehicleOdometer"}
+Switch                    evcc_loadpoint0_vehiclePresent              "Vehicle present [%s]"                            <switch>          {channel="evcc:device:demo:loadpoint0#vehiclePresent"}
+Number:Length             evcc_loadpoint0_vehicleRange                "Vehicle Range [%.0f km]"                                           {channel="evcc:device:demo:loadpoint0#vehicleRange"}
+Number:Dimensionless      evcc_loadpoint0_vehicleSoC                  "Vehicle SoC [%d %%]"                             <batterylevel>    {channel="evcc:device:demo:loadpoint0#vehicleSoC"}
+String                    evcc_loadpoint0_vehicleName                 "Vehicle name [%s]"                               <text>            {channel="evcc:device:demo:loadpoint0#vehicleTitle"}
 ```
 
 ### Sitemap
@@ -134,36 +136,36 @@ String                    evcc_demo_loadpoint0_vehicleName                 "Vehi
 ```perl
 sitemap evcc label="evcc Demo" {
     Frame label="General" {
-        Text item=evcc_demo_batteryPower
-        Text item=evcc_demo_batterySoC
-        Text item=evcc_demo_gridPower
-        Text item=evcc_demo_homePower
-        Text item=evcc_demo_pvPower
+        Text item=evcc_batteryPower
+        Text item=evcc_batterySoC
+        Text item=evcc_gridPower
+        Text item=evcc_homePower
+        Text item=evcc_pvPower
     }
     Frame label="Loadpoint 0" {
-        Text item=evcc_demo_loadpoint0_title
-        Text item=evcc_demo_loadpoint0_enabled label="Charging" {
-            Text item=evcc_demo_loadpoint0_charging
-            Text item=evcc_demo_loadpoint0_chargePower
-            Text item=evcc_demo_loadpoint0_chargeCurrent
-            Text item=evcc_demo_loadpoint0_activePhases
-            Text item=evcc_demo_loadpoint0_chargeDuration
-            Text item=evcc_demo_loadpoint0_chargeRemainingDuration
-            Text item=evcc_demo_loadpoint0_chargeRemainingEnergy
+        Text item=evcc_loadpoint0_title
+        Text item=evcc_loadpoint0_enabled label="Charging" {
+            Text item=evcc_loadpoint0_charging
+            Text item=evcc_loadpoint0_chargePower
+            Text item=evcc_loadpoint0_chargeCurrent
+            Text item=evcc_loadpoint0_activePhases
+            Text item=evcc_loadpoint0_chargeDuration
+            Text item=evcc_loadpoint0_chargeRemainingDuration
+            Text item=evcc_loadpoint0_chargeRemainingEnergy
         }
-        Switch item=evcc_demo_loadpoint0_mode mappings=["off"="Stop","now"="Now","minpv"="Min + PV", "pv"="Only PV"]
+        Switch item=evcc_loadpoint0_mode mappings=["off"="Stop","now"="Now","minpv"="Min + PV", "pv"="Only PV"]
         Text label="Charging settings" icon="settings" {
-            Setpoint item=evcc_demo_loadpoint0_targetSoC minValue=5 maxValue=100 step=5
-            Setpoint item=evcc_demo_loadpoint0_minCurrent minValue=6 maxValue=96 step=2
-            Setpoint item=evcc_demo_loadpoint0_maxCurrent minValue=6 maxValue=96 step=2
-            Setpoint item=evcc_demo_loadpoint0_minSoC minValue=0 maxValue=100 step=5
-            Setpoint item=evcc_demo_loadpoint0_phases minValue=1 maxValue=3 step=2
+            Setpoint item=evcc_loadpoint0_targetSoC minValue=5 maxValue=100 step=5
+            Setpoint item=evcc_loadpoint0_minCurrent minValue=6 maxValue=96 step=2
+            Setpoint item=evcc_loadpoint0_maxCurrent minValue=6 maxValue=96 step=2
+            Setpoint item=evcc_loadpoint0_minSoC minValue=0 maxValue=100 step=5
+            Setpoint item=evcc_loadpoint0_phases minValue=1 maxValue=3 step=2
         }
-        Text item=evcc_demo_loadpoint0_vehicleName label="Vehicle" {
-            Text item=evcc_demo_loadpoint0_vehicleCapacity
-            Text item=evcc_demo_loadpoint0_vehicleOdometer
-            Text item=evcc_demo_loadpoint0_vehicleRange
-            Text item=evcc_demo_loadpoint0_vehicleSoC
+        Text item=evcc_loadpoint0_vehicleName label="Vehicle" {
+            Text item=evcc_loadpoint0_vehicleCapacity
+            Text item=evcc_loadpoint0_vehicleOdometer
+            Text item=evcc_loadpoint0_vehicleRange
+            Text item=evcc_loadpoint0_vehicleSoC
         }
     }
 }

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
@@ -31,7 +31,8 @@ public class EvccBindingConstants {
     public static final ThingTypeUID THING_TYPE_DEVICE = new ThingTypeUID(BINDING_ID, "device");
 
     // List of all Channel Type UIDs
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_CAPACITY = new ChannelTypeUID(BINDING_ID, "batteryCapacity");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_CAPACITY = new ChannelTypeUID(BINDING_ID,
+            "batteryCapacity");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_POWER = new ChannelTypeUID(BINDING_ID, "batteryPower");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_SOC = new ChannelTypeUID(BINDING_ID, "batterySoC");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_PRIORITY_SOC = new ChannelTypeUID(BINDING_ID,

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
@@ -31,6 +31,7 @@ public class EvccBindingConstants {
     public static final ThingTypeUID THING_TYPE_DEVICE = new ThingTypeUID(BINDING_ID, "device");
 
     // List of all Channel Type UIDs
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_CAPACITY = new ChannelTypeUID(BINDING_ID, "batteryCapacity");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_POWER = new ChannelTypeUID(BINDING_ID, "batteryPower");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_SOC = new ChannelTypeUID(BINDING_ID, "batterySoC");
     public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_PRIORITY_SOC = new ChannelTypeUID(BINDING_ID,
@@ -88,6 +89,7 @@ public class EvccBindingConstants {
             "vehicleTitle");
 
     // List of all Channel ids
+    public static final String CHANNEL_BATTERY_CAPACITY = "batteryCapacity";
     public static final String CHANNEL_BATTERY_POWER = "batteryPower";
     public static final String CHANNEL_BATTERY_SOC = "batterySoC";
     public static final String CHANNEL_BATTERY_PRIORITY_SOC = "batteryPrioritySoC";

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
@@ -27,68 +27,6 @@ public class EvccBindingConstants {
 
     private static final String BINDING_ID = "evcc";
 
-    // List of all Thing Type UIDs
-    public static final ThingTypeUID THING_TYPE_DEVICE = new ThingTypeUID(BINDING_ID, "device");
-
-    // List of all Channel Type UIDs
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_CAPACITY = new ChannelTypeUID(BINDING_ID,
-            "batteryCapacity");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_POWER = new ChannelTypeUID(BINDING_ID, "batteryPower");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_SOC = new ChannelTypeUID(BINDING_ID, "batterySoC");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_PRIORITY_SOC = new ChannelTypeUID(BINDING_ID,
-            "batteryPrioritySoC");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_GRID_POWER = new ChannelTypeUID(BINDING_ID, "gridPower");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_HOME_POWER = new ChannelTypeUID(BINDING_ID, "homePower");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_PV_POWER = new ChannelTypeUID(BINDING_ID, "pvPower");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_ACTIVE_PHASES = new ChannelTypeUID(BINDING_ID,
-            "activePhases");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_CURRENT = new ChannelTypeUID(BINDING_ID,
-            "chargeCurrent");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_DURATION = new ChannelTypeUID(BINDING_ID,
-            "chargeDuration");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_POWER = new ChannelTypeUID(BINDING_ID,
-            "chargePower");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_REMAINING_DURATION = new ChannelTypeUID(
-            BINDING_ID, "chargeRemainingDuration");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_REMAINING_ENERGY = new ChannelTypeUID(
-            BINDING_ID, "chargeRemainingEnergy");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGED_ENERGY = new ChannelTypeUID(BINDING_ID,
-            "chargedEnergy");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGING = new ChannelTypeUID(BINDING_ID, "charging");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CONNECTED = new ChannelTypeUID(BINDING_ID,
-            "vehicleConnected");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CONNECTED_DURATION = new ChannelTypeUID(BINDING_ID,
-            "vehicleConnectedDuration");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_ENABLED = new ChannelTypeUID(BINDING_ID, "enabled");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_HAS_VEHICLE = new ChannelTypeUID(BINDING_ID,
-            "hasVehicle");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MAX_CURRENT = new ChannelTypeUID(BINDING_ID,
-            "maxCurrent");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MIN_CURRENT = new ChannelTypeUID(BINDING_ID,
-            "minCurrent");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MIN_SOC = new ChannelTypeUID(BINDING_ID, "minSoC");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MODE = new ChannelTypeUID(BINDING_ID, "mode");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_PHASES = new ChannelTypeUID(BINDING_ID, "phases");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TARGET_SOC = new ChannelTypeUID(BINDING_ID,
-            "targetSoC");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TARGET_TIME = new ChannelTypeUID(BINDING_ID,
-            "targetTime");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TARGET_TIME_ENABLED = new ChannelTypeUID(BINDING_ID,
-            "targetTimeEnabled");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TITLE = new ChannelTypeUID(BINDING_ID, "title");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_CAPACITY = new ChannelTypeUID(BINDING_ID,
-            "vehicleCapacity");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_ODOMETER = new ChannelTypeUID(BINDING_ID,
-            "vehicleOdometer");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_PRESENT = new ChannelTypeUID(BINDING_ID,
-            "vehiclePresent");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_RANGE = new ChannelTypeUID(BINDING_ID,
-            "vehicleRange");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_SOC = new ChannelTypeUID(BINDING_ID,
-            "vehicleSoC");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_TITLE = new ChannelTypeUID(BINDING_ID,
-            "vehicleTitle");
-
     // List of all Channel ids
     public static final String CHANNEL_BATTERY_CAPACITY = "batteryCapacity";
     public static final String CHANNEL_BATTERY_POWER = "batteryPower";
@@ -127,6 +65,76 @@ public class EvccBindingConstants {
     public static final String CHANNEL_LOADPOINT_VEHICLE_RANGE = "vehicleRange";
     public static final String CHANNEL_LOADPOINT_VEHICLE_SOC = "vehicleSoC";
     public static final String CHANNEL_LOADPOINT_VEHICLE_TITLE = "vehicleTitle";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_DEVICE = new ThingTypeUID(BINDING_ID, "device");
+
+    // List of all Channel Type UIDs
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_CAPACITY = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_BATTERY_CAPACITY);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_POWER = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_BATTERY_POWER);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_SOC = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_BATTERY_SOC);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_BATTERY_PRIORITY_SOC = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_BATTERY_PRIORITY_SOC);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_GRID_POWER = new ChannelTypeUID(BINDING_ID, CHANNEL_GRID_POWER);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_HOME_POWER = new ChannelTypeUID(BINDING_ID, CHANNEL_HOME_POWER);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_PV_POWER = new ChannelTypeUID(BINDING_ID, CHANNEL_PV_POWER);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_ACTIVE_PHASES = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_ACTIVE_PHASES);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_CURRENT = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CHARGE_CURRENT);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_DURATION = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CHARGE_DURATION);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_POWER = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CHARGE_POWER);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_REMAINING_DURATION = new ChannelTypeUID(
+            BINDING_ID, CHANNEL_LOADPOINT_CHARGE_REMAINING_DURATION);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGE_REMAINING_ENERGY = new ChannelTypeUID(
+            BINDING_ID, CHANNEL_LOADPOINT_CHARGE_REMAINING_ENERGY);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGED_ENERGY = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CHARGED_ENERGY);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CHARGING = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CHARGING);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CONNECTED = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CONNECTED);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_CONNECTED_DURATION = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_CONNECTED_DURATION);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_ENABLED = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_ENABLED);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_HAS_VEHICLE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_HAS_VEHICLE);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MAX_CURRENT = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_MAX_CURRENT);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MIN_CURRENT = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_MIN_CURRENT);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MIN_SOC = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_MIN_SOC);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_MODE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_MODE);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_PHASES = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_PHASES);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TARGET_SOC = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_TARGET_SOC);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TARGET_TIME = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_TARGET_TIME);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TARGET_TIME_ENABLED = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_TARGET_TIME_ENABLED);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TITLE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_TITLE);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_CAPACITY = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_VEHICLE_CAPACITY);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_ODOMETER = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_VEHICLE_ODOMETER);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_PRESENT = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_VEHICLE_PRESENT);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_RANGE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_VEHICLE_RANGE);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_SOC = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_VEHICLE_SOC);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_TITLE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_LOADPOINT_VEHICLE_TITLE);
 
     public static final int CONNECTION_TIMEOUT_MILLISEC = 5000;
     public static final int LONG_CONNECTION_TIMEOUT_MILLISEC = 60000;

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -85,7 +85,7 @@ public class EvccHandler extends BaseThingHandler {
                 return;
             }
             String channelIdWithoutGroup = channelUID.getIdWithoutGroup();
-            int loadpoint = Integer.parseInt(groupId.substring(9));
+            int loadpoint = Integer.parseInt(groupId.substring(9)) + 1;
             EvccAPI evccAPI = this.evccAPI;
             if (evccAPI == null) {
                 return;
@@ -206,7 +206,7 @@ public class EvccHandler extends BaseThingHandler {
 
     /**
      * Refreshes from evcc.
-     * 
+     *
      * First, checks connection and updates Thing status.
      * Second, creates all available channels.
      * Third, updates all channels.

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -39,6 +39,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
@@ -257,6 +258,7 @@ public class EvccHandler extends BaseThingHandler {
     private void createChannelsGeneral() {
         final String channelGroup = "general";
         if (batteryConfigured) {
+            createChannel(CHANNEL_BATTERY_CAPACITY, channelGroup, CHANNEL_TYPE_UID_BATTERY_CAPACITY, "Number:Energy");
             createChannel(CHANNEL_BATTERY_POWER, channelGroup, CHANNEL_TYPE_UID_BATTERY_POWER, "Number:Power");
             createChannel(CHANNEL_BATTERY_SOC, channelGroup, CHANNEL_TYPE_UID_BATTERY_SOC, "Number:Dimensionless");
             createChannel(CHANNEL_BATTERY_PRIORITY_SOC, channelGroup, CHANNEL_TYPE_UID_BATTERY_PRIORITY_SOC,
@@ -329,135 +331,140 @@ public class EvccHandler extends BaseThingHandler {
 
     // Units and description for vars: https://docs.evcc.io/docs/reference/configuration/messaging/#msg
     private void updateChannelsGeneral() {
-        Result result = this.result;
+        final Result result = this.result;
         if (result == null) {
             return;
         }
+        final ThingUID uid = getThing().getUID();
         ChannelUID channel;
         boolean batteryConfigured = this.batteryConfigured;
         if (batteryConfigured) {
+            float batteryCapacity = result.getBatteryCapacity();
+            channel = new ChannelUID(uid, "general", CHANNEL_BATTERY_CAPACITY);
+            updateState(channel, new QuantityType<>(batteryCapacity, Units.WATT_HOUR));
             float batteryPower = result.getBatteryPower();
-            channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_POWER);
+            channel = new ChannelUID(uid, "general", CHANNEL_BATTERY_POWER);
             updateState(channel, new QuantityType<>(batteryPower, Units.WATT));
             float batterySoC = result.getBatterySoC();
-            channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_SOC);
+            channel = new ChannelUID(uid, "general", CHANNEL_BATTERY_SOC);
             updateState(channel, new QuantityType<>(batterySoC, Units.PERCENT));
             float batteryPrioritySoC = result.getBatterySoC();
-            channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_BATTERY_PRIORITY_SOC);
+            channel = new ChannelUID(uid, "general", CHANNEL_BATTERY_PRIORITY_SOC);
             updateState(channel, new QuantityType<>(batteryPrioritySoC, Units.PERCENT));
         }
         boolean gridConfigured = this.gridConfigured;
         if (gridConfigured) {
             float gridPower = result.getGridPower();
-            channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_GRID_POWER);
+            channel = new ChannelUID(uid, "general", CHANNEL_GRID_POWER);
             updateState(channel, new QuantityType<>(gridPower, Units.WATT));
         }
         float homePower = result.getHomePower();
-        channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_HOME_POWER);
+        channel = new ChannelUID(uid, "general", CHANNEL_HOME_POWER);
         updateState(channel, new QuantityType<>(homePower, Units.WATT));
         boolean pvConfigured = this.pvConfigured;
         if (pvConfigured) {
             float pvPower = result.getPvPower();
-            channel = new ChannelUID(getThing().getUID(), "general", CHANNEL_PV_POWER);
+            channel = new ChannelUID(uid, "general", CHANNEL_PV_POWER);
             updateState(channel, new QuantityType<>(pvPower, Units.WATT));
         }
     }
 
     private void updateChannelsLoadpoint(int loadpointId) {
-        Result result = this.result;
+        final Result result = this.result;
         if (result == null) {
             return;
         }
-        String loadpointName = "loadpoint" + loadpointId;
+        final ThingUID uid = getThing().getUID();
+        final String loadpointName = "loadpoint" + loadpointId;
         ChannelUID channel;
         Loadpoint loadpoint = result.getLoadpoints()[loadpointId];
         int activePhases = loadpoint.getActivePhases();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_ACTIVE_PHASES);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_ACTIVE_PHASES);
         updateState(channel, new DecimalType(activePhases));
         float chargeCurrent = loadpoint.getChargeCurrent();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_CURRENT);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGE_CURRENT);
         updateState(channel, new QuantityType<>(chargeCurrent, Units.AMPERE));
         long chargeDuration = loadpoint.getChargeDuration();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_DURATION);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGE_DURATION);
         updateState(channel, new QuantityType<>(chargeDuration, MetricPrefix.NANO(Units.SECOND)));
         float chargePower = loadpoint.getChargePower();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_POWER);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGE_POWER);
         updateState(channel, new QuantityType<>(chargePower, Units.WATT));
         long chargeRemainingDuration = loadpoint.getChargeRemainingDuration();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_REMAINING_DURATION);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGE_REMAINING_DURATION);
         updateState(channel, new QuantityType<>(chargeRemainingDuration, MetricPrefix.NANO(Units.SECOND)));
         float chargeRemainingEnergy = loadpoint.getChargeRemainingEnergy();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGE_REMAINING_ENERGY);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGE_REMAINING_ENERGY);
         updateState(channel, new QuantityType<>(chargeRemainingEnergy, Units.WATT_HOUR));
         float chargedEnergy = loadpoint.getChargedEnergy();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGED_ENERGY);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGED_ENERGY);
         updateState(channel, new QuantityType<>(chargedEnergy, Units.WATT_HOUR));
         boolean charging = loadpoint.getCharging();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CHARGING);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CHARGING);
         updateState(channel, OnOffType.from(charging));
         boolean connected = loadpoint.getConnected();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CONNECTED);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CONNECTED);
         updateState(channel, OnOffType.from(connected));
         long connectedDuration = loadpoint.getConnectedDuration();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_CONNECTED_DURATION);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_CONNECTED_DURATION);
         updateState(channel, new QuantityType<>(connectedDuration, MetricPrefix.NANO(Units.SECOND)));
         boolean enabled = loadpoint.getEnabled();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_ENABLED);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_ENABLED);
         updateState(channel, OnOffType.from(enabled));
         boolean hasVehicle = loadpoint.getHasVehicle();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_HAS_VEHICLE);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_HAS_VEHICLE);
         updateState(channel, OnOffType.from(hasVehicle));
         float maxCurrent = loadpoint.getMaxCurrent();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MAX_CURRENT);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_MAX_CURRENT);
         updateState(channel, new QuantityType<>(maxCurrent, Units.AMPERE));
         float minCurrent = loadpoint.getMinCurrent();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MIN_CURRENT);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_MIN_CURRENT);
         updateState(channel, new QuantityType<>(minCurrent, Units.AMPERE));
         float minSoC = loadpoint.getMinSoC();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MIN_SOC);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_MIN_SOC);
         updateState(channel, new QuantityType<>(minSoC, Units.PERCENT));
         String mode = loadpoint.getMode();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_MODE);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_MODE);
         updateState(channel, new StringType(mode));
         int phases = loadpoint.getPhases();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_PHASES);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_PHASES);
         updateState(channel, new DecimalType(phases));
         targetSoC = loadpoint.getTargetSoC();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_TARGET_SOC);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_TARGET_SOC);
         updateState(channel, new QuantityType<>(targetSoC, Units.PERCENT));
         String targetTime = loadpoint.getTargetTime();
         if (targetTime == null) {
-            channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_TARGET_TIME_ENABLED);
+            channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_TARGET_TIME_ENABLED);
             updateState(channel, OnOffType.OFF);
             targetTimeEnabled = false;
         } else {
             this.targetTimeZDT = ZonedDateTime.parse(targetTime);
-            channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_TARGET_TIME);
+            channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_TARGET_TIME);
             updateState(channel, new DateTimeType(targetTimeZDT));
-            channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_TARGET_TIME_ENABLED);
+            channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_TARGET_TIME_ENABLED);
             updateState(channel, OnOffType.ON);
             targetTimeEnabled = true;
         }
         String title = loadpoint.getTitle();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_TITLE);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_TITLE);
         updateState(channel, new StringType(title));
         float vehicleCapacity = loadpoint.getVehicleCapacity();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_CAPACITY);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_VEHICLE_CAPACITY);
         updateState(channel, new QuantityType<>(vehicleCapacity, Units.WATT_HOUR));
         float vehicleOdometer = loadpoint.getVehicleOdometer();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_ODOMETER);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_VEHICLE_ODOMETER);
         updateState(channel, new QuantityType<>(vehicleOdometer, MetricPrefix.KILO(SIUnits.METRE)));
         boolean vehiclePresent = loadpoint.getVehiclePresent();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_PRESENT);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_VEHICLE_PRESENT);
         updateState(channel, OnOffType.from(vehiclePresent));
         float vehicleRange = loadpoint.getVehicleRange();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_RANGE);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_VEHICLE_RANGE);
         updateState(channel, new QuantityType<>(vehicleRange, MetricPrefix.KILO(SIUnits.METRE)));
         float vehicleSoC = loadpoint.getVehicleSoC();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_SOC);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_VEHICLE_SOC);
         updateState(channel, new QuantityType<>(vehicleSoC, Units.PERCENT));
         String vehicleTitle = loadpoint.getVehicleTitle();
-        channel = new ChannelUID(getThing().getUID(), loadpointName, CHANNEL_LOADPOINT_VEHICLE_TITLE);
+        channel = new ChannelUID(uid, loadpointName, CHANNEL_LOADPOINT_VEHICLE_TITLE);
         updateState(channel, new StringType(vehicleTitle));
     }
 

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This class represents a loadpoint object of the status response (/api/state).
- * This DTO was written for evcc version 0.106.3
+ * This DTO was written for evcc version 0.111.1
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -69,7 +69,7 @@ public class Loadpoint {
     @SerializedName("minCurrent")
     private float minCurrent;
 
-    @SerializedName("minSoC")
+    @SerializedName("minSoc")
     private float minSoC;
 
     @SerializedName("mode")
@@ -84,7 +84,7 @@ public class Loadpoint {
     @SerializedName("pvRemaining")
     private long pvRemaining;
 
-    @SerializedName("targetSoC")
+    @SerializedName("targetSoc")
     private float targetSoC;
 
     @SerializedName("targetTime")
@@ -105,7 +105,7 @@ public class Loadpoint {
     @SerializedName("vehicleRange")
     private float vehicleRange;
 
-    @SerializedName("vehicleSoC")
+    @SerializedName("vehicleSoc")
     private float vehicleSoC;
 
     @SerializedName("vehicleTitle")

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -26,6 +26,9 @@ public class Result {
 
     // "auth" is left out because it does not provide any useful information
 
+    @SerializedName("batteryCapacity")
+    private float batteryCapacity;
+
     @SerializedName("batteryConfigured")
     private boolean batteryConfigured;
 
@@ -58,6 +61,13 @@ public class Result {
 
     @SerializedName("siteTitle")
     private String siteTitle;
+
+    /**
+     * @return battery's capacity
+     */
+    public float getBatteryCapacity() {
+        return batteryCapacity;
+    }
 
     /**
      * @return whether battery is configured

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This class represents the result object of the status response (/api/state).
- * This DTO was written for evcc version 0.106.3
+ * This DTO was written for evcc version 0.111.1
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -32,7 +32,7 @@ public class Result {
     @SerializedName("batteryPower")
     private float batteryPower;
 
-    @SerializedName("batterySoC")
+    @SerializedName("batterySoc")
     private float batterySoC;
 
     @SerializedName("gridConfigured")
@@ -47,7 +47,7 @@ public class Result {
     @SerializedName("loadpoints")
     private Loadpoint[] loadpoints;
 
-    @SerializedName("prioritySoC")
+    @SerializedName("prioritySoc")
     private float batteryPrioritySoC;
 
     @SerializedName("pvConfigured")

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Status.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * This class represents the status response (/api/state).
- * This DTO was written for evcc version 0.106.3
+ * This DTO was written for evcc version 0.111.1
  *
  * @author Florian Hotze - Initial contribution
  */

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
@@ -24,6 +24,8 @@ channel-group-type.evcc.loadpoint.label = Loadpoint
 
 channel-type.evcc.activePhases.label = Charging active phases
 channel-type.evcc.activePhases.description = Current number of active phases while charging
+channel-type.evcc.batteryCapacity.label = Battery Capacity
+channel-type.evcc.batteryCapacity.description = Capacity of (home) battery
 channel-type.evcc.batteryPower.label = Battery Power
 channel-type.evcc.batteryPower.description = Current power from battery
 channel-type.evcc.batteryPrioritySoC.label = Battery Priority SoC
@@ -104,8 +106,3 @@ channel-type.evcc.vehicleSoC.label = Vehicle SoC
 channel-type.evcc.vehicleSoC.description = Current State of Charge of EV
 channel-type.evcc.vehicleTitle.label = Vehicle title
 channel-type.evcc.vehicleTitle.description = Name of EV
-
-# channel types
-
-offline.configuration-error.no-host = No host configured
-offline.communication-error.request-failed = Request failed

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
@@ -107,7 +107,7 @@ channel-type.evcc.vehicleSoC.description = Current State of Charge of EV
 channel-type.evcc.vehicleTitle.label = Vehicle title
 channel-type.evcc.vehicleTitle.description = Name of EV
 
-# channel types
+# thing status description
 
 offline.configuration-error.no-host = No host configured
 offline.communication-error.request-failed = Request failed

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
@@ -106,3 +106,8 @@ channel-type.evcc.vehicleSoC.label = Vehicle SoC
 channel-type.evcc.vehicleSoC.description = Current State of Charge of EV
 channel-type.evcc.vehicleTitle.label = Vehicle title
 channel-type.evcc.vehicleTitle.description = Name of EV
+
+# channel types
+
+offline.configuration-error.no-host = No host configured
+offline.communication-error.request-failed = Request failed

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -46,6 +46,13 @@
 	</channel-group-type>
 
 	<!-- Units and description on: https://docs.evcc.io/docs/reference/configuration/messaging/#msg -->
+	<channel-type id="batteryCapacity">
+		<item-type>Number:Energy</item-type>
+		<label>Battery Capacity</label>
+		<description>Capacity of (home) battery</description>
+		<category>Energy</category>
+		<state pattern="%.0f %unit%" readOnly="true"/>
+	</channel-type>
 	<channel-type id="batteryPower">
 		<item-type>Number:Power</item-type>
 		<label>Battery Power</label>


### PR DESCRIPTION
Fixes #14231.

evcc changed the API with version 0.111.0, see https://github.com/evcc-io/evcc/discussions/5522.
This API change breaks the binding:

> - all indexes become 1-based (instead of 0-based for REST and 1-based for MQTT)
> - SoC becomes Soc

I have also added a new channel for the home battery's capacity which is a new value available over the API.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>