### PR TITLE
Update README.md

### DIFF
--- a/bundles/org.openhab.binding.homeconnect/README.md
+++ b/bundles/org.openhab.binding.homeconnect/README.md
@@ -285,7 +285,7 @@ Please check log UI (http(s)://[YOUROPENHAB]:[YOURPORT]/homeconnect) and ask for
 
 ### Rate limit reached
 
-The Home Connect API enforces rate [limits](https://developer.home-connect.com/docs/general/ratelimiting). If you have a lot of `429` response codes in your request log section (http(s)://[YOUROPENHAB]:[YOURPORT]/log/requests), please check the error response.
+The Home Connect API enforces rate [limits](https://developer.home-connect.com/docs/general/ratelimiting). If you have a lot of `429` response codes in your request log section (http(s)://[YOUROPENHAB]:[YOURPORT]/homeconnect/log/requests), please check the error response.
 
 ### Error message 'Program not supported', 'Unsupported operation' or 'SDK.Error.UnsupportedOption'
 


### PR DESCRIPTION
URL for HomeConnect consol was wrong

# Title

- [homeconnect] URL mentioned for logging information was wrong

# Description

Mentioned logging URL was wrong (the "/homeconnect" was missing)

# Testing

Nothing to test here
