### PR TITLE
[deconz] [Proposal] Normalize valve value to zigbee specification

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
@@ -12,6 +12,10 @@
  */
 package org.openhab.binding.deconz.internal;
 
+import static java.util.Map.entry;
+
+import java.util.Map;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.ThingTypeUID;
@@ -143,4 +147,9 @@ public class BindingConstants {
     public static final int BRIGHTNESS_MIN = 0;
     public static final int BRIGHTNESS_MAX = 254;
     public static final double BRIGHTNESS_FACTOR = BRIGHTNESS_MAX / PercentType.HUNDRED.doubleValue();
+
+    public static final Map<String, Double> VALVE_PERCENT_SCALING_BY_VENDOR = Map
+            .ofEntries(entry("Eurotronic", 100d / 255));
+
+    public static final Map<String, Double> VALVE_PERCENT_SCALING_BY_MODEL_ID = Map.ofEntries();
 }

--- a/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/SensorsTest.java
+++ b/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/SensorsTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.openhab.binding.deconz.internal.BindingConstants.*;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,6 +138,7 @@ public class SensorsTest {
         ChannelUID channelModeUID = new ChannelUID(thingUID, "mode");
         ChannelUID channelTemperatureUID = new ChannelUID(thingUID, "temperature");
         Thing sensor = ThingBuilder.create(THING_TYPE_THERMOSTAT, thingUID)
+                .withProperties(Map.of(Thing.PROPERTY_VENDOR, "Eurotronic"))
                 .withChannel(ChannelBuilder.create(channelValveUID, "Number").build())
                 .withChannel(ChannelBuilder.create(channelHeatSetPointUID, "Number").build())
                 .withChannel(ChannelBuilder.create(channelModeUID, "String").build())
@@ -151,6 +153,37 @@ public class SensorsTest {
                 eq(new QuantityType<>(25, SIUnits.CELSIUS)));
         Mockito.verify(thingHandlerCallback).stateUpdated(eq(channelModeUID),
                 eq(new StringType(ThermostatMode.AUTO.name())));
+        Mockito.verify(thingHandlerCallback).stateUpdated(eq(channelTemperatureUID),
+                eq(new QuantityType<>(16.5, SIUnits.CELSIUS)));
+    }
+
+    @Test
+    public void thermostatDanfossSensorUpdateTest() throws IOException {
+        SensorMessage sensorMessage = DeconzTest.getObjectFromJson("thermostat_danfoss.json", SensorMessage.class,
+                gson);
+        assertNotNull(sensorMessage);
+
+        ThingUID thingUID = new ThingUID("deconz", "sensor");
+        ChannelUID channelValveUID = new ChannelUID(thingUID, "valve");
+        ChannelUID channelHeatSetPointUID = new ChannelUID(thingUID, "heatsetpoint");
+        ChannelUID channelModeUID = new ChannelUID(thingUID, "mode");
+        ChannelUID channelTemperatureUID = new ChannelUID(thingUID, "temperature");
+        Thing sensor = ThingBuilder.create(THING_TYPE_THERMOSTAT, thingUID)
+                .withProperties(Map.of(Thing.PROPERTY_VENDOR, "Danfoss"))
+                .withChannel(ChannelBuilder.create(channelValveUID, "Number").build())
+                .withChannel(ChannelBuilder.create(channelHeatSetPointUID, "Number").build())
+                .withChannel(ChannelBuilder.create(channelModeUID, "String").build())
+                .withChannel(ChannelBuilder.create(channelTemperatureUID, "Number").build()).build();
+        SensorThermostatThingHandler sensorThingHandler = new SensorThermostatThingHandler(sensor, gson);
+        sensorThingHandler.setCallback(thingHandlerCallback);
+
+        sensorThingHandler.messageReceived("", sensorMessage);
+        Mockito.verify(thingHandlerCallback).stateUpdated(eq(channelValveUID),
+                eq(new QuantityType<>(26.0, Units.PERCENT)));
+        Mockito.verify(thingHandlerCallback).stateUpdated(eq(channelHeatSetPointUID),
+                eq(new QuantityType<>(17, SIUnits.CELSIUS)));
+        Mockito.verify(thingHandlerCallback).stateUpdated(eq(channelModeUID),
+                eq(new StringType(ThermostatMode.UNKNOWN.name())));
         Mockito.verify(thingHandlerCallback).stateUpdated(eq(channelTemperatureUID),
                 eq(new QuantityType<>(16.5, SIUnits.CELSIUS)));
     }

--- a/bundles/org.openhab.binding.deconz/src/test/resources/org/openhab/binding/deconz/thermostat_danfoss.json
+++ b/bundles/org.openhab.binding.deconz/src/test/resources/org/openhab/binding/deconz/thermostat_danfoss.json
@@ -1,0 +1,35 @@
+{
+    "config": {
+        "battery": 66,
+        "displayflipped": false,
+        "externalsensortemp": -8000,
+        "externalwindowopen": false,
+        "heatsetpoint": 1700,
+        "locked": false,
+        "mountingmode": false,
+        "offset": 0,
+        "on": true,
+        "reachable": true,
+        "schedule": {},
+        "schedule_on": false
+    },
+    "ep": 1,
+    "etag": "c8f30aa4bfa1b25ee982fbff2941ee01",
+    "lastannounced": null,
+    "lastseen": "2023-01-01T21:12Z",
+    "manufacturername": "Danfoss",
+    "modelid": "eTRV0100",
+    "name": "Test Danfoss Thermostat",
+    "state": {
+        "errorcode": "0",
+        "lastupdated": "2023-01-01T21:12:18.529",
+        "mountingmodeactive": false,
+        "on": false,
+        "temperature": 1650,
+        "valve": 26,
+        "windowopen": "Closed"
+    },
+    "swversion": "01.18.0008 01.18",
+    "type": "ZHAThermostat",
+    "uniqueid": "0c:43:14:ff:fe:c7:1c:26-01-0201"
+}


### PR DESCRIPTION
A suggestion to work around #11517.

Deconz just passes the PIHeatingDemand without any normalization to the relevant range of valid values from the zigbee 
specification. The thermostat that was used as a template for the relevant code is unfortunately not standards compliant, so any standards compliant thermostats show incorrect valve values.

While it would be preferable to have this fixed in deconz itself, until that happens a workaround would be useful.
This PR is a suggestion to treat #11517. 

Signed-off-by: Daniel Demus <daniel-github@demus.dk>

