### PR TITLE
[jdbc] working version of PG schema check and TIMESTAMPTZ as default to match MySQL

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -180,6 +180,7 @@ public class JdbcMapper {
         ItemsVO isvo = new ItemsVO();
         isvo.setJdbcUriDatabaseName(conf.getDbName());
         isvo.setTableName(tableName);
+        isvo.setItemsManageTable(conf.getItemsManageTable());
         List<Column> is = conf.getDBDAO().doGetTableColumns(isvo);
         logTime("getTableColumns", timerStart, System.currentTimeMillis());
         return is;

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -313,7 +313,7 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
     }
 
     /**
-     * Check schema for integrity issues.
+     * Check schema of specific item table for integrity issues.
      *
      * @param tableName for which columns should be checked
      * @param itemName that corresponds to table
@@ -347,7 +347,8 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
                 if (!"time".equals(columnName)) {
                     issues.add("Column name 'time' expected, but is '" + columnName + "'");
                 }
-                if (!timeDataType.equalsIgnoreCase(column.getColumnType())) {
+                if (!timeDataType.equalsIgnoreCase(column.getColumnType())
+                        && !timeDataType.equalsIgnoreCase(column.getColumnTypeAlias())) {
                     issues.add("Column type '" + timeDataType + "' expected, but is '"
                             + column.getColumnType().toUpperCase() + "'");
                 }
@@ -358,7 +359,8 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
                 if (!"value".equals(columnName)) {
                     issues.add("Column name 'value' expected, but is '" + columnName + "'");
                 }
-                if (!valueDataType.equalsIgnoreCase(column.getColumnType())) {
+                if (!valueDataType.equalsIgnoreCase(column.getColumnType())
+                        && !valueDataType.equalsIgnoreCase(column.getColumnTypeAlias())) {
                     issues.add("Column type '" + valueDataType + "' expected, but is '"
                             + column.getColumnType().toUpperCase() + "'");
                 }
@@ -403,13 +405,17 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
         for (Column column : columns) {
             String columnName = column.getColumnName();
             if ("time".equalsIgnoreCase(columnName)) {
-                if (!"time".equals(columnName) || !timeDataType.equalsIgnoreCase(column.getColumnType())
+                if (!"time".equals(columnName)
+                        || (!timeDataType.equalsIgnoreCase(column.getColumnType())
+                                && !timeDataType.equalsIgnoreCase(column.getColumnTypeAlias()))
                         || column.getIsNullable()) {
                     alterTableColumn(tableName, "time", timeDataType, false);
                     isFixed = true;
                 }
             } else if ("value".equalsIgnoreCase(columnName)) {
-                if (!"value".equals(columnName) || !valueDataType.equalsIgnoreCase(column.getColumnType())
+                if (!"value".equals(columnName)
+                        || (!valueDataType.equalsIgnoreCase(column.getColumnType())
+                                && !valueDataType.equalsIgnoreCase(column.getColumnTypeAlias()))
                         || !column.getIsNullable()) {
                     alterTableColumn(tableName, "value", valueDataType, true);
                     isFixed = true;

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/dto/Column.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/dto/Column.java
@@ -18,6 +18,12 @@ import org.eclipse.jdt.annotation.Nullable;
 /**
  * Represents an INFORMATON_SCHEMA.COLUMNS table row.
  *
+ * MySQL returns type as column_type
+ *
+ * PostgreSQL returns "data_type" (e.g. "character varying") and "udt_name" as a type alias (e.g. "varchar")
+ * these should be aliased as the matching snake_case version of the attributes in this class. i.e.:
+ * SELECT column_name, data_type as column_type, udt_name as column_type_alias FROM information_schema.columns
+ *
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
@@ -26,6 +32,7 @@ public class Column {
     private @Nullable String columnName;
     private boolean isNullable;
     private @Nullable String columnType;
+    private @Nullable String columnTypeAlias;
 
     public String getColumnName() {
         String columnName = this.columnName;
@@ -35,6 +42,11 @@ public class Column {
     public String getColumnType() {
         String columnType = this.columnType;
         return columnType != null ? columnType : "";
+    }
+
+    public String getColumnTypeAlias() {
+        String columnTypeAlias = this.columnTypeAlias;
+        return columnTypeAlias != null ? columnTypeAlias : "";
     }
 
     public boolean getIsNullable() {
@@ -47,6 +59,10 @@ public class Column {
 
     public void setColumnType(String columnType) {
         this.columnType = columnType;
+    }
+
+    public void setColumnTypeAlias(String columnTypeAlias) {
+        this.columnTypeAlias = columnTypeAlias;
     }
 
     public void setIsNullable(boolean isNullable) {


### PR DESCRIPTION
It should fix https://github.com/openhab/openhab-addons/issues/12315 

This patch fixes two issues in the PostgreSQL implementation of the JDBC service addon:

## 1. TIMESTAMPTZ should be used as default type to match MySQL defaults

The  closest equivalent type to [MySQL](https://dev.mysql.com/doc/refman/8.0/en/datetime.html) `TIMESTAMP` is `TIMESTAMPTZ`in [PostgreSQL](https://www.postgresql.org/docs/current/datatype-datetime.html)  (`timestamp with time zone`).

With TIMESTAMPTZ, PostgreSQL converts the input timestamp to UTC, stores the UTC timestamp, and converts back to the timezone of the session on query time. Exactly what [MySQL does](https://dev.mysql.com/doc/refman/8.0/en/datetime.html) with `TIMESTAMP`.

In contrast, the PG `TIMESTAMP` type (the default we had up to now) discards any time zone information in the input timestamp and thus stores local time or whatever it was given ignoring any offsets (e.g. 10:00:00-0500 and 10:00:00 are stored as the same value despite being different moments in time).

This is better illustrated by running in Pg the examples from the MySQL manual: https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html

```
CREATE TABLE dt (id INTEGER serial, col TIMESTAMP);
CREATE TABLE ts (id INTEGER serial, col TIMESTAMPTZ);

SET TIME ZONE 'EST';
INSERT INTO ts (col) VALUES ('2020-01-01 10:10:10'), ('2020-01-01 10:10:10+05:30'), ('2020-01-01 10:10:10-08:00');

SET TIME ZONE '+00:00';
INSERT INTO ts (col) VALUES ('2020-01-01 10:10:10'), ('2020-01-01 10:10:10+05:30'), ('2020-01-01 10:10:10-08:00');

SET time zone 'EST';
INSERT INTO dt (col) VALUES ('2020-01-01 10:10:10'), ('2020-01-01 10:10:10+05:30'), ('2020-01-01 10:10:10-08:00');

SET TIME ZONE '+00:00';
INSERT INTO dt (col) VALUES ('2020-01-01 10:10:10'), ('2020-01-01 10:10:10+05:30'), ('2020-01-01 10:10:10-08:00');

SET time zone 'EST';
show timezone;

ohtest=> select col, extract(epoch from col) from dt;
         col         |      extract
---------------------+-------------------
 2020-01-01 10:10:10 | 1577873410.000000
 2020-01-01 10:10:10 | 1577873410.000000
 2020-01-01 10:10:10 | 1577873410.000000
 2020-01-01 10:10:10 | 1577873410.000000
 2020-01-01 10:10:10 | 1577873410.000000
 2020-01-01 10:10:10 | 1577873410.000000
(6 rows)

ohtest=> select col, extract(epoch from col) from ts;
          col           |      extract
------------------------+-------------------
 2020-01-01 10:10:10-05 | 1577891410.000000
 2019-12-31 23:40:10-05 | 1577853610.000000
 2020-01-01 13:10:10-05 | 1577902210.000000
 2020-01-01 05:10:10-05 | 1577873410.000000
 2019-12-31 23:40:10-05 | 1577853610.000000
 2020-01-01 13:10:10-05 | 1577902210.000000
(6 rows)
```

As one can verify above, the table `ts` with `TIMESTAMPTZ` matches the `TIMESTAMP` results from the [MySQL manual](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html), unlike the `dt` table which always stores the same value regardless of timezone in the literal or the session.

This patch changes the default to TIMESTAMPTZ (for new tables). The 2nd fix mentioned below allows users to convert existing TIMESTAMP columns to TIMESTAMPTZ.

## 2nd issue. Non-working Schema check and fix (console)

Console commands `jdbc schema check` and `jdbc schema fix` (and the associated internal functions) were not working since the sqlGetTableColumnTypes, doGetTableColumns and doAlterTableColumn were written according to the MySQL `information_schema.columns` but they are slightly different in PG.

Moreover, PostgreSQL uses aliases for types (e.g. "varchar" is equivalent "Character Varying") and these have to be checked as well as valid schema types.

This patch fixes the above issues ~and includes a `checkItemTables` function which is called on activation of the Persistence service and prints a single warning in the logs with the number of found schema issues (if any) and a suggested action  (equivalent to `jdbc schema check` but automatically running on startup)~ (EDIT: checkItemTables will be submitted as separate PR). 



