### PR TITLE
[RFXCOM] add MOOD_LIGHT for NOVY Fan

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -522,13 +522,13 @@ A Novy extractor fan.
 
 ##### Channels
 
-| Name            | Channel Type                        | Item Type     | Remarks                                              |
-| --------------- | ----------------------------------- | ------------- | ---------------------------------------------------- |
-| command         | [command](#channels)                | Switch        |                                                      |
-| commandString   | [commandString](#channels)          | String        | Options: POWER, UP, DOWN, LIGHT, LEARN, RESET_FILTER |
-| fanSpeedControl | [fanspeedcontrol](#channels)        | RollerShutter | Options: UP / DOWN                                   |
-| fanLight        | [fanlight](#channels)               | Switch        |                                                      |
-| signalLevel     | [system.signal-strength](#channels) | Number        |                                                      |
+| Name            | Channel Type                        | Item Type     | Remarks                                                          |
+| --------------- | ----------------------------------- | ------------- | ---------------------------------------------------------------- |
+| command         | [command](#channels)                | Switch        |                                                                  |
+| commandString   | [commandString](#channels)          | String        | Options: POWER, UP, DOWN, LIGHT, LEARN, RESET_FILTER, MOOD_LIGHT |
+| fanSpeedControl | [fanspeedcontrol](#channels)        | RollerShutter | Options: UP / DOWN                                               |
+| fanLight        | [fanlight](#channels)               | Switch        |                                                                  |
+| signalLevel     | [system.signal-strength](#channels) | Number        |                                                                  |
 
 ##### Configuration Options
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessage.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessage.java
@@ -128,7 +128,8 @@ public class RFXComFanMessage extends RFXComDeviceMessageImpl<RFXComFanMessage.S
         NOVY_DOWN(3, NOVY),
         NOVY_LIGHT(4, NOVY),
         NOVY_LEARN(5, NOVY),
-        NOVY_RESET_FILTER(6, NOVY);
+        NOVY_RESET_FILTER(6, NOVY),
+        NOVY_MOOD_LIGHT(7, NOVY);
 
         private final int command;
         private final Integer speed;
@@ -405,6 +406,7 @@ public class RFXComFanMessage extends RFXComDeviceMessageImpl<RFXComFanMessage.S
                 case "NATURAL_FLOW":
                 case "PAIR":
                 case "RESET_FILTER":
+                case "MOOD_LIGHT":
                 case "SPEED_1":
                 case "SPEED_2":
                 case "SPEED_3":


### PR DESCRIPTION
Small Improvement to the NOVY Fan support in RFXCOM Binding.
Added MOOD_LIGHT support in the CommandString

Snapshot to be found at: https://1drv.ms/u/s!AqvjAJaugtJEkoUaP3lEvOeGJmXofw?e=wGZSWJ

Signed-off-by: Frank Croket [Frank.Croket@outlook.com](mailto:frank.croket@outlook.com)

