### PR TITLE
[tesla] Fix account going offline every few seconds

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaAccountHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaAccountHandler.java
@@ -193,8 +193,8 @@ public class TeslaAccountHandler extends BaseBridgeHandler {
                 } else {
                     logger.warn("Reached the maximum number of errors ({}) for the current interval ({} seconds)",
                             API_MAXIMUM_ERRORS_IN_INTERVAL, API_ERROR_INTERVAL_SECONDS);
+                    apiIntervalErrors = 0;
                 }
-
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
             } else if ((System.currentTimeMillis() - apiIntervalTimestamp) > 1000 * API_ERROR_INTERVAL_SECONDS) {
                 logger.trace("Resetting the error counter. ({} errors in the last interval)", apiIntervalErrors);


### PR DESCRIPTION
If an account reaches the threshold of failed api calls, it is set to OFFLINE.
Once this happens, it will immediately go to OFFLINE again every time that it becomes back ONLINE.
This causes the vehicle to stay online and thus leads to vampire drain.

This PR resets the counter, so that the Thing stays ONLINE until the threshold is reached again.

This fix might quality as a backport to 3.4.x.

Signed-off-by: Kai Kreuzer <kai@openhab.org>
