### PR TITLE
[orbitbhyve] Fix for NumberFormatException when parsing json object

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/model/OrbitBhyveDevice.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/model/OrbitBhyveDevice.java
@@ -62,9 +62,6 @@ public class OrbitBhyveDevice {
     @SerializedName("water_sense_mode")
     String waterSenseMode = "";
 
-    @SerializedName("wifi_version")
-    int wifiVersion = 0;
-
     public String getName() {
         return name;
     }


### PR DESCRIPTION
Fixes #14307 

The binding throws a NumberFormatException when parsing the Json object returned from the "devices" API endpoint. The field is defined as an `int` in the DTO, but the B-Hyve API can return either 
```
“wifi_version”:0
```
or something like
```
“wifi_version”:“1.4.0”
```

The `wifi_version` is not used in the binding, nor do I see any reason why it might be used in the future. So from my perspective the easiest thing to do is to just delete it from the DTO.

I believe this should be a candidate to cherry-pick if there's another 3.4.x patch release.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
