### PR TITLE
[mielecloud] Fix i18n in addon.xml

### DIFF
--- a/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/addon/addon.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/binding.mielecloud.name</name>
-	<description>@text/binding.mielecloud.description</description>
+	<name>@text/addon.mielecloud.name</name>
+	<description>@text/addon.mielecloud.description</description>
 </addon:addon>


### PR DESCRIPTION
Fix i18n tags in addon.xml so binding name and description displays correctly in binding list.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
