### PR TITLE
[telegram] Invalid escape of underscore character when sending messages (Revert "Solves issue #11691 (#13758)")

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -237,8 +237,7 @@ public class TelegramActions implements ThingActions {
         }
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            String escapedMessage = message.replace("_", "\\_");
-            SendMessage sendMessage = new SendMessage(chatId, escapedMessage);
+            SendMessage sendMessage = new SendMessage(chatId, message);
             if (localHandler.getParseMode() != null) {
                 sendMessage.parseMode(localHandler.getParseMode());
             }


### PR DESCRIPTION
Commit 1d23c32de1e3831644494751c961d17d10628ec8 broke sending underscore character in messages #14204

This PR reverts commit 1d23c32de1e3831644494751c961d17d10628ec8 and fix #14204.

Signed-off-by: Daniel Schröter <d.schroeter@gmx.de>