### PR TITLE
[fineoffsetweatherstation] Fix java.lang.IllegalMonitorStateException

### DIFF
--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/service/GatewayQueryService.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/java/org/openhab/binding/fineoffsetweatherstation/internal/service/GatewayQueryService.java
@@ -73,14 +73,20 @@ public abstract class GatewayQueryService implements AutoCloseable {
 
     protected byte @Nullable [] executeCommand(String command, byte[] request,
             Function<byte[], Boolean> validateResponse) {
+        try {
+            if (!REQUEST_LOCK.tryLock(30, TimeUnit.SECONDS)) {
+                logger.debug("executeCommand({}): timed out while getting the lock", command);
+                return null;
+            }
+        } catch (InterruptedException e) {
+            logger.debug("executeCommand({}): was interrupted while getting the lock", command);
+            return null;
+        }
+
         byte[] buffer = new byte[2028];
         int bytesRead;
 
         try {
-            if (!REQUEST_LOCK.tryLock(30, TimeUnit.SECONDS)) {
-                logger.trace("executeCommand({}): time out while getting lock", command);
-                return null;
-            }
             Socket socket = getConnection();
             if (socket == null) {
                 return null;


### PR DESCRIPTION
This fix ensures, that the `ReentrantLock::unlock` method is only called, when the Thread is owning the lock.

resolves: #14322