### PR TITLE
Fix findbugs instanceof pattern matching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,7 @@ Import-Package: \\
           <configuration>
             <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
             <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
+            <spotbugsExclude>${basedirRoot}/tools/static-code-analysis/spotbugs/suppressions.xml</spotbugsExclude>
           </configuration>
           <executions>
             <execution>

--- a/tools/static-code-analysis/spotbugs/suppressions.xml
+++ b/tools/static-code-analysis/spotbugs/suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <!-- see https://github.com/spotbugs/spotbugs/issues/1992 -->
+    <Bug pattern="SA_LOCAL_SELF_COMPARISON"/>
+  </Match>
+</FindBugsFilter>

--- a/tools/static-code-analysis/spotbugs/suppressions.xml
+++ b/tools/static-code-analysis/spotbugs/suppressions.xml
@@ -1,5 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
+  <!-- Groovy files produce a lot of warnings and will be ignored -->
+  <Match>
+    <Source name="~.*\.groovy" />
+  </Match>
+  <!-- Excludes all bugs with priority higher than 4 -->
+  <Match>
+    <Rank value="4"/>
+    <Not>
+      <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC"/>
+    </Not>
+  </Match>
+  <!-- This pattern is not wanted as it reports usage of Throwable.getMessage() as argument to SLF4G logger -->
+  <Match>
+    <Bug pattern="SLF4J_MANUALLY_PROVIDED_MESSAGE"/>
+  </Match>
+  <!-- Allow util classes to have static loggers -->
+  <Match>
+    <Class name="~.*Utils"/>
+    <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC"/>
+  </Match>
+  <Match>
+    <Class name="~.*Util"/>
+    <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC"/>
+  </Match>
+  <!-- The format string is parameter, it can't be constant -->
+  <Match>
+    <Class name="org.openhab.core.model.script.actions.Log"/>
+    <Bug pattern="SLF4J_FORMAT_SHOULD_BE_CONST"/>
+  </Match>
+  <Match>
+    <Bug pattern="SLF4J_UNKNOWN_ARRAY"/>
+  </Match>
+  <Match>
+    <Bug pattern="SLF4J_SIGN_ONLY_FORMAT"/>
+  </Match>
   <Match>
     <!-- see https://github.com/spotbugs/spotbugs/issues/1992 -->
     <Bug pattern="SA_LOCAL_SELF_COMPARISON"/>


### PR DESCRIPTION
Findbugs can't properly handle `if (foo instanceof Bar bar)`. The same suppression is done in core.

Signed-off-by: Jan N. Klug <github@klug.nrw>