### PR TITLE
[airquality] Add missing binding description

### DIFF
--- a/bundles/org.openhab.binding.airquality/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.airquality/src/main/resources/OH-INF/addon/addon.xml
@@ -5,5 +5,6 @@
 
 	<type>binding</type>
 	<name>Air Quality Binding</name>
+	<description>Measure Air Quality Index and details about pollution particles for a given location.</description>
 
 </addon:addon>


### PR DESCRIPTION
Previously in binding.xsd:

```xml
<xs:element name="description" type="xs:string" minOccurs="0"/>
```

In addon.xsd:

```xml
<xs:element name="description" type="xs:string"/>
```

This had the following consequence:
```
2023-02-03 22:04:49.015 [WARN ] [ig.xml.osgi.XmlDocumentBundleTracker] - The XML document '/OH-INF/addon/addon.xml' in module 'org.openhab.binding.airquality' could not be parsed: The node 'description' is missing!
---- Debugging information ----
message             : The node 'description' is missing!
class               : org.openhab.core.addon.xml.internal.AddonInfoXmlResult
required-type       : org.openhab.core.addon.xml.internal.AddonInfoXmlResult
converter-type      : org.openhab.core.addon.xml.internal.AddonInfoConverter
path                : /addon
line number         : 9
version             : 1.4.19
-------------------------------
com.thoughtworks.xstream.converters.ConversionException: The node 'description' is missing!
---- Debugging information ----
message             : The node 'description' is missing!
class               : org.openhab.core.addon.xml.internal.AddonInfoXmlResult
required-type       : org.openhab.core.addon.xml.internal.AddonInfoXmlResult
converter-type      : org.openhab.core.addon.xml.internal.AddonInfoConverter
path                : /addon
line number         : 9
version             : 1.4.19
-------------------------------
	at org.openhab.core.config.xml.util.NodeIterator.next(NodeIterator.java:122) ~[?:?]
	at org.openhab.core.config.xml.util.NodeIterator.nextValue(NodeIterator.java:181) ~[?:?]
	at org.openhab.core.addon.xml.internal.AddonInfoConverter.unmarshal(AddonInfoConverter.java:84) ~[?:?]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:74) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:68) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:52) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:136) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1421) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1399) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1350) ~[bundleFile:1.4.19]
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1304) ~[bundleFile:1.4.19]
	at org.openhab.core.config.xml.util.XmlDocumentReader.readFromXML(XmlDocumentReader.java:105) ~[bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.parseDocuments(XmlDocumentBundleTracker.java:396) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.processBundle(XmlDocumentBundleTracker.java:382) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker$2.run(XmlDocumentBundleTracker.java:347) [bundleFile:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

I checked other bindings as well, and only this one didn't have a description.

Related to openhab/openhab-core#3050