### PR TITLE
Remove obsoleted author tags in addon.xml

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,5 @@
 	<type>binding</type>
 	<name>Bosch Smart Home Binding</name>
 	<description>This is the binding for Bosch Smart Home.</description>
-	<author>Stefan Kästle</author>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.ecotouch/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.ecotouch/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,5 @@
 	<type>binding</type>
 	<name>EcoTouch Binding</name>
 	<description>This is the binding for a Waterkotte EcoTouch heat pump.</description>
-	<author>Sebastian Held</author>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,5 @@
 	<type>binding</type>
 	<name>GPIO Binding</name>
 	<description>Adds GPIO support to openHAB.</description>
-	<author>Nils Bauer</author>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/addon/addon.xml
@@ -6,5 +6,5 @@
 	<type>binding</type>
 	<name>Hayward OmniLogix Binding</name>
 	<description>Binding for the Hayward OmniLogix swimming pool automation controller.</description>
-	<author>Matt Myers</author>
+
 </addon:addon>

--- a/bundles/org.openhab.binding.playstation/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.playstation/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,5 @@
 	<type>binding</type>
 	<name>Sony PlayStation Binding</name>
 	<description>Monitor and control your Sony PlayStation.</description>
-	<author>Fredrik Ahlström</author>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/addon/addon.xml
@@ -6,6 +6,5 @@
 	<type>binding</type>
 	<name>Sure Petcare Binding</name>
 	<description>This binding interacts with the Sure Petcare Connect range of cat flaps and feeders</description>
-	<author>Rene Scherer, Holger Eisold</author>
 
 </addon:addon>


### PR DESCRIPTION
According to XSD:

```xml
<xs:element name="author" type="xs:string" minOccurs="0">
  <xs:annotation>
    <xs:documentation>The organization maintaining the add-on (e.g. openHAB). Individual developer names should be avoided. 
   </xs:documentation>
  </xs:annotation>
</xs:element>
```