### PR TITLE
[jsscripting] Extend mapping of openhab-js classes to native openHAB counterparts

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-SymbolicName: ${project.artifactId}
 DynamicImport-Package: *
-Import-Package: org.openhab.core.automation.module.script,javax.management,javax.script,javax.xml.datatype,javax.xml.stream;version="[1.0,2)",org.osgi.framework;version="[1.8,2)",org.slf4j;version="[1.7,2)"
-Require-Capability: 
+Import-Package: org.openhab.core.automation.module.script,org.openhab.core.items,org.openhab.core.library.types,javax.management,javax.script,javax.xml.datatype,javax.xml.stream;version="[1.0,2)",org.osgi.framework;version="[1.8,2)",org.slf4j;version="[1.7,2)"
+Require-Capability:
     osgi.extender:=
       filter:="(osgi.extender=osgi.serviceloader.processor)",
     osgi.serviceloader:=

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -52,6 +52,8 @@ import org.openhab.automation.jsscripting.internal.fs.ReadOnlySeekableByteArrayC
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
 import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable;
 import org.openhab.core.automation.module.script.ScriptExtensionAccessor;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.types.QuantityType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,6 +113,14 @@ public class OpenhabGraalJSScriptEngine
                     (v) -> v.hasMember("minusDuration") && v.hasMember("toNanos"), v -> {
                         return Duration.ofNanos(v.invokeMember("toNanos").asLong());
                     }, HostAccess.TargetMappingPrecedence.LOW)
+
+            // Translate openhab-js Item to org.openhab.core.items.Item
+            .targetTypeMapping(Value.class, Item.class, (v) -> v.hasMember("rawItem"),
+                    v -> v.getMember("rawItem").as(Item.class), HostAccess.TargetMappingPrecedence.LOW)
+
+            // Translate openhab-js Quantity to org.openhab.core.library.types.QuantityType
+            .targetTypeMapping(Value.class, QuantityType.class, (v) -> v.hasMember("raw") && v.hasMember("toUnit"),
+                    v -> v.getMember("raw").as(QuantityType.class), HostAccess.TargetMappingPrecedence.LOW)
             .build();
 
     /** {@link Lock} synchronization of multi-thread access */

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -103,23 +103,22 @@ public class OpenhabGraalJSScriptEngine
     /** Provides unlimited host access as well as custom translations from JS to Java Objects */
     private static final HostAccess HOST_ACCESS = HostAccess.newBuilder(HostAccess.ALL)
             // Translate JS-Joda ZonedDateTime to java.time.ZonedDateTime
-            .targetTypeMapping(Value.class, ZonedDateTime.class, (v) -> v.hasMember("withFixedOffsetZone"), v -> {
-                return ZonedDateTime.parse(v.invokeMember("withFixedOffsetZone").invokeMember("toString").asString());
-            }, HostAccess.TargetMappingPrecedence.LOW)
+            .targetTypeMapping(Value.class, ZonedDateTime.class, v -> v.hasMember("withFixedOffsetZone"),
+                    v -> ZonedDateTime.parse(v.invokeMember("withFixedOffsetZone").invokeMember("toString").asString()),
+                    HostAccess.TargetMappingPrecedence.LOW)
 
             // Translate JS-Joda Duration to java.time.Duration
             .targetTypeMapping(Value.class, Duration.class,
                     // picking two members to check as Duration has many common function names
-                    (v) -> v.hasMember("minusDuration") && v.hasMember("toNanos"), v -> {
-                        return Duration.ofNanos(v.invokeMember("toNanos").asLong());
-                    }, HostAccess.TargetMappingPrecedence.LOW)
+                    v -> v.hasMember("minusDuration") && v.hasMember("toNanos"),
+                    v -> Duration.ofNanos(v.invokeMember("toNanos").asLong()), HostAccess.TargetMappingPrecedence.LOW)
 
             // Translate openhab-js Item to org.openhab.core.items.Item
-            .targetTypeMapping(Value.class, Item.class, (v) -> v.hasMember("rawItem"),
+            .targetTypeMapping(Value.class, Item.class, v -> v.hasMember("rawItem"),
                     v -> v.getMember("rawItem").as(Item.class), HostAccess.TargetMappingPrecedence.LOW)
 
             // Translate openhab-js Quantity to org.openhab.core.library.types.QuantityType
-            .targetTypeMapping(Value.class, QuantityType.class, (v) -> v.hasMember("raw") && v.hasMember("toUnit"),
+            .targetTypeMapping(Value.class, QuantityType.class, v -> v.hasMember("raw") && v.hasMember("toUnit"),
                     v -> v.getMember("raw").as(QuantityType.class), HostAccess.TargetMappingPrecedence.LOW)
             .build();
 


### PR DESCRIPTION
Addon part of https://github.com/openhab/openhab-js/issues/98.

### Description

This PR extends the target type mapping inside the JS Scripting addon to also translate the following openhab-js classes to their native openHAB Java counterparts when passing to Java methods:

- openhab-js `Item` -> `org.openhab.core.items.Item`
- openhab-js `Quantity` -> `org.openhab.core.library.types.QuantityType`

Regarding the updated bnd file: I hope I did the right (if I understood the docs correctly I did), but would be nice if one could have a look and verify that it is correct what I did.

### Testing

Use the following script to test:

```javascript
// Check JS-Item -> openHAB Item translation
actions.BusEvent.sendCommand(items.Temperature, "0 °C")

// Check JS-Quantity -> openHAB QuantityType translation
var QuantityType = Java.type('org.openhab.core.library.types.QuantityType')
QuantityType.valueOf('50 cm').add(Quantity('5 m'))
```

... or trust me given the simplicity of the code when comparing to the existing and well-working code.