### PR TITLE
[gardena] Adjust thread name for WEB clients (avoid IAE)

### DIFF
--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
@@ -56,6 +56,8 @@ import org.openhab.binding.gardena.internal.model.dto.command.GardenaCommand;
 import org.openhab.binding.gardena.internal.model.dto.command.GardenaCommandRequest;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.io.net.http.WebSocketFactory;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.util.ThingWebClientUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,23 +103,24 @@ public class GardenaSmartImpl implements GardenaSmart, GardenaSmartWebSocketList
     private final Object newDeviceTasksLock = new Object();
     private final List<ScheduledFuture<?>> newDeviceTasks = new ArrayList<>();
 
-    public GardenaSmartImpl(String id, GardenaConfig config, GardenaSmartEventListener eventListener,
+    public GardenaSmartImpl(ThingUID uid, GardenaConfig config, GardenaSmartEventListener eventListener,
             ScheduledExecutorService scheduler, HttpClientFactory httpClientFactory, WebSocketFactory webSocketFactory)
             throws GardenaException {
-        this.id = id;
+        this.id = uid.getId();
         this.config = config;
         this.eventListener = eventListener;
         this.scheduler = scheduler;
 
         logger.debug("Starting GardenaSmart");
         try {
-            httpClient = httpClientFactory.createHttpClient(id);
+            String name = ThingWebClientUtil.buildWebClientConsumerName(uid, null);
+            httpClient = httpClientFactory.createHttpClient(name);
             httpClient.setConnectTimeout(config.getConnectionTimeout() * 1000L);
             httpClient.setIdleTimeout(httpClient.getConnectTimeout());
             httpClient.start();
 
-            String webSocketId = String.valueOf(hashCode());
-            webSocketClient = webSocketFactory.createWebSocketClient(webSocketId);
+            name = ThingWebClientUtil.buildWebClientConsumerName(uid, "ws-");
+            webSocketClient = webSocketFactory.createWebSocketClient(name);
             webSocketClient.setConnectTimeout(config.getConnectionTimeout() * 1000L);
             webSocketClient.setStopTimeout(3000);
             webSocketClient.setMaxIdleTimeout(150000);

--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/handler/GardenaAccountHandler.java
@@ -173,8 +173,7 @@ public class GardenaAccountHandler extends BaseBridgeHandler implements GardenaS
             GardenaConfig gardenaConfig = getThing().getConfiguration().as(GardenaConfig.class);
             logger.debug("{}", gardenaConfig);
 
-            String id = getThing().getUID().getId();
-            gardenaSmart = new GardenaSmartImpl(id, gardenaConfig, this, scheduler, httpClientFactory,
+            gardenaSmart = new GardenaSmartImpl(getThing().getUID(), gardenaConfig, this, scheduler, httpClientFactory,
                     webSocketFactory);
             final GardenaDeviceDiscoveryService discoveryService = this.discoveryService;
             if (discoveryService != null) {


### PR DESCRIPTION
OH core method expects a name length between 4 and 20.

Avoid a possible IllegalArgumentException.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>