### PR TITLE
[lifx] Add support for newer downlights

### DIFF
--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxProduct.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxProduct.java
@@ -123,6 +123,8 @@ public enum LifxProduct {
     PRODUCT_118(118, "LIFX Z", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE)),
     PRODUCT_119(119, "LIFX Beam", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE)),
     PRODUCT_120(120, "LIFX Beam", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE)),
+    PRODUCT_121(121, "LIFX Downlight", new Features(TR_1500_9000, COLOR)),
+    PRODUCT_122(122, "LIFX Downlight", new Features(TR_1500_9000, COLOR)),
     PRODUCT_123(123, "LIFX Color", new Features(TR_1500_9000, COLOR)),
     PRODUCT_124(124, "LIFX Color", new Features(TR_1500_9000, COLOR)),
     PRODUCT_125(125, "LIFX White to Warm", new Features(TR_1500_9000)),


### PR DESCRIPTION
Allows for discovering the new downlights (PID 121, 122) and their features.

See: https://github.com/LIFX/products/blob/master/products.json