### PR TITLE
[jrubyscripting] Update to JRuby 9.3.10.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.3.9.0</jruby.version>
+    <jruby.version>9.3.10.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is a maintenance update for openhab 3.4.x branch which contains the latest fixes for jruby 9.3.x.

The main branch for openhab 4 will be upgraded to jruby 9.4.x version which is a major upgrade with "potentially" breaking changes, although so far none is known to conflict with the existing helper libraries.

