### PR TITLE
Fix build after core-changes

### DIFF
--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusPollerThingHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusPollerThingHandlerTest.java
@@ -375,24 +375,6 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
     }
 
     @Test
-    public void testInitializeWithNoBridge()
-            throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-        Configuration pollerConfig = new Configuration();
-        pollerConfig.put("refresh", 150L);
-        pollerConfig.put("start", 5);
-        pollerConfig.put("length", 13);
-        pollerConfig.put("type", "coil");
-        poller = createPollerThingBuilder("poller").withConfiguration(pollerConfig).build();
-        addThing(poller);
-        verifyEndpointBasicInitInteraction();
-
-        assertThat(poller.getStatus(), is(equalTo(ThingStatus.OFFLINE)));
-        assertThat(poller.getStatusInfo().getStatusDetail(), is(equalTo(ThingStatusDetail.BRIDGE_OFFLINE)));
-
-        verifyNoMoreInteractions(mockedModbusManager);
-    }
-
-    @Test
     public void testInitializeWithOfflineBridge()
             throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
         Configuration pollerConfig = new Configuration();

--- a/itests/org.openhab.binding.nest.tests/src/main/java/org/openhab/binding/nest/internal/wwn/handler/WWNThingHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.nest.tests/src/main/java/org/openhab/binding/nest/internal/wwn/handler/WWNThingHandlerOSGiTest.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Function;
@@ -36,6 +37,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.ArgumentMatchers;
 import org.openhab.binding.nest.internal.wwn.config.WWNAccountConfiguration;
 import org.openhab.binding.nest.internal.wwn.test.WWNTestAccountHandler;
 import org.openhab.binding.nest.internal.wwn.test.WWNTestApiServlet;
@@ -61,6 +63,7 @@ import org.openhab.core.thing.ThingProvider;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingTypeProvider;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.link.ItemChannelLink;
@@ -171,6 +174,11 @@ public abstract class WWNThingHandlerOSGiTest extends JavaOSGiTest {
         nestTestHandlerFactory.activate(componentContext,
                 Map.of(WWNTestHandlerFactory.REDIRECT_URL_CONFIG_PROPERTY, REDIRECT_URL));
         registerService(nestTestHandlerFactory);
+
+        ThingTypeProvider thingTypeProvider = mock(ThingTypeProvider.class);
+        when(thingTypeProvider.getThingType(ArgumentMatchers.any(ThingTypeUID.class), nullable(Locale.class)))
+                .thenReturn(mock(ThingType.class));
+        registerService(thingTypeProvider);
 
         nestTestHandlerFactory = getService(ThingHandlerFactory.class, WWNTestHandlerFactory.class);
         assertThat("Could not get NestTestHandlerFactory", nestTestHandlerFactory, is(notNullValue()));

--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -161,7 +161,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
 
         channelTypeUID = new ChannelTypeUID(NtpBindingConstants.BINDING_ID + ":channelType");
         channelTypeProvider = mock(ChannelTypeProvider.class);
-        when(channelTypeProvider.getChannelType(any(ChannelTypeUID.class), any(Locale.class)))
+        when(channelTypeProvider.getChannelType(any(ChannelTypeUID.class), nullable(Locale.class)))
                 .thenReturn(ChannelTypeBuilder.state(channelTypeUID, "label", CoreItemFactory.SWITCH).build());
         registerService(channelTypeProvider);
     }

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Locale;
 
 import javax.measure.quantity.ElectricPotential;
 import javax.measure.quantity.Temperature;
@@ -34,8 +35,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants;
 import org.openhab.binding.systeminfo.internal.SysteminfoHandlerFactory;
 import org.openhab.binding.systeminfo.internal.SysteminfoThingTypeProvider;
@@ -81,7 +85,10 @@ import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
 import org.openhab.core.thing.type.ChannelKind;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeProvider;
 import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.thing.type.ThingType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
@@ -95,6 +102,7 @@ import org.openhab.core.types.UnDefType;
  */
 @NonNullByDefault
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class SysteminfoOSGiTest extends JavaOSGiTest {
     private static final String DEFAULT_TEST_THING_NAME = "work";
     private static final String DEFAULT_TEST_ITEM_NAME = "test";
@@ -259,6 +267,22 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         Thing thing = ThingBuilder.create(thingTypeUID, thingUID).withConfiguration(thingConfiguration)
                 .withChannel(channel).build();
         systemInfoThing = thing;
+
+        // TODO: This is a technically not correct work-around as the thing types are currently not made available by
+        // the binding. It should be properly fixes in the binding that thing-types are added to the registry. The
+        // "correct" solution here would be to wait until the thing manager initializes the thing with a missing thing
+        // type, but that would make each test take 120+ s
+        ThingTypeProvider thingTypeProviderMock = mock(ThingTypeProvider.class);
+        when(thingTypeProviderMock.getThingType(ArgumentMatchers.any(ThingTypeUID.class), nullable(Locale.class)))
+                .thenReturn(mock(ThingType.class));
+        registerService(thingTypeProviderMock);
+
+        ChannelType channelTypeMock = mock(ChannelType.class);
+        when(channelTypeMock.getKind()).thenReturn(ChannelKind.STATE);
+        ChannelTypeProvider channelTypeProviderMock = mock(ChannelTypeProvider.class);
+        when(channelTypeProviderMock.getChannelType(ArgumentMatchers.any(ChannelTypeUID.class), nullable(Locale.class)))
+                .thenReturn(channelTypeMock);
+        registerService(channelTypeProviderMock);
 
         ManagedThingProvider managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
         assertThat(managedThingProvider, is(notNullValue()));

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoOSGiTest.java
@@ -125,7 +125,7 @@ public abstract class GenericWemoOSGiTest extends JavaOSGiTest {
         registerService(wemoHttpCallFactory, WemoHttpCallFactory.class.getName());
 
         ChannelTypeProvider channelTypeProvider = mock(ChannelTypeProvider.class);
-        when(channelTypeProvider.getChannelType(any(ChannelTypeUID.class), any(Locale.class))).thenReturn(
+        when(channelTypeProvider.getChannelType(any(ChannelTypeUID.class), nullable(Locale.class))).thenReturn(
                 ChannelTypeBuilder.state(DEFAULT_CHANNEL_TYPE_UID, "label", CoreItemFactory.SWITCH).build());
         registerService(channelTypeProvider);
     }


### PR DESCRIPTION
Thing initialization in core is now more strict, therefore some tests need to be adapted.