### PR TITLE
Change ffmpeg motion detection control to cover the whole range supported by ffmpeg

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraBindingConstants.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraBindingConstants.java
@@ -43,7 +43,7 @@ public class IpCameraBindingConstants {
         SNAPSHOT
     }
 
-    public static final BigDecimal BIG_DECIMAL_SCALE_MOTION = new BigDecimal(5000);
+    public static final BigDecimal BIG_DECIMAL_SCALE_MOTION = new BigDecimal(100);
     public static final long HLS_STARTUP_DELAY_MS = 4500;
     @SuppressWarnings("null")
     public static final int SERVLET_PORT = Integer.getInteger("org.osgi.service.http.port", 8080);


### PR DESCRIPTION
# Change  ffmpeg motion sensibility control

This shouldn't be merged as-is

In the current ipcamera binding the item controlling ffmpeg scene detection sensibility is a slider going from 1 to 100, which is divided by 5000 and used with [https://ffmpeg.org/ffmpeg-filters.html#select_002c-aselect](https://ffmpeg.org/ffmpeg-filters.html#select_002c-aselect). So the maximum scene detection probability we can use is `100/5000 = 0.02`
This is causing an issue with my camera where even a static scene is regularly detected as a new scene by ffmpeg with a probability of 0.02~0.03. I would like to use 0.1 as the threshold (i.e. `-an -vf select='gte(scene\,0.1)',metadata=print -f null -`)  but this isn't possible with the current divider of 5000.
In this pull request I've changed this divider to be 100 to allow the item to cover the whole range of ffmpeg scene detection probability, but :
- This is going to break existing setups as the motion control item value won't mean the same thing
- It doesn't allow to control the scene detection probability threshold with the same granularity

I don't know what the ideal value should be for the divider, but 5000 seems to high. @Skinah how did you choose this value ? The examples in ffmpeg doc [https://ffmpeg.org/ffmpeg-filters.html#Examples-160](https://ffmpeg.org/ffmpeg-filters.html#Examples-160) uses a threshold of 0.45 so I don't think my threshold of 0.1 is crazy.
