### PR TITLE
[km200] Added missing config descriptions

### DIFF
--- a/bundles/org.openhab.binding.km200/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.km200/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+	<config-description uri="thing-type:km200:config">
+	</config-description>
+	<config-description uri="channel-type:km200:config">
+	</config-description>
+</config-description:config-descriptions>


### PR DESCRIPTION
Added missing config descriptions. In the past it was not generating any errors but now the users will get a lot of warnings without this empty config description.
Community: [137906](https://community.openhab.org/t/km200-warning-at-startup/137906)
(it was #14484, not rebased to main)