### PR TITLE
[km200] removed unused configuration URIs

### DIFF
--- a/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/KM200BindingConstants.java
+++ b/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/KM200BindingConstants.java
@@ -25,8 +25,6 @@ import org.openhab.core.thing.ThingTypeUID;
 public class KM200BindingConstants {
 
     public static final String BINDING_ID = "km200";
-    public static final String CONFIG_DESCRIPTION_URI_CHANNEL = "channel-type:km200:config";
-    public static final String CONFIG_DESCRIPTION_URI_THING = "thing-type:km200:config";
 
     // Bridge UID
     public static final ThingTypeUID THING_TYPE_KMDEVICE = new ThingTypeUID(BINDING_ID, "kmdevice");

--- a/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/handler/KM200ThingHandler.java
+++ b/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/handler/KM200ThingHandler.java
@@ -16,8 +16,6 @@ import static org.openhab.binding.km200.internal.KM200BindingConstants.*;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -149,7 +147,6 @@ public class KM200ThingHandler extends BaseThingHandler {
     Channel createChannel(ChannelTypeUID channelTypeUID, ChannelUID channelUID, String root, String type,
             @Nullable String currentPathName, String description, String label, boolean addProperties,
             boolean switchProgram, StateDescriptionFragment state, String unitOfMeasure) {
-        URI configDescriptionUriChannel = null;
         Channel newChannel = null;
         ChannelType channelType = null;
         Map<String, String> chProperties = new HashMap<>();
@@ -162,20 +159,11 @@ public class KM200ThingHandler extends BaseThingHandler {
             logger.info("Channeltype {} not supported", type);
             return null;
         }
-        try {
-            configDescriptionUriChannel = new URI(CONFIG_DESCRIPTION_URI_CHANNEL);
-            channelType = ChannelTypeBuilder.state(channelTypeUID, label, type) //
-                    .withDescription(description) //
-                    .withCategory(checkCategory(unitOfMeasure, category, state.isReadOnly())) //
-                    .withStateDescriptionFragment(state) //
-                    .withConfigDescriptionURI(configDescriptionUriChannel).build();
-        } catch (URISyntaxException ex) {
-            logger.warn("Can't create ConfigDescription URI '{}', ConfigDescription for channels not avilable!",
-                    CONFIG_DESCRIPTION_URI_CHANNEL);
-            channelType = ChannelTypeBuilder.state(channelTypeUID, label, type) //
-                    .withDescription(description) //
-                    .withCategory(checkCategory(unitOfMeasure, category, state.isReadOnly())).build();
-        }
+        channelType = ChannelTypeBuilder.state(channelTypeUID, label, type) //
+                .withDescription(description) //
+                .withCategory(checkCategory(unitOfMeasure, category, state.isReadOnly())) //
+                .withStateDescriptionFragment(state).build();
+
         channelTypeProvider.addChannelType(channelType);
 
         chProperties.put("root", KM200Utils.translatesPathToName(root));


### PR DESCRIPTION
This PR removes unused configuration URI/description. This was prepared but never used. See users comments: [137906](https://community.openhab.org/t/km200-warning-at-startup/137906)