### PR TITLE
[denonmarantz] Add representation-property to thing-types xml

### DIFF
--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -29,6 +29,8 @@
 			</channel-group>
 		</channel-groups>
 
+		<representation-property>serialNumber</representation-property>
+
 		<config-description>
 			<parameter-group name="receiverProperties">
 				<label>Receiver Properties</label>


### PR DESCRIPTION
The discovery service calls `withrepresentationProperty` but it's not in thing-types.xml.

Signed-off-by: Mark Hilbush [mark@hilbush.com](mailto:mark@hilbush.com)
