### PR TITLE
[groovyscripting] Update Groovy to 4.0.9 and support slurpers

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/README.md
+++ b/bundles/org.openhab.automation.groovyscripting/README.md
@@ -1,6 +1,6 @@
 # Groovy Scripting
 
-This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.7 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
+This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.9 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
 
 ## Creating Groovy Scripts
 

--- a/bundles/org.openhab.automation.groovyscripting/pom.xml
+++ b/bundles/org.openhab.automation.groovyscripting/pom.xml
@@ -15,8 +15,8 @@
   <name>openHAB Add-ons :: Bundles :: Automation :: Groovy Scripting</name>
 
   <properties>
-    <bnd.importpackage>com.ibm.icu.*;resolution:=optional,groovy.runtime.metaclass;resolution:=optional,groovyjarjarantlr4.stringtemplate;resolution:=optional,org.abego.treelayout.*;resolution:=optional,org.apache.ivy.*;resolution:=optional,org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
-    <groovy.version>4.0.7</groovy.version>
+    <bnd.importpackage>com.ibm.icu.*;resolution:=optional,groovy.runtime.metaclass;resolution:=optional,groovyjarjarantlr4.stringtemplate;resolution:=optional,org.abego.treelayout.*;resolution:=optional,org.apache.ivy.*;resolution:=optional,org.fusesource.jansi.*;resolution:=optional,org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
+    <groovy.version>4.0.9</groovy.version>
   </properties>
 
   <dependencies>
@@ -34,10 +34,46 @@
     </dependency>
     <dependency>
       <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy-json</artifactId>
+      <version>${groovy.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
       <version>${groovy.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy-yaml</artifactId>
+      <version>${groovy.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <configuration>
+            <bnd><![CDATA[${oh.bndDefaults}
+Require-Capability:
+    osgi.extender:=
+      filter:="(osgi.extender=osgi.serviceloader.processor)",
+    osgi.serviceloader:=
+      filter:="(osgi.serviceloader=org.apache.groovy.json.FastStringServiceFactory)";
+      cardinality:=multiple
+SPI-Provider: *
+SPI-Consumer: *
+]]>
+            </bnd>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
 </project>

--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -44,7 +44,7 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
             .flatMap(List::stream) //
             .collect(Collectors.toUnmodifiableList());
 
-    private final GroovyClassLoader gcl = new GroovyClassLoader();
+    private final GroovyClassLoader gcl = new GroovyClassLoader(GroovyScriptEngineFactory.class.getClassLoader());
 
     public GroovyScriptEngineFactory() {
         String scriptDir = OpenHAB.getConfigFolder() + File.separator + FILE_DIRECTORY;

--- a/itests/org.openhab.automation.groovyscripting.tests/NOTICE
+++ b/itests/org.openhab.automation.groovyscripting.tests/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.automation.groovyscripting.tests/itest.bndrun
+++ b/itests/org.openhab.automation.groovyscripting.tests/itest.bndrun
@@ -1,0 +1,80 @@
+-include: ../itest-common.bndrun
+
+Bundle-SymbolicName: ${project.artifactId}
+Fragment-Host: org.openhab.automation.groovyscripting
+
+-runrequires: \
+	bnd.identity;id='org.openhab.automation.groovyscripting.tests',\
+	bnd.identity;id='org.openhab.core',\
+	bnd.identity;id='org.openhab.automation.groovyscripting'
+
+# We would like to use the "volatile" storage only
+-runblacklist: \
+	bnd.identity;id='org.openhab.core.storage.json'
+
+#
+# done
+#
+-runbundles: \
+	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
+	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
+	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.14.1,2.14.2)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.14.2,2.14.3)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.14.2,2.14.3)',\
+	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.14.2,2.14.3)',\
+	com.google.gson;version='[2.9.1,2.9.2)',\
+	com.sun.jna;version='[5.12.1,5.12.2)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
+	jakarta.annotation-api;version='[1.3.5,1.3.6)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	junit-jupiter-api;version='[5.8.1,5.8.2)',\
+	junit-jupiter-engine;version='[5.8.1,5.8.2)',\
+	junit-platform-commons;version='[1.8.1,1.8.2)',\
+	junit-platform-engine;version='[1.8.1,1.8.2)',\
+	junit-platform-launcher;version='[1.8.1,1.8.2)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	org.hamcrest;version='[2.2.0,2.2.1)',\
+	org.jsr-305;version='[3.0.2,3.0.3)',\
+	org.openhab.automation.groovyscripting;version='[4.0.0,4.0.1)',\
+	org.openhab.automation.groovyscripting.tests;version='[4.0.0,4.0.1)',\
+	org.openhab.core;version='[4.0.0,4.0.1)',\
+	org.openhab.core.automation;version='[4.0.0,4.0.1)',\
+	org.openhab.core.automation.module.script;version='[4.0.0,4.0.1)',\
+	org.openhab.core.config.core;version='[4.0.0,4.0.1)',\
+	org.openhab.core.ephemeris;version='[4.0.0,4.0.1)',\
+	org.openhab.core.io.console;version='[4.0.0,4.0.1)',\
+	org.openhab.core.test;version='[4.0.0,4.0.1)',\
+	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
+	org.openhab.core.transform;version='[4.0.0,4.0.1)',\
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.service.event;version='[1.4.0,1.4.1)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	org.yaml.snakeyaml;version='[1.33.0,1.33.1)',\
+	si-units;version='[2.1.0,2.1.1)',\
+	si.uom.si-quantity;version='[2.1.0,2.1.1)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)',\
+	xstream;version='[1.4.19,1.4.20)',\
+	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
+	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
+	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
+	org.eclipse.jetty.http;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.io;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.security;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.server;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.servlet;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
+	org.osgi.service.component;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.automation.groovyscripting.tests/pom.xml
+++ b/itests/org.openhab.automation.groovyscripting.tests/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.itests</groupId>
+    <artifactId>org.openhab.addons.reactor.itests</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.automation.groovyscripting.tests</artifactId>
+
+  <name>openHAB Add-ons :: Integration Tests :: Groovy Scripting</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.automation.groovyscripting</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/itests/org.openhab.automation.groovyscripting.tests/src/main/java/org/openhab/automation/groovyscripting/SlurperOSGiTest.java
+++ b/itests/org.openhab.automation.groovyscripting.tests/src/main/java/org/openhab/automation/groovyscripting/SlurperOSGiTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.groovyscripting;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.module.script.ScriptEngineContainer;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.test.java.JavaOSGiTest;
+
+/**
+ * This tests the JSON, XML and YAML slurpers using the Groovy scripting engine.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class SlurperOSGiTest extends JavaOSGiTest {
+
+    private @NonNullByDefault({}) ScriptEngine engine;
+
+    private final String path = "OH-INF/automation/jsr223/";
+
+    @BeforeEach
+    public void init() {
+        ScriptEngineManager scriptManager = getService(ScriptEngineManager.class);
+        ScriptEngineContainer container = scriptManager.createScriptEngine("groovy", "myGroovyEngine");
+        engine = container.getScriptEngine();
+    }
+
+    private void evalScript(String fileName) throws ScriptException, IOException {
+        URL url = bundleContext.getBundle().getResource(path + fileName);
+        engine.eval(new InputStreamReader(url.openStream()));
+    }
+
+    @Test
+    public void jsonSlurper() throws ScriptException, IOException {
+        evalScript("json-slurper.groovy");
+    }
+
+    @Test
+    public void xmlSlurper() throws ScriptException, IOException {
+        evalScript("xml-slurper.groovy");
+    }
+
+    @Test
+    public void yamlSlurper() throws ScriptException, IOException {
+        evalScript("yaml-slurper.groovy");
+    }
+}

--- a/itests/org.openhab.automation.groovyscripting.tests/src/main/resources/OH-INF/automation/jsr223/json-slurper.groovy
+++ b/itests/org.openhab.automation.groovyscripting.tests/src/main/resources/OH-INF/automation/jsr223/json-slurper.groovy
@@ -1,0 +1,22 @@
+import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.MatcherAssert.assertThat
+
+import groovy.json.JsonSlurper
+
+def json = '''\
+{
+  "person": {
+    "name": "John",
+    "age": 10,
+    "pets": ["cat", "dog"]
+  }
+}
+'''
+
+def result = new JsonSlurper().parseText(json)
+
+assertThat(result.person.name, is("John"))
+assertThat(result.person.age, is(10))
+assertThat(result.person.pets.size(), is(2))
+assertThat(result.person.pets[0], is("cat"))
+assertThat(result.person.pets[1], is("dog"))

--- a/itests/org.openhab.automation.groovyscripting.tests/src/main/resources/OH-INF/automation/jsr223/xml-slurper.groovy
+++ b/itests/org.openhab.automation.groovyscripting.tests/src/main/resources/OH-INF/automation/jsr223/xml-slurper.groovy
@@ -1,0 +1,23 @@
+import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.MatcherAssert.assertThat
+
+import groovy.xml.XmlSlurper
+
+def xml = '''\
+<root>
+  <person>
+    <name>Brigitte</name>
+    <age>34</age>
+    <pets>bird</pets>
+    <pets>fish</pets>
+  </person>
+</root>
+'''
+
+def result = new XmlSlurper().parseText(xml)
+
+assertThat(result.person.name, is("Brigitte"))
+assertThat(result.person.age, is(34))
+assertThat(result.person.pets.size(), is(2))
+assertThat(result.person.pets[0], is("bird"))
+assertThat(result.person.pets[1], is("fish"))

--- a/itests/org.openhab.automation.groovyscripting.tests/src/main/resources/OH-INF/automation/jsr223/yaml-slurper.groovy
+++ b/itests/org.openhab.automation.groovyscripting.tests/src/main/resources/OH-INF/automation/jsr223/yaml-slurper.groovy
@@ -1,0 +1,21 @@
+import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.MatcherAssert.assertThat
+
+import groovy.yaml.YamlSlurper
+
+def yaml = '''\
+person:
+  name: "Itsuki"
+  age: 78
+  pets:
+  - rabbit
+  - snake
+'''
+
+def result = new YamlSlurper().parseText(yaml)
+
+assertThat(result.person.name, is("Itsuki"))
+assertThat(result.person.age, is(78))
+assertThat(result.person.pets.size(), is(2))
+assertThat(result.person.pets[0], is("rabbit"))
+assertThat(result.person.pets[1], is("snake"))

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -17,6 +17,7 @@
   <name>openHAB Add-ons :: Integration Tests</name>
 
   <modules>
+    <module>org.openhab.automation.groovyscripting.tests</module>
     <module>org.openhab.automation.jsscriptingnashorn.tests</module>
     <module>org.openhab.binding.astro.tests</module>
     <module>org.openhab.binding.avmfritz.tests</module>


### PR DESCRIPTION
Updates Groovy from 4.0.7 to 4.0.9.

For release notes, see:

https://groovy-lang.org/changelogs/changelog-4.0.8.html
https://groovy-lang.org/changelogs/changelog-4.0.9.html

Adds dependencies and service loader config so JSON, XML and YAML can be more easily parsed using the `JsonSlurper`, `XmlSlurper` and `YamlSlurper`.