### PR TITLE
[kaleidescape] Remove Apache StringEscapeUtils

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/README.md
+++ b/bundles/org.openhab.binding.kaleidescape/README.md
@@ -229,7 +229,9 @@ String z1_Detail_DiscLocation "Disc Location: [%s]" { channel="kaleidescape:play
 ksecondsformat.js:
 
 ```javascript
-(function(totalSeconds) {
+(function(timestamp) {
+    var totalSeconds = Date.parse(timestamp) / 1000
+
     if (isNaN(totalSeconds)) {
         return '-';
     } else {

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/communication/KaleidescapeConnector.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/communication/KaleidescapeConnector.java
@@ -125,7 +125,7 @@ public abstract class KaleidescapeConnector {
             try {
                 readerThread.join(3000);
             } catch (InterruptedException e) {
-                logger.warn("Error joining readerThread: {}", e.getMessage());
+                logger.debug("Error joining readerThread: {}", e.getMessage());
             }
         }
     }

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/communication/KaleidescapeFormatter.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/communication/KaleidescapeFormatter.java
@@ -14,7 +14,6 @@ package org.openhab.binding.kaleidescape.internal.communication;
 
 import static org.openhab.binding.kaleidescape.internal.KaleidescapeBindingConstants.*;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -24,6 +23,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class KaleidescapeFormatter {
+    private static final String WITH_DELIMITER = "((?<=\\\\d[0-9]{3})|(?=\\\\d[0-9]{3}))";
+
     public static String formatString(String input) {
         if (!EMPTY.equals(input)) {
             // convert || back to :
@@ -45,13 +46,27 @@ public class KaleidescapeFormatter {
                 // convert \d147 & \d148 from review text into double quote
                 input = input.replace("\\d147", "\"");
                 input = input.replace("\\d148", "\"");
+            }
 
-                // fix the encoding for k mangled extended ascii characters (chars coming in as \dnnn)
-                // I.e. characters with accent, umlaut, etc., they need to be restored to the correct character
-                // example: Noel (with umlaut 'o') comes in as N\d246el
-                input = input.replaceAll("(?i)\\\\d([0-9]{3})", "\\&#$1;"); // first convert to html escaped codes
-                // then convert with unescapeHtml4, not sure how to do this without the Apache libraries :(
-                return StringEscapeUtils.unescapeHtml4(input);
+            // fix the encoding for k mangled extended ascii characters (chars coming in as \dnnn)
+            // I.e. characters with accent, umlaut, etc., they need to be restored to the correct character
+            // example: Noel (with umlaut 'o') comes in as N\d246el
+            if (input.contains("\\d")) {
+                StringBuilder fixedOutput = new StringBuilder();
+                String[] arr = input.split(WITH_DELIMITER);
+
+                for (String s : arr) {
+                    if (s.startsWith("\\d") && s.length() == 5) {
+                        try {
+                            fixedOutput.append((char) Integer.parseInt(s.substring(2, 5)));
+                        } catch (NumberFormatException e) {
+                            fixedOutput.append(s);
+                        }
+                    } else {
+                        fixedOutput.append(s);
+                    }
+                }
+                return fixedOutput.toString();
             }
         }
         return input;

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
@@ -424,7 +424,7 @@ public class KaleidescapeHandler extends BaseThingHandler implements Kaleidescap
                     // if the last successful polling update was more than 1.25 intervals ago,
                     // the component is not responding even though the connection is still good
                     if ((System.currentTimeMillis() - lastEventReceived) > (POLLING_INTERVAL_S * 1.25 * 1000)) {
-                        logger.warn("Component not responding to status requests");
+                        logger.debug("Component not responding to status requests");
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                 "Component not responding to status requests");
                         closeConnection();

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
@@ -113,6 +113,10 @@ public class KaleidescapeHandler extends BaseThingHandler implements Kaleidescap
         thing.setProperty(name, value);
     }
 
+    protected boolean isChannelLinked(String channel) {
+        return isLinked(channel);
+    }
+
     @Override
     public void initialize() {
         final String uid = this.getThing().getUID().getAsString();

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
@@ -406,7 +406,7 @@ public enum KaleidescapeMessageHandler {
                     // special case for cover art image
                     if (DETAIL_COVER_URL.equals(metaType)) {
                         handler.updateDetailChannel(metaType, new StringType(value));
-                        if (!value.isEmpty()) {
+                        if (!value.isEmpty() && handler.isChannelLinked(DETAIL + DETAIL_COVER_ART)) {
                             try {
                                 ContentResponse contentResponse = handler.httpClient.newRequest(value).method(GET)
                                         .timeout(10, TimeUnit.SECONDS).send();

--- a/bundles/org.openhab.binding.kaleidescape/src/test/java/org/openhab/binding/kaleidescape/internal/KaleidescapeFormatterTest.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/test/java/org/openhab/binding/kaleidescape/internal/KaleidescapeFormatterTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.kaleidescape.internal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.kaleidescape.internal.communication.KaleidescapeFormatter;
+
+/**
+ * Unit tests for {@link KaleidescapeFormatter}.
+ *
+ * @author Michael Lobstein - Initial contribution
+ */
+@NonNullByDefault
+public class KaleidescapeFormatterTest {
+    @Test
+    public void formatEncodedActorNameList() {
+        assertThat(KaleidescapeFormatter.formatString(
+                "Craig T. Nelson\\rHolly Hunter\\rJason Lee\\rSamuel L. Jackson\\rBrad Bird\\rSarah Vowell\\rSpencer Fox\\rWallace Shawn\\rElizabeth Pe\\d241a"),
+                is("Craig T. Nelson, Holly Hunter, Jason Lee, Samuel L. Jackson, Brad Bird, Sarah Vowell, Spencer Fox, Wallace Shawn, Elizabeth Peña"));
+    }
+
+    @Test
+    public void formatEncodedAlbumName() {
+        assertThat(KaleidescapeFormatter.formatString(
+                "Bart\\d243k\\: Concerto for Orchestra; Music for Strings, Percussion and Celesta; Hungarian Sketches"),
+                is("Bartók: Concerto for Orchestra; Music for Strings, Percussion and Celesta; Hungarian Sketches"));
+    }
+
+    @Test
+    public void formatEncodedUrl() {
+        assertThat(
+                KaleidescapeFormatter
+                        .formatString("http\\:\\/\\/10.100.12.194\\/panelcoverart\\/b9bca9a6f224fb54\\/4254312.jpg"),
+                is("http://10.100.12.194/panelcoverart/b9bca9a6f224fb54/4254312.jpg"));
+    }
+
+    @Test
+    public void formatEncodedProverb() {
+        assertThat(KaleidescapeFormatter.formatString(
+                "\\d196ll w\\d246rk \\d226nd \\d241o pl\\d226\\d255 m\\d228k\\d200s J\\d195\\d231k \\d229 d\\d249ll b\\d244\\d253"),
+                is("Äll wörk ând ño plâÿ mäkÈs JÃçk å dùll bôý"));
+    }
+
+    @Test
+    public void formatEncodedLatin1ExtentedAlphabetToChars() {
+        assertThat(KaleidescapeFormatter.formatString(
+                "\\d161\\d162\\d163\\d164\\d165\\d166\\d167\\d168\\d169\\d170\\d171\\d172\\d174\\d175\\d176\\d177\\d178\\d179\\d180\\d181\\d182\\d183\\d184\\d185\\d186\\d187\\d188\\d189\\d190\\d191\\d192\\d193\\d194\\d195\\d196\\d197\\d198\\d199\\d200\\d201\\d202\\d203\\d204\\d205\\d206\\d207\\d208\\d209\\d210\\d211\\d212\\d213\\d214\\d215\\d216\\d217\\d218\\d219\\d220\\d221\\d222\\d223\\d224\\d225\\d226\\d227\\d228\\d229\\d230\\d231\\d232\\d233\\d234\\d235\\d236\\d237\\d238\\d239\\d240\\d241\\d242\\d243\\d244\\d245\\d246\\d247\\d248\\d249\\d250\\d251\\d252\\d253\\d254\\d255"),
+                is("¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"));
+    }
+}


### PR DESCRIPTION
Replace StringEscapeUtils.unescapeHtml4() with basic Java methods to address #7722. Also a couple very minor tweaks that I have had pending for some time now.