### PR TITLE
[bsblan] Remove org.apache.commons

### DIFF
--- a/bundles/org.openhab.binding.bsblan/pom.xml
+++ b/bundles/org.openhab.binding.bsblan/pom.xml
@@ -14,4 +14,13 @@
 
   <name>openHAB Add-ons :: Bundles :: BSB-LAN Binding</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.unbescape</groupId>
+      <artifactId>unbescape</artifactId>
+      <version>1.1.6.RELEASE</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+  
 </project>

--- a/bundles/org.openhab.binding.bsblan/pom.xml
+++ b/bundles/org.openhab.binding.bsblan/pom.xml
@@ -22,5 +22,5 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
-  
+
 </project>

--- a/bundles/org.openhab.binding.bsblan/src/main/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverter.java
+++ b/bundles/org.openhab.binding.bsblan/src/main/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverter.java
@@ -14,7 +14,6 @@ package org.openhab.binding.bsblan.internal.helper;
 
 import static org.openhab.binding.bsblan.internal.BsbLanBindingConstants.*;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterDTO;
@@ -26,6 +25,7 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.unbescape.html.HtmlEscape;
 
 /**
  * The {@link BsbLanParameterHandler} is responsible for updating the data, which are
@@ -75,7 +75,7 @@ public class BsbLanParameterConverter {
     }
 
     private static State getStateForUnitChannel(BsbLanApiParameterDTO parameter) {
-        String value = StringEscapeUtils.unescapeHtml4(parameter.unit);
+        String value = HtmlEscape.unescapeHtml(parameter.unit);
         return new StringType(value);
     }
 


### PR DESCRIPTION
- Replaced the org.apache.commons with the unbescape package.

Not tested, just technicall change. Should work as this package has been used in several other bindings as replacement for `unescapeHtml4`