### PR TITLE
[ecobee] Increase temperature precision to decimal

### DIFF
--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
@@ -110,7 +110,7 @@ public final class EcobeeUtils {
             QuantityType<Temperature> convertedTemp = ((QuantityType<Temperature>) value)
                     .toUnit(ImperialUnits.FAHRENHEIT);
             if (convertedTemp != null) {
-                return Integer.valueOf((int)(convertedTemp.doubleValue() * 10));
+                return Integer.valueOf((int) (convertedTemp.doubleValue() * 10));
             }
         }
         throw new IllegalArgumentException("temperature is not a QuantityType");

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeUtils.java
@@ -110,7 +110,7 @@ public final class EcobeeUtils {
             QuantityType<Temperature> convertedTemp = ((QuantityType<Temperature>) value)
                     .toUnit(ImperialUnits.FAHRENHEIT);
             if (convertedTemp != null) {
-                return Integer.valueOf(convertedTemp.intValue() * 10);
+                return Integer.valueOf((int)(convertedTemp.doubleValue() * 10));
             }
         }
         throw new IllegalArgumentException("temperature is not a QuantityType");


### PR DESCRIPTION
Correcting rounding of setHold values so we have 0.1°F tolerance instead of 1°F.  Makes it easier to use in °C

Signed-off-by: Bevan Watkiss <darthbevis@gmail.com>