### PR TITLE
[neeo] Fix Servlet exceptions due to non-unique names

### DIFF
--- a/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/NeeoService.java
+++ b/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/NeeoService.java
@@ -282,7 +282,10 @@ public class NeeoService implements EventSubscriber, NetworkAddressChangeListene
                             sysInfo.getHostname(), ipAddress, clientBuilder);
                     servlets.add(newServlet);
 
-                    localContext.getHttpService().registerServlet(servletUrl, newServlet, new Hashtable<>(),
+                    Hashtable<Object, Object> initParams = new Hashtable<>();
+                    initParams.put("servlet-name", servletUrl);
+
+                    localContext.getHttpService().registerServlet(servletUrl, newServlet, initParams,
                             localContext.getHttpService().createDefaultHttpContext());
                     logger.debug("Started NEEO Listener at {}", servletUrl);
                 } catch (NamespaceException | ServletException | IOException e) {


### PR DESCRIPTION
It seems that Pax Web nowadays checks that the Servlet names are unique.

See: [ServletModel.addServletModel](https://github.com/ops4j/org.ops4j.pax.web/blame/f3350d3bc942109505d17497a8a23900f3abe7c3/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/ServerModel.java#L1443-L1459)

Fixes #14545