### PR TITLE
[jrubyscripting] Upgrade JRuby to 9.4.2.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.3.9.0</jruby.version>
+    <jruby.version>9.4.2.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is a major version upgrade from 9.3.x, raising the compatibility level up from Ruby 2.6 to Ruby 3.1