### PR TITLE
[enocean] Bugfix - condition in getPositionData function of EEP D2_05_00

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_05/D2_05_00.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_05/D2_05_00.java
@@ -84,8 +84,9 @@ public class D2_05_00 extends _VLDMessage {
 
     protected State getPositionData() {
         if (getCMD() == CMD_ACTUATOR_POSITION_RESPONE) {
-            if (bytes[0] != 127) {
-                return new PercentType(bytes[0] & 0x7f);
+            int position = bytes[0] & 0x7f;
+            if (position != 127) {
+                return new PercentType(position);
             }
         }
 


### PR DESCRIPTION
Fix #14528

Change condition in function getPositionData in EEP D2_05_00 to check data at offset 1 and size 7 instead offset 0 and size 8.

According the enocean documentation visible [here](http://tools.enocean-alliance.org/EEPViewer/profiles/D2/05/00/D2-05-00.pdf), the section `CMD 4 - Reply Position and Angle` the first bit is not used, so the validation should not evaluate it.
