### PR TITLE
Ignore HTTP errors != 400 for 2-FA authentication

### DIFF
--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudService.java
@@ -246,8 +246,16 @@ public class ICloudService {
             this.session.post(AUTH_ENDPOINT + "/verify/trusteddevice/securitycode", JsonUtils.toJson(requestBody),
                     headers);
         } catch (ICloudApiResponseException ex) {
-            logger.debug("Code verification failed.", ex);
-            return false;
+            logger.debug("Exception on code verification with HTTP status {}. Verification might still be successful.",
+                    ex.getStatusCode());
+            logger.trace("Exception on code verification with HTTP status {}. Verification might still be successful.",
+                    ex.getStatusCode(), ex);
+            // iCloud API returns different 4xx error codes even if validation is successful
+            // currently 400 seems to show that verification "really" failed.
+            if (ex.getStatusCode() == 400 || ex.getStatusCode() >= 500) {
+                this.logger.debug("Verification failed with HTTP status {}.", ex.getStatusCode());
+                return false;
+            }
         }
 
         logger.debug("Code verification successful.");


### PR DESCRIPTION
This PR should fix https://github.com/openhab/openhab-addons/issues/14323

It changes error handling for iCloud 2-fa authentication to ignore all http error except 400.