### PR TITLE
[openwebnet] Reset zones' alarm state channel when system is armed

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -278,10 +278,10 @@ _Notes on `shutter` position_
 Basic Scenarios and CEN/CEN+ Scenarios channels are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
 
 A powerful feature is to detect scenario activations and CEN/CEN+ buttons press events to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by BTicino scenario control modules or by CEN/CEN+ scenarios physical buttons.
-See [openwebnet.rules](#openwebnet-rules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
+See [openwebnet.rules](#openwebnetrules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
 
 It's also possible to send _virtual scenario activation_ and _virtual press_ events on the BUS, for example to enable the activation of MH202 or F420 scenarios from openHAB..
-See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
+See [openwebnet.sitemap](#openwebnetsitemap) & [openwebnet.rules](#openwebnetrules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
 
 - basic scenario channels are named `scenario` and possible events are: `SCENARIO_01` ... `SCENARIO_16` (or up to `SCENARIO_20` in case of module IR3456) when a scenario is activated
 - CEN/CEN+ channels are named `button#X` where `X` is the button number on the CEN/CEN+ Scenario Control device

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -278,10 +278,10 @@ _Notes on `shutter` position_
 Basic Scenarios and CEN/CEN+ Scenarios channels are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
 
 A powerful feature is to detect scenario activations and CEN/CEN+ buttons press events to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by BTicino scenario control modules or by CEN/CEN+ scenarios physical buttons.
-See [openwebnet.rules](#openwebnetrules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
+See [openwebnet.rules](#openwebnet-rules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
 
 It's also possible to send _virtual scenario activation_ and _virtual press_ events on the BUS, for example to enable the activation of MH202 or F420 scenarios from openHAB..
-See [openwebnet.sitemap](#openwebnetsitemap) & [openwebnet.rules](#openwebnetrules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
+See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
 
 - basic scenario channels are named `scenario` and possible events are: `SCENARIO_01` ... `SCENARIO_16` (or up to `SCENARIO_20` in case of module IR3456) when a scenario is activated
 - CEN/CEN+ channels are named `button#X` where `X` is the button number on the CEN/CEN+ Scenario Control device
@@ -526,5 +526,6 @@ Special thanks for helping on testing this binding go to:
 [@feodor](https://community.openhab.org/u/feodor),
 [@aconte80](https://community.openhab.org/u/aconte80),
 [@rubenfuser](https://community.openhab.org/u/rubenfuser),
-[@stamate_viorel](https://community.openhab.org/u/stamate_viorel)
+[@stamate_viorel](https://community.openhab.org/u/stamate_viorel),
+[@marchino](https://community.openhab.org/u/marchino)
 and many others at the fantastic openHAB community!

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -172,7 +172,7 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_ALARM_SYSTEM_NETWORK = "network";
     public static final String CHANNEL_ALARM_SYSTEM_BATTERY = "battery";
     public static final String CHANNEL_ALARM_ZONE_STATE = "state";
-    public static final String CHANNEL_ALARM_ZONE_ALARM_STATE = "alarm";
+    public static final String CHANNEL_ALARM_ZONE_ALARM = "alarm";
 
     // devices config properties
     public static final String CONFIG_PROPERTY_WHERE = "where";

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAlarmHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAlarmHandler.java
@@ -76,6 +76,9 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
         super.initialize();
         if (OpenWebNetBindingConstants.THING_TYPE_BUS_ALARM_ZONE.equals(thing.getThingTypeUID())) {
             zoneHandlers.add(this);
+            // initially set zone alarm to NONE (it will be set if specific alarm message is
+            // received)
+            updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_NONE));
         }
     }
 
@@ -129,7 +132,7 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void handleMessage(BaseOpenMessage msg) {
-        logger.debug("handleMessage({}) for thing: {} {}", msg, thing.getUID(), ((WhatAlarm) msg.getWhat()).name());
+        logger.debug("handleMessage({}) for: {} {}", msg, thing.getUID(), msg.getWhat());
         super.handleMessage(msg);
         ThingTypeUID thingType = thing.getThingTypeUID();
         if (THING_TYPE_BUS_ALARM_SYSTEM.equals(thingType)) {
@@ -229,19 +232,25 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
         switch (w) {
             case ZONE_ALARM_INTRUSION:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_INTRUSION));
+                break;
             case ZONE_ALARM_TAMPERING:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_TAMPERING));
+                break;
             case ZONE_ALARM_ANTI_PANIC:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_ANTI_PANIC));
+                break;
             case ZONE_ALARM_SILENT:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_SILENT));
+                break;
             case ZONE_ALARM_TECHNICAL:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_TECHNICAL));
+                break;
             case ZONE_ALARM_TECHNICAL_RESET:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_TECHNICAL_RESET));
+                break;
             default:
                 updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_NONE));
-                logger.debug("Alarm.updateZoneAlarm() Ignoring unsupported WHAT {}.", w);
+                logger.warn("Alarm.updateZoneAlarm() Ignoring unsupported WHAT {} for  zone {}", w, this.deviceWhere);
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -282,6 +282,9 @@ channel-type.openwebnet.zoneAlarm.state.option.INTRUSION = Intrusion
 channel-type.openwebnet.zoneAlarm.state.option.TAMPERING = Tampering
 channel-type.openwebnet.zoneAlarm.state.option.ANTI_PANIC = Anti Panic
 channel-type.openwebnet.zoneAlarm.state.option.SILENT = Silent
+channel-type.openwebnet.zoneAlarm.state.option.TECHNICAL = Technical
+channel-type.openwebnet.zoneAlarm.state.option.TECHNICAL_RESET = Technical Reset
+channel-type.openwebnet.zoneAlarm.state.option.NONE = None
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -454,6 +454,7 @@
 				<option value="TAMPERING">Tampering</option>
 				<option value="ANTI_PANIC">Anti Panic</option>
 				<option value="SILENT">Silent</option>
+				<option value="NONE">None</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -454,6 +454,8 @@
 				<option value="TAMPERING">Tampering</option>
 				<option value="ANTI_PANIC">Anti Panic</option>
 				<option value="SILENT">Silent</option>
+				<option value="TECHNICAL">Technical</option>
+				<option value="TECHNICAL_RESET">Technical Reset</option>
 				<option value="NONE">None</option>
 			</options>
 		</state>


### PR DESCRIPTION
This enhancement resets zones' alarm state when alarm system is (re-)armed. 
A new state NONE is added to `CHANNEL_ALARM_ZONE_ALARM_STATE` definition.
Fixes #14305 