### PR TITLE
Instruct contributors to always use "main" branch for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,9 @@ This can clutter your Git history and make your PR unuseable.
 Use "git rebase" instead. See this forum post for further details:
 https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358
 
+All PRs should be created using the "main" branch as base.
+Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.
+
 Add one or more appropriate labels to make your PR show up in the release notes.
 E.g. enhancement, bug, documentation, new binding
 This can only be done by yourself if you already contributed to this repo.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Pay attention to the below notes and to *the guidelines* for this repository.
 Feel free to delete any comment sections in the template (starting with "<!--").
 
 ATTENTION: Don't use "git merge" when working with your pull request branch!
-This can clutter your Git history and make your PR unuseable.
+This can clutter your Git history and make your PR unusable.
 Use "git rebase" instead. See this forum post for further details:
 https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358
 


### PR DESCRIPTION
This helps to prevent some frustration between contributors/maintainers.