### PR TITLE
[danfossairunit] Unify thing labels

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/discovery/DanfossAirUnitDiscoveryService.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/discovery/DanfossAirUnitDiscoveryService.java
@@ -33,9 +33,13 @@ import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +60,12 @@ public class DanfossAirUnitDiscoveryService extends AbstractDiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(DanfossAirUnitDiscoveryService.class);
 
-    public DanfossAirUnitDiscoveryService() {
+    @Activate
+    public DanfossAirUnitDiscoveryService(@Reference TranslationProvider i18nProvider,
+            @Reference LocaleProvider localeProvider) {
         super(SUPPORTED_THING_TYPES_UIDS, TIMEOUT_IN_SECONDS, true);
+        this.i18nProvider = i18nProvider;
+        this.localeProvider = localeProvider;
     }
 
     @Override
@@ -134,7 +142,7 @@ public class DanfossAirUnitDiscoveryService extends AbstractDiscoveryService {
                 ThingUID uid = new ThingUID(THING_TYPE_AIRUNIT, String.valueOf(receivePacket.getAddress().hashCode()));
 
                 DiscoveryResult result = DiscoveryResultBuilder.create(uid).withRepresentationProperty("host")
-                        .withProperties(properties).withLabel("Danfoss HRV").build();
+                        .withProperties(properties).withLabel("@text/discovery.danfossairunit.label").build();
                 thingDiscovered(result);
 
                 logger.debug("Thing discovered '{}'", result);

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/addon/addon.xml
@@ -6,5 +6,6 @@
 	<type>binding</type>
 	<name>DanfossAirUnit Binding</name>
 	<description>This is the binding for DanfossAirUnit.</description>
+	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/i18n/danfossairunit.properties
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/i18n/danfossairunit.properties
@@ -78,6 +78,10 @@ channel-type.danfossairunit.switch.label = Something that can be turned on or of
 channel-type.danfossairunit.temperature.label = Temperature
 channel-type.danfossairunit.temperature.description = Current temperature
 
+# discovery result
+
+discovery.danfossairunit.label = Danfoss Air Unit
+
 # thing status descriptions
 
 offline.connection-not-initialized = Air unit connection not initialized.


### PR DESCRIPTION
Discovery result uses old (hardcoded) label "Danfoss HRV" rather than "Danfoss Air Unit":
![image](https://user-images.githubusercontent.com/19519842/224491579-629d898e-b8fb-4eb6-af25-fd6d3733078e.png)

Now discovery result and manually added thing are unified as "Danfoss Air Unit" and localization support for discovery result has been added.

Also categorized binding as "local".