### PR TITLE
[yeelight] Add sptrip6 device

### DIFF
--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/discovery/YeelightDiscoveryService.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/discovery/YeelightDiscoveryService.java
@@ -99,6 +99,7 @@ public class YeelightDiscoveryService extends AbstractDiscoveryService implement
             case ct_bulb:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_CTBULB, device.getDeviceId());
             case stripe:
+            case strip6:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_STRIPE, device.getDeviceId());
             case desklamp:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_DESKLAMP, device.getDeviceId());
@@ -125,6 +126,7 @@ public class YeelightDiscoveryService extends AbstractDiscoveryService implement
             case ct_bulb:
                 return YeelightBindingConstants.THING_TYPE_CTBULB;
             case stripe:
+            case strip6:
                 return YeelightBindingConstants.THING_TYPE_STRIPE;
             case desklamp:
                 return YeelightBindingConstants.THING_TYPE_DESKLAMP;

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
@@ -48,6 +48,7 @@ public class DeviceFactory {
             case ct_bulb:
                 return new CtBulbDevice(id);
             case stripe:
+            case strip6:
                 return new PitayaDevice(id);
             case desklamp:
                 return new DesklampDevice(id);

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
@@ -346,6 +346,7 @@ public class DeviceManager {
             case ct_bulb:
                 return "Yeelight White LED Bulb v2";
             case stripe:
+            case strip6:
                 return "Yeelight Color LED Stripe";
             case desklamp:
                 return "Yeelight Mi LED Desk Lamp";


### PR DESCRIPTION
Signed-off-by: Alexandr Salamatov [goopilot@gmail.com](mailto:goopilot@gmail.com)

Added support of a new LED strip light (strip6). This issue was mentioned https://community.openhab.org/t/yeelight-new-stripe-model/118764

It looks very much like original stripe and has the following capabilities:

strip6
{ "ip": "X.X.X.X", "port": 55443, "capabilities": { "id": "0x00000000175f6828", "model": "strip6", "fw_ver": "20", "support": "get_prop set_default set_power toggle set_bright set_scene cron_add cron_get cron_del start_cf stop_cf set_name set_adjust adjust_bright set_ct_abx adjust_ct adjust_color set_rgb set_hsv set_music udp_sess_new udp_sess_keep_alive udp_chroma_sess_new", "power": "on", "bright": "100", "color_mode": "1", "ct": "3524", "rgb": "7864244", "hue": "147", "sat": "53", "name": "" } }

stripe
{ "ip": "X.X.X.X", "port": 55443, "capabilities": { "id": "0x000000000361cae2", "model": "stripe", "fw_ver": "50", "support": "get_prop set_default set_power toggle set_bright start_cf stop_cf set_scene cron_add cron_get cron_del set_ct_abx set_rgb set_hsv set_adjust adjust_bright adjust_ct adjust_color set_music set_name", "power": "on", "bright": "100", "color_mode": "1", "ct": "6500", "rgb": "16777215", "hue": "0", "sat": "0", "name": "" } }

So new supported commands are: udp_sess_new, udp_sess_keep_alive, udp_chroma_sess_new which I did not implement.

https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.yeelight/4.0.0-SNAPSHOT/org.openhab.binding.yeelight-4.0.0-SNAPSHOT.jar