### PR TITLE
[jrubyscripting] Filter files that are added to the watch list

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/JRubyScriptFileWatcher.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/JRubyScriptFileWatcher.java
@@ -66,6 +66,7 @@ public class JRubyScriptFileWatcher extends AbstractScriptFileWatcher {
         if (scriptEngineFactory.isFileInGemHome(path) || scriptEngineFactory.isFileInLoadPath(path)) {
             return Optional.empty();
         }
-        return super.getScriptType(scriptFilePath);
+
+        return super.getScriptType(scriptFilePath).filter(type -> scriptEngineFactory.getScriptTypes().contains(type));
     }
 }


### PR DESCRIPTION
~Depends on https://github.com/openhab/openhab-core/pull/3451~
The original NPE bug is fixed entirely within https://github.com/openhab/openhab-core/pull/3451 so this PR no longer depends on it. 

Somewhat related though is to filter the file types that are added to the watch list, so that the filewatcher won't try to load files with other extensions within the `automation/ruby` (sub)directory.


