### PR TITLE
Fix NullPointerException when getting network interface name

### DIFF
--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/discovery/MulticastListener.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.benqprojector.internal.discovery;
 
-import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingConstants.DEFAULT_PORT;
-import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingConstants.THING_PROPERTY_HOST;
-import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingConstants.THING_PROPERTY_PORT;
+import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingConstants.*;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -59,8 +57,9 @@ public class MulticastListener {
      */
     public MulticastListener(String ipv4Address) throws IOException, SocketException {
         InetAddress ifAddress = InetAddress.getByName(ipv4Address);
+        NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
         logger.debug("Discovery job using address {} on network interface {}", ifAddress.getHostAddress(),
-                NetworkInterface.getByInetAddress(ifAddress).getName());
+                netIF != null ? netIF.getName() : "UNKNOWN");
         socket = new MulticastSocket(AMX_MULTICAST_PORT);
         socket.setInterface(ifAddress);
         socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT_SEC);

--- a/bundles/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/handler/BigAssFanHandler.java
+++ b/bundles/org.openhab.binding.bigassfan/src/main/java/org/openhab/binding/bigassfan/internal/handler/BigAssFanHandler.java
@@ -1024,9 +1024,9 @@ public class BigAssFanHandler extends BaseThingHandler {
             deviceIsConnected = false;
             try {
                 ifAddress = InetAddress.getByName(ipv4Address);
-
+                NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
                 logger.debug("Handler for {} using address {} on network interface {}", thing.getUID(), ipv4Address,
-                        NetworkInterface.getByInetAddress(ifAddress).getName());
+                        netIF != null ? netIF.getName() : "UNKNOWN");
             } catch (UnknownHostException e) {
                 logger.warn("Handler for {} got UnknownHostException getting local IPv4 net interface: {}",
                         thing.getUID(), e.getMessage(), e);

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.epsonprojector.internal.discovery;
 
-import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.DEFAULT_PORT;
-import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.THING_PROPERTY_HOST;
-import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.THING_PROPERTY_PORT;
+import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.*;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -59,8 +57,9 @@ public class MulticastListener {
      */
     public MulticastListener(String ipv4Address) throws IOException, SocketException {
         InetAddress ifAddress = InetAddress.getByName(ipv4Address);
+        NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
         logger.debug("Discovery job using address {} on network interface {}", ifAddress.getHostAddress(),
-                NetworkInterface.getByInetAddress(ifAddress).getName());
+                netIF != null ? netIF.getName() : "UNKNOWN");
         socket = new MulticastSocket(AMX_MULTICAST_PORT);
         socket.setInterface(ifAddress);
         socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT_SEC);

--- a/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/discovery/MulticastListener.java
@@ -63,8 +63,9 @@ public class MulticastListener {
      */
     public MulticastListener(String ipv4Address) throws IOException, SocketException {
         InetAddress ifAddress = InetAddress.getByName(ipv4Address);
+        NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
         logger.debug("Discovery job using address {} on network interface {}", ifAddress.getHostAddress(),
-                NetworkInterface.getByInetAddress(ifAddress).getName());
+                netIF != null ? netIF.getName() : "UNKNOWN");
         socket = new MulticastSocket(GC_MULTICAST_PORT);
         socket.setInterface(ifAddress);
         socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT);

--- a/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/handler/GlobalCacheHandler.java
+++ b/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/handler/GlobalCacheHandler.java
@@ -105,8 +105,9 @@ public class GlobalCacheHandler extends BaseThingHandler {
         logger.debug("Initializing thing {}", thingID());
         try {
             ifAddress = InetAddress.getByName(ipv4Address);
+            NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
             logger.debug("Handler using address {} on network interface {}", ifAddress.getHostAddress(),
-                    NetworkInterface.getByInetAddress(ifAddress).getName());
+                    netIF != null ? netIF.getName() : "UNKNOWN");
         } catch (SocketException e) {
             logger.error("Handler got Socket exception creating multicast socket: {}", e.getMessage());
             markThingOfflineWithError(ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, "No suitable network interface");


### PR DESCRIPTION
While it occurs very rarely, it's possible for `NetworkInterface.getByInetAddress` to return null. This PR prevents the NPE in all bindings where this call is used.

Reported on forum [here](https://community.openhab.org/t/globalcache-binding-error-upgrade-from-openhab-3-2-to-3-4-2/145214).

Signed-off-by: Mark Hilbush [mark@hilbush.com](mailto:mark@hilbush.com)
