### PR TITLE
Replace deprecated MulticastSocket methods

### DIFF
--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/discovery/MulticastListener.java
@@ -17,11 +17,14 @@ import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingCon
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -44,6 +47,7 @@ public class MulticastListener {
     private final Logger logger = LoggerFactory.getLogger(MulticastListener.class);
 
     private MulticastSocket socket;
+    private InetSocketAddress inetSocketAddress;
 
     // BenQ projector devices announce themselves on the AMX DDD multicast port
     private static final String AMX_MULTICAST_GROUP = "239.255.250.250";
@@ -57,20 +61,25 @@ public class MulticastListener {
      */
     public MulticastListener(String ipv4Address) throws IOException, SocketException {
         InetAddress ifAddress = InetAddress.getByName(ipv4Address);
-        NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
+        NetworkInterface networkInterface = getMulticastInterface(ipv4Address);
         logger.debug("Discovery job using address {} on network interface {}", ifAddress.getHostAddress(),
-                netIF != null ? netIF.getName() : "UNKNOWN");
+                networkInterface.getName());
         socket = new MulticastSocket(AMX_MULTICAST_PORT);
-        socket.setInterface(ifAddress);
+        socket.setNetworkInterface(networkInterface);
         socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT_SEC);
-        InetAddress mcastAddress = InetAddress.getByName(AMX_MULTICAST_GROUP);
-        socket.joinGroup(mcastAddress);
+        inetSocketAddress = new InetSocketAddress(InetAddress.getByName(AMX_MULTICAST_GROUP), AMX_MULTICAST_PORT);
+        socket.joinGroup(inetSocketAddress, null);
         logger.debug("Multicast listener joined multicast group {}:{}", AMX_MULTICAST_GROUP, AMX_MULTICAST_PORT);
     }
 
     public void shutdown() {
         logger.debug("Multicast listener closing down multicast socket");
-        socket.close();
+        try {
+            socket.leaveGroup(inetSocketAddress, null);
+            socket.close();
+        } catch (IOException e) {
+            logger.debug("Exception shutting down multicast socket");
+        }
     }
 
     /*
@@ -128,5 +137,26 @@ public class MulticastListener {
             logger.debug("Multicast listener doesn't know how to parse beacon: {}", beacon);
         }
         return null;
+    }
+
+    private NetworkInterface getMulticastInterface(String interfaceIpAddress) throws SocketException {
+        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        NetworkInterface networkInterface;
+        while (networkInterfaces.hasMoreElements()) {
+            networkInterface = networkInterfaces.nextElement();
+            if (networkInterface.isLoopback()) {
+                continue;
+            }
+            for (InterfaceAddress interfaceAddress : networkInterface.getInterfaceAddresses()) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Found interface address {} -> {}", interfaceAddress.toString(),
+                            interfaceAddress.getAddress().toString());
+                }
+                if (interfaceAddress.getAddress().toString().endsWith("/" + interfaceIpAddress)) {
+                    return networkInterface;
+                }
+            }
+        }
+        throw new SocketException("Unable to get network interface for " + interfaceIpAddress);
     }
 }

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/discovery/MulticastListener.java
@@ -78,7 +78,7 @@ public class MulticastListener {
             socket.leaveGroup(inetSocketAddress, null);
             socket.close();
         } catch (IOException e) {
-            logger.debug("Exception shutting down multicast socket");
+            logger.debug("Exception shutting down multicast socket: {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
@@ -17,11 +17,14 @@ import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingC
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -44,6 +47,7 @@ public class MulticastListener {
     private final Logger logger = LoggerFactory.getLogger(MulticastListener.class);
 
     private MulticastSocket socket;
+    private InetSocketAddress inetSocketAddress;
 
     // Epson projector devices announce themselves on the AMX DDD multicast port
     private static final String AMX_MULTICAST_GROUP = "239.255.250.250";
@@ -57,20 +61,25 @@ public class MulticastListener {
      */
     public MulticastListener(String ipv4Address) throws IOException, SocketException {
         InetAddress ifAddress = InetAddress.getByName(ipv4Address);
-        NetworkInterface netIF = NetworkInterface.getByInetAddress(ifAddress);
+        NetworkInterface networkInterface = getMulticastInterface(ipv4Address);
         logger.debug("Discovery job using address {} on network interface {}", ifAddress.getHostAddress(),
-                netIF != null ? netIF.getName() : "UNKNOWN");
+                networkInterface.getName());
         socket = new MulticastSocket(AMX_MULTICAST_PORT);
-        socket.setInterface(ifAddress);
+        socket.setNetworkInterface(networkInterface);
         socket.setSoTimeout(DEFAULT_SOCKET_TIMEOUT_SEC);
-        InetAddress mcastAddress = InetAddress.getByName(AMX_MULTICAST_GROUP);
-        socket.joinGroup(mcastAddress);
+        inetSocketAddress = new InetSocketAddress(InetAddress.getByName(AMX_MULTICAST_GROUP), AMX_MULTICAST_PORT);
+        socket.joinGroup(inetSocketAddress, null);
         logger.debug("Multicast listener joined multicast group {}:{}", AMX_MULTICAST_GROUP, AMX_MULTICAST_PORT);
     }
 
     public void shutdown() {
         logger.debug("Multicast listener closing down multicast socket");
-        socket.close();
+        try {
+            socket.leaveGroup(inetSocketAddress, null);
+            socket.close();
+        } catch (IOException e) {
+            logger.debug("Exception shutting down multicast socket");
+        }
     }
 
     /*
@@ -128,5 +137,26 @@ public class MulticastListener {
             logger.debug("Multicast listener doesn't know how to parse beacon: {}", beacon);
         }
         return null;
+    }
+
+    private NetworkInterface getMulticastInterface(String interfaceIpAddress) throws SocketException {
+        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        NetworkInterface networkInterface;
+        while (networkInterfaces.hasMoreElements()) {
+            networkInterface = networkInterfaces.nextElement();
+            if (networkInterface.isLoopback()) {
+                continue;
+            }
+            for (InterfaceAddress interfaceAddress : networkInterface.getInterfaceAddresses()) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Found interface address {} -> {}", interfaceAddress.toString(),
+                            interfaceAddress.getAddress().toString());
+                }
+                if (interfaceAddress.getAddress().toString().endsWith("/" + interfaceIpAddress)) {
+                    return networkInterface;
+                }
+            }
+        }
+        throw new SocketException("Unable to get network interface for " + interfaceIpAddress);
     }
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/discovery/MulticastListener.java
@@ -78,7 +78,7 @@ public class MulticastListener {
             socket.leaveGroup(inetSocketAddress, null);
             socket.close();
         } catch (IOException e) {
-            logger.debug("Exception shutting down multicast socket");
+            logger.debug("Exception shutting down multicast socket: {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/discovery/MulticastListener.java
+++ b/bundles/org.openhab.binding.globalcache/src/main/java/org/openhab/binding/globalcache/internal/discovery/MulticastListener.java
@@ -85,7 +85,7 @@ public class MulticastListener {
             socket.leaveGroup(inetSocketAddress, null);
             socket.close();
         } catch (IOException e) {
-            logger.debug("Exception shutting down multicast socket");
+            logger.debug("Exception shutting down multicast socket: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Replace deprecated `MulticastSocket` methods `setInterface` and `joinGroup`.

I believe these are the bindings that need to be changed: globalcache, benqprojector, epsonprojector, lcn.

Note I did not change lcn because the model is different than gc, benq, and epson. I was afraid I would break something, and I have no way to test my changes.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
