### PR TITLE
[eKey] Add sourceIp in cases of NAT (Kubernetes deployments)

### DIFF
--- a/bundles/org.openhab.binding.ekey/README.md
+++ b/bundles/org.openhab.binding.ekey/README.md
@@ -6,8 +6,8 @@ This binding connects to [ekey](https://ekey.net/) converter UDP (CV-LAN) using 
 
 This binding only supports one thing type:
 
-| Thing       | Thing Type | Description                                 |
-|-------------|------------|---------------------------------------------|
+| Thing | Thing Type | Description                            |
+|-------|------------|----------------------------------------|
 | cvlan | Thing      | Represents a single ekey converter UDP |
 
 ## Thing Configuration
@@ -20,7 +20,7 @@ The binding uses the following configuration parameters.
 | port      | The port as configured during the UDP Converter configuration.  e.g. 56000 (Binding default)                                                                                             |
 | protocol  | Can be RARE, MULTI or HOME depending on what the system supports. Binding defaults to RARE                                                                                               |
 | delimiter | The delimiter is also defined on the ekey UDP converter - use the ekey configuration software to determine which delimiter is used or to change it.  Binding default is `_` (underscore) |
-| natIp  | [Optional] IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)                                                          |
+| natIp     | [Optional] IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)                                                          |
 
 ## Channels
 
@@ -29,7 +29,7 @@ The binding uses the following configuration parameters.
 | action     | Number    | R/M/H    | This indicates whether access was granted (value=0) or denied (value=-1).                                                                                                                                                                             | 0,-1 (136 and 137 with RARE protocol |
 | fingerId   | Number    | R/M/H    | This indicates the finger that was used by a person.                                                                                                                                                                                                  | 0-9,-1                               |
 | fsName     | String    | M        | This returns the 4-character-long name that was specified on the controller for the specific terminals.                                                                                                                                               |                                      |
-| fsSerial     | Number    | R/M/H        | This returns the serial number for the specific terminal.                                     |
+| fsSerial   | Number    | R/M/H    | This returns the serial number for the specific terminal.                                                                                                                                                                                             |                                      |
 | inputId    | Number    | M        | This indicates which of the four digital inputs was triggered. Value is number of Input. "-1" indicates that no input was triggered.                                                                                                                  | 0-4,-1                               |
 | keyId      | Number    | M        | This indicates which of the four keys was used. See ekey documentation on "keys".                                                                                                                                                                     | 0-4,-1                               |
 | relayId    | Number    | R/H      | This indicates which relay has been switched.                                                                                                                                                                                                         | 0-3,-1                               |

--- a/bundles/org.openhab.binding.ekey/README.md
+++ b/bundles/org.openhab.binding.ekey/README.md
@@ -20,7 +20,7 @@ The binding uses the following configuration parameters.
 | port      | The port as configured during the UDP Converter configuration.  e.g. 56000 (Binding default)                                                                                             |
 | protocol  | Can be RARE, MULTI or HOME depending on what the system supports. Binding defaults to RARE                                                                                               |
 | delimiter | The delimiter is also defined on the ekey UDP converter - use the ekey configuration software to determine which delimiter is used or to change it.  Binding default is `_` (underscore) |
-| sourceIp  | [Optional] IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)                                                          |
+| natIp  | [Optional] IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)                                                          |
 
 ## Channels
 

--- a/bundles/org.openhab.binding.ekey/README.md
+++ b/bundles/org.openhab.binding.ekey/README.md
@@ -14,12 +14,13 @@ This binding only supports one thing type:
 
 The binding uses the following configuration parameters.
 
-| Parameter | Description                                                    |
-|-----------|----------------------------------------------------------------|
-| ipAddress | IPv4 address of the eKey udp converter.  A static IP address is recommended.|
-| port      | The port as configured during the UDP Converter configuration.  e.g. 56000 (Binding default)     |
-| protocol  | Can be RARE, MULTI or HOME depending on what the system supports. Binding defaults to RARE  |
-| delimiter | The delimiter is also defined on the ekey UDP converter - use the ekey configuration software to determine which delimiter is used or to change it.  Binding default is `_` (underscore)  |
+| Parameter | Description                                                                                                                                                                              |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ipAddress | IPv4 address of the eKey udp converter.  A static IP address is recommended.                                                                                                             |
+| port      | The port as configured during the UDP Converter configuration.  e.g. 56000 (Binding default)                                                                                             |
+| protocol  | Can be RARE, MULTI or HOME depending on what the system supports. Binding defaults to RARE                                                                                               |
+| delimiter | The delimiter is also defined on the ekey UDP converter - use the ekey configuration software to determine which delimiter is used or to change it.  Binding default is `_` (underscore) |
+| sourceIp  | [Optional] IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)                                                          |
 
 ## Channels
 

--- a/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/EkeyConfiguration.java
+++ b/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/EkeyConfiguration.java
@@ -13,11 +13,13 @@
 package org.openhab.binding.ekey.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link EkeyConfiguration} class contains fields mapping thing configuration parameters.
  *
  * @author Hans-Jörg Merk - Initial contribution
+ * @author Robert Delbrück - Add sourceIp
  */
 @NonNullByDefault
 public class EkeyConfiguration {
@@ -26,4 +28,5 @@ public class EkeyConfiguration {
     public int port;
     public String protocol = "";
     public String delimiter = "";
+    public @Nullable String sourceIp;
 }

--- a/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/EkeyConfiguration.java
+++ b/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/EkeyConfiguration.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * The {@link EkeyConfiguration} class contains fields mapping thing configuration parameters.
  *
  * @author Hans-Jörg Merk - Initial contribution
- * @author Robert Delbrück - Add sourceIp
+ * @author Robert Delbrück - Add natIp
  */
 @NonNullByDefault
 public class EkeyConfiguration {
@@ -28,5 +28,5 @@ public class EkeyConfiguration {
     public int port;
     public String protocol = "";
     public String delimiter = "";
-    public @Nullable String sourceIp;
+    public @Nullable String natIp;
 }

--- a/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/api/EkeyUdpPacketReceiver.java
+++ b/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/api/EkeyUdpPacketReceiver.java
@@ -119,7 +119,8 @@ public class EkeyUdpPacketReceiver {
                         lastPacket = packet.getData();
                         readMessage(lastPacket);
                     } else {
-                        logger.warn("Packet received from unknown source- {}", packet.getData());
+                        logger.warn("Packet received from unknown source (ip={}) - {}",
+                                packet.getAddress().getHostAddress(), packet.getData());
                     }
                 } catch (UnknownHostException e) {
                     logger.debug("Exception during address conversion - {}", e.getMessage());

--- a/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/handler/EkeyHandler.java
+++ b/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/handler/EkeyHandler.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Hans-Jörg Merk - Initial contribution
+ * @author Robert Delbrück - Add sourceIp
  */
 @NonNullByDefault
 public class EkeyHandler extends BaseThingHandler implements EkeyPacketListener {
@@ -82,8 +84,8 @@ public class EkeyHandler extends BaseThingHandler implements EkeyPacketListener 
                 populateChannels(config.protocol);
                 String readerThreadName = "OH-binding-" + getThing().getUID().getAsString();
 
-                EkeyUdpPacketReceiver localReceiver = receiver = new EkeyUdpPacketReceiver(config.ipAddress,
-                        config.port, readerThreadName);
+                EkeyUdpPacketReceiver localReceiver = receiver = new EkeyUdpPacketReceiver(
+                        Optional.ofNullable(config.sourceIp).orElse(config.ipAddress), config.port, readerThreadName);
                 localReceiver.addEkeyPacketListener(this);
                 try {
                     localReceiver.openConnection();

--- a/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/handler/EkeyHandler.java
+++ b/bundles/org.openhab.binding.ekey/src/main/java/org/openhab/binding/ekey/internal/handler/EkeyHandler.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Hans-Jörg Merk - Initial contribution
- * @author Robert Delbrück - Add sourceIp
+ * @author Robert Delbrück - Add natIp
  */
 @NonNullByDefault
 public class EkeyHandler extends BaseThingHandler implements EkeyPacketListener {
@@ -85,7 +85,7 @@ public class EkeyHandler extends BaseThingHandler implements EkeyPacketListener 
                 String readerThreadName = "OH-binding-" + getThing().getUID().getAsString();
 
                 EkeyUdpPacketReceiver localReceiver = receiver = new EkeyUdpPacketReceiver(
-                        Optional.ofNullable(config.sourceIp).orElse(config.ipAddress), config.port, readerThreadName);
+                        Optional.ofNullable(config.natIp).orElse(config.ipAddress), config.port, readerThreadName);
                 localReceiver.addEkeyPacketListener(this);
                 try {
                     localReceiver.openConnection();

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey.properties
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey.properties
@@ -15,8 +15,8 @@ thing-type.config.ekey.protocol.label = Protocol
 thing-type.config.ekey.protocol.description = Can be RARE, MULTI or HOME depending on what the system supports
 thing-type.config.ekey.delimiter.label = Delimiter
 thing-type.config.ekey.delimiter.description = The delimiter is also defined on the ekey UDP converter - use the ekey configuration software to determine which delimiter is used or to change it. Another option is _ (underscore)
-thing-type.config.ekey.sourceIp.label = Source IP
-thing-type.config.ekey.sourceIp.description = IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)
+thing-type.config.ekey.natIp.label = NAT IP
+thing-type.config.ekey.natIp.description = NAT rewritten source IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)
 
 # channel types
 channel-type.ekey.userId.label = User ID

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey.properties
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey.properties
@@ -15,6 +15,8 @@ thing-type.config.ekey.protocol.label = Protocol
 thing-type.config.ekey.protocol.description = Can be RARE, MULTI or HOME depending on what the system supports
 thing-type.config.ekey.delimiter.label = Delimiter
 thing-type.config.ekey.delimiter.description = The delimiter is also defined on the ekey UDP converter - use the ekey configuration software to determine which delimiter is used or to change it. Another option is _ (underscore)
+thing-type.config.ekey.sourceIp.label = Source IP
+thing-type.config.ekey.sourceIp.description = IPv4 address of a received eKey udp packet. Can be different from the ipAddress when using NAT. (e.g. in Kubernetes)
 
 # channel types
 channel-type.ekey.userId.label = User ID

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey_de.properties
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey_de.properties
@@ -15,6 +15,8 @@ thing-type.config.ekey.protocol.label = Protokoll
 thing-type.config.ekey.protocol.description = Das vom ekey converter UDP verwendete Protokoll (RARE, MULTI oder HOME, abhängig vom verwendeten System).
 thing-type.config.ekey.delimiter.label = Abstandshalter
 thing-type.config.ekey.delimiter.description = Der im ekey converter UDP Protokoll verwendete Feldtrenner.
+thing-type.config.ekey.sourceIp.label = Quell IP
+thing-type.config.ekey.sourceIp.description = IPv4 Addresse eines eKey UDP Pakets. Kann abweichend von der ipAddress sein wenn NAT genutzt wird (z.B. in Kubernetes) 
 
 # channel types
 channel-type.ekey.userId.label = Benutzer ID

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey_de.properties
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey_de.properties
@@ -15,8 +15,6 @@ thing-type.config.ekey.protocol.label = Protokoll
 thing-type.config.ekey.protocol.description = Das vom ekey converter UDP verwendete Protokoll (RARE, MULTI oder HOME, abhängig vom verwendeten System).
 thing-type.config.ekey.delimiter.label = Abstandshalter
 thing-type.config.ekey.delimiter.description = Der im ekey converter UDP Protokoll verwendete Feldtrenner.
-thing-type.config.ekey.natIp.label = NAT IP
-thing-type.config.ekey.natIp.description = IPv4 Addresse eines eKey UDP Pakets. Kann abweichend von der ipAddress sein wenn NAT genutzt wird (z.B. in Kubernetes) 
 
 # channel types
 channel-type.ekey.userId.label = Benutzer ID

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey_de.properties
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/i18n/ekey_de.properties
@@ -15,8 +15,8 @@ thing-type.config.ekey.protocol.label = Protokoll
 thing-type.config.ekey.protocol.description = Das vom ekey converter UDP verwendete Protokoll (RARE, MULTI oder HOME, abhängig vom verwendeten System).
 thing-type.config.ekey.delimiter.label = Abstandshalter
 thing-type.config.ekey.delimiter.description = Der im ekey converter UDP Protokoll verwendete Feldtrenner.
-thing-type.config.ekey.sourceIp.label = Quell IP
-thing-type.config.ekey.sourceIp.description = IPv4 Addresse eines eKey UDP Pakets. Kann abweichend von der ipAddress sein wenn NAT genutzt wird (z.B. in Kubernetes) 
+thing-type.config.ekey.natIp.label = NAT IP
+thing-type.config.ekey.natIp.description = IPv4 Addresse eines eKey UDP Pakets. Kann abweichend von der ipAddress sein wenn NAT genutzt wird (z.B. in Kubernetes) 
 
 # channel types
 channel-type.ekey.userId.label = Benutzer ID

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/thing/thing-types.xml
@@ -41,10 +41,10 @@
 				<description>@text/thing-type.config.ekey.delimiter.description</description>
 				<default>_</default>
 			</parameter>
-			<parameter name="sourceIp" type="text" required="false">
+			<parameter name="natIp" type="text" required="false">
 				<context>network-address</context>
-				<label>@text/thing-type.config.ekey.sourceIp.label</label>
-				<description>@text/thing-type.config.ekey.sourceIp.description</description>
+				<label>@text/thing-type.config.ekey.natIp.label</label>
+				<description>@text/thing-type.config.ekey.natIp.description</description>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ekey/src/main/resources/OH-INF/thing/thing-types.xml
@@ -41,6 +41,11 @@
 				<description>@text/thing-type.config.ekey.delimiter.description</description>
 				<default>_</default>
 			</parameter>
+			<parameter name="sourceIp" type="text" required="false">
+				<context>network-address</context>
+				<label>@text/thing-type.config.ekey.sourceIp.label</label>
+				<description>@text/thing-type.config.ekey.sourceIp.description</description>
+			</parameter>
 		</config-description>
 	</thing-type>
 


### PR DESCRIPTION
This adds a new configuration parameter sourceIp.
It's required when using NAT (e.g. in Kubernetes deployments).
While the binding verifies that the packet source ip is equal to the ipAddress this will fail.
With NAT the packet source ip is the ip of your host.
Without that feature it's not working within kubernetes deployments

https://github.com/openhab/openhab-addons/issues/14599