### PR TITLE
[mqtt.generic] Don't log state description from provider when not found

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelStateDescriptionProvider.java
@@ -68,7 +68,9 @@ public class MqttChannelStateDescriptionProvider implements DynamicStateDescript
     public @Nullable StateDescription getStateDescription(Channel channel,
             @Nullable StateDescription originalStateDescription, @Nullable Locale locale) {
         StateDescription description = descriptions.get(channel.getUID());
-        logger.trace("Providing state description for channel {}", channel.getUID());
+        if (description != null) {
+            logger.trace("Providing state description for channel {}", channel.getUID());
+        }
         return description;
     }
 


### PR DESCRIPTION
Fixes #9782