### PR TITLE
[tapocontrol] Color values must be int, not decimal

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/README.md
+++ b/bundles/org.openhab.binding.tapocontrol/README.md
@@ -70,9 +70,9 @@ All devices support some of the following channels:
 |           | output1          | Switch                 | Power socket 1 on or off            | P300                                                             |
 |           | output2          | Switch                 | Power socket 2 on or off            | P300                                                             |
 |           | output3          | Switch                 | Power socket 3 on or off            | P300                                                             |
-|           | brightness       | Dimmer                 | Brightness 0-100%                   | L510, L530, L610, L630, L900                                     |
-|           | colorTemperature | Number                 | White-Color-Temp 2500-6500K         | L510, L530, L610, L630, L900                                     |
-|           | color            | Color                  | Color                               | L530, L630, L900                                                 |
+|           | brightness       | Dimmer                 | Brightness 0-100%                   | L510, L530, L610, L630, L900, L920                               |
+|           | colorTemperature | Number                 | White-Color-Temp 2500-6500K         | L510, L530, L610, L630, L900, L920                                     |
+|           | color            | Color                  | Color                               | L530, L630, L900, L920                                                 |
 | effects   | fxName           | String                 | Active lightning effect (readonly)  | L530                                                             |
 | device    | wifiSignal       | Number                 | WiFi-quality-level                  | P100, P105, P110, P115, L510, L530, L610, L630, L900, L920, L930 |
 |           | onTime           | Number:Time            | seconds output is on                | P100, P105, P110, P115, L510, L530, L900, L920, L930             |

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/constants/TapoThingConstants.java
@@ -111,7 +111,7 @@ public class TapoThingConstants {
     public static final String CLOUD_JSON_KEY_TYPE = "deviceType";
 
     /*** DEVICE JSON STRINGS (DEVICE) ***/
-    public static final String JSON_KEY_BRIGHTNES = "brightness";
+    public static final String JSON_KEY_BRIGHTNESS = "brightness";
     public static final String JSON_KEY_COLORTEMP = "color_temp";
     public static final String JSON_KEY_FW = "fw_ver";
     public static final String JSON_KEY_HUE = "hue";

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoLightStrip.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoLightStrip.java
@@ -121,7 +121,7 @@ public class TapoLightStrip extends TapoDevice {
         } else {
             HashMap<String, Object> newState = new HashMap<>();
             newState.put(JSON_KEY_ON, true);
-            newState.put(JSON_KEY_BRIGHTNES, newBrightness);
+            newState.put(JSON_KEY_BRIGHTNESS, newBrightness);
             connector.sendDeviceCommands(newState);
         }
     }
@@ -136,7 +136,7 @@ public class TapoLightStrip extends TapoDevice {
         newState.put(JSON_KEY_ON, true);
         newState.put(JSON_KEY_HUE, command.getHue().intValue());
         newState.put(JSON_KEY_SATURATION, command.getSaturation().intValue());
-        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness().intValue());
+        newState.put(JSON_KEY_BRIGHTNESS, command.getBrightness().intValue());
         connector.sendDeviceCommands(newState);
     }
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoLightStrip.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoLightStrip.java
@@ -136,7 +136,7 @@ public class TapoLightStrip extends TapoDevice {
         newState.put(JSON_KEY_ON, true);
         newState.put(JSON_KEY_HUE, command.getHue().intValue());
         newState.put(JSON_KEY_SATURATION, command.getSaturation().intValue());
-        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness().intValue();
+        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness().intValue());
         connector.sendDeviceCommands(newState);
     }
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoLightStrip.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoLightStrip.java
@@ -134,9 +134,9 @@ public class TapoLightStrip extends TapoDevice {
     protected void setColor(HSBType command) {
         HashMap<String, Object> newState = new HashMap<>();
         newState.put(JSON_KEY_ON, true);
-        newState.put(JSON_KEY_HUE, command.getHue());
-        newState.put(JSON_KEY_SATURATION, command.getSaturation());
-        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness());
+        newState.put(JSON_KEY_HUE, command.getHue().intValue());
+        newState.put(JSON_KEY_SATURATION, command.getSaturation().intValue());
+        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness().intValue();
         connector.sendDeviceCommands(newState);
     }
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoSmartBulb.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoSmartBulb.java
@@ -118,7 +118,7 @@ public class TapoSmartBulb extends TapoDevice {
         } else {
             HashMap<String, Object> newState = new HashMap<>();
             newState.put(JSON_KEY_ON, true);
-            newState.put(JSON_KEY_BRIGHTNES, newBrightness);
+            newState.put(JSON_KEY_BRIGHTNESS, newBrightness);
             connector.sendDeviceCommands(newState);
         }
     }
@@ -133,7 +133,7 @@ public class TapoSmartBulb extends TapoDevice {
         newState.put(JSON_KEY_ON, true);
         newState.put(JSON_KEY_HUE, command.getHue().intValue());
         newState.put(JSON_KEY_SATURATION, command.getSaturation().intValue());
-        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness().intValue());
+        newState.put(JSON_KEY_BRIGHTNESS, command.getBrightness().intValue());
         newState.put(JSON_KEY_LIGHTNING_DYNAMIC_ENABLE, false);
         connector.sendDeviceCommands(newState);
     }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoUniversalDevice.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/device/TapoUniversalDevice.java
@@ -125,7 +125,7 @@ public class TapoUniversalDevice extends TapoDevice {
         } else {
             HashMap<String, Object> newState = new HashMap<>();
             newState.put(JSON_KEY_ON, true);
-            newState.put(JSON_KEY_BRIGHTNES, newBrightness);
+            newState.put(JSON_KEY_BRIGHTNESS, newBrightness);
             connector.sendDeviceCommands(newState);
         }
     }
@@ -140,7 +140,7 @@ public class TapoUniversalDevice extends TapoDevice {
         newState.put(JSON_KEY_ON, true);
         newState.put(JSON_KEY_HUE, command.getHue());
         newState.put(JSON_KEY_SATURATION, command.getSaturation());
-        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness());
+        newState.put(JSON_KEY_BRIGHTNESS, command.getBrightness());
         connector.sendDeviceCommands(newState);
     }
 

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/structures/TapoDeviceInfo.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/structures/TapoDeviceInfo.java
@@ -84,7 +84,7 @@ public class TapoDeviceInfo {
     }
 
     private void setData() {
-        this.brightness = jsonObjectToInt(jsonObject, JSON_KEY_BRIGHTNES);
+        this.brightness = jsonObjectToInt(jsonObject, JSON_KEY_BRIGHTNESS);
         this.colorTemp = jsonObjectToInt(jsonObject, JSON_KEY_COLORTEMP, BULB_MIN_COLORTEMP);
         this.deviceId = jsonObjectToString(jsonObject, JSON_KEY_ID);
         this.deviceOn = jsonObjectToBool(jsonObject, JSON_KEY_ON);

--- a/bundles/org.openhab.binding.tapocontrol/src/test/java/org/openhab/binding/tapocontrol/internal/device/TapoUniversalDevice.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/test/java/org/openhab/binding/tapocontrol/internal/device/TapoUniversalDevice.java
@@ -125,7 +125,7 @@ public class TapoUniversalDevice extends TapoDevice {
         } else {
             HashMap<String, Object> newState = new HashMap<>();
             newState.put(JSON_KEY_ON, true);
-            newState.put(JSON_KEY_BRIGHTNES, newBrightness);
+            newState.put(JSON_KEY_BRIGHTNESS, newBrightness);
             connector.sendDeviceCommands(newState);
         }
     }
@@ -140,7 +140,7 @@ public class TapoUniversalDevice extends TapoDevice {
         newState.put(JSON_KEY_ON, true);
         newState.put(JSON_KEY_HUE, command.getHue());
         newState.put(JSON_KEY_SATURATION, command.getSaturation());
-        newState.put(JSON_KEY_BRIGHTNES, command.getBrightness());
+        newState.put(JSON_KEY_BRIGHTNESS, command.getBrightness());
         connector.sendDeviceCommands(newState);
     }
 

--- a/bundles/org.openhab.binding.tapocontrol/src/test/java/org/openhab/binding/tapocontrol/internal/structures/TapoDeviceInfo.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/test/java/org/openhab/binding/tapocontrol/internal/structures/TapoDeviceInfo.java
@@ -102,7 +102,7 @@ public class TapoDeviceInfo {
     }
 
     private void setData() {
-        this.brightness = jsonObjectToInt(jsonObject, JSON_KEY_BRIGHTNES);
+        this.brightness = jsonObjectToInt(jsonObject, JSON_KEY_BRIGHTNESS);
         this.colorTemp = jsonObjectToInt(jsonObject, JSON_KEY_COLORTEMP, BULB_MIN_COLORTEMP);
         this.deviceId = jsonObjectToString(jsonObject, JSON_KEY_ID);
         this.deviceOn = jsonObjectToBool(jsonObject, JSON_KEY_ON);


### PR DESCRIPTION
Fix for L920 lightstrip when sending colour values with decimals (server reported error -1008)
Also updated the doc with actual channels listed for L920 in README.

NOTE: Problem may be inherent in bulb implementation as code is duplicated. Detected throgh sitemap in Android sitemap.