### PR TITLE
[MQTT] Add example usage for incoming value transformations using a map

### DIFF
--- a/bundles/org.openhab.transform.map/README.md
+++ b/bundles/org.openhab.transform.map/README.md
@@ -33,6 +33,9 @@ white\ space=using escape
 | `white space` | `using escape` |
 | `anything`    | `default`      |
 
+## Usage as a Thing Channel Transformation
+
+To use the above map on a Channel value coming into your Thing, set the Incoming Value Transformations value to `MAP:binary.map`.
 
 ## Usage as a Profile
 


### PR DESCRIPTION
# Add example usage for incoming value transformations using a map.

# Description

This is a quick improvement to the docs for the Map Transformation. It has an example map file, but didn't have an example of how to use that file as an input transform. This will hopefully help beginners who want to use maps.

I'm just getting started with OH, so I welcome any fixes to my terminology, or caveats around which particular versions / contexts this example works in.

More context at [this community post](https://community.openhab.org/t/oh3-transformation-service-config-for-js-and-map-in-a-thing-channel-what-worked-qs-about-what-didnt/145507)

Signed-off-by: Mark Fickett <mfseas@gmail.com>
