### PR TITLE
[Yeelight] Support of ceil26 and ceiling11 devices

### DIFF
--- a/bundles/org.openhab.binding.yeelight/README.md
+++ b/bundles/org.openhab.binding.yeelight/README.md
@@ -4,16 +4,17 @@ This binding integrates the [Yeelight Lighting Product](https://www.yeelight.com
 
 ## Supported Things
 
-| Device                                                                                 | Thing ID   | Device model                      |
-|----------------------------------------------------------------------------------------|------------|-----------------------------------|
-| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/)          | `ceiling`  | `ceiling`, `ceiling3`             |
-| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/)          | `ceiling1` | `ceiling1`, `ceiling11`, `ceil26` |
-| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/)          | `ceiling4` | `ceiling4`                        |
-| [Yeelight LED Color Bulb](https://us.yeelight.com/category/smart-bulb/)                | `wonder`   | `color`, `color4`                 |
-| [Yeelight LED White Bulb](https://us.yeelight.com/category/smart-bulb/)                | `dolhin`   | `mono`                            |
-| [Yeelight LED White Bulb v2](https://us.yeelight.com/category/smart-bulb/)             | `ct_bulb`  | `ct_bulb`                         |
-| [Yeelight LED Color Stripe](https://us.yeelight.com/shop/yeelight-led-lightstrip-pro/) | `stripe`   | `stripe`, `strip6`                |
-| [Yeelight Mi LED Desk Lamp](https://us.yeelight.com/category/table-lighting/)          | `desklamp` | `desklamp`                        |
+| Device                                                                        | Thing type ID | Device model                      |
+|-------------------------------------------------------------------------------|---------------|-----------------------------------|
+| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/) | `ceiling`     | `ceiling`, `ceiling3`             |
+| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/) | `ceiling1`    | `ceiling1`, `ceiling11`, `ceil26` |
+| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/) | `ceiling4`    | `ceiling4`                        |
+| [Yeelight LED Color Bulb](https://us.yeelight.com/category/smart-bulb/)       | `wonder`      | `color`, `color4`                 |
+| [Yeelight LED White Bulb](https://us.yeelight.com/category/smart-bulb/)       | `dolphin`     | `mono`                            |
+| [Yeelight LED White Bulb v2](https://us.yeelight.com/category/smart-bulb/)    | `ct_bulb`     | `ct_bulb`                         |
+| [Yeelight LED Color Stripe](https://us.yeelight.com/category/led-strip/)      | `stripe`      | `stripe`, `strip6`                |
+| [Yeelight Mi LED Desk Lamp](https://us.yeelight.com/category/table-lighting/) | `desklamp`    | `desklamp`                        |
+
 ## Preconditions
 
 To control Yeelight devices with this binding, you need to connect the device to your local network at first with the Yeelight app.

--- a/bundles/org.openhab.binding.yeelight/README.md
+++ b/bundles/org.openhab.binding.yeelight/README.md
@@ -4,11 +4,16 @@ This binding integrates the [Yeelight Lighting Product](https://www.yeelight.com
 
 ## Supported Things
 
-- Yeelight LED White Bulb (Thing type `mono`, `mono4`)
-- Yeelight LED Color Bulb (Thing type `color`, `color4`)
-- Yeelight LED Color Stripe (Thing type `stripe`, `strip6`)
-- Yeelight LED Ceiling Light (Thing type `ceiling`, `ceiling1`, `ceiling3`, `ceiling4`, `ceiling11`, `ceil26`)
-- Other (Thing type `ct_bulb`, `desklamp`)
+| Device                                                                                 | Thing ID   | Device model                      |
+|----------------------------------------------------------------------------------------|------------|-----------------------------------|
+| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/)          | `ceiling`  | `ceiling`, `ceiling3`             |
+| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/)          | `ceiling1` | `ceiling1`, `ceiling11`, `ceil26` |
+| [Yeelight LED Ceiling Light](https://us.yeelight.com/category/ceiling-light/)          | `ceiling4` | `ceiling4`                        |
+| [Yeelight LED Color Bulb](https://us.yeelight.com/category/smart-bulb/)                | `wonder`   | `color`, `color4`                 |
+| [Yeelight LED White Bulb](https://us.yeelight.com/category/smart-bulb/)                | `dolhin`   | `mono`                            |
+| [Yeelight LED White Bulb v2](https://us.yeelight.com/category/smart-bulb/)             | `ct_bulb`  | `ct_bulb`                         |
+| [Yeelight LED Color Stripe](https://us.yeelight.com/shop/yeelight-led-lightstrip-pro/) | `stripe`   | `stripe`, `strip6`                |
+| [Yeelight Mi LED Desk Lamp](https://us.yeelight.com/category/table-lighting/)          | `desklamp` | `desklamp`                        |
 ## Preconditions
 
 To control Yeelight devices with this binding, you need to connect the device to your local network at first with the Yeelight app.

--- a/bundles/org.openhab.binding.yeelight/README.md
+++ b/bundles/org.openhab.binding.yeelight/README.md
@@ -4,11 +4,11 @@ This binding integrates the [Yeelight Lighting Product](https://www.yeelight.com
 
 ## Supported Things
 
-- [Yeelight LED White Bulb](https://www.yeelight.com/zh_CN/product/wifi-led-w) (Thing type `dolphin`)
-- [Yeelight LED Color Bulb](https://www.yeelight.com/zh_CN/product/wifi-led-c) (Thing type `wonder`)
-- [Yeelight LED Color Stripe](https://www.yeelight.com/zh_CN/product/pitaya) (Thing type `stripe`)
-- [Yeelight LED Ceiling Light](https://www.yeelight.com/en_US/product/luna) (Thing type `ceiling`)
-
+- Yeelight LED White Bulb (Thing type `mono`, `mono4`)
+- Yeelight LED Color Bulb (Thing type `color`, `color4`)
+- Yeelight LED Color Stripe (Thing type `stripe`, `strip6`)
+- Yeelight LED Ceiling Light (Thing type `ceiling`, `ceiling1`, `ceiling3`, `ceiling4`, `ceiling11`, `ceil26`)
+- Other (Thing type `ct_bulb`, `desklamp`)
 ## Preconditions
 
 To control Yeelight devices with this binding, you need to connect the device to your local network at first with the Yeelight app.

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/discovery/YeelightDiscoveryService.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/discovery/YeelightDiscoveryService.java
@@ -88,6 +88,8 @@ public class YeelightDiscoveryService extends AbstractDiscoveryService implement
             case ceiling3:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_CEILING, device.getDeviceId());
             case ceiling1:
+            case ceil26:
+            case ceiling11:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_CEILING1, device.getDeviceId());
             case ceiling4:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_CEILING4, device.getDeviceId());
@@ -113,6 +115,8 @@ public class YeelightDiscoveryService extends AbstractDiscoveryService implement
             case ceiling:
                 return YeelightBindingConstants.THING_TYPE_CEILING;
             case ceiling1:
+            case ceil26:
+            case ceiling11:
                 return YeelightBindingConstants.THING_TYPE_CEILING1;
             case ceiling3:
                 return YeelightBindingConstants.THING_TYPE_CEILING3;

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
@@ -37,6 +37,8 @@ public class DeviceFactory {
                 return new CeilingDevice(id);
             case ceiling1:
             case ceiling3:
+            case ceil26:
+            case ceiling11:
                 return new CeilingDeviceWithNightDevice(id);
             case ceiling4:
                 return new CeilingDeviceWithAmbientDevice(id);

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/enums/DeviceType.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/enums/DeviceType.java
@@ -27,6 +27,8 @@ public enum DeviceType {
     ceiling1,
     ceiling3,
     ceiling4,
+    ceil26,
+    ceiling11,
     stripe,
     strip6,
     desklamp

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
@@ -335,6 +335,8 @@ public class DeviceManager {
                 return "Yeelight LED Ceiling";
             case ceiling1:
             case ceiling3:
+            case ceil26:
+            case ceiling11:
                 return "Yeelight LED Ceiling with night mode";
             case ceiling4:
                 return "Yeelight LED Ceiling with ambient light";


### PR DESCRIPTION
Signed-off-by: Alexandr Salamatov [goopilot@gmail.com](mailto:goopilot@gmail.com)

Added support of a ceiling lights YLXD41YL (ceiling11) and YLXD76YL (ceil26).

Capabilities are same as ceiling1

ceiling1
`
{'ip': '192.168.112.65', 'port': 55443, 'capabilities': {'id': '0x0000000007e7f54d', 'model': 'ceiling1', 'fw_ver': '193', 'support': 'get_prop set_default set_power toggle set_bright set_scene cron_add cron_get cron_del start_cf stop_cf set_ct_abx set_name set_adjust adjust_bright adjust_ct', 'power': 'on', 'bright': '100', 'color_mode': '2', 'ct': '3500', 'rgb': '0', 'hue': '0', 'sat': '0', 'name': ''}}
`

ceil26
`
{'ip': '192.168.112.108', 'port': 55443, 'capabilities': {'id': '0x0000000015627cc9', 'model': 'ceil26', 'fw_ver': '18', 'support': 'get_prop set_default set_power toggle set_bright set_scene cron_add cron_get cron_del start_cf stop_cf set_adjust adjust_bright set_name set_ct_abx adjust_ct', 'power': 'on', 'bright': '100', 'color_mode': '2', 'ct': '3500', 'rgb': '0', 'hue': '0', 'sat': '0', 'name': ''}}
`

ceiling11
`
{'ip': '192.168.XXX.YYY', 'port': 55443, 'capabilities': {'hue': '0', 'color_mode': '2', 'name': '', 'power': 'on', 'support': 'get_prop set_default set_power toggle set_bright set_scene cron_add cron_get cron_del start_cf stop_cf set_ct_abx set_name set_adjust adjust_bright adjust_ct', 'rgb': '0', 'fw_ver': '19', 'bright': '66', 'model': 'ceiling11', 'ct': '4000', 'id': '0x000000001234aa56', 'sat': '0'}}
`

This will close 2 issues: https://github.com/openhab/openhab-addons/issues/11246 and https://github.com/openhab/openhab-addons/issues/11293