### PR TITLE
Trigger full build when add-on is removed

### DIFF
--- a/.github/scripts/maven-build
+++ b/.github/scripts/maven-build
@@ -94,7 +94,10 @@ function build_addon() {
 
 function build_based_on_changes() {
     local changed_addon=$(changed_addons | xargs)
-    if [ $(echo $changed_addon | wc -w) -eq 1 ] && [ $(addon_unrelated_changed_files $changed_addon | wc -l) -eq 0 ]; then
+    if [ $(echo $changed_addon | wc -w) -eq 1 ] && \
+        [ $(addon_unrelated_changed_files $changed_addon | wc -l) -eq 0 ] && \
+        [ -d "./bundles/$changed_addon" ]
+    then
         build_addon $changed_addon
     else
         build_all


### PR DESCRIPTION
When an add-on is removed a partial build fails and instead a full build should be done.

See: https://github.com/openhab/openhab-addons/pull/14675#issuecomment-1484020311

Tested in my fork using https://github.com/wborn/openhab-addons/pull/9.
