### PR TITLE
[boschshc] updated boschshc code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,7 +48,7 @@
 /bundles/org.openhab.binding.bluetooth.ruuvitag/ @ssalonen
 /bundles/org.openhab.binding.bondhome/ @ccutrer
 /bundles/org.openhab.binding.boschindego/ @jofleck @jlaur
-/bundles/org.openhab.binding.boschshc/ @stefan-kaestle @coeing @GerdZanker
+/bundles/org.openhab.binding.boschshc/ @david-pace @GerdZanker
 /bundles/org.openhab.binding.bosesoundtouch/ @marvkis @tratho
 /bundles/org.openhab.binding.broadlinkthermostat/ @flo-02-mu
 /bundles/org.openhab.binding.bsblan/ @hypetsch


### PR DESCRIPTION
# updated boschshc code owner

Thank you, Stefan & Christian! Welcome David!

## Updated Code Owner for BoschSHC Binding.

This update of the code owner reflects the changes of the last years.

Thank you @stefan-kaestle for the initial code contribution of the binding and only with the great contributions & time invest from @coeing the code was accepted for the openhab main branch.

Of cause focus changes and Christian was [Looking for developers](https://github.com/stefan-kaestle/openhab2-addons/issues/114) already back in 2021.

And now a new, but very experienced Java developer joined. David provided already many good pull requests and pushes the code quality and SmartHomeController tests to a new level and is now a new code owner. Therefore, a warm welcome @david-pace !


