### PR TITLE
[mqtt.homeassistant] fix JSON Schema lights

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -181,17 +181,18 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
         }
 
         if (jsonState.state != null) {
-            onOffValue.update(new StringType(jsonState.state));
+            onOffValue.update(onOffValue.parseCommand(new StringType(jsonState.state)));
             if (brightnessValue.getChannelState() instanceof UnDefType) {
-                brightnessValue.update((OnOffType) onOffValue.getChannelState());
+                brightnessValue.update(brightnessValue.parseCommand((OnOffType) onOffValue.getChannelState()));
             }
             if (colorValue.getChannelState() instanceof UnDefType) {
-                colorValue.update((OnOffType) onOffValue.getChannelState());
+                colorValue.update(colorValue.parseCommand((OnOffType) onOffValue.getChannelState()));
             }
         }
 
         if (jsonState.brightness != null) {
-            brightnessValue.update(new DecimalType(Objects.requireNonNull(jsonState.brightness)));
+            brightnessValue.update(
+                    brightnessValue.parseCommand(new DecimalType(Objects.requireNonNull(jsonState.brightness))));
             if (colorValue.getChannelState() instanceof HSBType) {
                 HSBType color = (HSBType) colorValue.getChannelState();
                 colorValue.update(new HSBType(color.getHue(), color.getSaturation(),


### PR DESCRIPTION
https://github.com/openhab/openhab-addons/pull/12238 was merged after JSON Schema Light was implemented, and changed some assumptions. this commit adjusts to the changed interface

