### PR TITLE
[gardena] Improve GardenaSmartImpl initialization order

### DIFF
--- a/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
+++ b/bundles/org.openhab.binding.gardena/src/main/java/org/openhab/binding/gardena/internal/GardenaSmartImpl.java
@@ -111,19 +111,20 @@ public class GardenaSmartImpl implements GardenaSmart, GardenaSmartWebSocketList
         this.eventListener = eventListener;
         this.scheduler = scheduler;
 
+        String name = ThingWebClientUtil.buildWebClientConsumerName(uid, null);
+        httpClient = httpClientFactory.createHttpClient(name);
+        httpClient.setConnectTimeout(config.getConnectionTimeout() * 1000L);
+        httpClient.setIdleTimeout(httpClient.getConnectTimeout());
+
+        name = ThingWebClientUtil.buildWebClientConsumerName(uid, "ws-");
+        webSocketClient = webSocketFactory.createWebSocketClient(name);
+        webSocketClient.setConnectTimeout(config.getConnectionTimeout() * 1000L);
+        webSocketClient.setStopTimeout(3000);
+        webSocketClient.setMaxIdleTimeout(150000);
+
         logger.debug("Starting GardenaSmart");
         try {
-            String name = ThingWebClientUtil.buildWebClientConsumerName(uid, null);
-            httpClient = httpClientFactory.createHttpClient(name);
-            httpClient.setConnectTimeout(config.getConnectionTimeout() * 1000L);
-            httpClient.setIdleTimeout(httpClient.getConnectTimeout());
             httpClient.start();
-
-            name = ThingWebClientUtil.buildWebClientConsumerName(uid, "ws-");
-            webSocketClient = webSocketFactory.createWebSocketClient(name);
-            webSocketClient.setConnectTimeout(config.getConnectionTimeout() * 1000L);
-            webSocketClient.setStopTimeout(3000);
-            webSocketClient.setMaxIdleTimeout(150000);
             webSocketClient.start();
 
             // initially load access token


### PR DESCRIPTION
If an exception occurs during httpClient.start(), webSocketClient remained null, which led to another (then unhandled) exception being thrown by dispose(), called in the exception handler.
With the new initialization order it's ensured webSocketClient is not null at dispose() time, thus allowing proper propagation of the exception thrown at HTTP startup.
