### PR TITLE
[solarwatt] Add smart heater device support

### DIFF
--- a/bundles/org.openhab.binding.solarwatt/README.md
+++ b/bundles/org.openhab.binding.solarwatt/README.md
@@ -7,7 +7,7 @@ All supported values and devices were discovered while playing with my own energ
 ## Supported Things
 
 | Thing Type ID    | Devices                                                |
-| ---------------- | ------------------------------------------------------ |
+|------------------|--------------------------------------------------------|
 | energymanager    | EnergyManager itself.                                  |
 | location         | Location part of the EnergyManager.                    |
 | pvplant          | Power producing part of the EnergyManager.             |
@@ -16,6 +16,7 @@ All supported values and devices were discovered while playing with my own energ
 | batteryconverter | battery storage systems; e.g. MyReserve                |
 | powermeter       | powermeters; e.g. S0BusCounter, MyReserve              |
 | evstation        | electric-vehicle charging station; e.g. Keba Wallbox   |
+| smartheater      | Radiators for PV systems; e.g. EGO SmartHeater         |
 
 ## Discovery
 
@@ -141,6 +142,18 @@ All of _Inverter_ plus
 | --------------- | -------------------- | ----------------------------------- |
 | feedInLimit     | Number:Dimensionless | Current derating setting in percent |
 
+### SmartHeater
+
+| Channel Type ID   | Item Type          | Description                            |
+|-------------------|--------------------|----------------------------------------|
+| workACIn          | Number:Energy      | Energy fed into smart heater           |
+| powerACIn         | Number:Power       | Power fed into smart heater            |
+| temperature       | Number:Temperature | Current heating temperature in celsius |
+| temperatureBoiler | Number:Temperature | Current boiler temperature in celsius  |
+| temperatureSet    | Number:Temperature | Set temperature                        |
+| temperatureSetMin | Number:Temperature | Minimum adjustable temperature         |
+| temperatureSetMax | Number:Temperature | Maximum adjustable temperature         |
+
 ## Example
 
 demo.things:
@@ -249,4 +262,13 @@ Number Solarwatt_Manager_ERC05000008007_FractionCPULoadAverageLastFifteenMinutes
 // Gridflow com.kiwigrid.kiwiapp.gridflow.GridFlow
 Number Solarwatt_Gridflow_UrnKiwigridGridflowERC05000008007_CurrentLimit "CurrentLimit [%d A]" <energy> ["Point"]  {channel="solarwatt:gridflow:56f4ac2fa2:urn-kiwigrid-gridflow-ERC05-000008007:currentLimit"}
 Number Solarwatt_Gridflow_UrnKiwigridGridflowERC05000008007_FeedInLimit "FeedInLimit [%d %%]" <status> ["Point"]  {channel="solarwatt:gridflow:56f4ac2fa2:urn-kiwigrid-gridflow-ERC05-000008007:feedInLimit"}
+
+// SmartHeater com.kiwigrid.devices.smartheater.SmartHeater
+Number:Power Solarwatt_Smartheater_UrnEgoSmartheater62018833_PowerACIn "SmartHeater powerACIn [%.2f W]" <energy> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:powerACIn" }
+Number:Energy Solarwatt_Smartheater_UrnEgoSmartheater62018833_WorkACIn "SmartHeater workACIn [%.2f Wh]" <energy> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:workACIn" }
+Number:Temperature Solarwatt_Smartheater_UrnEgoSmartheater62018833_TemperatureBoiler "SmartHeater temperatureBoiler [%.1f °C]" <temperature> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:temperatureBoiler" }
+Number:Temperature Solarwatt_Smartheater_UrnEgoSmartheater62018833_Temperature "SmartHeater temperature [%.1f °C]" <temperature> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:temperature" }
+Number:Temperature Solarwatt_Smartheater_UrnEgoSmartheater62018833_TemperatureSet "SmartHeater temperatureSet [%.1f °C]" <temperature> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:temperatureSet" }
+Number:Temperature Solarwatt_Smartheater_UrnEgoSmartheater62018833_TemperatureSetMax "SmartHeater temperatureSetMax [%.1f °C]" <temperature> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:temperatureSetMax" }
+Number:Temperature Solarwatt_Smartheater_UrnEgoSmartheater62018833_TemperatureSetMin "SmartHeater temperatureSetMin [%.1f °C]" <temperature> { channel="solarwatt:smartheater:urn-ego-smartheater-62018833:temperatureSetMin" }
 ```

--- a/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/SolarwattBindingConstants.java
+++ b/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/SolarwattBindingConstants.java
@@ -39,6 +39,7 @@ public class SolarwattBindingConstants {
     public static final ThingTypeUID THING_TYPE_EVSTATION = new ThingTypeUID(BINDING_ID, "evstation");
     public static final ThingTypeUID THING_TYPE_PVPLANT = new ThingTypeUID(BINDING_ID, "pvplant");
     public static final ThingTypeUID THING_TYPE_GRIDFLOW = new ThingTypeUID(BINDING_ID, "gridflow");
+    public static final ThingTypeUID THING_TYPE_SMARTHEATER = new ThingTypeUID(BINDING_ID, "smartheater");
 
     public static final String PROPERTY_ID_NAME = "IdName";
     public static final String PROPERTY_ID_FIRMWARE = "IdFirmware";
@@ -116,6 +117,11 @@ public class SolarwattBindingConstants {
     public static final SolarwattTag CHANNEL_VOLTAGE_BATTERY_CELL_MAX = new SolarwattTag("VoltageBatteryCellMax");
     public static final SolarwattTag CHANNEL_VOLTAGE_BATTERY_CELL_MIN = new SolarwattTag("VoltageBatteryCellMin");
     public static final SolarwattTag CHANNEL_VOLTAGE_BATTERY_CELL_MEAN = new SolarwattTag("VoltageBatteryCellMean");
+    public static final SolarwattTag CHANNEL_TEMPERATURE = new SolarwattTag("Temperature");
+    public static final SolarwattTag CHANNEL_TEMPERATURE_SET_MAX = new SolarwattTag("TemperatureSetMax");
+    public static final SolarwattTag CHANNEL_TEMPERATURE_BOILER = new SolarwattTag("TemperatureBoiler");
+    public static final SolarwattTag CHANNEL_TEMPERATURE_SET_MIN = new SolarwattTag("TemperatureSetMin");
+    public static final SolarwattTag CHANNEL_TEMPERATURE_SET = new SolarwattTag("TemperatureSet");
 
     // thing configuration and properties keys
     public static final String THING_PROPERTIES_GUID = "guid";

--- a/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/SolarwattHandlerFactory.java
+++ b/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/SolarwattHandlerFactory.java
@@ -46,7 +46,7 @@ public class SolarwattHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_ENERGY_MANAGER,
             THING_TYPE_INVERTER, THING_TYPE_POWERMETER, THING_TYPE_EVSTATION, THING_TYPE_BATTERYCONVERTER,
-            THING_TYPE_LOCATION, THING_TYPE_PVPLANT, THING_TYPE_GRIDFLOW);
+            THING_TYPE_LOCATION, THING_TYPE_PVPLANT, THING_TYPE_GRIDFLOW, THING_TYPE_SMARTHEATER);
 
     private final HttpClient commonHttpClient;
     private final SolarwattChannelTypeProvider channelTypeProvider;

--- a/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/discovery/SolarwattDevicesDiscoveryService.java
+++ b/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/discovery/SolarwattDevicesDiscoveryService.java
@@ -12,7 +12,15 @@
  */
 package org.openhab.binding.solarwatt.internal.discovery;
 
-import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.*;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_PROPERTIES_GUID;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_BATTERYCONVERTER;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_EVSTATION;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_GRIDFLOW;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_INVERTER;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_LOCATION;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_POWERMETER;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_PVPLANT;
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.THING_TYPE_SMARTHEATER;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +37,7 @@ import org.openhab.binding.solarwatt.internal.domain.model.Inverter;
 import org.openhab.binding.solarwatt.internal.domain.model.Location;
 import org.openhab.binding.solarwatt.internal.domain.model.PVPlant;
 import org.openhab.binding.solarwatt.internal.domain.model.PowerMeter;
+import org.openhab.binding.solarwatt.internal.domain.model.SmartHeater;
 import org.openhab.binding.solarwatt.internal.handler.EnergyManagerHandler;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -137,6 +146,7 @@ public class SolarwattDevicesDiscoveryService extends AbstractDiscoveryService
                 this.logger.warn("No device data for solarwatt devices in discovery for energy manager {}.", bridgeUID);
             } else {
                 devices.forEach((key, entry) -> {
+                    this.logger.debug("scanForDeviceThings: {}-{}", entry.getClass(), entry.getGuid());
                     if (entry instanceof BatteryConverter) {
                         this.discover(bridgeUID, entry, THING_TYPE_BATTERYCONVERTER);
                     } else if (entry instanceof Inverter) {
@@ -151,6 +161,10 @@ public class SolarwattDevicesDiscoveryService extends AbstractDiscoveryService
                         this.discover(bridgeUID, entry, THING_TYPE_PVPLANT);
                     } else if (entry instanceof GridFlow) {
                         this.discover(bridgeUID, entry, THING_TYPE_GRIDFLOW);
+                    } else if (entry instanceof SmartHeater) {
+                        this.discover(bridgeUID, entry, THING_TYPE_SMARTHEATER);
+                    } else {
+                        this.logger.debug("Found unhandled device");
                     }
                 });
             }

--- a/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/domain/model/SmartHeater.java
+++ b/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/domain/model/SmartHeater.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solarwatt.internal.domain.model;
+
+import static org.openhab.binding.solarwatt.internal.SolarwattBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solarwatt.internal.domain.dto.DeviceDTO;
+
+/**
+ * Base class for a EGO Smart Heaters ... see
+ * https://www.solarwatt.de/betriebsanleitungen/solarwatt-manager/solarwatt-manager-flex/geraete-verbinden/ego-smartheater
+ *
+ * This fields have been identified to exist:
+ * com.kiwigrid.devices.smartheater.SmartHeater=[
+ * TemperatureSetMax,
+ * PowerACInLimit,
+ * Temperature,
+ * DateProduction,
+ * IdFingerPrint,
+ * StateVisibleIsSet,
+ * StateErrorList,
+ * PasswordLock,
+ * IdManufacturer,
+ * WorkACIn,
+ * PowerACInLimits,
+ * TemperatureBoiler,
+ * IdFirmware,
+ * IdModelCode,
+ * IdName,
+ * IdInterfaceList,
+ * TemperatureSetMin,
+ * IdDriver,
+ * StateDevice,
+ * TemperatureSet,
+ * PowerACIn,
+ * IdSerialNumber,
+ * PowerACInMax,
+ * IdFingerPrintVersion,
+ * IdLabelSet,
+ * StateLockedIsSet
+ * ]
+ *
+ * @author Thomas Schumm - Initial contribution
+ */
+@NonNullByDefault
+public class SmartHeater extends Device {
+    public static final String SOLAR_WATT_CLASSNAME = "com.kiwigrid.devices.smartheater.SmartHeater";
+
+    public SmartHeater(DeviceDTO deviceDTO) {
+        super(deviceDTO);
+    }
+
+    @Override
+    public void update(DeviceDTO deviceDTO) {
+        super.update(deviceDTO);
+
+        this.addWattHourQuantity(CHANNEL_WORK_AC_IN, deviceDTO);
+        this.addWattQuantity(CHANNEL_POWER_AC_IN, deviceDTO);
+        this.addCelsiusQuantity(CHANNEL_TEMPERATURE, deviceDTO);
+        this.addCelsiusQuantity(CHANNEL_TEMPERATURE_SET_MAX, deviceDTO);
+        this.addCelsiusQuantity(CHANNEL_TEMPERATURE_BOILER, deviceDTO);
+        this.addCelsiusQuantity(CHANNEL_TEMPERATURE_SET_MIN, deviceDTO);
+        this.addCelsiusQuantity(CHANNEL_TEMPERATURE_SET, deviceDTO);
+    }
+
+    @Override
+    protected String getSolarWattLabel() {
+        return "SmartHeater";
+    }
+}

--- a/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/factory/EnergyManagerDevicesFactory.java
+++ b/bundles/org.openhab.binding.solarwatt/src/main/java/org/openhab/binding/solarwatt/internal/factory/EnergyManagerDevicesFactory.java
@@ -36,6 +36,7 @@ import org.openhab.binding.solarwatt.internal.domain.model.S0Counter;
 import org.openhab.binding.solarwatt.internal.domain.model.ScheduleApp;
 import org.openhab.binding.solarwatt.internal.domain.model.SimpleSwitcher;
 import org.openhab.binding.solarwatt.internal.domain.model.SmartEnergyManagement;
+import org.openhab.binding.solarwatt.internal.domain.model.SmartHeater;
 import org.openhab.binding.solarwatt.internal.domain.model.SunSpecInverter;
 
 /**
@@ -124,6 +125,9 @@ public class EnergyManagerDevicesFactory {
         }
         if (deviceDTO.getDeviceModelStrings().contains(ProfileApp.SOLAR_WATT_CLASSNAME)) {
             return new ProfileApp(deviceDTO);
+        }
+        if (deviceDTO.getDeviceModelStrings().contains(SmartHeater.SOLAR_WATT_CLASSNAME)) {
+            return new SmartHeater(deviceDTO);
         }
 
         // Objects on level 0

--- a/bundles/org.openhab.binding.solarwatt/src/main/resources/OH-INF/i18n/solarwatt.properties
+++ b/bundles/org.openhab.binding.solarwatt/src/main/resources/OH-INF/i18n/solarwatt.properties
@@ -21,6 +21,8 @@ thing-type.solarwatt.powermeter.label = Power Meter
 thing-type.solarwatt.powermeter.description = Power meter for produced or consumed energy
 thing-type.solarwatt.pvplant.label = PV Plant
 thing-type.solarwatt.pvplant.description = Photovoltaic plant generating DC from solar energy.
+thing-type.solarwatt.smartheater.label = SmartHeater
+thing-type.solarwatt.smartheater.description = Smart heater for the production of hot water.
 
 # thing types config
 

--- a/bundles/org.openhab.binding.solarwatt/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarwatt/src/main/resources/OH-INF/thing/thing-types.xml
@@ -105,4 +105,17 @@
 		<config-description-ref uri="thing-type:solarwatt:device"/>
 	</thing-type>
 
+	<thing-type id="smartheater">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="energymanager"/>
+		</supported-bridge-type-refs>
+
+		<label>SmartHeater</label>
+		<description>smart heater for the production of hot water.</description>
+
+		<representation-property>IdName</representation-property>
+
+		<config-description-ref uri="thing-type:solarwatt:device"/>
+	</thing-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.solarwatt/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarwatt/src/main/resources/OH-INF/thing/thing-types.xml
@@ -111,7 +111,7 @@
 		</supported-bridge-type-refs>
 
 		<label>SmartHeater</label>
-		<description>smart heater for the production of hot water.</description>
+		<description>Smart heater for the production of hot water.</description>
 
 		<representation-property>IdName</representation-property>
 


### PR DESCRIPTION
The [EGO Smart Heater](https://www.ego-seibert.de/produkte/pseudo-sub1/smart-heater) screw-in heater stores excess photovoltaic energy fully automatically as hot water. These changes add support for this device to the solarwatt binding.

The test version of the binding can be found [here](https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.solarwatt/4.0.0-SNAPSHOT/).