### PR TITLE
[astro] Add getTotalRadiation to AstroActions 

### DIFF
--- a/bundles/org.openhab.binding.astro/README.md
+++ b/bundles/org.openhab.binding.astro/README.md
@@ -265,6 +265,15 @@ Example :
  logInfo("AstroActions", "{} will be positioned at elevation {} - azimuth {}",sunEvent, elevation.toString,azimuth.toString)
 ```
 
+### getTotalRadiation(timeStamp)
+Retrieves the total radiation(QuantityType) of the sun at the requested instant.
+Thing method only applies to Sun thing type.
+
+```java
+ val totalRadiation = sunActions.getTotalRadiation(ZonedDateTime.now)
+ logInfo("AstroActions", "Currently, the total sun radiation is {}",   totalRadiation.toString)
+```
+
 ## Tips
 
 Do not worry if for example the "astro dawn" is undefined at your location.

--- a/bundles/org.openhab.binding.astro/README.md
+++ b/bundles/org.openhab.binding.astro/README.md
@@ -266,7 +266,8 @@ Example :
 ```
 
 ### getTotalRadiation(timeStamp)
-Retrieves the total radiation(QuantityType) of the sun at the requested instant.
+
+Retrieves the total radiation (QuantityType<Intensity>) of the sun at the requested instant.
 Thing method only applies to Sun thing type.
 
 ```java

--- a/bundles/org.openhab.binding.astro/README.md
+++ b/bundles/org.openhab.binding.astro/README.md
@@ -272,7 +272,7 @@ Thing method only applies to Sun thing type.
 
 ```java
  val totalRadiation = sunActions.getTotalRadiation(ZonedDateTime.now)
- logInfo("AstroActions", "Currently, the total sun radiation is {}",   totalRadiation.toString)
+ logInfo("AstroActions", "Currently, the total sun radiation is {}", totalRadiation.toString)
 ```
 
 ## Tips

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
@@ -89,7 +89,7 @@ public class AstroActions implements ThingActions {
     }
 
     @RuleAction(label = "get the total sun radiation", description = "Get the total sun radiation for a given time.")
-    public @Nullable @ActionOutput(name = "getTotalRadiation", label = "TotalRadiation", type = "org.openhab.core.library.types.QuantityType<org.openhab.core.library.dimension.Intensity>") QuantityType<Intensity> getTotalRadiation(
+    public @Nullable @ActionOutput(name = "getTotalRadiation", label = "Total Radiation", type = "org.openhab.core.library.types.QuantityType<org.openhab.core.library.dimension.Intensity>") QuantityType<Intensity> getTotalRadiation(
             @ActionInput(name = "date", label = "Date", required = false, description = "Considered date") @Nullable ZonedDateTime date) {
         logger.debug("Astro action 'getTotalRadiation' called");
         AstroThingHandler theHandler = this.handler;
@@ -141,7 +141,7 @@ public class AstroActions implements ThingActions {
         return ((AstroActions) actions).getAzimuth(date);
     }
 
-    public static @Nullable QuantityType<Intensity> getTotalRadiation(ThingActions actions, @Nullable ZonedDateTime date) {
+    public static @Nullable QuantityType<Angle> getTotalRadiation(ThingActions actions, @Nullable ZonedDateTime date) {
         return ((AstroActions) actions).getTotalRadiation(date);
     }
 

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
@@ -141,7 +141,8 @@ public class AstroActions implements ThingActions {
         return ((AstroActions) actions).getAzimuth(date);
     }
 
-    public static @Nullable QuantityType<Intensity> getTotalRadiation(ThingActions actions, @Nullable ZonedDateTime date) {
+    public static @Nullable QuantityType<Intensity> getTotalRadiation(ThingActions actions,
+            @Nullable ZonedDateTime date) {
         return ((AstroActions) actions).getTotalRadiation(date);
     }
 

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
@@ -94,9 +94,8 @@ public class AstroActions implements ThingActions {
         logger.debug("Astro action 'getTotalRadiation' called");
         AstroThingHandler theHandler = this.handler;
         if (theHandler != null) {
-            if (theHandler instanceof SunHandler) {
-                SunHandler handler = (SunHandler) theHandler;
-                Radiation radiation = handler.getRadiationAt(date != null ? date : ZonedDateTime.now());
+            if (theHandler instanceof SunHandler sunHandler) {
+                Radiation radiation = sunHandler.getRadiationAt(date != null ? date : ZonedDateTime.now());
                 return radiation.getTotal();
             } else {
                 logger.info("Astro Action service ThingHandler is not a SunHandler!");

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
@@ -21,10 +21,12 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.astro.internal.AstroBindingConstants;
 import org.openhab.binding.astro.internal.handler.AstroThingHandler;
 import org.openhab.binding.astro.internal.handler.SunHandler;
+import org.openhab.binding.astro.internal.model.Radiation;
 import org.openhab.binding.astro.internal.model.SunPhaseName;
 import org.openhab.core.automation.annotation.ActionInput;
 import org.openhab.core.automation.annotation.ActionOutput;
 import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.library.dimension.Intensity;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.thing.binding.ThingActions;
 import org.openhab.core.thing.binding.ThingActionsScope;
@@ -86,6 +88,25 @@ public class AstroActions implements ThingActions {
         return null;
     }
 
+    @RuleAction(label = "get the total sun radiation", description = "Get the total sun radiation for a given time.")
+    public @Nullable @ActionOutput(name = "getTotalRadiation", label = "TotalRadiation", type = "org.openhab.core.library.types.QuantityType<org.openhab.core.library.dimension.Intensity>") QuantityType<Intensity> getTotalRadiation(
+            @ActionInput(name = "date", label = "Date", required = false, description = "Considered date") @Nullable ZonedDateTime date) {
+        logger.debug("Astro action 'getTotalRadiation' called");
+        AstroThingHandler theHandler = this.handler;
+        if (theHandler != null) {
+            if (theHandler instanceof SunHandler) {
+                SunHandler handler = (SunHandler) theHandler;
+                Radiation radiation = handler.getRadiationAt(date != null ? date : ZonedDateTime.now());
+                return radiation.getTotal();
+            } else {
+                logger.info("Astro Action service ThingHandler is not a SunHandler!");
+            }
+        } else {
+            logger.info("Astro Action service ThingHandler is null!");
+        }
+        return null;
+    }
+
     @RuleAction(label = "get the date time of a sun event", description = "Get the date time of a sun event.")
     public @Nullable @ActionOutput(name = "getEventTime", type = "java.time.ZonedDateTime") ZonedDateTime getEventTime(
             @ActionInput(name = "phaseName", label = "Phase", required = true, description = "Requested phase") String phaseName,
@@ -118,6 +139,10 @@ public class AstroActions implements ThingActions {
 
     public static @Nullable QuantityType<Angle> getAzimuth(ThingActions actions, @Nullable ZonedDateTime date) {
         return ((AstroActions) actions).getAzimuth(date);
+    }
+
+    public static @Nullable QuantityType<Intensity> getTotalRadiation(ThingActions actions, @Nullable ZonedDateTime date) {
+        return ((AstroActions) actions).getTotalRadiation(date);
     }
 
     public static @Nullable ZonedDateTime getEventTime(ThingActions actions, @Nullable String phaseName,

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/action/AstroActions.java
@@ -141,7 +141,7 @@ public class AstroActions implements ThingActions {
         return ((AstroActions) actions).getAzimuth(date);
     }
 
-    public static @Nullable QuantityType<Angle> getTotalRadiation(ThingActions actions, @Nullable ZonedDateTime date) {
+    public static @Nullable QuantityType<Intensity> getTotalRadiation(ThingActions actions, @Nullable ZonedDateTime date) {
         return ((AstroActions) actions).getTotalRadiation(date);
     }
 

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/SunHandler.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/SunHandler.java
@@ -21,11 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.astro.internal.calc.SunCalc;
 import org.openhab.binding.astro.internal.job.DailyJobSun;
 import org.openhab.binding.astro.internal.job.Job;
-import org.openhab.binding.astro.internal.model.Planet;
-import org.openhab.binding.astro.internal.model.Position;
-import org.openhab.binding.astro.internal.model.Range;
-import org.openhab.binding.astro.internal.model.Sun;
-import org.openhab.binding.astro.internal.model.SunPhaseName;
+import org.openhab.binding.astro.internal.model.*;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.scheduler.CronScheduler;
 import org.openhab.core.thing.Thing;
@@ -95,6 +91,16 @@ public class SunHandler extends AstroThingHandler {
                 thingConfig.useMeteorologicalSeason);
     }
 
+    private Sun getPositionedSunAt(ZonedDateTime date) {
+        Sun localSun = getSunAt(date);
+        Double latitude = thingConfig.latitude;
+        Double longitude = thingConfig.longitude;
+        Double altitude = thingConfig.altitude;
+        sunCalc.setPositionalInfo(GregorianCalendar.from(date), latitude != null ? latitude : 0,
+                longitude != null ? longitude : 0, altitude != null ? altitude : 0, localSun);
+        return localSun;
+    }
+
     public @Nullable ZonedDateTime getEventTime(SunPhaseName sunPhase, ZonedDateTime date, boolean begin) {
         Range eventRange = getSunAt(date).getAllRanges().get(sunPhase);
         if (eventRange != null) {
@@ -107,12 +113,12 @@ public class SunHandler extends AstroThingHandler {
 
     @Override
     public @Nullable Position getPositionAt(ZonedDateTime date) {
-        Sun localSun = getSunAt(date);
-        Double latitude = thingConfig.latitude;
-        Double longitude = thingConfig.longitude;
-        Double altitude = thingConfig.altitude;
-        sunCalc.setPositionalInfo(GregorianCalendar.from(date), latitude != null ? latitude : 0,
-                longitude != null ? longitude : 0, altitude != null ? altitude : 0, localSun);
+        Sun localSun = getPositionedSunAt(date);
         return localSun.getPosition();
+    }
+
+    public @Nullable Radiation getRadiationAt(ZonedDateTime date) {
+        Sun localSun = getPositionedSunAt(date);
+        return localSun.getRadiation();
     }
 }


### PR DESCRIPTION
This is enhancement of Astro binding. There is added getTotalRadiation to AstroActions allowing the user to get total radiation of the sun at the requested instant. The documentation of the Astro binding is updated as well. The proposed enhancement is tested and works also in the previous version 3.4.2.