### PR TITLE
[nanoleaf] Use new core class ColorUtil for RGB conversion

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/HexagonCorners.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/HexagonCorners.java
@@ -27,6 +27,7 @@ import org.openhab.binding.nanoleaf.internal.layout.Point2D;
 import org.openhab.binding.nanoleaf.internal.layout.ShapeType;
 import org.openhab.binding.nanoleaf.internal.model.PositionDatum;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.util.ColorUtil;
 
 /**
  * A hexagon shape.
@@ -132,7 +133,7 @@ public class HexagonCorners extends Panel {
 
     private static Color getColor(int panelId, PanelState state) {
         HSBType color = state.getHSBForPanel(panelId);
-        return new Color(color.getRGB());
+        return new Color(ColorUtil.hsbTosRgb(color));
     }
 
     private Color getAverageColor(PanelState state) {

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/Point.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/Point.java
@@ -24,6 +24,7 @@ import org.openhab.binding.nanoleaf.internal.layout.PanelState;
 import org.openhab.binding.nanoleaf.internal.layout.Point2D;
 import org.openhab.binding.nanoleaf.internal.layout.ShapeType;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.util.ColorUtil;
 
 /**
  * A shape without any area.
@@ -55,7 +56,7 @@ public class Point extends Panel {
 
         if (settings.shouldFillWithColor()) {
             HSBType color = state.getHSBForPanel(panelId);
-            graphics.setColor(new Color(color.getRGB()));
+            graphics.setColor(new Color(ColorUtil.hsbTosRgb(color)));
             graphics.fillOval(pos.getX(), pos.getY(), POINT_DIAMETER, POINT_DIAMETER);
         }
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/Shape.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/Shape.java
@@ -24,6 +24,7 @@ import org.openhab.binding.nanoleaf.internal.layout.PanelState;
 import org.openhab.binding.nanoleaf.internal.layout.Point2D;
 import org.openhab.binding.nanoleaf.internal.layout.ShapeType;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.util.ColorUtil;
 
 /**
  * Draws shapes, which are panels with a single LED.
@@ -77,7 +78,7 @@ public abstract class Shape extends Panel {
         }
 
         HSBType color = state.getHSBForPanel(getPanelId());
-        graphics.setColor(new Color(color.getRGB()));
+        graphics.setColor(new Color(ColorUtil.hsbTosRgb(color)));
         if (settings.shouldFillWithColor()) {
             graphics.fillPolygon(p);
         }

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/SingleLine.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/layout/shape/SingleLine.java
@@ -29,6 +29,7 @@ import org.openhab.binding.nanoleaf.internal.layout.Point2D;
 import org.openhab.binding.nanoleaf.internal.layout.ShapeType;
 import org.openhab.binding.nanoleaf.internal.model.PositionDatum;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.util.ColorUtil;
 
 /**
  * A single line.
@@ -123,6 +124,6 @@ public class SingleLine extends Panel {
 
     private static Color getColor(int panelId, PanelState state) {
         HSBType color = state.getHSBForPanel(panelId);
-        return new Color(color.getRGB());
+        return new Color(ColorUtil.hsbTosRgb(color));
     }
 }


### PR DESCRIPTION
Use new class ```ColorUtil``` which has recently been added to core in https://github.com/openhab/openhab-core/pull/3479.

```HsbType::getRGB()``` has been replaced since it has been deprecated.