### PR TITLE
[dsmr] Use lower-case country codes in addon.xml

### DIFF
--- a/bundles/org.openhab.binding.dsmr/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.dsmr/src/main/resources/OH-INF/addon/addon.xml
@@ -7,5 +7,5 @@
 	<name>DSMR Binding</name>
 	<description>This binding integrates Dutch, Belgium, Luxembourg and Austrian Smart Meters</description>
 	<connection>local</connection>
-	<countries>NL,BE,LU,AT</countries>
+	<countries>nl,be,lu,at</countries>
 </addon:addon>


### PR DESCRIPTION
When using upper-case country codes the XSD pattern does not match and IDEs will show errors for this.

See: https://github.com/openhab/website/blob/257652aafc8a4ff56a2d75198f910abba7445a3d/.vuepress/public/schemas/addon-1.0.0.xsd#L60-L64

![error](https://user-images.githubusercontent.com/12213581/230877452-289af8e4-a7de-4a0e-a6f3-dec7e445651e.png)

Caused by: #14380
