### PR TITLE
[mqtt][tradfri][webthing] Adapt to ColorUtil changes in core

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
@@ -28,6 +28,7 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.UnDefType;
+import org.openhab.core.util.ColorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,14 +145,12 @@ public class ColorValue extends Value {
                 return String.format(formatPattern, hsbState.getHue().intValue(), hsbState.getSaturation().intValue(),
                         hsbState.getBrightness().intValue());
             case RGB:
-                PercentType[] rgb = hsbState.toRGB();
-                return String.format(formatPattern, rgb[0].toBigDecimal().multiply(factor).intValue(),
-                        rgb[1].toBigDecimal().multiply(factor).intValue(),
-                        rgb[2].toBigDecimal().multiply(factor).intValue());
+                int[] rgb = ColorUtil.hsbToRgb(hsbState);
+                return String.format(formatPattern, rgb[0], rgb[1], rgb[2]);
             case XYY:
-                PercentType[] xyY = hsbState.toXY();
-                return String.format(Locale.ROOT, formatPattern, xyY[0].floatValue() / 100.0f,
-                        xyY[1].floatValue() / 100.0f, hsbState.getBrightness().floatValue());
+                double[] xyY = ColorUtil.hsbToXY(hsbState);
+                return String.format(Locale.ROOT, formatPattern, xyY[0], xyY[1],
+                        hsbState.getBrightness().doubleValue());
             default:
                 throw new NotSupportedException(String.format("Non supported color mode: {}", this.colorMode));
         }

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.generic;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,6 +50,7 @@ import org.openhab.binding.mqtt.generic.values.PercentageValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.Units;
@@ -248,7 +250,7 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("26,26,26"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
@@ -256,15 +258,14 @@ public class ChannelStateTests {
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("26,26,26"));
 
         HSBType t = HSBType.fromRGB(12, 18, 231);
 
         c.processMessage("state", "12,18,231".getBytes());
         assertThat(value.getChannelState(), is(t)); // HSB
-        // rgb -> hsv -> rgb is quite lossy
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("11,18,231"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$d,%2$d,%1$d"), is("231,18,11"));
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("12,18,231"));
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$d,%2$d,%1$d"), is("231,18,12"));
     }
 
     @Test
@@ -296,25 +297,39 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUIDMock, value, channelStateUpdateListenerMock));
         c.start(connectionMock, mock(ScheduledExecutorService.class), 100);
 
+        // incoming messages
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.322700,0.329000,10.00"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
-        assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.000000,0.000000,0.00"));
+        // note we don't care what color value is currently stored, just that brightness is off
+        assertThat(((HSBType) value.getChannelState()).getBrightness(), is(PercentType.ZERO));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.322700,0.329000,10.00"));
 
         HSBType t = ColorUtil.xyToHsb(new double[] { 0.3f, 0.6f });
-
         c.processMessage("state", "0.3,0.6,100".getBytes());
         assertTrue(((HSBType) value.getChannelState()).closeTo(t, 0.001)); // HSB
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.300000,0.599900,100.00"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$.1f,%2$.4f,%1$.4f"),
-                is("100.0,0.5999,0.3000"));
+
+        // outgoing messages
+        // these use the 0.3,0.6,100 from above, but care more about proper formatting of the outgoing message
+        // than about the precise value (since color conversions have happened)
+        assertCloseTo(value.getMQTTpublishValue((Command) value.getChannelState(), null), "0.300000,0.600000,100.00");
+        assertCloseTo(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$.1f,%2$.2f,%1$.2f"),
+                "100.0,0.60,0.30");
+    }
+
+    // also ensures the string elements are the same _length_, i.e. the correct precision for each element
+    private void assertCloseTo(String aString, String bString) {
+        String[] aElements = aString.split(",");
+        String[] bElements = bString.split(",");
+        double[] a = Arrays.stream(aElements).mapToDouble(Double::parseDouble).toArray();
+        double[] b = Arrays.stream(bElements).mapToDouble(Double::parseDouble).toArray();
+        for (int i = 0; i < a.length; i++) {
+            assertThat(aElements[i].length(), is(bElements[i].length()));
+            assertThat(a[i], closeTo(b[i], 0.002));
+        }
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -54,6 +54,7 @@ import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.Command;
+import org.openhab.core.util.ColorUtil;
 
 /**
  * Tests the {@link ChannelState} class.
@@ -262,8 +263,8 @@ public class ChannelStateTests {
         c.processMessage("state", "12,18,231".getBytes());
         assertThat(value.getChannelState(), is(t)); // HSB
         // rgb -> hsv -> rgb is quite lossy
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("11,18,232"));
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$d,%2$d,%1$d"), is("232,18,11"));
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("11,18,231"));
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$d,%2$d,%1$d"), is("231,18,11"));
     }
 
     @Test
@@ -307,13 +308,13 @@ public class ChannelStateTests {
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.322700,0.329000,10.00"));
 
-        HSBType t = HSBType.fromXY(0.3f, 0.6f);
+        HSBType t = ColorUtil.xyToHsb(new double[] { 0.3f, 0.6f });
 
         c.processMessage("state", "0.3,0.6,100".getBytes());
-        assertThat(value.getChannelState(), is(t)); // HSB
-        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.298700,0.601500,100.00"));
+        assertTrue(((HSBType) value.getChannelState()).closeTo(t, 0.001)); // HSB
+        assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), null), is("0.300000,0.599900,100.00"));
         assertThat(value.getMQTTpublishValue((Command) value.getChannelState(), "%3$.1f,%2$.4f,%1$.4f"),
-                is("100.0,0.6015,0.2987"));
+                is("100.0,0.5999,0.3000"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
@@ -41,6 +41,7 @@ import org.openhab.binding.mqtt.homeassistant.internal.HaID;
 import org.openhab.binding.mqtt.homeassistant.internal.HandlerConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.handler.HomeAssistantThingHandler;
+import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
@@ -173,7 +174,12 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
     @SuppressWarnings("null")
     protected static void assertState(AbstractComponent<@NonNull ? extends AbstractChannelConfiguration> component,
             String channelId, State state) {
-        assertThat(component.getChannel(channelId).getState().getCache().getChannelState(), is(state));
+        State actualState = component.getChannel(channelId).getState().getCache().getChannelState();
+        if ((actualState instanceof HSBType actualHsb) && (state instanceof HSBType stateHsb)) {
+            assertThat(actualHsb.closeTo(stateHsb, 0.01), is(true));
+        } else {
+            assertThat(actualState, is(state));
+        }
     }
 
     protected void spyOnChannelUpdates(AbstractComponent<@NonNull ? extends AbstractChannelConfiguration> component,
@@ -254,7 +260,7 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
 
     /**
      * Send command to a thing's channel
-     * 
+     *
      * @param component component
      * @param channelId channel
      * @param command command to send

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLightTests.java
@@ -137,7 +137,7 @@ public class DefaultSchemaLightTests extends AbstractComponentTests {
 
         // Brightness commands should route to the correct topic, converted to RGB
         sendCommand(component, Light.COLOR_CHANNEL_ID, new PercentType(50));
-        assertPublished("zigbee2mqtt/light/set/rgb", "127,127,127");
+        assertPublished("zigbee2mqtt/light/set/rgb", "128,128,128");
 
         // OnOff commands should route to the correct topic
         sendCommand(component, Light.COLOR_CHANNEL_ID, OnOffType.OFF);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
@@ -76,7 +76,7 @@ public class JSONSchemaLightTests extends AbstractComponentTests {
         publishMessage("zigbee2mqtt/light/state", "{ \"color\": {\"r\": 10, \"g\": 20, \"b\": 30 } }");
         assertState(component, Light.COLOR_CHANNEL_ID, HSBType.fromRGB(10, 20, 30));
         publishMessage("zigbee2mqtt/light/state", "{ \"brightness\": 255 }");
-        assertState(component, Light.COLOR_CHANNEL_ID, new HSBType("209.99999999999999,66.6666666666666700,100"));
+        assertState(component, Light.COLOR_CHANNEL_ID, new HSBType("210,67,100"));
 
         sendCommand(component, Light.COLOR_CHANNEL_ID, HSBType.BLUE);
         assertPublished("zigbee2mqtt/light/set/state",

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
@@ -76,7 +76,7 @@ public class JSONSchemaLightTests extends AbstractComponentTests {
         publishMessage("zigbee2mqtt/light/state", "{ \"color\": {\"r\": 10, \"g\": 20, \"b\": 30 } }");
         assertState(component, Light.COLOR_CHANNEL_ID, HSBType.fromRGB(10, 20, 30));
         publishMessage("zigbee2mqtt/light/state", "{ \"brightness\": 255 }");
-        assertState(component, Light.COLOR_CHANNEL_ID, new HSBType("210,67,100"));
+        assertState(component, Light.COLOR_CHANNEL_ID, new HSBType("209.99999999999999,66.6666666666666700,100"));
 
         sendCommand(component, Light.COLOR_CHANNEL_ID, HSBType.BLUE);
         assertPublished("zigbee2mqtt/light/set/state",

--- a/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/TradfriColorTest.java
+++ b/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/TradfriColorTest.java
@@ -36,7 +36,7 @@ public class TradfriColorTest {
         HSBType hsbType = color.getHSB();
         assertNotNull(hsbType);
         assertEquals(312, hsbType.getHue().intValue());
-        assertEquals(92, hsbType.getSaturation().intValue());
+        assertEquals(91, hsbType.getSaturation().intValue());
         assertEquals(100, hsbType.getBrightness().intValue());
     }
 
@@ -48,7 +48,7 @@ public class TradfriColorTest {
         assertEquals(84, (int) color.brightness);
         HSBType hsbType = color.getHSB();
         assertNotNull(hsbType);
-        assertEquals(93, hsbType.getHue().intValue());
+        assertEquals(92, hsbType.getHue().intValue());
         assertEquals(65, hsbType.getSaturation().intValue());
         assertEquals(34, hsbType.getBrightness().intValue());
     }
@@ -61,7 +61,7 @@ public class TradfriColorTest {
         assertEquals(1, (int) color.brightness);
         HSBType hsbType = color.getHSB();
         assertNotNull(hsbType);
-        assertEquals(93, hsbType.getHue().intValue());
+        assertEquals(92, hsbType.getHue().intValue());
         assertEquals(65, hsbType.getSaturation().intValue());
         assertEquals(1, hsbType.getBrightness().intValue());
     }
@@ -75,7 +75,7 @@ public class TradfriColorTest {
         HSBType hsbType = color.getHSB();
         assertNotNull(hsbType);
         assertEquals(156, hsbType.getHue().intValue());
-        assertEquals(77, hsbType.getSaturation().intValue());
+        assertEquals(76, hsbType.getSaturation().intValue());
         assertEquals(72, hsbType.getBrightness().intValue());
     }
 

--- a/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/link/WebthingChannelLinkTest.java
+++ b/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/link/WebthingChannelLinkTest.java
@@ -140,8 +140,8 @@ public class WebthingChannelLinkTest {
         performDataTypeMappingTest("targettemp_prop", 18.6, new DecimalType(18.6), 23.2, new DecimalType(23.2));
         performDataTypeMappingTest("open_prop", true, OpenClosedType.OPEN, false, OpenClosedType.CLOSED);
         performDataTypeMappingTest("colortemp_prop", 10, new PercentType(10), 60, new PercentType(60));
-        performDataTypeMappingTest("color_prop", "#f2fe00", new HSBType("62.834645669291325,100,99.60784313725490"),
-                "#ff0000", new HSBType("0.0,100.0,100.0"));
+        performDataTypeMappingTest("color_prop", "#f2fe00", new HSBType("63,100,100"), "#ff0000",
+                new HSBType("0.0,100.0,100.0"));
         performDataTypeMappingTest("colormode_prop", "color", new StringType("color"), "temperature",
                 new StringType("temperature"));
         performDataTypeMappingTest("brightness_prop", 33, new PercentType(33), 65, new PercentType(65));

--- a/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/link/WebthingChannelLinkTest.java
+++ b/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/link/WebthingChannelLinkTest.java
@@ -140,8 +140,8 @@ public class WebthingChannelLinkTest {
         performDataTypeMappingTest("targettemp_prop", 18.6, new DecimalType(18.6), 23.2, new DecimalType(23.2));
         performDataTypeMappingTest("open_prop", true, OpenClosedType.OPEN, false, OpenClosedType.CLOSED);
         performDataTypeMappingTest("colortemp_prop", 10, new PercentType(10), 60, new PercentType(60));
-        performDataTypeMappingTest("color_prop", "#f2fe00", new HSBType("63,100,100"), "#ff0000",
-                new HSBType("0.0,100.0,100.0"));
+        performDataTypeMappingTest("color_prop", "#f2fe00", new HSBType("62.834645669291325,100,99.60784313725490"),
+                "#ff0000", new HSBType("0.0,100.0,100.0"));
         performDataTypeMappingTest("colormode_prop", "color", new StringType("color"), "temperature",
                 new StringType("temperature"));
         performDataTypeMappingTest("brightness_prop", 33, new PercentType(33), 65, new PercentType(65));

--- a/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/link/WebthingChannelLinkTest.java
+++ b/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/link/WebthingChannelLinkTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.webthing.internal.link;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
@@ -185,7 +185,12 @@ public class WebthingChannelLinkTest {
         message.data = Map.of(propertyName, initialValue);
         websocketConnectionFactory.webSocketRef.get().sendToClient(message);
 
-        assertEquals(initialState, testWebthingThingHandler.itemState.get(channelUID));
+        Command actualState = testWebthingThingHandler.itemState.get(channelUID);
+        if ((actualState instanceof HSBType actualHsb) && (initialState instanceof HSBType initialStateHsb)) {
+            assertTrue(actualHsb.closeTo(initialStateHsb, 0.01));
+        } else {
+            assertEquals(initialState, actualState);
+        }
 
         ChannelToPropertyLink.establish(testWebthingThingHandler, channel, webthing, propertyName);
         testWebthingThingHandler.listeners.get(channelUID).onItemStateChanged(channelUID, updatedState);


### PR DESCRIPTION
Adapt tests due to https://github.com/openhab/openhab-core/pull/3542.
To be merged after core change.

This PR fixes the broken tests after core change for now, but especially the tests checking for double valued numbers should be changed to allow small differences between colors (e.g. a deviation of 0.5% due to color conversions),