### PR TITLE
[openwebnet] Add a time stamp when an alarm zone event occurs

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -228,6 +228,7 @@ OPEN command to execute: *5*8#134##
 | `battery`                    | `bus_alarm_system`                     | String      | Alarm system battery state (`OK`, `FAULT`, `UNLOADED`)                |      R      |
 | `armed`                      | `bus_alarm_system`                     | Switch      | Alarm system is armed (`ON`) or disarmed (`OFF`)                      |      R      |
 | `alarm`                      | `bus_alarm_zone`                       | String      | Current alarm for the zone  (`SILENT`, `INTRUSION`, `TAMPERING`, `ANTI_PANIC`) |      R      |
+| `timestamp`                  | `bus_alarm_zone`                       | DateTime  | Current date and time of the zone's alarm event (YY/MM/DD hh:mm:ss)   |      R      |
 
 ### Thermo channels
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -173,6 +173,7 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_ALARM_SYSTEM_BATTERY = "battery";
     public static final String CHANNEL_ALARM_ZONE_STATE = "state";
     public static final String CHANNEL_ALARM_ZONE_ALARM = "alarm";
+    public static final String CHANNEL_ALARM_ZONE_ALARM_TIMESTAMP = "timestamp";
 
     // devices config properties
     public static final String CONFIG_PROPERTY_WHERE = "where";

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAlarmHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetAlarmHandler.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
+import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
  * {@link OpenWebNetThingHandler}.
  *
  * @author Massimo Valla - Initial contribution
+ * @author Giovanni Fabiani - Add zone alarm's tismestamp feature
  */
 @NonNullByDefault
 public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
@@ -79,6 +81,8 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
             // initially set zone alarm to NONE (it will be set if specific alarm message is
             // received)
             updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_NONE));
+            // initializing timestamp
+            updateState(CHANNEL_ALARM_ZONE_ALARM_TIMESTAMP, new DateTimeType());
         }
     }
 
@@ -122,7 +126,7 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
                 send(Alarm.requestSystemStatus());
                 lastAllDevicesRefreshTS = System.currentTimeMillis();
             } catch (OWNException e) {
-                logger.warn("Excpetion while requesting alarm system status: {}", e.getMessage());
+                logger.warn("Exception while requesting alarm system status: {}", e.getMessage());
             }
         } else {
             logger.debug("--- refreshDevice() : refreshing SINGLE... ({})", thing.getUID());
@@ -218,6 +222,7 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
             case ZONE_ALARM_TECHNICAL:
             case ZONE_ALARM_TECHNICAL_RESET:
                 updateZoneAlarm(w);
+                updateState(CHANNEL_ALARM_ZONE_ALARM_TIMESTAMP, new DateTimeType());
                 break;
             default:
                 logger.debug("Alarm.updateZone() Ignoring unsupported WHAT {}. Frame={}", msg.getWhat(), msg);
@@ -257,6 +262,7 @@ public class OpenWebNetAlarmHandler extends OpenWebNetThingHandler {
     private void resetAllZonesAlarmState() {
         for (OpenWebNetAlarmHandler h : zoneHandlers) {
             h.updateState(CHANNEL_ALARM_ZONE_ALARM, new StringType(ALARM_NONE));
+            h.updateState(CHANNEL_ALARM_ZONE_ALARM_TIMESTAMP, new DateTimeType());
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -285,6 +285,8 @@ channel-type.openwebnet.zoneAlarm.state.option.SILENT = Silent
 channel-type.openwebnet.zoneAlarm.state.option.TECHNICAL = Technical
 channel-type.openwebnet.zoneAlarm.state.option.TECHNICAL_RESET = Technical Reset
 channel-type.openwebnet.zoneAlarm.state.option.NONE = None
+channel-type.openwebnet.zoneAlarmTimestamp.label = Zone Alarm Timestamp
+channel-type.openwebnet.zoneAlarmTimestamp.description = Current alarm's timestamp for the zone (read only).
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAlarmZone.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAlarmZone.xml
@@ -17,12 +17,14 @@
 			<!-- read only -->
 			<channel id="state" typeId="alarmZoneState"/>
 			<channel id="alarm" typeId="zoneAlarm"/>
+			<channel id="timestamp" typeId="zoneAlarmTimestamp"/>
 		</channels>
 
 		<properties>
 			<property name="vendor">BTicino/Legrand</property>
 			<property name="model">Alarm zone as configured in the Alarm System Unit</property>
 			<property name="ownDeviceType">5200</property>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 
 		<representation-property>ownId</representation-property>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -461,6 +461,15 @@
 		</state>
 	</channel-type>
 
+	<channel-type id="zoneAlarmTimestamp">
+		<item-type>DateTime</item-type>
+		<label>Zone Alarm Timestamp</label>
+		<description>Current alarm's timestamp for the zone (read only).</description>
+		<category>Time</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+
 	<channel-type id="alarmZoneState">
 		<item-type>Switch</item-type>
 		<label>Alarm Zone State</label>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/update/update.xml
@@ -1,0 +1,13 @@
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="openwebnet:bus_alarm_zone">
+		<instruction-set targetVersion="1">
+			<add-channel id="timestamp">
+				<type>openwebnet:zoneAlarmTimestamp</type>
+			</add-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
**Description:**
This PR allows to show a time stamp when an alarm zone event occurs on Bticino/Legrand Alarm systems such as an Intrusion or a Tampering This PR closes #14535

**Test**
Tested on BTicino/Legrand bulgrar-alarm unit 3486