### PR TITLE
[mqtt.homeassistant] Support color temp on JSON schema lights

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -75,20 +75,19 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
 
     public JSONSchemaLight(ComponentFactory.ComponentConfiguration builder) {
         super(builder);
+        colorModeValue = new TextValue();
+    }
+
+    @Override
+    protected void buildChannels() {
         List<LightColorMode> supportedColorModes = channelConfiguration.supportedColorModes;
         if (supportedColorModes != null && supportedColorModes.contains(LightColorMode.COLOR_MODE_COLOR_TEMP)) {
             colorModeValue = new TextValue(
                     supportedColorModes.stream().map(LightColorMode::serializedName).toArray(String[]::new));
             buildChannel(COLOR_MODE_CHANNEL_ID, colorModeValue, "Color Mode", this).isAdvanced(true).build();
-        } else {
-            colorModeValue = new TextValue();
         }
-    }
 
-    @Override
-    protected void buildChannels() {
         if (channelConfiguration.colorMode) {
-            List<LightColorMode> supportedColorModes = channelConfiguration.supportedColorModes;
             if (supportedColorModes == null || channelConfiguration.supportedColorModes.isEmpty()) {
                 throw new UnsupportedComponentException("JSON schema light with color modes '" + getHaID()
                         + "' does not define supported_color_modes!");

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/LightColorMode.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/LightColorMode.java
@@ -61,4 +61,13 @@ public enum LightColorMode {
     public static boolean hasRGB(List<LightColorMode> supportedColorModes) {
         return WITH_RGB.stream().anyMatch(cm -> supportedColorModes.contains(cm));
     }
+
+    public String serializedName() {
+        try {
+            return LightColorMode.class.getDeclaredField(toString()).getAnnotation(SerializedName.class).value();
+        } catch (NoSuchFieldException e) {
+            // can't happen
+            return "";
+        }
+    }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/LightColorMode.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/LightColorMode.java
@@ -67,7 +67,7 @@ public enum LightColorMode {
             return LightColorMode.class.getDeclaredField(toString()).getAnnotation(SerializedName.class).value();
         } catch (NoSuchFieldException e) {
             // can't happen
-            return "";
+            throw new IllegalStateException(e);
         }
     }
 }


### PR DESCRIPTION
also adds a color_mode channel if color temp is possible, so you can know how the bulb is behaving

