### PR TITLE
Upgrade maven-surefire-plugin to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0</version>
           <configuration>
             <argLine>
               --add-opens java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
This fixes deprecation warnings when runnings tests with Maven 3.9.x:

`[WARNING] Parameter 'localRepository' is deprecated core expression; Avoid use of ArtifactRepository type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.`

See: https://issues.apache.org/jira/browse/SUREFIRE-2154

Related to openhab/openhab-core#3512