### PR TITLE
[renault] update default Kamereon API Key

### DIFF
--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/RenaultConfiguration.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/RenaultConfiguration.java
@@ -28,5 +28,5 @@ public class RenaultConfiguration {
     public String vin = "";
     public int refreshInterval = 10;
     public int updateDelay = 30;
-    public String kamereonApiKey = "VAX7XYKGfa92yMvXculCkEFyfZbuM7Ss";
+    public String kamereonApiKey = "YjkKtHmGfaceeuExUDKGxrLZGGvtVS0J";
 }

--- a/bundles/org.openhab.binding.renault/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.renault/src/main/resources/OH-INF/thing/thing-types.xml
@@ -94,7 +94,7 @@
 			<parameter name="kamereonApiKey" type="text">
 				<label>Kamereon API Key</label>
 				<description>Access code for MyRenault Services.</description>
-				<default>VAX7XYKGfa92yMvXculCkEFyfZbuM7Ss</default>
+				<default>YjkKtHmGfaceeuExUDKGxrLZGGvtVS0J</default>
 			</parameter>
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
# Update default Kamereon API Key in Renault binding

The API key used in the Renault binding to access the MyRenault services changes sometimes...  This can be updated in the bindings configuration to repair communication of existing installations.

This PR updates the default key to the new one for new installations.