### PR TITLE
[mqtt.homeassistant] don't set range on current temp channel

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -232,9 +232,8 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
                 channelConfiguration.awayModeStateTopic, commandFilter);
 
         buildOptionalChannel(CURRENT_TEMPERATURE_CH_ID,
-                new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp, precision,
-                        channelConfiguration.temperatureUnit.getUnit()),
-                updateListener, null, null, channelConfiguration.currentTemperatureTemplate,
+                new NumberValue(null, null, precision, channelConfiguration.temperatureUnit.getUnit()), updateListener,
+                null, null, channelConfiguration.currentTemperatureTemplate,
                 channelConfiguration.currentTemperatureTopic, commandFilter);
 
         buildOptionalChannel(FAN_MODE_CH_ID, new TextValue(channelConfiguration.fanModes.toArray(new String[0])),


### PR DESCRIPTION
the min/max from the config are specifically only for the set point. i.e. for a heater in winter when the heater is off, it may have a set point range of 65-104°F, but if it's off for an unoccopied room the ambient temperature might drop far below 65