### PR TITLE
[ipcamera] Fix servlet exceptions due to non unique names

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/IpCameraServlet.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/IpCameraServlet.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.Properties;
 
 import javax.servlet.ServletOutputStream;
@@ -59,6 +60,8 @@ public abstract class IpCameraServlet extends HttpServlet {
 
     public void startListening() {
         try {
+            Hashtable<Object, Object> initParameters = new Hashtable<>();
+            initParameters.put("servlet-name", "/ipcamera/" + handler.getThing().getUID().getId());
             httpService.registerServlet("/ipcamera/" + handler.getThing().getUID().getId(), this, initParameters,
                     httpService.createDefaultHttpContext());
         } catch (Exception e) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/IpCameraServlet.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/IpCameraServlet.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Dictionary;
-import java.util.Hashtable;
 import java.util.Properties;
 
 import javax.servlet.ServletOutputStream;
@@ -60,7 +59,6 @@ public abstract class IpCameraServlet extends HttpServlet {
 
     public void startListening() {
         try {
-            Hashtable<Object, Object> initParameters = new Hashtable<>();
             initParameters.put("servlet-name", "/ipcamera/" + handler.getThing().getUID().getId());
             httpService.registerServlet("/ipcamera/" + handler.getThing().getUID().getId(), this, initParameters,
                     httpService.createDefaultHttpContext());


### PR DESCRIPTION
[IP camera] on OH4 has the same servlet issue that was fixed by PR #14554.  This PR uses that PR as a template to fix the issue in the IPcamera binding.  (That issue being that only one camera was able to stream.) This was tested locally on OH4M2 and it works.  Also the referenced PR worked with [neeo] and this used that PR as a template.

Signed-off-by: Bob Eckhoff  <katmandodo@yahoo.com>