### PR TITLE
[ecovacs] Allow loading device descriptions from a user file

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/README.md
+++ b/bundles/org.openhab.binding.ecovacs/README.md
@@ -173,3 +173,20 @@ Bridge ecovacs:ecovacsapi:ecovacsapi [ email="your.email@provider.com", password
 }
 ```
 
+## Adding support for unsupported models
+
+When encountering an unsupported model during discovery, the binding creates a log message like this one:
+
+```
+2023-04-21 12:02:39.607 [INFO ] [acs.internal.api.impl.EcovacsApiImpl] - Found unsupported device DEEBOT N8 PRO CARE (class s1f8g7, company eco-ng), ignoring.
+```
+
+In such a case, please [create an issue on GitHub](https://github.com/openhab/openhab-addons/issues), listing the contents of the log line.
+In addition to that, If the model is similar to an already supported one, you can try to add the support for yourself (until getting an updated binding).
+For doing so, you can follow the following steps:
+
+- in the `<OPENHAB_USERDATA>/evocacs` folder, create a file named `custom_device_descs.json`
+- the format of that file is the same as [the built-in device list](https://raw.githubusercontent.com/openhab/openhab-addons/main/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json)
+- for a model that is very similar to an existing one, create an entry with `modelName`, `deviceClass` (from the log line) and `deviceClassLink` (`deviceClass` of the similar model)
+- for other models, you can also try experimenting with creating a full entry, but it's likely that the binding code will need to be updated in that case
+

--- a/bundles/org.openhab.binding.ecovacs/README.md
+++ b/bundles/org.openhab.binding.ecovacs/README.md
@@ -182,11 +182,11 @@ When encountering an unsupported model during discovery, the binding creates a l
 ```
 
 In such a case, please [create an issue on GitHub](https://github.com/openhab/openhab-addons/issues), listing the contents of the log line.
-In addition to that, If the model is similar to an already supported one, you can try to add the support yourself (until getting an updated binding).
+In addition to that, if the model is similar to an already supported one, you can try to add the support yourself (until getting an updated binding).
 For doing so, you can follow the following steps:
 
-- in the `<OPENHAB_USERDATA>/evocacs` folder, create a file named `custom_device_descs.json`
-- the format of that file is the same as [the built-in device list](https://raw.githubusercontent.com/openhab/openhab-addons/main/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json)
+- create the folder `<OPENHAB_USERDATA>/evocacs` (if not done previously)
+- create a file named `custom_device_descs.json`, whose format of that file is the same as [the built-in device list](https://raw.githubusercontent.com/openhab/openhab-addons/main/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json)
 - for a model that is very similar to an existing one, create an entry with `modelName`, `deviceClass` (from the log line) and `deviceClassLink` (`deviceClass` of the similar model)
 - for other models, you can also try experimenting with creating a full entry, but it's likely that the binding code will need to be updated in that case
 

--- a/bundles/org.openhab.binding.ecovacs/README.md
+++ b/bundles/org.openhab.binding.ecovacs/README.md
@@ -182,7 +182,7 @@ When encountering an unsupported model during discovery, the binding creates a l
 ```
 
 In such a case, please [create an issue on GitHub](https://github.com/openhab/openhab-addons/issues), listing the contents of the log line.
-In addition to that, If the model is similar to an already supported one, you can try to add the support for yourself (until getting an updated binding).
+In addition to that, If the model is similar to an already supported one, you can try to add the support yourself (until getting an updated binding).
 For doing so, you can follow the following steps:
 
 - in the `<OPENHAB_USERDATA>/evocacs` folder, create a file named `custom_device_descs.json`

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsApiImpl.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsApiImpl.java
@@ -210,11 +210,11 @@ public final class EcovacsApiImpl implements EcovacsApi {
             try (Reader reader = Files.newBufferedReader(customDescsPath)) {
                 int builtins = descs.size();
                 for (DeviceDescription desc : loadSupportedDeviceData(reader)) {
-                    if (descs.containsKey(desc.deviceClass)) {
+                    DeviceDescription builtinDesc = descs.put(desc.deviceClass, desc);
+                    if (builtinDesc != null) {
                         logger.trace("Overriding built-in description for {} with custom description",
                                 desc.deviceClass);
                     }
-                    descs.put(desc.deviceClass, desc);
                 }
                 logger.trace("Loaded {} custom device descriptions", descs.size() - builtins);
             } catch (IOException | JsonSyntaxException e) {

--- a/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json
+++ b/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json
@@ -304,6 +304,11 @@
         "deviceClass": "yu362x",
         "deviceClassLink": "h18jkh"
     },
+    {
+        "modelName": "DEEBOT N8 PRO CARE",
+        "deviceClass": "s1f8g7",
+        "deviceClassLink": "h18jkh"
+    },
 
     {
         "modelName": "DEEBOT OZMO T8+",


### PR DESCRIPTION
If a new device is released within our release cycle, getting the description for that device into the binding was impossible for users before. With this change, they can create an override file in their installation (with contents we'll need to supply to them), which serves as a stop-gap solution until the next OH release.

Additionally, add the definition for the device that triggered this change to the supported device list.
