### PR TITLE
[jdbc] Upgrade MySQL Connector/J to 8.0.33

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -13,7 +13,7 @@ The following databases are currently supported and tested:
 | [H2](https://www.h2database.com/)            | [h2-1.4.191.jar](https://mvnrepository.com/artifact/com.h2database/h2) |
 | [HSQLDB](http://hsqldb.org/)                 | [hsqldb-2.3.3.jar](https://mvnrepository.com/artifact/org.hsqldb/hsqldb) |
 | [MariaDB](https://mariadb.org/)              | [mariadb-java-client-3.0.8.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client) |
-| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-8.0.31.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j) |
+| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-8.0.33.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j) |
 | [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.4.3.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
 | [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.16.1.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
 | [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.4.3.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -34,7 +34,7 @@
 	<feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/8.0.31</bundle>
+		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/8.0.33</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -330,7 +330,7 @@ public class JdbcConfiguration {
                         warn += "\tMariaDB:   version >= 3.0.8 from              https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client\n";
                         break;
                     case "mysql":
-                        warn += "\tMySQL:     version >= 8.0.31 from             https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
+                        warn += "\tMySQL:     version >= 8.0.33 from             https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
                         break;
                     case "postgresql":
                         warn += "\tPostgreSQL:version >= 42.4.3 from             https://mvnrepository.com/artifact/org.postgresql/postgresql\n";


### PR DESCRIPTION
Release notes:
- https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-32.html
- https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-33.html

Fixes vulnerabilities from dependencies:
- [CVE-2022-3510](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3510)
- [CVE-2022-3509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3509)
- [CVE-2022-3171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171)

Library:
- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.0.33

Tested by installing compiled bundle as well as mysql-connector into addons directory:
```
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        24-04-2023     21:21        2481560 mysql-connector-j.jar
-a----        24-04-2023     21:20         346593 org.openhab.persistence.jdbc-4.0.0-SNAPSHOT.jar
```

Then checking in database that items are persisted after the upgrade.

Previous upgrade: #13991