### PR TITLE
[mqtt.espmilighthub] Fix things do not come ONLINE if MQTT Client Status Topic not supplied.

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -42,6 +42,9 @@ Leave this blank.
 **mqtt_state_topic_pattern:**
 `milight/states/:device_id/:device_type/:group_id`
 
+**MQTT Client Status Topic:**
+`milight/status`
+
 **group_state_fields:**
 IMPORTANT: Make sure only the following are ticked:
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -537,8 +537,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttMessag
                 return;
             }
             this.connection = connection;
-            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NOT_YET_READY,
-                    "Waiting for 'milight/status: connected' MQTT message to be recieved. Check hub has 'MQTT Client Status Topic' configured.");
+            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.CONFIGURATION_PENDING,
+                    "Waiting for 'milight/status: connected' MQTT message to be received. Check hub has 'MQTT Client Status Topic' configured.");
             connection.subscribe(fullStatesTopic, this);
             connection.subscribe(STATUS_TOPIC, this);
         }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -537,6 +537,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttMessag
                 return;
             }
             this.connection = connection;
+            updateStatus(ThingStatus.INITIALIZING, ThingStatusDetail.CONFIGURATION_PENDING,
+                    "Waiting for 'milight/status: connected' MQTT message to be recieved. Check hub has 'MQTT Client Status Topic' configured.");
             connection.subscribe(fullStatesTopic, this);
             connection.subscribe(STATUS_TOPIC, this);
         }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -487,7 +487,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttMessag
                 updateStatus(ThingStatus.ONLINE);
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Milight Hub is not connected to your MQTT broker.");
+                        "Waiting for 'milight/status: connected' MQTT message to be sent from your ESP Milight hub.");
             }
         } else {
             try {
@@ -537,7 +537,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttMessag
                 return;
             }
             this.connection = connection;
-            updateStatus(ThingStatus.INITIALIZING, ThingStatusDetail.CONFIGURATION_PENDING,
+            updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NOT_YET_READY,
                     "Waiting for 'milight/status: connected' MQTT message to be recieved. Check hub has 'MQTT Client Status Topic' configured.");
             connection.subscribe(fullStatesTopic, this);
             connection.subscribe(STATUS_TOPIC, this);


### PR DESCRIPTION
Added the extra needed steps to the readme file and also helpful thing status messages to guide a user on what is now needed after PR #13800

Without doing extra setup steps, the last PR has caused all the things to stay on initializing status as the connected MQTT message that is needed never gets received.

Signed-off-by: Matthew Skinner <matt@pcmus.com>