### PR TITLE
[sleepiq] Restore type adapter for LocalDate

### DIFF
--- a/bundles/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/api/dto/SleepDataSession.java
+++ b/bundles/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/api/dto/SleepDataSession.java
@@ -21,7 +21,7 @@ import com.google.gson.annotations.SerializedName;
  */
 public class SleepDataSession {
 
-    @SerializedName("avgSleepIQ")
+    @SerializedName("sleepQuotient")
     private Integer sessionAverageSleepIQ;
 
     @SerializedName("avgHeartRate")

--- a/bundles/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/api/impl/GsonGenerator.java
+++ b/bundles/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/api/impl/GsonGenerator.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.sleepiq.internal.api.impl;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -28,6 +29,7 @@ import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.FoundationOutl
 import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.FoundationOutletTypeAdapter;
 import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.FoundationPositionTypeAdapter;
 import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.FoundationPresetTypeAdapter;
+import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.LocalDateTypeAdapter;
 import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.SideTypeAdapter;
 import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.SleepNumberRequestAdapter;
 import org.openhab.binding.sleepiq.internal.api.impl.typeadapters.TimeSinceTypeAdapter;
@@ -50,6 +52,7 @@ public class GsonGenerator {
     public static Gson create(boolean prettyPrint) {
         GsonBuilder builder = new GsonBuilder();
         builder.registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeTypeAdapter());
+        builder.registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter());
         builder.registerTypeAdapter(TimeSince.class, new TimeSinceTypeAdapter());
         builder.registerTypeAdapter(SleepNumberRequest.class, new SleepNumberRequestAdapter());
         builder.registerTypeAdapter(Side.class, new SideTypeAdapter());

--- a/bundles/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/api/impl/typeadapters/LocalDateTypeAdapter.java
+++ b/bundles/org.openhab.binding.sleepiq/src/main/java/org/openhab/binding/sleepiq/internal/api/impl/typeadapters/LocalDateTypeAdapter.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.sleepiq.internal.api.impl.typeadapters;
+
+import java.time.LocalDate;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Type adapter for jsr310 {@link LocalDate} class.
+ *
+ * @author Christophe Bornet - Initial contribution
+ */
+@NonNullByDefault
+public class LocalDateTypeAdapter extends TemporalTypeAdapter<LocalDate> {
+
+    public LocalDateTypeAdapter() {
+        super(LocalDate::parse);
+    }
+}


### PR DESCRIPTION
This type adapter was mistakenly deleted when I migrated the 3rd party code to openHAB in PR #14180

Also fix name of json object in `SleepDataSession` dto.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
