### PR TITLE
[mapdb] Make serialization asynchronous

### DIFF
--- a/bundles/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/MapDbPersistenceService.java
+++ b/bundles/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/MapDbPersistenceService.java
@@ -73,7 +73,9 @@ public class MapDbPersistenceService implements QueryablePersistenceService {
 
     private final ExecutorService threadPool = ThreadPoolManager.getPool(getClass().getSimpleName());
 
-    /** holds the local instance of the MapDB database */
+    /**
+     * holds the local instance of the MapDB database
+     */
 
     private @NonNullByDefault({}) DB db;
     private @NonNullByDefault({}) Map<String, String> map;
@@ -182,12 +184,12 @@ public class MapDbPersistenceService implements QueryablePersistenceService {
         mItem.setName(localAlias);
         mItem.setState(state);
         mItem.setTimestamp(new Date());
-        String json = serialize(mItem);
-        map.put(localAlias, json);
-        commit();
-        if (logger.isDebugEnabled()) {
+        threadPool.submit(() -> {
+            String json = serialize(mItem);
+            map.put(localAlias, json);
+            db.commit();
             logger.debug("Stored '{}' with state '{}' as '{}' in MapDB database", localAlias, state, json);
-        }
+        });
     }
 
     @Override
@@ -215,10 +217,6 @@ public class MapDbPersistenceService implements QueryablePersistenceService {
         }
 
         return Optional.of(item);
-    }
-
-    private void commit() {
-        threadPool.submit(() -> db.commit());
     }
 
     private static <T> Stream<T> streamOptional(Optional<T> opt) {

--- a/itests/org.openhab.persistence.mapdb.tests/src/main/java/org/openhab/persistence/mapdb/MapDbPersistenceServiceOSGiTest.java
+++ b/itests/org.openhab.persistence.mapdb.tests/src/main/java/org/openhab/persistence/mapdb/MapDbPersistenceServiceOSGiTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,9 @@ public class MapDbPersistenceServiceOSGiTest extends JavaOSGiTest {
     private static void removeDirRecursive(final String dir) throws IOException {
         final Path path = Paths.get(dir);
         if (Files.exists(path)) {
-            Files.walk(path).map(Path::toFile).sorted().forEach(File::delete);
+            try (Stream<Path> stream = Files.walk(path)) {
+                stream.map(Path::toFile).sorted().forEach(File::delete);
+            }
         }
     }
 
@@ -79,12 +82,12 @@ public class MapDbPersistenceServiceOSGiTest extends JavaOSGiTest {
 
         persistenceService.store(item);
 
-        assertThat(persistenceService.getItemInfo(), hasItem(hasProperty("name", equalTo(name))));
+        waitForAssert(() -> assertThat(persistenceService.getItemInfo(), hasItem(hasProperty("name", equalTo(name)))));
 
         persistenceService.store(item, alias);
 
-        assertThat(persistenceService.getItemInfo(),
-                hasItems(hasProperty("name", equalTo(name)), hasProperty("name", equalTo(alias))));
+        waitForAssert(() -> assertThat(persistenceService.getItemInfo(),
+                hasItems(hasProperty("name", equalTo(name)), hasProperty("name", equalTo(alias)))));
     }
 
     @Test
@@ -102,8 +105,8 @@ public class MapDbPersistenceServiceOSGiTest extends JavaOSGiTest {
 
         persistenceService.store(item);
 
-        assertThat(persistenceService.query(filter),
-                contains(allOf(hasProperty("name", equalTo(name)), hasProperty("state", equalTo(state)))));
+        waitForAssert(() -> assertThat(persistenceService.query(filter),
+                contains(allOf(hasProperty("name", equalTo(name)), hasProperty("state", equalTo(state))))));
     }
 
     @Test
@@ -127,7 +130,7 @@ public class MapDbPersistenceServiceOSGiTest extends JavaOSGiTest {
         persistenceService.store(item, alias);
 
         assertThat(persistenceService.query(filterByName), is(emptyIterable()));
-        assertThat(persistenceService.query(filterByAlias),
-                contains(allOf(hasProperty("name", equalTo(alias)), hasProperty("state", equalTo(state)))));
+        waitForAssert(() -> assertThat(persistenceService.query(filterByAlias),
+                contains(allOf(hasProperty("name", equalTo(alias)), hasProperty("state", equalTo(state))))));
     }
 }


### PR DESCRIPTION
Fixes #14899 

The serialization was done synchronously. Calls to GSON are time-consuming and should therefore be done asynchronously to allow `.store` to return fast.