### PR TITLE
Nanoleaf codeowners change

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -223,7 +223,7 @@
 /bundles/org.openhab.binding.mynice/ @clinique
 /bundles/org.openhab.binding.myq/ @digitaldan
 /bundles/org.openhab.binding.mystrom/ @pail23
-/bundles/org.openhab.binding.nanoleaf/ @raepple @stefan-hoehn
+/bundles/org.openhab.binding.nanoleaf/ @stefan-hoehn
 /bundles/org.openhab.binding.neato/ @jjlauterbach
 /bundles/org.openhab.binding.neeo/ @tmrobert8
 /bundles/org.openhab.binding.neohub/ @andrewfg


### PR DESCRIPTION
mraepple was the original contributor of the nanoleaf addon but hasn't been active for around 2 years now. Keeping him part of the codeowners leads to him being asked as a reviewer for every PR while he never responded for that in the past. 
I am still grateful that he originally created the addon but I would now like to take him out of the codeowners.