### PR TITLE
[hue] Fix discovery label consistency

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -101,7 +101,9 @@ public class HueBindingConstants {
 
     public static final String NORMALIZE_ID_REGEX = "[^a-zA-Z0-9_]";
 
-    //
+    public static final String DISCOVERY_LABEL_PATTERN = "Philips Hue (%s)";
+
+    // I18N string references
     public static final String TEXT_OFFLINE_COMMUNICATION_ERROR = "@text/offline.communication-error";
     public static final String TEXT_OFFLINE_CONFIGURATION_ERROR_INVALID_SSL_CERIFICATE = "@text/offline.conf-error-invalid-ssl-certificate";
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeMDNSDiscoveryParticipant.java
@@ -107,7 +107,7 @@ public class HueBridgeMDNSDiscoveryParticipant implements MDNSDiscoveryParticipa
             if (uid != null) {
                 String host = service.getHostAddresses()[0];
                 String id = service.getPropertyString(MDNS_PROPERTY_BRIDGE_ID);
-                String friendlyName = String.format("%s (%s)", service.getName(), host);
+                String friendlyName = String.format(DISCOVERY_LABEL_PATTERN, host);
                 return DiscoveryResultBuilder.create(uid) //
                         .withProperties(Map.of( //
                                 HOST, host, //

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -49,10 +49,10 @@ import com.google.gson.reflect.TypeToken;
 @NonNullByDefault
 public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
 
-    private static final String MODEL_NAME_PHILIPS_HUE = "\"name\":\"Philips hue\"";
     protected static final String BRIDGE_INDICATOR = "fffe";
+
+    private static final String MODEL_NAME_PHILIPS_HUE = "\"name\":\"Philips hue\"";
     private static final String DISCOVERY_URL = "https://discovery.meethue.com/";
-    protected static final String LABEL_PATTERN = "Philips Hue (%s)";
     private static final String CONFIG_URL_PATTERN = "http://%s/api/0/config";
     private static final int REQUEST_TIMEOUT = 5000;
     private static final int DISCOVERY_TIMEOUT = 10;
@@ -81,7 +81,7 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
                         .withProperties(Map.of( //
                                 HOST, host, //
                                 Thing.PROPERTY_SERIAL_NUMBER, serialNumber)) //
-                        .withLabel(String.format(LABEL_PATTERN, host)) //
+                        .withLabel(String.format(DISCOVERY_LABEL_PATTERN, host)) //
                         .withRepresentationProperty(Thing.PROPERTY_SERIAL_NUMBER) //
                         .build();
                 thingDiscovered(result);

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.hue.internal.HueBindingConstants;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -61,7 +62,7 @@ public class HueBridgeNupnpDiscoveryOSGITest extends JavaOSGiTest {
 
     private void checkDiscoveryResult(DiscoveryResult result, String expIp, String expSn) {
         assertThat(result.getBridgeUID(), nullValue());
-        assertThat(result.getLabel(), is(String.format(HueBridgeNupnpDiscovery.LABEL_PATTERN, expIp)));
+        assertThat(result.getLabel(), is(String.format(HueBindingConstants.DISCOVERY_LABEL_PATTERN, expIp)));
         assertThat(result.getProperties().get("ipAddress"), is(expIp));
         assertThat(result.getProperties().get("serialNumber"), is(expSn));
     }


### PR DESCRIPTION
With #14871 NUPnP is now working again, which reintroduces overlapping discovery mechanisms - see https://github.com/openhab/openhab-addons/pull/14871#issuecomment-1530142059

For mDNS, `service.getName()` returns "Philips Hue - XXXXXX" where XXXXXX is the last 6 characters of the serial number. This is connected to `service.getQualifiedName()` which is "Philips Hue - XXXXXX._hue._tcp.local.".

There is no reason for including these characters in the label. The full serial number is already visible just below - even two times:
![image](https://user-images.githubusercontent.com/19519842/235527291-cb1a7c92-bce2-4030-97d9-480bb52d73ff.png)

Therefore this PR aligns the label with the label of NUPnP discovery.

This eliminates the problem of the discovery result label changing back and forth:
- Philips Hue - XXXXXX (192.168.0.251)
- Philips Hue (192.168.0.251)