### PR TITLE
[solarwatt] Update README.md

### DIFF
--- a/bundles/org.openhab.binding.solarwatt/README.md
+++ b/bundles/org.openhab.binding.solarwatt/README.md
@@ -4,6 +4,16 @@ Binding to query a [solarwatt](https://www.solarwatt.de/) [energy manager](https
 
 All supported values and devices were discovered while playing with my own energy manager.
 
+## Supported devices
+* Solarwatt Energymanager; ie. the DIN rail mounted device in your house distribution.
+
+## Not supported by this binding
+* Solarwatt Manager/Manager Flex; ie. the black square device that is wall mounted.
+ 
+The Solarwatt Manager already contains an OpenHAB installation which can be connected to
+other installations via [Remote openHAB Binding](https://www.openhab.org/addons/bindings/remoteopenhab/).
+
+
 ## Supported Things
 
 | Thing Type ID    | Devices                                                |


### PR DESCRIPTION
 to reflect support with regards to newer/other solarwatt products.

This modifies the readme to support users to choose the correct binding for their device as some questions popped up in this discussion [https://community.openhab.org/t/solarwatt-new-binding-for-solarwatt-energy-manager/116452](https://community.openhab.org/t/solarwatt-new-binding-for-solarwatt-energy-manager/116452)

