### PR TITLE
[nuvo] Fix ALLOFF event to source button channels

### DIFF
--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -692,7 +692,7 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
                 // Publish the ALLOFF event to all button channels for awareness in source rules
                 updateChannelState(NuvoEnum.SYSTEM, CHANNEL_TYPE_BUTTONPRESS, ZERO + COMMA + ALLOFF);
                 NuvoEnum.VALID_SOURCES.forEach(source -> {
-                    updateChannelState(NuvoEnum.valueOf(source), CHANNEL_TYPE_BUTTONPRESS, ALLOFF);
+                    updateChannelState(NuvoEnum.valueOf(source), CHANNEL_BUTTON_PRESS, ALLOFF);
                 });
 
                 break;


### PR DESCRIPTION
The publishing of the ALLOFF event to the source channels does not work properly in #14248. The legacy channel id 'button_press' needs to be used when updating the channel state.