### PR TITLE
[boschindego] Refactor OAuth2 implementation

### DIFF
--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/AuthorizationController.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/AuthorizationController.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal;
+
+import static org.openhab.binding.boschindego.internal.BoschIndegoBindingConstants.*;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.boschindego.internal.exceptions.IndegoAuthenticationException;
+import org.openhab.binding.boschindego.internal.exceptions.IndegoException;
+import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
+import org.openhab.core.auth.client.oauth2.OAuthClientService;
+import org.openhab.core.auth.client.oauth2.OAuthException;
+import org.openhab.core.auth.client.oauth2.OAuthResponseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AuthorizationController} acts as a bridge between
+ * {@link OAuthClientService} and {@link IndegoController}.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class AuthorizationController implements AuthorizationProvider {
+
+    private static final String BEARER = "Bearer ";
+
+    private final Logger logger = LoggerFactory.getLogger(AuthorizationController.class);
+
+    private OAuthClientService oAuthClientService;
+
+    public AuthorizationController(OAuthClientService oAuthClientService) {
+        this.oAuthClientService = oAuthClientService;
+    }
+
+    public void setOAuthClientService(OAuthClientService oAuthClientService) {
+        this.oAuthClientService = oAuthClientService;
+    }
+
+    public String getAuthorizationHeader() throws IndegoException {
+        final AccessTokenResponse accessTokenResponse;
+        try {
+            accessTokenResponse = getAccessToken();
+        } catch (OAuthException | OAuthResponseException e) {
+            logger.debug("Error fetching access token: {}", e.getMessage(), e);
+            throw new IndegoAuthenticationException(
+                    "Error fetching access token. Invalid authcode? Please generate a new one -> "
+                            + getAuthorizationUrl(),
+                    e);
+        } catch (IOException e) {
+            throw new IndegoException("An unexpected IOException occurred: " + e.getMessage(), e);
+        }
+        if (accessTokenResponse.getAccessToken() == null || accessTokenResponse.getAccessToken().isEmpty()) {
+            throw new IndegoAuthenticationException(
+                    "No access token. Is this thing authorized? -> " + getAuthorizationUrl());
+        }
+        if (accessTokenResponse.getRefreshToken() == null || accessTokenResponse.getRefreshToken().isEmpty()) {
+            throw new IndegoAuthenticationException("No refresh token. Please reauthorize -> " + getAuthorizationUrl());
+        }
+
+        return BEARER + accessTokenResponse.getAccessToken();
+    }
+
+    public AccessTokenResponse getAccessToken() throws OAuthException, OAuthResponseException, IOException {
+        AccessTokenResponse accessTokenResponse = oAuthClientService.getAccessTokenResponse();
+        if (accessTokenResponse == null) {
+            throw new OAuthException("No access token response");
+        }
+
+        return accessTokenResponse;
+    }
+
+    private String getAuthorizationUrl() {
+        try {
+            return oAuthClientService.getAuthorizationUrl(BSK_REDIRECT_URI, BSK_SCOPE, null);
+        } catch (OAuthException e) {
+            return "";
+        }
+    }
+}

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/AuthorizationListener.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/AuthorizationListener.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * {@link} AuthorizationListener} is used for notifying {@link BoschAccountHandler}
+ * when authorization state has changed and for notifying {@link BoschIndegoHandler}
+ * when authorization flow is completed.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public interface AuthorizationListener {
+    /**
+     * Called upon successful OAuth authorization.
+     */
+    void onSuccessfulAuthorization();
+
+    /**
+     * Called upon failed OAuth authorization.
+     */
+    void onFailedAuthorization(Throwable throwable);
+
+    /**
+     * Called upon successful completion of OAuth authorization flow.
+     */
+    void onAuthorizationFlowCompleted();
+}

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/AuthorizationProvider.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/AuthorizationProvider.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschindego.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.boschindego.internal.exceptions.IndegoException;
+
+/**
+ * The {@link AuthorizationProvider} is responsible for providing
+ * authorization headers needed for communicating with the Bosch Indego
+ * cloud services.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public interface AuthorizationProvider {
+    /**
+     * Get HTTP authorization header for authenticating with Bosch Indego services.
+     *
+     * @return the header contents
+     * @throws IndegoException if not authorized
+     */
+    String getAuthorizationHeader() throws IndegoException;
+}

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoDeviceController.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/IndegoDeviceController.java
@@ -35,7 +35,6 @@ import org.openhab.binding.boschindego.internal.exceptions.IndegoException;
 import org.openhab.binding.boschindego.internal.exceptions.IndegoInvalidCommandException;
 import org.openhab.binding.boschindego.internal.exceptions.IndegoInvalidResponseException;
 import org.openhab.binding.boschindego.internal.exceptions.IndegoTimeoutException;
-import org.openhab.core.auth.client.oauth2.OAuthClientService;
 import org.openhab.core.library.types.RawType;
 
 /**
@@ -61,11 +60,12 @@ public class IndegoDeviceController extends IndegoController {
      * Initialize the controller instance.
      * 
      * @param httpClient the HttpClient for communicating with the service
-     * @param oAuthClientService the OAuthClientService for authorization
+     * @param authorizationProvider the AuthorizationProvider for authenticating with the service
      * @param serialNumber the serial number of the device instance
      */
-    public IndegoDeviceController(HttpClient httpClient, OAuthClientService oAuthClientService, String serialNumber) {
-        super(httpClient, oAuthClientService);
+    public IndegoDeviceController(HttpClient httpClient, AuthorizationProvider authorizationProvider,
+            String serialNumber) {
+        super(httpClient, authorizationProvider);
         if (serialNumber.isBlank()) {
             throw new IllegalArgumentException("Serial number must be provided");
         }

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschAccountHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschAccountHandler.java
@@ -61,7 +61,7 @@ public class BoschAccountHandler extends BaseBridgeHandler {
 
         this.oAuthFactory = oAuthFactory;
 
-        oAuthClientService = oAuthFactory.createOAuthClientService(getThing().getUID().getAsString(), BSK_TOKEN_URI,
+        oAuthClientService = oAuthFactory.createOAuthClientService(thing.getUID().getAsString(), BSK_TOKEN_URI,
                 BSK_AUTH_URI, BSK_CLIENT_ID, null, BSK_SCOPE, false);
         controller = new IndegoController(httpClient, oAuthClientService);
     }
@@ -72,7 +72,7 @@ public class BoschAccountHandler extends BaseBridgeHandler {
 
         scheduler.execute(() -> {
             try {
-                AccessTokenResponse accessTokenResponse = this.oAuthClientService.getAccessTokenResponse();
+                AccessTokenResponse accessTokenResponse = oAuthClientService.getAccessTokenResponse();
                 if (accessTokenResponse == null) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                             "@text/offline.conf-error.oauth2-unauthorized");
@@ -91,11 +91,17 @@ public class BoschAccountHandler extends BaseBridgeHandler {
 
     @Override
     public void dispose() {
-        oAuthFactory.ungetOAuthService(this.getThing().getUID().getAsString());
+        oAuthFactory.ungetOAuthService(thing.getUID().getAsString());
     }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void handleRemoval() {
+        oAuthFactory.deleteServiceAndAccessToken(thing.getUID().getAsString());
+        super.handleRemoval();
     }
 
     @Override

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschAccountHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschAccountHandler.java
@@ -68,6 +68,12 @@ public class BoschAccountHandler extends BaseBridgeHandler {
 
     @Override
     public void initialize() {
+        OAuthClientService oAuthClientService = oAuthFactory.getOAuthClientService(thing.getUID().getAsString());
+        if (oAuthClientService == null) {
+            throw new IllegalStateException("OAuth handle doesn't exist");
+        }
+        this.oAuthClientService = oAuthClientService;
+
         updateStatus(ThingStatus.UNKNOWN);
 
         scheduler.execute(() -> {

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.boschindego.internal.AuthorizationListener;
 import org.openhab.binding.boschindego.internal.AuthorizationProvider;
 import org.openhab.binding.boschindego.internal.BoschIndegoTranslationProvider;
 import org.openhab.binding.boschindego.internal.DeviceStatus;
@@ -59,7 +60,6 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
-import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.UnDefType;
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
  * @author Jacob Laursen - Refactoring, bugfixing and removal of dependency towards abandoned library
  */
 @NonNullByDefault
-public class BoschIndegoHandler extends BaseThingHandler {
+public class BoschIndegoHandler extends BaseThingHandler implements AuthorizationListener {
 
     private static final String MAP_POSITION_STROKE_COLOR = "#8c8b6d";
     private static final String MAP_POSITION_FILL_COLOR = "#fff701";
@@ -130,9 +130,9 @@ public class BoschIndegoHandler extends BaseThingHandler {
             return;
         }
 
-        ThingHandler handler = bridge.getHandler();
-        if (handler instanceof BoschAccountHandler accountHandler) {
-            this.authorizationProvider = accountHandler.getAuthorizationProvider();
+        if (bridge.getHandler() instanceof BoschAccountHandler accountHandler) {
+            authorizationProvider = accountHandler.getAuthorizationProvider();
+            accountHandler.registerAuthorizationListener(this);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "@text/offline.conf-error.missing-bridge");
@@ -155,11 +155,23 @@ public class BoschIndegoHandler extends BaseThingHandler {
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE
                 && getThing().getStatusInfo().getStatus() == ThingStatus.OFFLINE) {
-            // Trigger immediate state refresh upon authorization success.
-            rescheduleStatePoll(0, stateInactiveRefreshIntervalSeconds, true);
+            updateStatus(ThingStatus.UNKNOWN);
         } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
+    }
+
+    public void onSuccessfulAuthorization() {
+        // Ignore
+    }
+
+    public void onFailedAuthorization(Throwable throwable) {
+        // Ignore
+    }
+
+    public void onAuthorizationFlowCompleted() {
+        // Trigger immediate state refresh upon authorization success.
+        rescheduleStatePoll(0, stateInactiveRefreshIntervalSeconds, true);
     }
 
     private boolean rescheduleStatePoll(int delaySeconds, int refreshIntervalSeconds, boolean force) {
@@ -182,6 +194,13 @@ public class BoschIndegoHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            if (bridge.getHandler() instanceof BoschAccountHandler accountHandler) {
+                accountHandler.unregisterAuthorizationListener(this);
+            }
+        }
+
         ScheduledFuture<?> pollFuture = this.statePollFuture;
         if (pollFuture != null) {
             pollFuture.cancel(true);
@@ -211,8 +230,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
                 sendCommand(((DecimalType) command).intValue());
             }
         } catch (IndegoAuthenticationException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.comm-error.authentication-failure");
+            // Ignore, will be handled by bridge
         } catch (IndegoTimeoutException e) {
             updateStatus(lastOperatingDataStatus = ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/offline.comm-error.unreachable");
@@ -297,9 +315,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
         try {
             refreshState();
         } catch (IndegoAuthenticationException e) {
-            logger.warn("Failed to authenticate: {}", e.getMessage());
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.comm-error.authentication-failure");
+            // Ignore, will be handled by bridge
         } catch (IndegoTimeoutException e) {
             updateStatus(lastOperatingDataStatus = ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/offline.comm-error.unreachable");
@@ -420,8 +436,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
             refreshLastCuttingTime();
             refreshNextCuttingTime();
         } catch (IndegoAuthenticationException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.comm-error.authentication-failure");
+            // Ignore, will be handled by bridge
         } catch (IndegoException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
@@ -443,8 +458,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
         try {
             refreshNextCuttingTime();
         } catch (IndegoAuthenticationException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.comm-error.authentication-failure");
+            // Ignore, will be handled by bridge
         } catch (IndegoException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.boschindego.internal.AuthorizationProvider;
 import org.openhab.binding.boschindego.internal.BoschIndegoTranslationProvider;
 import org.openhab.binding.boschindego.internal.DeviceStatus;
 import org.openhab.binding.boschindego.internal.IndegoDeviceController;
@@ -41,7 +42,6 @@ import org.openhab.binding.boschindego.internal.exceptions.IndegoAuthenticationE
 import org.openhab.binding.boschindego.internal.exceptions.IndegoException;
 import org.openhab.binding.boschindego.internal.exceptions.IndegoInvalidCommandException;
 import org.openhab.binding.boschindego.internal.exceptions.IndegoTimeoutException;
-import org.openhab.core.auth.client.oauth2.OAuthClientService;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
@@ -94,7 +94,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
     private final TimeZoneProvider timeZoneProvider;
     private Instant devicePropertiesUpdated = Instant.MIN;
 
-    private @NonNullByDefault({}) OAuthClientService oAuthClientService;
+    private @NonNullByDefault({}) AuthorizationProvider authorizationProvider;
     private @NonNullByDefault({}) IndegoDeviceController controller;
     private @Nullable ScheduledFuture<?> statePollFuture;
     private @Nullable ScheduledFuture<?> cuttingTimePollFuture;
@@ -132,7 +132,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
 
         ThingHandler handler = bridge.getHandler();
         if (handler instanceof BoschAccountHandler accountHandler) {
-            this.oAuthClientService = accountHandler.getOAuthClientService();
+            this.authorizationProvider = accountHandler.getAuthorizationProvider();
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
                     "@text/offline.conf-error.missing-bridge");
@@ -142,7 +142,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
         devicePropertiesUpdated = Instant.MIN;
         updateProperty(Thing.PROPERTY_SERIAL_NUMBER, config.serialNumber);
 
-        controller = new IndegoDeviceController(httpClient, oAuthClientService, config.serialNumber);
+        controller = new IndegoDeviceController(httpClient, authorizationProvider, config.serialNumber);
 
         updateStatus(ThingStatus.UNKNOWN);
         previousStateCode = Optional.empty();

--- a/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/i18n/boschindego.properties
+++ b/bundles/org.openhab.binding.boschindego/src/main/resources/OH-INF/i18n/boschindego.properties
@@ -58,6 +58,7 @@ offline.conf-error.oauth2-unauthorized = Unauthorized
 offline.comm-error.oauth2-authorization-failed = Failed to authorize
 offline.comm-error.authentication-failure = Failed to authenticate with Bosch SingleKey ID
 offline.comm-error.unreachable = Device is unreachable
+online.authorization-completed = Authorization completed
 
 # indego states
 


### PR DESCRIPTION
This refactoring addresses some issues:
- When a bridge thing is removed, the corresponding OAuth2 token will now be deleted.
- When authorization fails (for example when renewing token), the bridge will now change status to **OFFLINE** with proper authorization failure description, and as a consequence child things will have status detail `BRIDGE_OFFLINE` rather than the authorization failure description.
- Reinitialization of bridge things would cause authorization to fail for child things. This is now fixed.

Follow-up to #14745