### PR TITLE
Disable integration tests for bindings requiring an update after core…

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -25,13 +25,19 @@
     <module>org.openhab.binding.hue.tests</module>
     <module>org.openhab.binding.max.tests</module>
     <module>org.openhab.binding.mielecloud.tests</module>
-    <module>org.openhab.binding.modbus.tests</module>
+    <!-- Modbus tests disabled until fixed (CoreItemFactory)
+      <module>org.openhab.binding.modbus.tests</module>
+    -->
     <module>org.openhab.binding.mqtt.homeassistant.tests</module>
     <module>org.openhab.binding.mqtt.homie.tests</module>
-    <module>org.openhab.binding.mqtt.ruuvigateway.tests</module>
+    <!-- MQTT ruuvigateway tests disabled until fixed (CoreItemFactory + NumberItem)
+      <module>org.openhab.binding.mqtt.ruuvigateway.tests</module>
+    -->
     <module>org.openhab.binding.nest.tests</module>
     <module>org.openhab.binding.ntp.tests</module>
-    <module>org.openhab.binding.systeminfo.tests</module>
+    <!-- Systeminfo tests disabled until fixed (NumberItem)
+      <module>org.openhab.binding.systeminfo.tests</module>
+    -->
     <module>org.openhab.binding.tradfri.tests</module>
     <module>org.openhab.binding.wemo.tests</module>
     <module>org.openhab.persistence.mapdb.tests</module>


### PR DESCRIPTION
… changes

Related to openhab/openhab-core#3600

Signed-off-by: Laurent Garnier <lg.hc@free.fr>