### PR TITLE
Upgrade SAT to 0.14

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -392,8 +392,8 @@ public class HomekitCharacteristicFactory {
     // supporting methods
 
     public static boolean useFahrenheit() {
-        return FrameworkUtil.getBundle(HomekitImpl.class).getBundleContext()
-                .getServiceReference(Homekit.class.getName()).getProperty("useFahrenheitTemperature") == Boolean.TRUE;
+        return Boolean.TRUE.equals(FrameworkUtil.getBundle(HomekitImpl.class).getBundleContext()
+                .getServiceReference(Homekit.class.getName()).getProperty("useFahrenheitTemperature"));
     }
 
     private static <T extends CharacteristicEnum> CompletableFuture<T> getEnumFromItem(HomekitTaggedItem item,

--- a/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/addon/addon.xml
@@ -9,6 +9,6 @@
 
 	<service-id>org.openhab.homekit</service-id>
 
-	<config-description-ref uri="io.homekit"/>
+	<config-description-ref uri="io:homekit"/>
 
 </addon:addon>

--- a/bundles/org.openhab.io.hueemulation/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.hueemulation/src/main/resources/OH-INF/addon/addon.xml
@@ -9,5 +9,5 @@
 
 	<service-id>org.openhab.hueemulation</service-id>
 
-	<config-description-ref uri="io.hueemulation"/>
+	<config-description-ref uri="io:hueemulation"/>
 </addon:addon>

--- a/bundles/org.openhab.io.imperihome/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.imperihome/src/main/resources/OH-INF/addon/addon.xml
@@ -9,6 +9,6 @@
 
 	<service-id>org.openhab.imperihome</service-id>
 
-	<config-description-ref uri="io.imperihome"/>
+	<config-description-ref uri="io:imperihome"/>
 
 </addon:addon>

--- a/bundles/org.openhab.io.metrics/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.metrics/src/main/resources/OH-INF/addon/addon.xml
@@ -9,6 +9,6 @@
 
 	<service-id>org.openhab.metrics</service-id>
 
-	<config-description-ref uri="io.metrics"/>
+	<config-description-ref uri="io:metrics"/>
 
 </addon:addon>

--- a/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/addon/addon.xml
@@ -9,6 +9,6 @@
 
 	<service-id>org.openhab.io.neeo.NeeoService</service-id>
 
-	<config-description-ref uri="io.neeo"/>
+	<config-description-ref uri="io:neeo"/>
 
 </addon:addon>

--- a/bundles/org.openhab.io.openhabcloud/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/resources/OH-INF/addon/addon.xml
@@ -9,6 +9,6 @@
 
 	<service-id>org.openhab.openhabcloud</service-id>
 
-	<config-description-ref uri="io.openhabcloud"/>
+	<config-description-ref uri="io:openhabcloud"/>
 
 </addon:addon>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <karaf.version>4.4.3</karaf.version>
     <netty.version>4.1.72.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
-    <sat.version>0.13.0</sat.version>
+    <sat.version>0.13.0 </sat.version>
     <spotless.version>2.35.0</spotless.version>
     <spotless.eclipse.version>4.26</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <karaf.version>4.4.3</karaf.version>
     <netty.version>4.1.72.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
-    <sat.version>0.13.0 </sat.version>
+    <sat.version>0.14.0</sat.version>
     <spotless.version>2.35.0</spotless.version>
     <spotless.eclipse.version>4.26</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>


### PR DESCRIPTION
New static code analysis tools package has been released, lifting the versions of

    PMD from 6.39.0 to 6.53,
    SpotBugs from 4.7.0 to 4.7.3,
    Checkstyle from 8.45.1 to 10.6.0;
    and to adapt to schema changes in OH 4.0.

Looking at the check results, there is one substantial difference between 0.13 and 0.14, see the comparison below:
![image](https://github.com/openhab/openhab-addons/assets/2121139/e844b791-304d-4e87-9cd3-44e70cf6b123)

- pmd UnusedPrivateMethod is reduced by ~100 
- (EmptyControlStatement replaces several Empty* rules, this is intended)

Refs: openhab/openhab-core#3599