### PR TITLE
[jsscripting] Allow configuring from add-on page

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/OH-INF/addon/addon.xml
@@ -9,5 +9,6 @@
 	<connection>none</connection>
 
 	<service-id>org.openhab.jsscripting</service-id>
+	<config-description-ref uri="automation:jsscripting"/>
 
 </addon:addon>


### PR DESCRIPTION
This was not possible because the config description was missing in the addon.xml.