### PR TITLE
[jdbc] Fix addon-info

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-derby.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-derby.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon:addon id="jdbc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<addon:addon id="jdbc-derby" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>persistence</type>
-	<name>JDBC persistence</name>
+	<name>JDBC persistence (Derby)</name>
 	<description>This is the persistence add-on for JDBC.</description>
 
 	<service-id>org.openhab.jdbc</service-id>

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-h2.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-h2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="jdbc-h2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>JDBC persistence (H2)</name>
+	<description>This is the persistence add-on for JDBC.</description>
+
+	<service-id>org.openhab.jdbc</service-id>
+
+	<config-description-ref uri="persistence:jdbc"/>
+
+</addon:addon>

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-hsqldb.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-hsqldb.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="jdbc-hsqldb" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>JDBC persistence (HSQLDB)</name>
+	<description>This is the persistence add-on for JDBC.</description>
+
+	<service-id>org.openhab.jdbc</service-id>
+
+	<config-description-ref uri="persistence:jdbc"/>
+
+</addon:addon>

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-mariadb.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-mariadb.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="jdbc-mariadb" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>JDBC persistence (MariaDB)</name>
+	<description>This is the persistence add-on for JDBC.</description>
+
+	<service-id>org.openhab.jdbc</service-id>
+
+	<config-description-ref uri="persistence:jdbc"/>
+
+</addon:addon>

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-mysql.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-mysql.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="jdbc-mysql" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>JDBC persistence (MySQL)</name>
+	<description>This is the persistence add-on for JDBC.</description>
+
+	<service-id>org.openhab.jdbc</service-id>
+
+	<config-description-ref uri="persistence:jdbc"/>
+
+</addon:addon>

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-postgresql.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-postgresql.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="jdbc-postgresql" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>JDBC persistence (PostgreSQL)</name>
+	<description>This is the persistence add-on for JDBC.</description>
+
+	<service-id>org.openhab.jdbc</service-id>
+
+	<config-description-ref uri="persistence:jdbc"/>
+
+</addon:addon>

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-sqlite.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-sqlite.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="jdbc-mariadb" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>JDBC persistence (SQLite)</name>
+	<description>This is the persistence add-on for JDBC.</description>
+
+	<service-id>org.openhab.jdbc</service-id>
+
+	<config-description-ref uri="persistence:jdbc"/>
+
+</addon:addon>


### PR DESCRIPTION
JDBC defines several add-ons with different add-on ids. Therefore separate addon.xml files are needed (one for each id)