### PR TITLE
[opensprinkler] made http connection to OS more robust

### DIFF
--- a/bundles/org.openhab.binding.opensprinkler/setJavaVersion.pwsh
+++ b/bundles/org.openhab.binding.opensprinkler/setJavaVersion.pwsh
@@ -1,0 +1,1 @@
+$env:JAVA_HOME = '/usr/libexec/java_home -v 1.7.0_7'

--- a/bundles/org.openhab.binding.opensprinkler/setJavaVersion.sh
+++ b/bundles/org.openhab.binding.opensprinkler/setJavaVersion.sh
@@ -1,0 +1,1 @@
+export JAVA_HOME=`/usr/libexec/java_home -v 1.7.0_7`

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBindingConstants.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBindingConstants.java
@@ -48,6 +48,9 @@ public class OpenSprinklerBindingConstants {
     public static final String JSON_OPTION_STATION_COUNT = "nstations";
     public static final String JSON_OPTION_RESULT = "result";
     public static final int DEFAULT_REFRESH_RATE = 60;
+    public static final int DEFAULT_TIMEOUT = 5;
+    public static final int DEFFAULT_RETRIES = 3;
+    public static final int DEFAULT_RETRY_DELAY = 10;
     public static final int DISCOVERY_THREAD_POOL_SIZE = 15;
     public static final boolean DISCOVERY_DEFAULT_AUTO_DISCOVER = false;
     public static final int DISCOVERY_DEFAULT_TIMEOUT_RATE = 500;

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
@@ -379,22 +379,44 @@ class OpenSprinklerHttpApiV100 implements OpenSprinklerApi {
             } else {
                 location = url;
             }
-            ContentResponse response;
-            try {
-                response = withGeneralProperties(httpClient.newRequest(location)).timeout(5, TimeUnit.SECONDS)
-                        .method(HttpMethod.GET).send();
-            } catch (InterruptedException | TimeoutException | ExecutionException e) {
-                throw new CommunicationApiException("Request to OpenSprinkler device failed: " + e.getMessage());
+            ContentResponse response = null;
+            int retriesLeft = config.retry;
+            if (retriesLeft <= 0) {
+                retriesLeft = 1;
             }
-            if (response.getStatus() != HTTP_OK_CODE) {
+            boolean connectionSuccess = false;
+            while (connectionSuccess == false && retriesLeft > 0) {
+                retriesLeft--;
+                try {
+                    response = withGeneralProperties(httpClient.newRequest(location))
+                            .timeout(config.timeout, TimeUnit.SECONDS).method(HttpMethod.GET).send();
+                    connectionSuccess = true;
+                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                    // throw new CommunicationApiException("Request to OpenSprinkler device failed: " + e.getMessage());
+                    logger.warn("Request to OpenSprinkler device failed (retries left: " + retriesLeft + "): "
+                            + e.getMessage());
+                    try {
+                        Thread.sleep(1000 * config.retryDelay);
+
+                    } catch (Exception sleepException) {
+                        logger.warn("Exception while sleeping: " + sleepException.getMessage());
+                    }
+                }
+            }
+            if (connectionSuccess == false) {
+                throw new CommunicationApiException("Request to OpenSprinkler device failed");
+            }
+            if (response != null && response.getStatus() != HTTP_OK_CODE) {
                 throw new CommunicationApiException(
                         "Error sending HTTP GET request to " + url + ". Got response code: " + response.getStatus());
+            } else if (response != null) {
+                String content = response.getContentAsString();
+                if ("{\"result\":2}".equals(content)) {
+                    throw new UnauthorizedApiException("Unauthorized, check your password is correct");
+                }
+                return content;
             }
-            String content = response.getContentAsString();
-            if ("{\"result\":2}".equals(content)) {
-                throw new UnauthorizedApiException("Unauthorized, check your password is correct");
-            }
-            return content;
+            return "";
         }
 
         private Request withGeneralProperties(Request request) {

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
@@ -12,7 +12,15 @@
  */
 package org.openhab.binding.opensprinkler.internal.api;
 
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.*;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_DISABLE_MANUAL_MODE;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_ENABLE_MANUAL_MODE;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_OPTIONS_INFO;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_PASSWORD;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_STATION_INFO;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_STATUS_INFO;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.DEFAULT_STATION_COUNT;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.HTTPS_REQUEST_URL_PREFIX;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.HTTP_REQUEST_URL_PREFIX;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -393,13 +401,12 @@ class OpenSprinklerHttpApiV100 implements OpenSprinklerApi {
                     connectionSuccess = true;
                 } catch (InterruptedException | TimeoutException | ExecutionException e) {
                     // throw new CommunicationApiException("Request to OpenSprinkler device failed: " + e.getMessage());
-                    logger.warn("Request to OpenSprinkler device failed (retries left: " + retriesLeft + "): "
-                            + e.getMessage());
+                    logger.warn("Request to OpenSprinkler device failed (retries left: {}): {}", retriesLeft, e.getMessage());
                     try {
                         Thread.sleep(1000 * config.retryDelay);
 
                     } catch (Exception sleepException) {
-                        logger.warn("Exception while sleeping: " + sleepException.getMessage());
+                        logger.warn("Exception while sleeping: {}",sleepException.getMessage());
                     }
                 }
             }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/config/OpenSprinklerHttpInterfaceConfig.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/config/OpenSprinklerHttpInterfaceConfig.java
@@ -43,6 +43,22 @@ public class OpenSprinklerHttpInterfaceConfig {
      * Number of seconds in between refreshes from the OpenSprinkler device.
      */
     public int refresh = 60;
+
+    /**
+     * Number of seconds for connection timeouts
+     */
+    public int timeout = 5;
+
+    /**
+     * Number of retries in case of connection timeouts
+     */
+    public int retry = 3;
+
+    /**
+     * Number of seconds delay between connection retries
+     */
+    public int retryDelay = 10;
+
     /**
      * The basic auth username to use when the OpenSprinkler device is behind a reverse proxy with basic auth enabled.
      */

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -32,6 +32,21 @@
 				<description>Specifies the refresh interval in seconds.</description>
 				<default>60</default>
 			</parameter>
+			<parameter name="retry" type="integer">
+				<label>Retry Count</label>
+				<description>Specifies the number of retries on connection timeouts.</description>
+				<default>3</default>
+			</parameter>
+			<parameter name="retryDelay" type="integer">
+				<label>Retry Delay</label>
+				<description>Specifies delay between retries in seconds∏.</description>
+				<default>10</default>
+			</parameter>
+			<parameter name="timeout" type="integer">
+				<label>Timeout</label>
+				<description>Specifies the connection timeout in seconds.</description>
+				<default>5</default>
+			</parameter>
 			<parameter name="basicUsername" type="text">
 				<label>Basic Auth Username</label>
 				<description>Used if the OpenSprinkler device is behind a basic auth protected reverse proxy.</description>


### PR DESCRIPTION
Improvement: 
* timeout for connections can be configured
* connection retries are now possible and configurable
* delay between retries is configurable

Reason:
my OS has bad WiFi reception and goes offline from time to time due to timeouts. To make the binding more resilient, I introduced retries on connection timeouts with configurable parameters.