### PR TITLE
[robonect] Fix `NullPointerException` on reinitialization

### DIFF
--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectBindingConstants.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectBindingConstants.java
@@ -22,7 +22,7 @@ import org.openhab.core.thing.ThingTypeUID;
  */
 public class RobonectBindingConstants {
 
-    private static final String BINDING_ID = "robonect";
+    public static final String BINDING_ID = "robonect";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_AUTOMOWER = new ThingTypeUID(BINDING_ID, "mower");

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectHandlerFactory.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectHandlerFactory.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.robonect.internal.handler.RobonectHandler;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.net.http.HttpClientFactory;
@@ -29,10 +28,7 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link RobonectHandlerFactory} is responsible for creating things and thing
@@ -46,32 +42,14 @@ public class RobonectHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_AUTOMOWER);
 
-    private final Logger logger = LoggerFactory.getLogger(RobonectHandlerFactory.class);
-
-    private HttpClient httpClient;
+    private HttpClientFactory httpClientFactory;
     private TimeZoneProvider timeZoneProvider;
 
     @Activate
     public RobonectHandlerFactory(@Reference HttpClientFactory httpClientFactory,
             @Reference TimeZoneProvider timeZoneProvider) {
-        this.httpClient = httpClientFactory.createHttpClient(BINDING_ID);
+        this.httpClientFactory = httpClientFactory;
         this.timeZoneProvider = timeZoneProvider;
-
-        try {
-            this.httpClient.start();
-        } catch (Exception e) {
-            logger.error("Exception while trying to start HTTP client", e);
-            throw new IllegalStateException("Could not create HttpClient");
-        }
-    }
-
-    @Deactivate
-    public void deactivate() {
-        try {
-            this.httpClient.stop();
-        } catch (Exception e) {
-            logger.warn("Exception while trying to stop HTTP client", e);
-        }
     }
 
     @Override
@@ -84,7 +62,7 @@ public class RobonectHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_AUTOMOWER)) {
-            return new RobonectHandler(thing, httpClient, timeZoneProvider);
+            return new RobonectHandler(thing, httpClientFactory, timeZoneProvider);
         }
 
         return null;

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -243,7 +243,7 @@ public class RobonectHandler extends BaseThingHandler {
             if (info.getHealth() != null) {
                 updateState(CHANNEL_HEALTH_TEMP,
                         new QuantityType<>(info.getHealth().getTemperature(), SIUnits.CELSIUS));
-                updateState(CHANNEL_HEALTH_HUM, new QuantityType(info.getHealth().getHumidity(), Units.PERCENT));
+                updateState(CHANNEL_HEALTH_HUM, new QuantityType<>(info.getHealth().getHumidity(), Units.PERCENT));
             }
             if (info.getTimer() != null) {
                 if (info.getTimer().getNext() != null) {
@@ -362,13 +362,7 @@ public class RobonectHandler extends BaseThingHandler {
                     timeZoneString, timeZoneProvider.getTimeZone(), e);
         }
 
-        try {
-            httpClient.start();
-            robonectClient = new RobonectClient(httpClient, endpoint);
-        } catch (Exception e) {
-            logger.error("Exception while trying to start http client", e);
-            throw new RuntimeException("Exception while trying to start http client", e);
-        }
+        robonectClient = new RobonectClient(httpClient, endpoint);
         Runnable runnable = new MowerChannelPoller(TimeUnit.SECONDS.toMillis(robonectConfig.getOfflineTimeout()));
         int pollInterval = robonectConfig.getPollInterval();
         pollingJob = scheduler.scheduleWithFixedDelay(runnable, 0, pollInterval, TimeUnit.SECONDS);
@@ -376,12 +370,11 @@ public class RobonectHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
+        ScheduledFuture<?> pollingJob = this.pollingJob;
         if (pollingJob != null) {
             pollingJob.cancel(true);
-            pollingJob = null;
+            this.pollingJob = null;
         }
-
-        httpClient = null;
     }
 
     /**

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
@@ -20,7 +20,6 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.eclipse.jetty.client.HttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +41,7 @@ import org.openhab.binding.robonect.internal.model.Status;
 import org.openhab.binding.robonect.internal.model.Timer;
 import org.openhab.binding.robonect.internal.model.Wlan;
 import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -69,16 +69,17 @@ public class RobonectHandlerTest {
     private @Mock Thing robonectThingMock;
     private @Mock RobonectClient robonectClientMock;
     private @Mock ThingHandlerCallback callbackMock;
-    private @Mock HttpClient httpClientMock;
+    private @Mock HttpClientFactory httpClientFactoryMock;
     private @Mock TimeZoneProvider timezoneProvider;
 
     @BeforeEach
     public void setUp() {
-        subject = new RobonectHandler(robonectThingMock, httpClientMock, timezoneProvider);
+        Mockito.when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
+        Mockito.when(timezoneProvider.getTimeZone()).thenReturn(ZoneId.of("Europe/Berlin"));
+
+        subject = new RobonectHandler(robonectThingMock, httpClientFactoryMock, timezoneProvider);
         subject.setCallback(callbackMock);
         subject.setRobonectClient(robonectClientMock);
-
-        Mockito.when(timezoneProvider.getTimeZone()).thenReturn(ZoneId.of("Europe/Berlin"));
     }
 
     @Test
@@ -97,7 +98,6 @@ public class RobonectHandlerTest {
 
         // when
         when(robonectClientMock.getMowerInfo()).thenReturn(mowerInfo);
-        when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
 
         subject.handleCommand(new ChannelUID(new ThingUID("1:2:3"), RobonectBindingConstants.CHANNEL_TIMER_NEXT_TIMER),
                 RefreshType.REFRESH);
@@ -141,7 +141,6 @@ public class RobonectHandlerTest {
         // when
         when(robonectClientMock.getMowerInfo()).thenReturn(mowerInfo);
         when(robonectClientMock.errorList()).thenReturn(errorList);
-        when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
 
         subject.handleCommand(new ChannelUID(new ThingUID("1:2:3"), RobonectBindingConstants.CHANNEL_STATUS),
                 RefreshType.REFRESH);
@@ -192,7 +191,6 @@ public class RobonectHandlerTest {
 
         // when
         when(robonectClientMock.getMowerInfo()).thenReturn(mowerInfo);
-        when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
 
         subject.handleCommand(new ChannelUID(new ThingUID("1:2:3"), RobonectBindingConstants.CHANNEL_STATUS),
                 RefreshType.REFRESH);
@@ -223,7 +221,6 @@ public class RobonectHandlerTest {
 
         // when
         when(robonectClientMock.getMowerInfo()).thenReturn(mowerInfo);
-        when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
 
         subject.handleCommand(new ChannelUID(new ThingUID("1:2:3"), RobonectBindingConstants.CHANNEL_STATUS),
                 RefreshType.REFRESH);
@@ -259,7 +256,6 @@ public class RobonectHandlerTest {
         // when
         when(robonectClientMock.getMowerInfo()).thenReturn(mowerInfo);
         when(robonectClientMock.errorList()).thenReturn(errorList);
-        when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
 
         subject.handleCommand(new ChannelUID(new ThingUID("1:2:3"), RobonectBindingConstants.CHANNEL_STATUS),
                 RefreshType.REFRESH);


### PR DESCRIPTION
Fixes #15001
Related to #9429

Because of this:

https://github.com/openhab/openhab-addons/blob/ccab566172da7e3e86b39ab5dfab6471959e3959/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectClient.java#L160-L183

I refactored the code to create a custom HTTP client to not mess with the `AuthenticationStore` of the shared HTTP client.

JARs:
- [org.openhab.binding.robonect-3.4.5-SNAPSHOT.jar](https://drive.google.com/file/d/1wpeK-9pDoFNJJcz34qGG3s8MEL7nWGjk/view?usp=sharing)
- [org.openhab.binding.robonect-4.0.0-SNAPSHOT.jar](https://drive.google.com/file/d/1X052s8OREsJ2W35sIeuWBFAkpmG8h9xn/view?usp=sharing)