### PR TITLE
[airthings] Adapt channels to new dimention for Radon measurements

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.airthings/README.md
+++ b/bundles/org.openhab.binding.bluetooth.airthings/README.md
@@ -37,21 +37,21 @@ Following channels are supported for `Airthings Wave Mini` thing:
 
 The `Airthings Wave Plus` thing has additionally the following channels:
 
-| Channel ID         | Item Type                | Description                                 |
-| ------------------ | ------------------------ | ------------------------------------------- |
-| pressure           | Number:Pressure          | The measured air pressure                   |
-| co2                | Number:Dimensionless     | The measured CO2 level                      |
-| radon_st_avg       | Number:Density           | The measured radon short term average level |
-| radon_lt_avg       | Number:Density           | The measured radon long term average level  |
+| Channel ID         | Item Type                        | Description                                 |
+| ------------------ | -------------------------------- | ------------------------------------------- |
+| pressure           | Number:Pressure                  | The measured air pressure                   |
+| co2                | Number:Dimensionless             | The measured CO2 level                      |
+| radon_st_avg       | Number:RadiationSpecificActivity | The measured radon short term average level |
+| radon_lt_avg       | Number:RadiationSpecificActivity | The measured radon long term average level  |
 
 The `Airthings Wave Gen 1` thing has the following channels:
 
-| Channel ID         | Item Type                | Description                                 |
-| ------------------ | ------------------------ | ------------------------------------------- |
-| radon_st_avg       | Number:Density           | The measured radon short term average level |
-| radon_lt_avg       | Number:Density           | The measured radon long term average level  |
-| temperature        | Number:Temperature       | The measured temperature                    |
-| humidity           | Number:Dimensionless     | The measured humidity                       |
+| Channel ID         | Item Type                        | Description                                 |
+| ------------------ | -------------------------------- | ------------------------------------------- |
+| radon_st_avg       | Number:RadiationSpecificActivity | The measured radon short term average level |
+| radon_lt_avg       | Number:RadiationSpecificActivity | The measured radon long term average level  |
+| temperature        | Number:Temperature               | The measured temperature                    |
+| humidity           | Number:Dimensionless             | The measured humidity                       |
 
 Note: For the `Airthings Wave Gen 1`, only one channel can be updated at each refreshInterval, so it will take refreshInterval x 4 cycles to sequentially update all 4 channels  
 
@@ -66,11 +66,11 @@ bluetooth:airthings_wave_plus:adapter1:sensor1  "Airthings Wave Plus Sensor 1" (
 airthings.items:
 
 ```java
-Number:Temperature      temperature     "Temperature [%.1f %unit%]"                   { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:temperature" }
-Number:Dimensionless    humidity        "Humidity [%d %unit%]"                        { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:humidity" }
-Number:Pressure         pressure        "Air Pressure [%d %unit%]"                    { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:pressure" }
-Number:Dimensionless    co2             "CO2 level [%d %unit%]"                       { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:co2" }
-Number:Dimensionless    tvoc            "TVOC level [%d %unit%]"                      { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:tvoc" }
-Number:Density          radon_st_avg    "Radon short term average level [%d %unit%]"  { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:radon_st_avg" }
-Number:Density          radon_lt_avg    "Radon long term average level [%d %unit%]"   { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:radon_lt_avg" }
+Number:Temperature                  temperature     "Temperature [%.1f %unit%]"                   { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:temperature" }
+Number:Dimensionless                humidity        "Humidity [%d %unit%]"                        { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:humidity" }
+Number:Pressure                     pressure        "Air Pressure [%d %unit%]"                    { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:pressure" }
+Number:Dimensionless                co2             "CO2 level [%d %unit%]"                       { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:co2" }
+Number:Dimensionless                tvoc            "TVOC level [%d %unit%]"                      { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:tvoc" }
+Number:RadiationSpecificActivity    radon_st_avg    "Radon short term average level [%d %unit%]"  { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:radon_st_avg" }
+Number:RadiationSpecificActivity    radon_lt_avg    "Radon long term average level [%d %unit%]"   { channel="bluetooth:airthings_wave_plus:adapter1:sensor1:radon_lt_avg" }
 ```

--- a/bundles/org.openhab.binding.bluetooth.airthings/src/main/java/org/openhab/binding/bluetooth/airthings/internal/AirthingsWavePlusHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.airthings/src/main/java/org/openhab/binding/bluetooth/airthings/internal/AirthingsWavePlusHandler.java
@@ -22,7 +22,7 @@ import javax.measure.quantity.Pressure;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.library.dimension.Density;
+import org.openhab.core.library.dimension.RadiationSpecificActivity;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
@@ -77,13 +77,13 @@ public class AirthingsWavePlusHandler extends AbstractAirthingsHandler {
             }
             Number radonShortTermAvg = data.get(AirthingsDataParser.RADON_SHORT_TERM_AVG);
             if (radonShortTermAvg != null) {
-                updateState(CHANNEL_ID_RADON_ST_AVG,
-                        new QuantityType<Density>(radonShortTermAvg, Units.BECQUEREL_PER_CUBIC_METRE));
+                updateState(CHANNEL_ID_RADON_ST_AVG, new QuantityType<RadiationSpecificActivity>(radonShortTermAvg,
+                        Units.BECQUEREL_PER_CUBIC_METRE));
             }
             Number radonLongTermAvg = data.get(AirthingsDataParser.RADON_LONG_TERM_AVG);
             if (radonLongTermAvg != null) {
                 updateState(CHANNEL_ID_RADON_LT_AVG,
-                        new QuantityType<Density>(radonLongTermAvg, Units.BECQUEREL_PER_CUBIC_METRE));
+                        new QuantityType<RadiationSpecificActivity>(radonLongTermAvg, Units.BECQUEREL_PER_CUBIC_METRE));
             }
         } catch (AirthingsParserException e) {
             logger.error("Failed to parse data received from Airthings sensor: {}", e.getMessage());


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/pull/3608

Note: Existing configurations must be changed to use the new dimension `RadiationSpecificActivity ` instead of `Density`.