### PR TITLE
[ipcamera] Fix discovery crashes when networks have access rights issues in docker

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/README.md
+++ b/bundles/org.openhab.binding.ipcamera/README.md
@@ -133,10 +133,11 @@ Thing ipcamera:hikvision:West "West Camera"
 
 ## Discovery
 
-The discovery feature of openHAB can be used to find and setup any ONVIF cameras.
+The discovery feature of openHAB can be used to find and setup ONVIF cameras.
 This method should be preferred as it will discover the cameras IP, ports and URLs for you, making the setup much easier.
 The binding needs to use UDP port 3702 to discover the cameras with, so this port needs to be unblocked by your firewall or add the camera manually if the camera is not auto found.
 To use the discovery, just press the `+` icon located in the Inbox, then select the IpCamera binding from the list of installed bindings.
+The binding will only search using openHAB's currently selected primary network address, see <https://www.openhab.org/docs/settings/>.
 If your camera is not found after a few searches, it may not be ONVIF and in this case you will need to manually add the camera via the UI.
 Cameras that are not ONVIF should be added as a `generic` thing type and you will need to provide the URLs manually.
 

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraDiscoveryService.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraDiscoveryService.java
@@ -22,9 +22,12 @@ import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +42,12 @@ import org.slf4j.LoggerFactory;
 public class IpCameraDiscoveryService extends AbstractDiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(IpCameraDiscoveryService.class);
+    private final NetworkAddressService networkAddressService;
 
-    public IpCameraDiscoveryService() {
+    @Activate
+    public IpCameraDiscoveryService(@Reference NetworkAddressService networkAddressService) {
         super(SUPPORTED_THING_TYPES, 0, false);
+        this.networkAddressService = networkAddressService;
     }
 
     @Override
@@ -65,7 +71,7 @@ public class IpCameraDiscoveryService extends AbstractDiscoveryService {
     @Override
     protected void startScan() {
         removeOlderResults(getTimestampOfLastScan());
-        OnvifDiscovery onvifDiscovery = new OnvifDiscovery(this);
+        OnvifDiscovery onvifDiscovery = new OnvifDiscovery(networkAddressService, this);
         try {
             onvifDiscovery.discoverCameras();
         } catch (UnknownHostException | InterruptedException e) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
@@ -144,8 +144,18 @@ public class OnvifDiscovery {
             if (!xAddr.isEmpty()) {
                 searchReply(xAddr, xml);
             } else if (xml.contains("onvif")) {
-                logger.info("Possible ONVIF camera found at:{}", packet.sender().getHostString());
-                ipCameraDiscoveryService.newCameraFound("onvif", packet.sender().getHostString(), 80);
+                String brand;
+                try {
+                    brand = getBrandFromLoginPage(packet.sender().getHostString());
+                } catch (IOException e) {
+                    brand = "onvif";
+                }
+                logger.info("Possible {} camera found at:{}", brand, packet.sender().getHostString());
+                if (brand.equals("reolink")) {
+                    ipCameraDiscoveryService.newCameraFound(brand, packet.sender().getHostString(), 80);
+                } else {
+                    ipCameraDiscoveryService.newCameraFound(brand, packet.sender().getHostString(), 80);
+                }
             }
         }
     }
@@ -155,14 +165,16 @@ public class OnvifDiscovery {
             return "dahua";
         } else if (response.toLowerCase().contains("dahua")) {
             return "dahua";
+        } else if (response.toLowerCase().contains("doorbird")) {
+            return "doorbird";
         } else if (response.toLowerCase().contains("foscam")) {
             return "foscam";
         } else if (response.toLowerCase().contains("hikvision")) {
             return "hikvision";
         } else if (response.toLowerCase().contains("instar")) {
             return "instar";
-        } else if (response.toLowerCase().contains("doorbird")) {
-            return "doorbird";
+        } else if (response.toLowerCase().contains("reolink")) {
+            return "reolink";
         } else if (response.toLowerCase().contains("ipc-")) {
             return "dahua";
         } else if (response.toLowerCase().contains("dh-sd")) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
@@ -90,8 +90,9 @@ public class OnvifDiscovery {
                             && inetAddress.isSiteLocalAddress()) {
                         if (inetAddress.getHostAddress().equals(primaryHostAddress)) {
                             results.add(networkInterface);
+                            logger.info("Scanning network {} for any ONVIF cameras", primaryHostAddress);
                         } else {
-                            logger.debug("Skipping network {} as it was not selected as openHAB's primary network",
+                            logger.debug("Skipping network {} as it was not selected as openHAB's 'Primary Address'",
                                     inetAddress.getHostAddress());
                         }
                     } else {
@@ -210,7 +211,8 @@ public class OnvifDiscovery {
     public void discoverCameras() throws UnknownHostException, InterruptedException {
         List<NetworkInterface> nics = getLocalNICs();
         if (nics == null || nics.isEmpty()) {
-            logger.debug("No valid networks detected to use for camera discovery");
+            logger.warn(
+                    "No 'Primary Address' selected to use for camera discovery. Check openHAB's Network Settings page to select a valid Primary Address.");
             return;
         }
         NetworkInterface networkInterface = nics.get(0);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
@@ -151,8 +151,8 @@ public class OnvifDiscovery {
                     brand = "onvif";
                 }
                 logger.info("Possible {} camera found at:{}", brand, packet.sender().getHostString());
-                if (brand.equals("reolink")) {
-                    ipCameraDiscoveryService.newCameraFound(brand, packet.sender().getHostString(), 80);
+                if ("reolink".equals(brand)) {
+                    ipCameraDiscoveryService.newCameraFound(brand, packet.sender().getHostString(), 8000);
                 } else {
                     ipCameraDiscoveryService.newCameraFound(brand, packet.sender().getHostString(), 80);
                 }
@@ -179,8 +179,6 @@ public class OnvifDiscovery {
             return "dahua";
         } else if (response.toLowerCase().contains("dh-sd")) {
             return "dahua";
-        } else if (response.toLowerCase().contains("reolink")) {
-            return "reolink";
         }
         return "onvif";
     }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
@@ -90,7 +90,7 @@ public class OnvifDiscovery {
                             && inetAddress.isSiteLocalAddress()) {
                         if (inetAddress.getHostAddress().equals(primaryHostAddress)) {
                             results.add(networkInterface);
-                            logger.info("Scanning network {} for any ONVIF cameras", primaryHostAddress);
+                            logger.debug("Scanning network {} for any ONVIF cameras", primaryHostAddress);
                         } else {
                             logger.debug("Skipping network {} as it was not selected as openHAB's 'Primary Address'",
                                     inetAddress.getHostAddress());


### PR DESCRIPTION
This PR fixes the issue reported here that most likely is an access issue caused by the use of docker. Closes #14500 

It restricts the binding to only search the network that openHAB has setup as the primary address so if one of your networks causes issues the binding will no longer try to search using all internal networks, but only the selected one.

The PR also improves the discovery of cameras that do not reply with an ONVIF xaddress and will try to discover the brand from the cameras login page.

This pull request will automatically be built and available under the following links if anyone wants to test:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.ipcamera/4.0.0-SNAPSHOT/org.openhab.binding.ipcamera-4.0.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>