### PR TITLE
[influxdb] Handle exceptions gracefully

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/InfluxDB1RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/InfluxDB1RepositoryImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
+import org.influxdb.InfluxDBIOException;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Pong;
@@ -130,7 +131,7 @@ public class InfluxDB1RepositoryImpl implements InfluxDBRepository {
             BatchPoints batchPoints = BatchPoints.database(configuration.getDatabaseName())
                     .retentionPolicy(configuration.getRetentionPolicy()).points(points).build();
             currentClient.write(batchPoints);
-        } catch (InfluxException e) {
+        } catch (InfluxException | InfluxDBIOException e) {
             logger.debug("Writing to database failed", e);
             return false;
         }
@@ -176,7 +177,7 @@ public class InfluxDB1RepositoryImpl implements InfluxDBRepository {
             } else {
                 throw new InfluxException("API not present");
             }
-        } catch (InfluxException e) {
+        } catch (InfluxException | InfluxDBIOException e) {
             logger.warn("Failed to execute query '{}': {}", filter, e.getMessage());
             return List.of();
         }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.influxdb.InfluxDBIOException;
 import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.persistence.influxdb.internal.FilterCriteriaQueryCreator;
 import org.openhab.persistence.influxdb.internal.InfluxDBConfiguration;
@@ -138,7 +139,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
             List<Point> clientPoints = influxPoints.stream().map(this::convertPointToClientFormat)
                     .filter(Optional::isPresent).map(Optional::get).toList();
             currentWriteAPI.writePoints(clientPoints);
-        } catch (InfluxException e) {
+        } catch (InfluxException | InfluxDBIOException e) {
             logger.debug("Writing to database failed", e);
             return false;
         }
@@ -173,7 +174,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
         try {
             deleteAPI.delete(start, stop, predicate, configuration.getRetentionPolicy(),
                     configuration.getDatabaseName());
-        } catch (InfluxException e) {
+        } catch (InfluxException | InfluxDBIOException e) {
             logger.debug("Deleting from database failed", e);
             return false;
         }
@@ -213,7 +214,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
             } else {
                 throw new InfluxException("API not present");
             }
-        } catch (InfluxException e) {
+        } catch (InfluxException | InfluxDBIOException e) {
             logger.warn("Failed to execute query '{}': {}", filter, e.getMessage());
             return List.of();
         }


### PR DESCRIPTION
As reported on the forum (https://community.openhab.org/t/oh4-m2-m3-influxdb-restoreonstartup-fails-timeout-exceptions-in-startup-logs/146915)the influx persistence service does not properly handle exceptions. 

This does NOT fix the reported issue, but it prevents the persistence service from crashing and flooding the log with stack traces. The original issue seems to be a connection issue where the socket times out.