### PR TITLE
[km200] Fix support for older MB-LAN (=KM200, version 1.0) by avoiding query of an unsupported attribute.

### DIFF
--- a/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/KM200Cryption.java
+++ b/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/KM200Cryption.java
@@ -83,9 +83,10 @@ public class KM200Cryption {
         try {
             /* Check whether the length of the decryptData is NOT multiplies of 16 */
             if ((decodedB64.length & 0xF) != 0) {
+                logger.debug("Length of message is {}.", decodedB64.length);
                 /* Return the data */
                 retString = new String(decodedB64, remoteDevice.getCharSet());
-                logger.debug("Did NOT decrypt message");
+                logger.debug("Did NOT decrypt message, returning {}.", retString);
                 return retString;
             }
             // --- create cipher
@@ -95,7 +96,7 @@ public class KM200Cryption {
             byte[] decryptedDataWOZP = removeZeroPadding(decryptedData);
             return (new String(decryptedDataWOZP, remoteDevice.getCharSet()));
         } catch (UnsupportedEncodingException | GeneralSecurityException e) {
-            logger.warn("Exception on encoding", e);
+            logger.warn("Exception on encoding ({})", e.getMessage());
             return null;
         }
     }
@@ -119,7 +120,7 @@ public class KM200Cryption {
                 logger.debug("Base64encoding not possible: {}", e.getMessage());
             }
         } catch (UnsupportedEncodingException | GeneralSecurityException e) {
-            logger.warn("Exception on encoding", e);
+            logger.warn("Exception on encoding ({})", e.getMessage());
         }
         return null;
     }

--- a/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/KM200Device.java
+++ b/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/KM200Device.java
@@ -75,6 +75,7 @@ public class KM200Device {
     public KM200Device(HttpClient httpClient) {
         serviceTreeMap = new HashMap<>();
         getBlacklistMap().add("/gateway/firmware");
+        getBlacklistMap().add("/gateway/registrations");
         virtualList = new ArrayList<>();
         comCryption = new KM200Cryption(this);
         deviceCommunicator = new KM200Comm<>(this, httpClient);
@@ -330,6 +331,7 @@ public class KM200Device {
     public @Nullable JsonObject getServiceNode(String service) {
         String decodedData = null;
         JsonObject nodeRoot = null;
+        logger.debug("{}: trying to query information.", service);
         byte[] recData = deviceCommunicator.getDataFromService(service.toString());
         try {
             if (recData == null) {
@@ -347,6 +349,7 @@ public class KM200Device {
                 decodedData = "";
                 return nodeRoot;
             } else {
+                logger.debug("{}: trying to decode: {}.", service, recData.toString());
                 decodedData = comCryption.decodeMessage(recData);
                 if (decodedData == null) {
                     logger.warn("Decoding of the KM200 message is not possible!");
@@ -355,9 +358,10 @@ public class KM200Device {
             }
             if (decodedData.length() > 0) {
                 if ("SERVICE NOT AVAILABLE".equals(decodedData)) {
-                    logger.debug("{}: SERVICE NOT AVAILABLE", service);
+                    logger.warn("{}: SERVICE NOT AVAILABLE", service);
                     return null;
                 } else {
+                    logger.debug("{}: trying to parse {}", service, decodedData.toString());
                     nodeRoot = (JsonObject) JsonParser.parseString(decodedData);
                 }
             } else {


### PR DESCRIPTION
# Fixed support for MB-LAN (=KM200, version 1.0) by avoiding query of an unsupported attribute.

The oldest device seems to cause some trouble for this binding as it queries the attribute /gateway/registrations, which leads to an inconsistency in the gateway answers. This prevents the binding to move forward into the initialized mode.

Solving the old [bug report](https://community.openhab.org/t/km200-km50-100-200-gateway-uninitialized-handler-initializing-error/107615).