### PR TITLE
[knx] Fix DPT 10.001 handling

### DIFF
--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/ValueDecoder.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/ValueDecoder.java
@@ -215,8 +215,11 @@ public class ValueDecoder {
         try {
             date = new SimpleDateFormat(TIME_DAY_FORMAT, Locale.US).parse(value);
         } catch (ParseException pe) {
-            date = new SimpleDateFormat(TIME_FORMAT, Locale.US).parse(value);
-            throw pe;
+            try {
+                date = new SimpleDateFormat(TIME_FORMAT, Locale.US).parse(value);
+            } catch (ParseException pe2) {
+                throw pe2;
+            }
         }
         return DateTimeType.valueOf(new SimpleDateFormat(DateTimeType.DATE_PATTERN).format(date));
     }


### PR DESCRIPTION
The custom function to handle DPT 10.001 incorrectly handled the exception when a value that is not in the format "EEE, HH:MM:SS" was fed into the function. It now correctly handles "HH:MM:SS" data sent by KNX actors

Signed-Off-By: Karel Goderis <karel.goderis@me.com>
