### PR TITLE
[transform.vat] Suppress warnings for NULL/UNDEF

### DIFF
--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/VATTransformationService.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/VATTransformationService.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationService;
+import org.openhab.core.types.UnDefType;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,9 @@ public class VATTransformationService implements TransformationService {
         try {
             source = new QuantityType<>(sourceString);
         } catch (IllegalArgumentException e) {
+            if (UnDefType.NULL.toString().equals(sourceString) || UnDefType.UNDEF.toString().equals(sourceString)) {
+                return sourceString;
+            }
             logger.warn("Input value '{}' could not be converted to a valid number", sourceString);
             throw new TransformationException("VAT Transformation can only be used with numeric inputs", e);
         }

--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/profile/VATTransformationProfile.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/profile/VATTransformationProfile.java
@@ -30,6 +30,7 @@ import org.openhab.core.transform.TransformationService;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
 import org.openhab.transform.vat.internal.config.VATConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,11 +85,12 @@ public class VATTransformationProfile implements StateProfile {
 
     private Type transformState(Type state) {
         String result = state.toFullString();
+        String percentage = getVATPercentage();
         try {
-            result = TransformationHelper.transform(service, getVATPercentage(), "%s", result);
+            result = TransformationHelper.transform(service, percentage, "%s", result);
         } catch (TransformationException e) {
             logger.warn("Could not apply '{}' transformation on state '{}' with value '{}'.", PROFILE_TYPE_UID.getId(),
-                    state, getVATPercentage());
+                    state, percentage);
         }
         Type resultType = state;
         if (result != null) {
@@ -96,6 +98,8 @@ public class VATTransformationProfile implements StateProfile {
                 resultType = DecimalType.valueOf(result);
             } else if (state instanceof QuantityType) {
                 resultType = QuantityType.valueOf(result);
+            } else if (state instanceof UnDefType) {
+                resultType = UnDefType.valueOf(result);
             }
             logger.debug("Transformed '{}' into '{}'", state, resultType);
         }


### PR DESCRIPTION
There is no reason to log warnings when source value is of type `UnDefType`:
```
2023-06-12 22:55:55.356 [WARN ] [at.internal.VATTransformationService] - Input value 'UNDEF' could not be converted to a valid number
2023-06-12 22:55:55.357 [WARN ] [nal.profile.VATTransformationProfile] - Could not apply 'VAT' transformation on state 'UNDEF' with value '25'.
2023-06-12 22:55:55.357 [DEBUG] [nal.profile.VATTransformationProfile] - Transformed 'UNDEF' into 'UNDEF'
```

Regression from #14529