### PR TITLE
[influxdb] Fix crash on transient connection failure

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/InfluxDB1RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/InfluxDB1RepositoryImpl.java
@@ -44,8 +44,6 @@ import org.openhab.persistence.influxdb.internal.InfluxPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.influxdb.exceptions.InfluxException;
-
 /**
  * Implementation of {@link InfluxDBRepository} for InfluxDB 1.0
  *
@@ -109,7 +107,7 @@ public class InfluxDB1RepositoryImpl implements InfluxDBRepository {
                     logger.warn("database ping error, version is: \"{}\" response time was \"{}\"", version,
                             pong.getResponseTime());
                 }
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 logger.warn("database error: {}", e.getMessage(), e);
             }
         } else {
@@ -130,7 +128,7 @@ public class InfluxDB1RepositoryImpl implements InfluxDBRepository {
             BatchPoints batchPoints = BatchPoints.database(configuration.getDatabaseName())
                     .retentionPolicy(configuration.getRetentionPolicy()).points(points).build();
             currentClient.write(batchPoints);
-        } catch (InfluxException e) {
+        } catch (Exception e) {
             logger.debug("Writing to database failed", e);
             return false;
         }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
@@ -46,7 +46,6 @@ import com.influxdb.client.WriteApi;
 import com.influxdb.client.domain.Ready;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
-import com.influxdb.exceptions.InfluxException;
 import com.influxdb.query.FluxTable;
 
 /**
@@ -138,7 +137,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
             List<Point> clientPoints = influxPoints.stream().map(this::convertPointToClientFormat)
                     .filter(Optional::isPresent).map(Optional::get).toList();
             currentWriteAPI.writePoints(clientPoints);
-        } catch (InfluxException e) {
+        } catch (Exception e) {
             logger.debug("Writing to database failed", e);
             return false;
         }
@@ -173,7 +172,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
         try {
             deleteAPI.delete(start, stop, predicate, configuration.getRetentionPolicy(),
                     configuration.getDatabaseName());
-        } catch (InfluxException e) {
+        } catch (Exception e) {
             logger.debug("Deleting from database failed", e);
             return false;
         }


### PR DESCRIPTION
When the connection to the DB fails during a write request (or between `checkConnection()` and the actual write), the periodic commit task crashes due to an unchecked exception by InfluxDB:

```
2023-06-13 19:32:15.637 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception:
org.influxdb.InfluxDBIOException: java.net.ConnectException: Failed to connect to influxdb/[2a01:4f9:c010:5b89:2:0:0:a]:8086
        at org.influxdb.impl.InfluxDBImpl.execute(InfluxDBImpl.java:841) ~[?:?]
        at org.influxdb.impl.InfluxDBImpl.write(InfluxDBImpl.java:470) ~[?:?]
        at org.openhab.persistence.influxdb.internal.influx1.InfluxDB1RepositoryImpl.write(InfluxDB1RepositoryImpl.java:132) ~[?:?]
        at org.openhab.persistence.influxdb.InfluxDBPersistenceService.commit(InfluxDBPersistenceService.java:285) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.net.ConnectException: Failed to connect to influxdb/[2a01:4f9:c010:5b89:2:0:0:a]:8086
        at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265) ~[?:?]
        at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183) ~[?:?]
        at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224) ~[?:?]
        at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[?:?]
        at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[?:?]
        at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[?:?]
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at org.influxdb.impl.BasicAuthInterceptor.intercept(BasicAuthInterceptor.java:22) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at org.influxdb.impl.GzipRequestInterceptor.intercept(GzipRequestInterceptor.java:42) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.java:152) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229) ~[?:?]
        at okhttp3.RealCall.execute(RealCall.java:81) ~[?:?]
        at retrofit2.OkHttpCall.execute(OkHttpCall.java:188) ~[?:?]
        at org.influxdb.impl.InfluxDBImpl.execute(InfluxDBImpl.java:829) ~[?:?]
        ... 9 more
Caused by: java.net.ConnectException: Connection refused
        at sun.nio.ch.Net.pollConnect(Native Method) ~[?:?]
        at sun.nio.ch.Net.pollConnectNow(Net.java:672) ~[?:?]
        at sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:542) ~[?:?]
        at sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597) ~[?:?]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327) ~[?:?]
        at java.net.Socket.connect(Socket.java:633) ~[?:?]
        at okhttp3.internal.platform.Platform.connectSocket(Platform.java:130) ~[?:?]
        at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263) ~[?:?]
        at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183) ~[?:?]
        at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224) ~[?:?]
        at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[?:?]
        at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[?:?]
        at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[?:?]
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at org.influxdb.impl.BasicAuthInterceptor.intercept(BasicAuthInterceptor.java:22) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at org.influxdb.impl.GzipRequestInterceptor.intercept(GzipRequestInterceptor.java:42) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.java:152) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[?:?]
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[?:?]
        at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229) ~[?:?]
        at okhttp3.RealCall.execute(RealCall.java:81) ~[?:?]
        at retrofit2.OkHttpCall.execute(OkHttpCall.java:188) ~[?:?]
        at org.influxdb.impl.InfluxDBImpl.execute(InfluxDBImpl.java:829) ~[?:?]
        ... 9 more
```
The persistence service doesn't recover from this state.

InfluxDB uses unchecked exceptions and the current implementation doesn't catch all of them (e.g. `InfluxDBIOException` is not inherited from `InfluxException`).

This PR catches `Exception` (consistently) to make sure the periodic task is not terminated and the write requests are queued in case of an error. If I see correctly an `OutOfMemoryError` can occur on a permanent error due to the queueing, but this seems to be a general issue with this persistence.