### PR TITLE
[Telegram] Support processing of channel messages

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -281,6 +281,9 @@ public class TelegramHandler extends BaseThingHandler {
             String replyId = null;
 
             Message message = update.message();
+            if (message == null) {
+                message = update.channelPost();
+            }
             CallbackQuery callbackQuery = update.callbackQuery();
 
             if (message != null) {
@@ -297,8 +300,10 @@ public class TelegramHandler extends BaseThingHandler {
                 JsonObject messageRaw = JsonParser.parseString(gson.toJson(message)).getAsJsonObject();
                 JsonObject messagePayload = new JsonObject();
                 messagePayload.addProperty("message_id", message.messageId());
-                messagePayload.addProperty("from",
-                        String.join(" ", new String[] { message.from().firstName(), message.from().lastName() }));
+                if (messageRaw.has("from")) {
+                    messagePayload.addProperty("from",
+                            String.join(" ", new String[] { message.from().firstName(), message.from().lastName() }));
+                }
                 messagePayload.addProperty("chat_id", message.chat().id());
                 if (messageRaw.has("text")) {
                     messagePayload.addProperty("text", message.text());
@@ -371,9 +376,11 @@ public class TelegramHandler extends BaseThingHandler {
                 // process metadata
                 if (lastMessageURL != null || lastMessageText != null) {
                     lastMessageDate = message.date();
-                    lastMessageFirstName = message.from().firstName();
-                    lastMessageLastName = message.from().lastName();
-                    lastMessageUsername = message.from().username();
+                    if (message.from() != null) {
+                        lastMessageFirstName = message.from().firstName();
+                        lastMessageLastName = message.from().lastName();
+                        lastMessageUsername = message.from().username();
+                    }
                 }
             } else if (callbackQuery != null && callbackQuery.message() != null
                     && callbackQuery.message().text() != null) {


### PR DESCRIPTION
# Description

Updates from channels were ignored (see also https://community.openhab.org/t/telegram-bot-does-not-receive-messages-from-the-channel/101913/3).

Use channelPost() API to get channel message. lastName, firstName, username can be null.


# Testing

https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.telegram/4.0.0-SNAPSHOT/org.openhab.binding.telegram-4.0.0-SNAPSHOT.jar