### PR TITLE
[rrd4j] Improve timestamp handling

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -206,10 +206,12 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         }
 
         try {
-        if (now < db.getLastUpdateTime()) {
-            logger.warn("RRD4J does not support adding past value this={}, last update={}. Discarding {} - {}", now, db.getLastUpdateTime(), name, value);
-            return;
-        }} catch (IOException ignored) {
+            if (now < db.getLastUpdateTime()) {
+                logger.warn("RRD4J does not support adding past value this={}, last update={}. Discarding {} - {}", now,
+                        db.getLastUpdateTime(), name, value);
+                return;
+            }
+        } catch (IOException ignored) {
             // we can ignore that here, we'll fail again later.
         }
 

--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -205,6 +205,14 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             return;
         }
 
+        try {
+        if (now < db.getLastUpdateTime()) {
+            logger.warn("RRD4J does not support adding past value this={}, last update={}. Discarding {} - {}", now, db.getLastUpdateTime(), name, value);
+            return;
+        }} catch (IOException ignored) {
+            // we can ignore that here, we'll fail again later.
+        }
+
         ConsolFun function = getConsolidationFunction(db);
         if (function != ConsolFun.AVERAGE) {
             try {
@@ -231,8 +239,8 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             Sample sample = db.createSample();
             sample.setTime(now);
             double storeValue = value;
-            if (db.getDatasource(DATASOURCE_STATE).getType() == DsType.COUNTER) { // counter values must be
-                                                                                  // adjusted by stepsize
+            if (db.getDatasource(DATASOURCE_STATE).getType() == DsType.COUNTER) {
+                // counter values must be adjusted by stepsize
                 storeValue = value * db.getRrdDef().getStep();
             }
             sample.setValue(DATASOURCE_STATE, storeValue);
@@ -247,8 +255,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
                     job.cancel(true);
                     scheduledJobs.remove(name);
                 }
-                job = scheduler.schedule(() -> internalStore(name, value, now + 1, false), 1, TimeUnit.SECONDS);
-                scheduledJobs.put(name, job);
+                internalStore(name, value, now + 1, false);
             } else {
                 logger.warn("Could not persist '{}' to rrd4j database: {}", name, e.getMessage());
             }


### PR DESCRIPTION
Fixes #15054 

Storage retry is now tried immediately, not scheduled. This should prevent having the "next" value being stored before the current one.