### PR TITLE
[openwebnet] Thermo: add support for 4-zones CU

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -280,10 +280,10 @@ A "stop time" parameter is usually set on the physical actuator (eg. F411U2) eit
 Basic Scenarios and CEN/CEN+ Scenarios channels are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
 
 A powerful feature is to detect scenario activations and CEN/CEN+ buttons press events to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by BTicino scenario control modules or by CEN/CEN+ scenarios physical buttons.
-See [openwebnet.rules](#openwebnetrules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
+See [openwebnet.rules](#openwebnet-rules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
 
 It's also possible to send _virtual scenario activation_ and _virtual press_ events on the BUS, for example to enable the activation of MH202 or F420 scenarios from openHAB..
-See [openwebnet.sitemap](#openwebnetsitemap) & [openwebnet.rules](#openwebnetrules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
+See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
 
 - basic scenario channels are named `scenario` and possible events are: `SCENARIO_01` ... `SCENARIO_16` (or up to `SCENARIO_20` in case of module IR3456) when a scenario is activated
 - CEN/CEN+ channels are named `button#X` where `X` is the button number on the CEN/CEN+ Scenario Control device
@@ -530,6 +530,7 @@ Special thanks for helping on testing this binding go to:
 [@rubenfuser](https://community.openhab.org/u/rubenfuser),
 [@stamate_viorel](https://community.openhab.org/u/stamate_viorel),
 [@marchino](https://community.openhab.org/u/marchino),
-[@the-ninth](https://community.openhab.org/u/the-ninth)
+[@the-ninth](https://community.openhab.org/u/the-ninth),
+[@giacob](https://community.openhab.org/u/giacob)
 
 and many others at the fantastic openHAB community!

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -147,7 +147,7 @@ Thermo zones can be configured defining a `bus_thermo_zone` Thing for each zone 
 
 - the `where` configuration parameter (`OpenWebNet Address`):
   - example BUS/SCS zone `1` --> `where="1"`
-- the `standAlone` configuration parameter (`boolean`, default: `true`): identifies if the zone is managed or not by a Central Unit (4 or 99 zones). `standAlone=true` means no Central Unit is present in the system.
+- the `standAlone` configuration parameter (`boolean`, default: `true`): identifies if the zone is managed or not by a Central Unit (4- or 99-zones). `standAlone=true` means no Central Unit is present in the system.
 
 Temperature sensors can be configured defining a `bus_thermo_sensor` Thing with the following parameters:
 
@@ -155,19 +155,18 @@ Temperature sensors can be configured defining a `bus_thermo_sensor` Thing with 
   - example sensor `5` of external zone `00` --> `where="500"`
   - example: slave sensor `3` of zone `2` --> `where="302"`
 
-The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing with the `where` configuration parameter (`OpenWebNet Address`) set to `where="0"`.
+The (optional) Central Unit can be configured defining a `bus_themo_cu` Thing with the `where` configuration parameter (`OpenWebNet Address`) set to `where="#0"` for a 99-zone Central Unit or `where="#0#1"` for a 4-zone Central Unit.
 
 ##### Thermo Central Unit integration missing points
 
 - Read setPoint temperature and current mode
-- Holiday activation command (all zones)
-- Discovery
+- Holiday/Vacation activation command
 
 #### Configuring Alarm and Auxiliary (AUX)
 
 **NOTE 1** Receiving AUX messages originating from the BUS is not supported yet, only sending messages to the BUS is supported
 
-**NOTE 2** Alarm messages on BUS are not sent by MyHOMEServer1, therfore this gateway cannot be used to integrate the BTicino Alarm system
+**NOTE 2** Alarm messages on BUS are not sent by MyHOMEServer1, therefore this gateway cannot be used to integrate the BTicino Alarm system
 
 BUS Auxiliary commands (WHO=9) can be used to send on the BUS commands to control, for example, external devices or a BTicino Alarm system.
 
@@ -280,10 +279,10 @@ A "stop time" parameter is usually set on the physical actuator (eg. F411U2) eit
 Basic Scenarios and CEN/CEN+ Scenarios channels are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
 
 A powerful feature is to detect scenario activations and CEN/CEN+ buttons press events to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by BTicino scenario control modules or by CEN/CEN+ scenarios physical buttons.
-See [openwebnet.rules](#openwebnet-rules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
+See [openwebnet.rules](#openwebnetrules) for examples on how to define rules that trigger on scenarios and on CEN/CEN+ button press events.
 
 It's also possible to send _virtual scenario activation_ and _virtual press_ events on the BUS, for example to enable the activation of MH202 or F420 scenarios from openHAB..
-See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
+See [openwebnet.sitemap](#openwebnetsitemap) & [openwebnet.rules](#openwebnetrules) sections for examples on how to use the `activateScenario` and `virtualPress` actions connected to a pushbutton on a sitemap.
 
 - basic scenario channels are named `scenario` and possible events are: `SCENARIO_01` ... `SCENARIO_16` (or up to `SCENARIO_20` in case of module IR3456) when a scenario is activated
 - CEN/CEN+ channels are named `button#X` where `X` is the button number on the CEN/CEN+ Scenario Control device
@@ -326,7 +325,7 @@ Bridge openwebnet:bus_gateway:mybridge "MyHOMEServer1" [ host="192.168.1.35", pa
       bus_energy_meter              CENTRAL_Ta           "Energy Meter Ta"          [ where="51" ]
       bus_energy_meter              CENTRAL_Tb           "Energy Meter Tb"          [ where="52" ]
 
-      bus_thermo_cu                 CU_3550              "99 zones central unit"    [ where="0" ]
+      bus_thermo_cu                 CU_3550              "99 zones Central Unit"    [ where="#0" ]
       bus_thermo_zone               LR_zone              "Living Room Zone"         [ where="2"]
       bus_thermo_sensor             EXT_tempsensor       "External Temperature"     [ where="500"]
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.9.1</version>
+      <version>0.10.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.10.0-SNAPSHOT</version>
+      <version>0.10.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -253,13 +253,12 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
             logger.debug("CU found: {}", w);
             if (w.value().charAt(0) == '#') { // 99-zone CU
                 thingLabel += " 99-zone";
-                logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO CU found 99-zone: where={}, whereConfig={}", w,
+                logger.debug("@@@@@ THERMO CU found 99-zone: where={}, ownId={}, whereConfig={}", w, ownId,
                         whereConfig);
             } else {
                 thingLabel += " 4-zone";
                 whereConfig = "#" + w.value();
-                logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO CU found 4-zone: where={}, whereConfig={}", w,
-                        whereConfig);
+                logger.debug("@@@@ THERMO CU found 4-zone: where={}, ownId={}, whereConfig={}", w, ownId, whereConfig);
             }
         } else if (OpenWebNetBindingConstants.THING_TYPE_BUS_THERMO_ZONE.equals(thingTypeUID)) {
             if (cuFound) {
@@ -267,7 +266,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
                 properties.put(OpenWebNetBindingConstants.CONFIG_PROPERTY_STANDALONE, false);
             }
             whereConfig = "" + ((WhereThermo) w).getZone();
-            logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO ZONE found: where={}, whereConfig={}, standalone={}", w,
+            logger.debug("@@@@@ THERMO ZONE found: where={}, ownId={}, whereConfig={}, standalone={}", w, ownId,
                     whereConfig, properties.get(OpenWebNetBindingConstants.CONFIG_PROPERTY_STANDALONE));
         }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -94,10 +94,10 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
      * Create and notify to Inbox a new DiscoveryResult based on WHERE,
      * OpenDeviceType and BaseOpenMessage
      *
-     * @param where      the discovered device's address (WHERE)
+     * @param where the discovered device's address (WHERE)
      * @param deviceType {@link OpenDeviceType} of the discovered device
-     * @param message    the OWN message received that identified the device
-     *                   (optional)
+     * @param message the OWN message received that identified the device
+     *            (optional)
      */
     public void newDiscoveryResult(@Nullable Where where, OpenDeviceType deviceType,
             @Nullable BaseOpenMessage baseMsg) {
@@ -268,8 +268,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
             }
             whereConfig = "" + ((WhereThermo) w).getZone();
             logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO ZONE found: where={}, whereConfig={}, standalone={}", w,
-                    whereConfig,
-                    properties.get(OpenWebNetBindingConstants.CONFIG_PROPERTY_STANDALONE));
+                    whereConfig, properties.get(OpenWebNetBindingConstants.CONFIG_PROPERTY_STANDALONE));
         }
 
         if (w instanceof WhereZigBee && WhereZigBee.UNIT_02.equals(((WhereZigBee) w).getUnit())) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -253,11 +253,13 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
             logger.debug("CU found: {}", w);
             if (w.value().charAt(0) == '#') { // 99-zone CU
                 thingLabel += " 99-zone";
-                logger.debug("CU found 99-zone: where={}, whereConfig={}", w, whereConfig);
+                logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO CU found 99-zone: where={}, whereConfig={}", w,
+                        whereConfig);
             } else {
                 thingLabel += " 4-zone";
                 whereConfig = "#" + w.value();
-                logger.debug("CU found 4-zone: where={}, whereConfig={}", w, whereConfig);
+                logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO CU found 4-zone: where={}, whereConfig={}", w,
+                        whereConfig);
             }
         } else if (OpenWebNetBindingConstants.THING_TYPE_BUS_THERMO_ZONE.equals(thingTypeUID)) {
             if (cuFound) {
@@ -265,7 +267,9 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
                 properties.put(OpenWebNetBindingConstants.CONFIG_PROPERTY_STANDALONE, false);
             }
             whereConfig = "" + ((WhereThermo) w).getZone();
-            logger.debug("ZONE found: where={}, whereConfig={}", w, whereConfig);
+            logger.debug("@@@@@@@@@@@@@@@@@@@@@@@@@ THERMO ZONE found: where={}, whereConfig={}, standalone={}", w,
+                    whereConfig,
+                    properties.get(OpenWebNetBindingConstants.CONFIG_PROPERTY_STANDALONE));
         }
 
         if (w instanceof WhereZigBee && WhereZigBee.UNIT_02.equals(((WhereZigBee) w).getUnit())) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -708,7 +708,8 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
                 if (str.indexOf('#') == 0) { // Thermo central unit (#0) or zone via central unit (#Z, Z=[1-99]) --> Z,
                                              // Alarm Zone (#Z) --> Z
                     str = str.substring(1);
-                } else if (str.indexOf('#') > 0) { // Thermo zone Z and actuator N (Z#N, Z=[1-99], N=[1-9]) --> Z
+                } else if (str.indexOf('#') > 0 && str.charAt(0) != '0') { // Thermo zone Z and actuator N (Z#N,
+                                                                           // Z=[1-99], N=[1-9]) --> Z
                     str = str.substring(0, str.indexOf('#'));
                 }
             }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -296,6 +296,8 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     protected void handleMessage(BaseOpenMessage msg) {
         super.handleMessage(msg);
 
+        logger.debug("@@@@ Thermo.handleMessage(): {}", msg.toStringVerbose());
+
         if (isCentralUnit) {
             if (msg.getWhat() == null) {
                 return;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThermoregulationHandler.java
@@ -62,7 +62,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
     private Thermoregulation.Function currentFunction = Thermoregulation.Function.GENERIC;
     private Thermoregulation.OperationMode currentMode = Thermoregulation.OperationMode.MANUAL;
 
-    private boolean isStandAlone = true;
+    private boolean isStandAlone = true; // true if zone is not associated to a CU
 
     private boolean isCentralUnit = false;
 
@@ -95,6 +95,7 @@ public class OpenWebNetThermoregulationHandler extends OpenWebNetThingHandler {
             if (standAloneConfig != null) {
                 isStandAlone = Boolean.parseBoolean(standAloneConfig.toString());
             }
+            logger.debug("@@@@@@@@@@@@@@@@@@@@  THERMO ZONE INITIALIZE isStandAlone={}", isStandAlone);
         } else {
 
             /*

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -87,7 +87,7 @@ thing-type.config.openwebnet.bus_on_off_switch.where.description = Example: A/PL
 thing-type.config.openwebnet.bus_scenario_control.where.label = OpenWebNet Address (where)
 thing-type.config.openwebnet.bus_scenario_control.where.description = Example: scenario control module address 53 --> where=53. On local bus: where=53#4#01
 thing-type.config.openwebnet.bus_thermo_cu.where.label = OpenWebNet Address (where)
-thing-type.config.openwebnet.bus_thermo_cu.where.description = The Central Unit can only assume where=0.
+thing-type.config.openwebnet.bus_thermo_cu.where.description = For Thermo Central Unit 99-zones --> where=#0, for 4-zones --> where=#0#1
 thing-type.config.openwebnet.bus_thermo_sensor.where.label = OpenWebNet Address (where)
 thing-type.config.openwebnet.bus_thermo_sensor.where.description = Example: sensor 3 of zone 2 --> where=302. Sensor 5 of external zone 00 --> where=500
 thing-type.config.openwebnet.bus_thermo_zone.standAlone.label = Stand-alone

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
@@ -41,8 +41,8 @@
 			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>
 				<description>For Thermo Central Unit 99-zones --> where=#0, for 4-zones --> where=#0#1</description>
-			</parameter>	
-			
+			</parameter>
+
 		</config-description>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoCentralUnit.xml
@@ -38,11 +38,11 @@
 		<representation-property>ownId</representation-property>
 
 		<config-description>
-			<parameter name="where" type="text" readOnly="true">
+			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>
-				<description>The Central Unit can only assume where=0.</description>
-				<default>0</default>
-			</parameter>
+				<description>For Thermo Central Unit 99-zones --> where=#0, for 4-zones --> where=#0#1</description>
+			</parameter>	
+			
 		</config-description>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
+++ b/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * using {@link OpenWebNetBridgeHandler} methods: normalizeWhere(),
  * ownIdFromWhoWhere(), ownIdFromMessage(), thingIdFromWhere()
  *
- * @author Massimo Valla - Initial contribution, updates
+ * @author Massimo Valla - Initial contribution, various updates
  * @author Andrea Conte - Energy management
  * @author Giovanni Fabiani - Auxiliary message support
  */
@@ -59,7 +59,10 @@ public class OwnIdTest {
      * BUS Switch           51              51                  1.51            51
      * BUS Local Bus        25#4#01         25h4h01             1.25h4h01       25h4h01
      * BUS Autom            93              93                  2.93            93
-     * BUS Thermo           #1 or 1         1                   4.1             1
+     * BUS Thermo zone      1               1                   4.1             1
+     * BUS Thermo zone CU   #1              1                   4.1             1
+     * BUS Thermo CU 99-z   #0              0                   4.0             0
+     * BUS Thermo CU 4-z    #0#1            0                   4.0h1           0h1
      * BUS Thermo actuator  1#2             1                   4.1             1
      * BUS TempSensor       500             500                 4.500           500
      * BUS Energy           51              51                  18.51           51
@@ -76,15 +79,17 @@ public class OwnIdTest {
 
     public enum TEST {
         // @formatter:off
-        // msg, who, where, normW, ownId, thingId
+        // msg, who, where, normalizeWhere, ownId, thingId
         zb_switch("*1*1*789309801#9##", Who.fromValue(1), new WhereZigBee("789309801#9"), "789309800h9", "1.789309800h9", "789309800h9"),
         zb_switch_2u_1("*1*1*789301201#9##", Who.fromValue(1), new WhereZigBee("789301201#9"), "789301200h9", "1.789301200h9", "789301200h9"),
         zb_switch_2u_2("*1*1*789301202#9##", Who.fromValue(1),    new WhereZigBee("789301202#9"), "789301200h9", "1.789301200h9", "789301200h9"),
         bus_switch("*1*1*51##", Who.fromValue(1), new WhereLightAutom("51"),"51", "1.51", "51"),
         bus_localbus("*1*1*25#4#01##",  Who.fromValue(1), new WhereLightAutom("25#4#01"), "25h4h01", "1.25h4h01", "25h4h01"),
         bus_autom("*2*0*93##",Who.fromValue(2),  new WhereLightAutom("93"), "93", "2.93", "93"),
-        bus_thermo_via_cu("*#4*#1*0*0020##",  Who.fromValue(4), new WhereThermo("#1"), "1", "4.1", "1"),
-        bus_thermo("*#4*1*0*0020##", Who.fromValue(4),  new WhereThermo("1"),  "1", "4.1", "1"),
+        bus_thermo_zone("*#4*1*0*0020##", Who.fromValue(4),  new WhereThermo("1"),  "1", "4.1", "1"),
+        bus_thermo_zone_via_cu("*#4*#1*0*0020##",  Who.fromValue(4), new WhereThermo("#1"), "1", "4.1", "1"),
+        bus_thermo_cu_99("*#4*#0##",   Who.fromValue(4), new WhereThermo("#0") ,"0", "4.0", "0"),
+        bus_thermo_cu_4("*#4*#0#1##",   Who.fromValue(4), new WhereThermo("#0#1") ,"0h1", "4.0h1", "0h1"),
         bus_thermo_act("*#4*1#2*20*0##",   Who.fromValue(4), new WhereThermo("1#2") ,"1", "4.1", "1"),
         bus_tempSensor("*#4*500*15*1*0020*0001##",Who.fromValue(4),  new WhereThermo("500"), "500", "4.500", "500"),
         bus_energy("*#18*51*113##",   Who.fromValue(18), new WhereEnergyManagement("51"),  "51", "18.51", "51"),

--- a/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
+++ b/bundles/org.openhab.binding.openwebnet/src/test/java/org/openhab/binding/openwebnet/internal/handler/OwnIdTest.java
@@ -62,7 +62,7 @@ public class OwnIdTest {
      * BUS Thermo zone      1               1                   4.1             1
      * BUS Thermo zone CU   #1              1                   4.1             1
      * BUS Thermo CU 99-z   #0              0                   4.0             0
-     * BUS Thermo CU 4-z    #0#1            0                   4.0h1           0h1
+     * BUS Thermo CU 4-z    #0#1            0h1                 4.0h1           0h1
      * BUS Thermo actuator  1#2             1                   4.1             1
      * BUS TempSensor       500             500                 4.500           500
      * BUS Energy           51              51                  18.51           51


### PR DESCRIPTION
This PR adds support for 4-zones Thermo Central Units, like BTicino model N4695 in addition to the 99-zone Central Unit.
Changes have been made to support its WHERE address format (#0#1) and device discovery to distinguish between 99-zone and 4-zone CU.

This PR also updates the dependency to the openwebnet4j lib to its latest version: 0.10.0

Changes have been tested positively with some users in the community.

This PR fixes issue #14444.


