### PR TITLE
[openwebnet] add date time synchronization feature for bus_gateway Things

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -107,6 +107,7 @@ Configuration parameters are:
   - if the BUS/SCS gateway is configured to accept connections from the openHAB computer IP address, no password should be required
   - in all other cases, a password must be configured. This includes gateways that have been discovered and added from Inbox: without a password configured they will remain OFFLINE
 - `discoveryByActivation`: discover BUS devices when they are activated also when a device scan hasn't been started from Inbox (`boolean`, _optional_, default: `false`). See [Discovery by Activation](#discovery-by-activation).
+- `dateTimeSynch`: synchronise date and time of slave elements on the SCS BUS using openHAB timestamp (`boolean`, _optional_, default: `false`). Set this parameter to `true` to send time-date synchronisation commands on the BUS when the timestamp received from the gateway differs by more than 1 minute from that of openHAB. Useful if the BUS gateway is not syncronized with Internet time servers and with daylight saving time changes.
 
 Alternatively the BUS/SCS Gateway thing can be configured using the `.things` file, see `openwebnet.things` example [below](#full-example).
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.9.1</version>
+      <version>0.10.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.10.0-SNAPSHOT</version>
+      <version>0.10.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/config/OpenWebNetBusBridgeConfig.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/config/OpenWebNetBusBridgeConfig.java
@@ -30,6 +30,7 @@ public class OpenWebNetBusBridgeConfig {
     private @Nullable String host;
     private String passwd = "12345";
     private boolean discoveryByActivation = false;
+    private boolean dateTimeSynch = false;
 
     public BigDecimal getPort() {
         return port;
@@ -45,5 +46,9 @@ public class OpenWebNetBusBridgeConfig {
 
     public Boolean getDiscoveryByActivation() {
         return discoveryByActivation;
+    }
+
+    public Boolean getDateTimeSynch() {
+        return dateTimeSynch;
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -74,6 +74,8 @@ thing-type.config.openwebnet.bus_dry_contact_ir.where.label = OpenWebNet Address
 thing-type.config.openwebnet.bus_dry_contact_ir.where.description = Automation Dry Contacts (N=1-201): example N=60 --> where=360. Alarm Dry Contacts and IR sensors (Zone=1-9, N=1-9): example Zone=4, N=5 --> where=345
 thing-type.config.openwebnet.bus_energy_meter.where.label = OpenWebNet Address (where)
 thing-type.config.openwebnet.bus_energy_meter.where.description = Example: 5N with N=[1-255]
+thing-type.config.openwebnet.bus_gateway.dateTimeSynch.label = Date Time Synchronisation
+thing-type.config.openwebnet.bus_gateway.dateTimeSynch.description = Synchronise date and time of slave elements on the SCS BUS using openHAB timestamp (default: false)
 thing-type.config.openwebnet.bus_gateway.discoveryByActivation.label = Discovery By Activation
 thing-type.config.openwebnet.bus_gateway.discoveryByActivation.description = Discover BUS devices when they are activated (also when a device scan is not active) (default: false)
 thing-type.config.openwebnet.bus_gateway.host.label = Host

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusGateway.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusGateway.xml
@@ -45,6 +45,12 @@
 				<default>false</default>
 			</parameter>
 
+			<parameter name="dateTimeSynch" type="boolean">
+				<label>Date Time Synchronisation</label>
+				<description>Synchronise date and time of slave elements on the SCS BUS using openHAB timestamp (default: false)</description>
+				<default>false</default>
+			</parameter>
+
 		</config-description>
 
 	</bridge-type>


### PR DESCRIPTION
This enhancement PR adds a `dateTimeSynch` configuration parameter to `bus_gateway` Things to  synchronise date and time of slave elements on the SCS BUS using openHAB timestamp.
If this parameter is set to `true` the handler will send time-date synchronisation commands on the BUS when the timestamp received from the gateway differs by more than 1 minute from that of openHAB. 
This enhancement is useful if the BUS gateway is not syncronized with Internet time servers and with daylight saving time changes.

Feature has been tested successfully with one community user.

Fixes #12018 