### PR TITLE
[yamahamusiccast] Fix DecimalType commands for volumeDB channel

### DIFF
--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/YamahaMusiccastHandler.java
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/YamahaMusiccastHandler.java
@@ -228,7 +228,7 @@ public class YamahaMusiccastHandler extends BaseThingHandler {
                     }
                     break;
                 case CHANNEL_VOLUMEDB:
-                    setVolumeDb(((QuantityType<?>) command).floatValue(), zone, this.host);
+                    setVolumeDb(Float.parseFloat(command.toString().replace(" dB", "")), zone, this.host);
                     localSyncVolume = Boolean.parseBoolean(getThing().getConfiguration().get("syncVolume").toString());
                     if (localSyncVolume == Boolean.TRUE) {
                         tmpString = getDistributionInfo(this.host);
@@ -238,8 +238,8 @@ public class YamahaMusiccastHandler extends BaseThingHandler {
                             if ("server".equals(localRole)) {
                                 for (JsonElement ip : distributioninfo.getClientList()) {
                                     JsonObject clientObject = ip.getAsJsonObject();
-                                    setVolumeDbLinkedDevice(((DecimalType) command).floatValue(), zone,
-                                            clientObject.get("ip_address").getAsString());
+                                    setVolumeDbLinkedDevice(Float.parseFloat(command.toString().replace(" dB", "")),
+                                            zone, clientObject.get("ip_address").getAsString());
                                 }
                             }
                         }

--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/YamahaMusiccastHandler.java
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/java/org/openhab/binding/yamahamusiccast/internal/YamahaMusiccastHandler.java
@@ -228,7 +228,16 @@ public class YamahaMusiccastHandler extends BaseThingHandler {
                     }
                     break;
                 case CHANNEL_VOLUMEDB:
-                    setVolumeDb(Float.parseFloat(command.toString().replace(" dB", "")), zone, this.host);
+                    float volumeDb;
+                    if (command instanceof QuantityType<?> qt) {
+                        volumeDb = qt.toUnit(Units.DECIBEL).floatValue();
+                    } else if (command instanceof DecimalType dt) {
+                        volumeDb = dt.floatValue();
+                    } else {
+                        logger.debug("Command has wrong type, QuantityType or DecimalType required!");
+                        return;
+                    }
+                    setVolumeDb(volumeDb, zone, this.host);
                     localSyncVolume = Boolean.parseBoolean(getThing().getConfiguration().get("syncVolume").toString());
                     if (localSyncVolume == Boolean.TRUE) {
                         tmpString = getDistributionInfo(this.host);
@@ -238,8 +247,8 @@ public class YamahaMusiccastHandler extends BaseThingHandler {
                             if ("server".equals(localRole)) {
                                 for (JsonElement ip : distributioninfo.getClientList()) {
                                     JsonObject clientObject = ip.getAsJsonObject();
-                                    setVolumeDbLinkedDevice(Float.parseFloat(command.toString().replace(" dB", "")),
-                                            zone, clientObject.get("ip_address").getAsString());
+                                    setVolumeDbLinkedDevice(volumeDb, zone,
+                                            clientObject.get("ip_address").getAsString());
                                 }
                             }
                         }


### PR DESCRIPTION
The volumeDB channel did not accept DecimalType commands because it attempted to cast any commands to QuantityType and then call `.floatValue()` on it. I'm not sure why I did it this way when adding that channel, this PR fixes the problem.