### PR TITLE
[radiothermostat] Skip sync clock when override is on

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -40,7 +40,8 @@ Click the 'Show advanced' checkbox on the Thing configuration page to display th
 For both the heating and cooling programs, the 7-day repeating schedule has 4 setpoint periods per day (Morning, Day, Evening, Night).
 In order for the heating or cooling program to be valid, all time and setpoint fields must be populated.
 The time is expressed in 24-hour (HH:mm) format and the time value for each successive period within a day must be greater than the previous period.
-Once the schedule is populated and the configuration saved, the new schedule will be sent to the thermostat during binding initialization, overwriting its existing schedule.
+Once the schedule is populated and the configuration saved, the new schedule will be sent to the thermostat each time the binding is initialized, overwriting its existing schedule.
+If the thermostat's current setpoint was overridden, it will be reset to the applicable program setpoint.
 
 If one or more time or setpoint fields are left blank in a given schedule and the configuration saved, the Thing will display a configuration error until the entries are corrected.
 A heating or cooling schedule with all fields left blank will be ignored by the binding.
@@ -61,6 +62,8 @@ curl http://$THERMOSTAT_IP/cloud -d '{"authkey":""}' -X POST
 - The main caveat for using this binding is to keep in mind that the web server in the thermostat is very slow. Do not over load it with excessive amounts of simultaneous commands.
 - When changing the thermostat mode, the current temperature set point is cleared and a refresh of the thermostat data is done to get the new mode's set point.
 - Since retrieving the thermostat's data is the slowest operation, it will take several seconds after changing the mode before the new set point is displayed.
+- Clock sync will not occur if `override` flag is on (i.e. the program setpoint has been manually overridden) because syncing time will reset the temperature back to the program setpoint.
+- The `override` flag is not reported correctly on older thermostat versions (i.e. /tstat/model reports v1.09)
 - The 'Program Mode' command is untested and according to the published API is only available on a CT80 Rev B.
 - Humidity information is available only when using a CT80 thermostat.
 

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/dto/RadioThermostatDTO.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/dto/RadioThermostatDTO.java
@@ -19,7 +19,7 @@ package org.openhab.binding.radiothermostat.internal.dto;
  * @author Michael Lobstein - Initial contribution
  */
 public class RadioThermostatDTO {
-    private RadioThermostatTstatDTO thermostatData;
+    private RadioThermostatTstatDTO thermostatData = new RadioThermostatTstatDTO();
     private Integer humidity;
     private RadioThermostatRuntimeDTO runtime;
 

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/dto/RadioThermostatTstatDTO.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/dto/RadioThermostatTstatDTO.java
@@ -106,6 +106,10 @@ public class RadioThermostatTstatDTO {
         return override;
     }
 
+    public void setOverride(Integer override) {
+        this.override = override;
+    }
+
     public Integer getHold() {
         return hold;
     }

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -235,22 +235,27 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
      * Sync the thermostat's clock with the host system clock
      */
     private void syncThermostatClock() {
-        Calendar c = Calendar.getInstance();
+        boolean success = false;
 
-        // The thermostat week starts as Monday = 0, subtract 2 since in standard DoW Monday = 2
-        int thermDayOfWeek = c.get(Calendar.DAY_OF_WEEK) - 2;
-        // Sunday will be -1, so add 7 to make it 6
-        if (thermDayOfWeek < 0) {
-            thermDayOfWeek += 7;
+        // don't sync clock if override is on because it will reset temporary hold
+        if (rthermData.getThermostatData().getOverride() == null
+                || rthermData.getThermostatData().getOverride().compareTo(0) == 0) {
+            Calendar c = Calendar.getInstance();
+
+            // The thermostat week starts as Monday = 0, subtract 2 since in standard DoW Monday = 2
+            int thermDayOfWeek = c.get(Calendar.DAY_OF_WEEK) - 2;
+            // Sunday will be -1, so add 7 to make it 6
+            if (thermDayOfWeek < 0) {
+                thermDayOfWeek += 7;
+            }
+
+            success = connector.sendCommand(null, null,
+                    String.format(JSON_TIME, thermDayOfWeek, c.get(Calendar.HOUR_OF_DAY), c.get(Calendar.MINUTE)),
+                    TIME_RESOURCE).contains("success");
         }
 
-        final String response = connector.sendCommand(null, null,
-                String.format(JSON_TIME, thermDayOfWeek, c.get(Calendar.HOUR_OF_DAY), c.get(Calendar.MINUTE)),
-                TIME_RESOURCE);
-
         // if sync call was successful run again in one hour, if un-successful try again in one minute
-        this.clockSyncJob = scheduler.schedule(this::syncThermostatClock, (response.contains("success") ? 60 : 1),
-                TimeUnit.MINUTES);
+        this.clockSyncJob = scheduler.schedule(this::syncThermostatClock, (success ? 60 : 1), TimeUnit.MINUTES);
     }
 
     /**
@@ -365,13 +370,15 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
                     }
                     break;
                 case SET_POINT:
-                    String cmdKey = null;
+                    String cmdKey;
                     if (rthermData.getThermostatData().getMode() == 1) {
                         cmdKey = this.setpointCmdKeyPrefix + "heat";
                         rthermData.getThermostatData().setHeatTarget(Double.valueOf(cmdInt));
+                        rthermData.getThermostatData().setOverride(1);
                     } else if (rthermData.getThermostatData().getMode() == 2) {
                         cmdKey = this.setpointCmdKeyPrefix + "cool";
                         rthermData.getThermostatData().setCoolTarget(Double.valueOf(cmdInt));
+                        rthermData.getThermostatData().setOverride(1);
                     } else {
                         // don't do anything if we are not in heat or cool mode
                         break;


### PR DESCRIPTION
To help alleviate the effects of the shutdown of the thermostat manufacturer's cloud service, the configuration parameter to sync the thermostat's clock from the host system clock was made to default to true in #14149. Accordingly, the thermostat clock will be synced once per hour. However, there is an issue with the thermostat in that an overridden temperature set point gets reset to the program set point when the sync occurs.

This PR attempts to work around the issue by checking the status of the override flag and skips the sync if the override is on. Unfortunately this is not a perfect solution because I noticed that one of my thermostats has an older internal firmware version (v1.09) and never reports that the override is on via the api.