### PR TITLE
[bondhome] Suppress warning messages

### DIFF
--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BPUPListener.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BPUPListener.java
@@ -133,7 +133,7 @@ public class BPUPListener implements Runnable {
                     @Nullable
                     String bondId = response.bondId;
                     if (bondId == null || !bondId.equalsIgnoreCase(bridgeHandler.getBridgeId())) {
-                        logger.warn("Response isn't from expected Bridge!  Expected: {}  Got: {}",
+                        logger.trace("Response isn't from expected Bridge! Expected: {} Got: {}",
                                 bridgeHandler.getBridgeId(), bondId);
                     } else {
                         bridgeHandler.setBridgeOnline(inPacket.getAddress().getHostAddress());
@@ -201,7 +201,7 @@ public class BPUPListener implements Runnable {
         BPUPUpdate update = transformUpdatePacket(packet);
         if (update != null) {
             if (!update.bondId.equalsIgnoreCase(bridgeHandler.getBridgeId())) {
-                logger.warn("Response isn't from expected Bridge!  Expected: {}  Got: {}", bridgeHandler.getBridgeId(),
+                logger.trace("Response isn't from expected Bridge! Expected: {} Got: {}", bridgeHandler.getBridgeId(),
                         update.bondId);
             }
 
@@ -236,7 +236,7 @@ public class BPUPListener implements Runnable {
         try {
             response = this.gsonBuilder.fromJson(responseJson, BPUPUpdate.class);
         } catch (JsonParseException e) {
-            logger.warn("Error parsing json! {}", e.getMessage());
+            logger.debug("Error parsing json! {}", e.getMessage());
         }
         return response;
     }
@@ -277,7 +277,7 @@ public class BPUPListener implements Runnable {
                 this.socket = s;
                 logger.trace("Datagram Socket reconnected using port {}.", s.getPort());
             } catch (SocketException exception) {
-                logger.warn("Problem creating new socket : {}", exception.getLocalizedMessage());
+                logger.trace("Problem creating new socket : {}", exception.getLocalizedMessage());
             }
         }
     }

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -194,7 +194,7 @@ public class BondHttpApi {
         try {
             response = request.send();
         } catch (Exception e) {
-            logger.warn("Unable to execute device action {} against device {}: {}", deviceId, action, e.getMessage());
+            logger.debug("Unable to execute device action {} against device {}: {}", deviceId, action, e.getMessage());
             return;
         }
 

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/discovery/BondDiscoveryService.java
@@ -108,7 +108,7 @@ public class BondDiscoveryService extends AbstractDiscoveryService implements Th
                 }
             }
         } catch (BondException ignored) {
-            logger.warn("Error getting devices for discovery: {}", ignored.getMessage());
+            logger.debug("Error getting devices for discovery: {}", ignored.getMessage());
         } finally {
             removeOlderResults(getTimestampOfLastScan());
         }

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondBridgeHandler.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/handler/BondBridgeHandler.java
@@ -232,7 +232,7 @@ public class BondBridgeHandler extends BaseBridgeHandler {
                 logger.trace("could not read topic type from push update or type was not state.");
             }
         } else {
-            logger.warn("Can not read device Id from push update.");
+            logger.trace("Cannot read device Id from push update.");
         }
     }
 
@@ -285,7 +285,7 @@ public class BondBridgeHandler extends BaseBridgeHandler {
      */
     public void setBridgeOnline(String bridgeAddress) {
         if (!config.isValid()) {
-            logger.warn("Configuration error, cannot set the bridghe online without configuration");
+            logger.warn("Configuration error, cannot set the bridge online without configuration");
             return;
         } else if (!config.ipAddress.equals(bridgeAddress)) {
             logger.debug("IP address of Bond {} has changed to {}", config.serialNumber, bridgeAddress);


### PR DESCRIPTION
I am seeing occasional spurious warning messages from bondhome in my openhab.log like this:

![image](https://github.com/openhab/openhab-addons/assets/26532542/b439476b-5326-482a-9803-e470e10b0232)

This PR changes almost all warn() logging calls to trace() or debug() to prevent these messages from being logged.