### PR TITLE
[jsscriptingnashorn] Fix addon.xml

### DIFF
--- a/bundles/org.openhab.automation.jsscriptingnashorn/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/src/main/resources/OH-INF/addon/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon:addon id="jsscripting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<addon:addon id="jsscriptingnashorn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 


### PR DESCRIPTION
See #15125 

The addon-id was wrong (the same as for `jsscripting`), leading to wrong responses of the add-on service when both are installed.
