### PR TITLE
[jdbc] stabilize timescale db type replacement

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcTimescaledbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcTimescaledbDAO.java
@@ -41,7 +41,7 @@ public class JdbcTimescaledbDAO extends JdbcPostgresqlDAO {
         Properties properties = (Properties) this.databaseProps.clone();
         // Adjust the jdbc url since the service name 'timescaledb' is only used to differentiate the DAOs
         if (properties.containsKey("jdbcUrl")) {
-            properties.put("jdbcUrl", properties.getProperty("jdbcUrl").replace("timescaledb", "postgresql"));
+            properties.put("jdbcUrl", properties.getProperty("jdbcUrl").replace("jdbc:timescaledb", "jdbc:postgresql"));
         }
         return properties;
     }


### PR DESCRIPTION
The db type in jdbc:<dbtype>://... will be replaced from timescaledb to postgresql.
When the host/service is named timescaledb too (could happen easily on kubernetes), this will be replaced as well so the connection url isn't correct anymore.
With this change it couldn't happen that the connection url is modified erroneous. 

The change was already build locally and run on my production environment without any errors.