### PR TITLE
[kaleidescape] Fix image channel MIME type

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
@@ -413,7 +413,7 @@ public enum KaleidescapeMessageHandler {
                                 int httpStatus = contentResponse.getStatus();
                                 if (httpStatus == OK_200) {
                                     handler.updateDetailChannel(DETAIL_COVER_ART,
-                                            new RawType(contentResponse.getContent(), RawType.DEFAULT_MIME_TYPE));
+                                            new RawType(contentResponse.getContent(), "image/jpeg"));
                                 } else {
                                     handler.updateDetailChannel(DETAIL_COVER_ART, UnDefType.NULL);
                                 }


### PR DESCRIPTION
Fixes issue where the image channel would work in sitemaps viewed in a browser but not in the openHAB android app.