### PR TITLE
[nuvo] Fix image channel MIME type

### DIFF
--- a/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
+++ b/bundles/org.openhab.binding.nuvo/src/main/java/org/openhab/binding/nuvo/internal/handler/NuvoHandler.java
@@ -1372,7 +1372,7 @@ public class NuvoHandler extends BaseThingHandler implements NuvoMessageEventLis
                 state = new QuantityType<Time>(Integer.parseInt(value) / 10, NuvoHandler.API_SECOND_UNIT);
                 break;
             case CHANNEL_ALBUM_ART:
-                state = new RawType(bytes, RawType.DEFAULT_MIME_TYPE);
+                state = new RawType(bytes, "image/jpeg");
                 break;
             default:
                 break;


### PR DESCRIPTION
Fixes issue where the image channel would work in sitemaps viewed in a browser but not in the openHAB android app.