### PR TITLE
[Telegram] Log when cameras do not support BASIC auth support.

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -352,7 +352,13 @@ public class TelegramActions implements ThingActions {
                         byte[] fileContent = contentResponse.getContent();
                         sendPhoto = new SendPhoto(chatId, fileContent);
                     } else {
-                        logger.warn("Download from {} failed with status: {}", photoURL, contentResponse.getStatus());
+                        if (contentResponse.getStatus() == 401
+                                && contentResponse.getHeaders().get(HttpHeader.WWW_AUTHENTICATE).contains("igest")) {
+                            logger.warn("Download from {} failed due to no BASIC http auth support.", photoURL);
+                        } else {
+                            logger.warn("Download from {} failed with status: {}", photoURL,
+                                    contentResponse.getStatus());
+                        }
                         sendTelegram(chatId, caption + ":Download failed with status " + contentResponse.getStatus());
                         return false;
                     }
@@ -555,7 +561,13 @@ public class TelegramActions implements ThingActions {
                         byte[] fileContent = contentResponse.getContent();
                         sendVideo = new SendVideo(chatId, fileContent);
                     } else {
-                        logger.warn("Download from {} failed with status: {}", videoURL, contentResponse.getStatus());
+                        if (contentResponse.getStatus() == 401
+                                && contentResponse.getHeaders().get(HttpHeader.WWW_AUTHENTICATE).contains("igest")) {
+                            logger.warn("Download from {} failed due to no BASIC http auth support.", videoURL);
+                        } else {
+                            logger.warn("Download from {} failed with status: {}", videoURL,
+                                    contentResponse.getStatus());
+                        }
                         sendTelegram(chatId, caption + ":Download failed with status " + contentResponse.getStatus());
                         return false;
                     }


### PR DESCRIPTION
This PR will now log when a camera is asking for Digest auth as the binding only support BASIC. A number of users have been calling it a bug here so this PR will just make it 100% clear what the cause is:

closes #9792

Signed-off-by: Matthew Skinner <matt@pcmus.com>