### PR TITLE
[hue] Fix reconnection, parallel commands, trigger channels, and light level formula

### DIFF
--- a/bundles/org.openhab.binding.hue/doc/readme_v2.md
+++ b/bundles/org.openhab.binding.hue/doc/readme_v2.md
@@ -69,8 +69,8 @@ Device things support some of the following channels:
 | dynamics              | Number:Time        | Sets the duration of dynamic transitions between light states. (Advanced)                                           |
 | alert                 | String             | Allows setting an alert on a light e.g. flashing them. (Advanced)                                                   |
 | effect                | String             | Allows setting an effect on a light e.g. 'candle' effect. (Advanced)                                                |
-| button-last-event     | Number             | Informs which button was last pressed in the device. (Trigger Channel)                                              |
-| rotary-steps          | Number             | Informs about the number of rotary steps of the last rotary dial movement. (Trigger Channel)                        |
+| button-last-event     | (String)           | Informs which button was last pressed in the device. (Trigger Channel)                                              |
+| rotary-steps          | (String)           | Informs about the number of rotary steps of the last rotary dial movement. (Trigger Channel)                        |
 | motion                | Switch             | Shows if motion has been detected by the sensor. (Read Only)                                                        |
 | motion-enabled        | Switch             | Supports enabling / disabling the motion sensor. (Advanced)                                                         |
 | light-level           | Number:Illuminance | Shows the current light level measured by the sensor. (Read Only)                                                   |

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/connection/Clip2Bridge.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/connection/Clip2Bridge.java
@@ -917,13 +917,14 @@ public class Clip2Bridge implements Closeable {
     }
 
     /**
-     * Use an HTTP/2 PUT command to send a resource to the server.
+     * Use an HTTP/2 PUT command to send a resource to the server. Note: the Hue bridge server can sometimes get
+     * confused by parallel PUT commands, so use 'synchronized' to prevent that.
      *
      * @param resource the resource to put.
      * @throws ApiException if something fails.
      * @throws InterruptedException
      */
-    public void putResource(Resource resource) throws ApiException, InterruptedException {
+    public synchronized void putResource(Resource resource) throws ApiException, InterruptedException {
         if (onlineState == State.CLOSED) {
             return;
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Button.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Button.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.hue.internal.dto.clip2;
 
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.hue.internal.dto.clip2.enums.ButtonEventType;
-import org.openhab.core.library.types.StringType;
-import org.openhab.core.types.State;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -26,17 +27,17 @@ import com.google.gson.annotations.SerializedName;
  */
 @NonNullByDefault
 public class Button {
-    private @NonNullByDefault({}) @SerializedName("last_event") String lastEvent;
+    private @Nullable @SerializedName("last_event") String lastEvent;
 
     /**
      * @return the last button event as an enum.
-     * @throws IllegalArgumentException if lastEvent is bad.
+     * @throws IllegalArgumentException if lastEvent is null or bad.
      */
     public ButtonEventType getLastEvent() throws IllegalArgumentException {
-        return ButtonEventType.valueOf(lastEvent.toUpperCase());
-    }
-
-    public State getLastEventState() {
-        return new StringType(getLastEvent().name());
+        String lastEvent = this.lastEvent;
+        if (Objects.nonNull(lastEvent)) {
+            return ButtonEventType.valueOf(lastEvent.toUpperCase());
+        }
+        throw new IllegalArgumentException("lastEvent field is null");
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/LightLevel.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/LightLevel.java
@@ -40,16 +40,15 @@ public class LightLevel {
     }
 
     /**
-     * Raw sensor light level is '10000 * log10(lux) + 1' so apply the inverse formula to convert to Lux.
+     * Raw sensor light level formula is '10000 * log10(lux + 1)' so apply the inverse formula to convert back to Lux.
+     * NOTE: the Philips/Signify API documentation quotes the formula as '10000 * log10(lux) + 1', however this code
+     * author thinks that that formula is wrong since zero Lux would cause a log10(0) negative infinity overflow!
      *
      * @return a QuantityType with light level in Lux, or UNDEF.
      */
     public State getLightLevelState() {
         if (lightLevelValid) {
-            double rawLightLevel = lightLevel;
-            if (rawLightLevel > 1f) {
-                return new QuantityType<>(Math.pow(10f, (rawLightLevel - 1f) / 10000f), Units.LUX);
-            }
+            return new QuantityType<>(Math.pow(10f, (double) lightLevel / 10000f) - 1f, Units.LUX);
         }
         return UnDefType.UNDEF;
     }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Resource.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Resource.java
@@ -196,11 +196,6 @@ public class Resource {
         return UnDefType.NULL;
     }
 
-    public State getButtonLastEventState() {
-        Button button = this.button;
-        return Objects.nonNull(button) ? button.getLastEventState() : UnDefType.NULL;
-    }
-
     public List<ResourceReference> getChildren() {
         List<ResourceReference> children = this.children;
         return Objects.nonNull(children) ? children : List.of();

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -507,14 +507,9 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
      */
     public void onConnectionOffline() {
         if (assetsLoaded) {
-            try {
-                getClip2Bridge().setExternalRestartScheduled();
-                cancelTask(checkConnectionTask, false);
-                checkConnectionTask = scheduler.schedule(() -> checkConnection(), RECONNECT_DELAY_SECONDS,
-                        TimeUnit.SECONDS);
-            } catch (AssetNotLoadedException e) {
-                // should never occur
-            }
+            cancelTask(checkConnectionTask, false);
+            checkConnectionTask = scheduler.schedule(() -> checkConnection(), RECONNECT_DELAY_SECONDS,
+                    TimeUnit.SECONDS);
         }
     }
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -486,7 +486,15 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
 
             String applicationKey = config.applicationKey;
             applicationKey = Objects.nonNull(applicationKey) ? applicationKey : "";
-            clip2Bridge = new Clip2Bridge(httpClientFactory, this, ipAddress, applicationKey);
+
+            try {
+                clip2Bridge = new Clip2Bridge(httpClientFactory, this, ipAddress, applicationKey);
+            } catch (ApiException e) {
+                logger.trace("initializeAssets() communication error on '{}'", ipAddress, e);
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/offline.api2.comm-error.exception [\"" + e.getMessage() + "\"]");
+                return;
+            }
 
             assetsLoaded = true;
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -783,9 +783,10 @@ public class Clip2ThingHandler extends BaseThingHandler {
                 if (fullUpdate) {
                     addSupportedChannel(CHANNEL_2_BUTTON_LAST_EVENT);
                     controlIds.put(resource.getId(), resource.getControlId());
+                } else {
+                    State buttonState = resource.getButtonEventState(controlIds);
+                    updateState(CHANNEL_2_BUTTON_LAST_EVENT, buttonState, fullUpdate);
                 }
-                State buttonState = resource.getButtonEventState(controlIds);
-                updateState(CHANNEL_2_BUTTON_LAST_EVENT, buttonState, fullUpdate);
                 break;
 
             case DEVICE_POWER:
@@ -828,8 +829,9 @@ public class Clip2ThingHandler extends BaseThingHandler {
             case RELATIVE_ROTARY:
                 if (fullUpdate) {
                     addSupportedChannel(CHANNEL_2_ROTARY_STEPS);
+                } else {
+                    updateState(CHANNEL_2_ROTARY_STEPS, resource.getRotaryStepsState(), fullUpdate);
                 }
-                updateState(CHANNEL_2_ROTARY_STEPS, resource.getRotaryStepsState(), fullUpdate);
                 break;
 
             case TEMPERATURE:


### PR DESCRIPTION
This PR fixes a number of issues raised since the initial release of API v2 support as follows:

1. Shortly before merging #13570 we discussed in this [thread](https://github.com/openhab/openhab-addons/pull/13570#discussion_r1241265369) some potential open issues concerning the handling of GO_AWAY events sent by the Hue bridge server. This PR resolves those issues.

2. When multiple HTTP PUT commands are sent over parallel HTTP2 streams, the Hue Bridge server will sometimes get confused, and return an HTML error. This PR resolves that issue by serializing the PUT commands.

3. A user reported a bug in the start up behaviour of  button trigger channels [here](https://community.openhab.org/t/philips-hue-clip-2-api-v2-discussion-thread/142111/166). When the binding is started up, it would wrongly activate the OH trigger channels for buttons with the last button event (button up). There was also a similar issue for rotary dials. This PR resolves those issues. Trigger channels are no longer activated on start up. However they are activated as before when actual new SSE events are received.

4. A user reported a bug with the formula for converting raw light level to Lux [here](https://community.openhab.org/t/philips-hue-clip-2-api-v2-discussion-thread/142111/178). This PR resolves that issue.

5. The Hue Bridge can sometimes send button events with a null 'last_event' field (probably occurs when a battery powered button comes and goes from the Zigbee net). This could cause an NPE. This PR resolves that issue.