### PR TITLE
[chromecast] Support for more audio streams through the audio servlet

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
@@ -80,6 +80,7 @@ public class ChromecastAudioSink extends AudioSinkAsync {
                 // it is an external URL, the speaker can access it itself and play it.
                 URLAudioStream urlAudioStream = (URLAudioStream) audioStream;
                 url = urlAudioStream.getURL();
+                tryClose(audioStream);
             } else {
                 if (callbackUrl != null) {
                     // we serve it on our own HTTP server

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
@@ -12,15 +12,21 @@
  */
 package org.openhab.binding.chromecast.internal;
 
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.chromecast.internal.handler.ChromecastHandler;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioHTTPServer;
+import org.openhab.core.audio.AudioSinkAsync;
 import org.openhab.core.audio.AudioStream;
-import org.openhab.core.audio.FixedLengthAudioStream;
+import org.openhab.core.audio.StreamServed;
 import org.openhab.core.audio.URLAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
-import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,29 +36,43 @@ import org.slf4j.LoggerFactory;
  * @author Jason Holmes - Initial contribution
  */
 @NonNullByDefault
-public class ChromecastAudioSink {
+public class ChromecastAudioSink extends AudioSinkAsync {
     private final Logger logger = LoggerFactory.getLogger(ChromecastAudioSink.class);
+
+    private static final Set<AudioFormat> SUPPORTED_FORMATS = Set.of(AudioFormat.MP3, AudioFormat.WAV);
+    private static final Set<Class<? extends AudioStream>> SUPPORTED_STREAMS = Set.of(AudioStream.class);
 
     private static final String MIME_TYPE_AUDIO_WAV = "audio/wav";
     private static final String MIME_TYPE_AUDIO_MPEG = "audio/mpeg";
 
-    private final ChromecastCommander commander;
+    private final ChromecastHandler handler;
     private final AudioHTTPServer audioHTTPServer;
     private final @Nullable String callbackUrl;
 
-    public ChromecastAudioSink(ChromecastCommander commander, AudioHTTPServer audioHTTPServer,
+    public ChromecastAudioSink(ChromecastHandler handler, AudioHTTPServer audioHTTPServer,
             @Nullable String callbackUrl) {
-        this.commander = commander;
+        this.handler = handler;
         this.audioHTTPServer = audioHTTPServer;
         this.callbackUrl = callbackUrl;
     }
 
-    public void process(@Nullable AudioStream audioStream) throws UnsupportedAudioFormatException {
+    @Override
+    public String getId() {
+        return handler.getThing().getUID().toString();
+    }
+
+    @Override
+    public @Nullable String getLabel(@Nullable Locale locale) {
+        return handler.getThing().getLabel();
+    }
+
+    @Override
+    public void processAsynchronously(@Nullable AudioStream audioStream) throws UnsupportedAudioFormatException {
         if (audioStream == null) {
             // in case the audioStream is null, this should be interpreted as a request to end any currently playing
             // stream.
             logger.trace("Stop currently playing stream.");
-            commander.handleCloseApp(OnOffType.ON);
+            handler.stop();
         } else {
             final String url;
             if (audioStream instanceof URLAudioStream) {
@@ -63,10 +83,15 @@ public class ChromecastAudioSink {
                 if (callbackUrl != null) {
                     // we serve it on our own HTTP server
                     String relativeUrl;
-                    if (audioStream instanceof FixedLengthAudioStream) {
-                        relativeUrl = audioHTTPServer.serve((FixedLengthAudioStream) audioStream, 10);
-                    } else {
-                        relativeUrl = audioHTTPServer.serve(audioStream);
+                    try {
+                        StreamServed streamServed = audioHTTPServer.serve(audioStream, 10, true);
+                        relativeUrl = streamServed.url();
+                        // we have to run the delayed task when the server has completely played the stream
+                        streamServed.playEnd().thenRun(() -> this.playbackFinished(audioStream));
+                    } catch (IOException e) {
+                        logger.warn("Chromecast binding was not able to handle the audio stream (cache on disk failed)",
+                                e);
+                        return;
                     }
                     url = callbackUrl + relativeUrl;
                 } else {
@@ -74,8 +99,28 @@ public class ChromecastAudioSink {
                     return;
                 }
             }
-            commander.playMedia("Notification", url,
+            handler.playURL("Notification", url,
                     AudioFormat.MP3.isCompatible(audioStream.getFormat()) ? MIME_TYPE_AUDIO_MPEG : MIME_TYPE_AUDIO_WAV);
         }
+    }
+
+    @Override
+    public Set<AudioFormat> getSupportedFormats() {
+        return SUPPORTED_FORMATS;
+    }
+
+    @Override
+    public Set<Class<? extends AudioStream>> getSupportedStreams() {
+        return SUPPORTED_STREAMS;
+    }
+
+    @Override
+    public PercentType getVolume() throws IOException {
+        return handler.getVolume();
+    }
+
+    @Override
+    public void setVolume(PercentType percentType) throws IOException {
+        handler.setVolume(percentType);
     }
 }

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastAudioSink.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.chromecast.internal;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Locale;
 import java.util.Set;
 
@@ -91,16 +92,27 @@ public class ChromecastAudioSink extends AudioSinkAsync {
                     } catch (IOException e) {
                         logger.warn("Chromecast binding was not able to handle the audio stream (cache on disk failed)",
                                 e);
+                        tryClose(audioStream);
                         return;
                     }
                     url = callbackUrl + relativeUrl;
                 } else {
                     logger.warn("We do not have any callback url, so Chromecast cannot play the audio stream!");
+                    tryClose(audioStream);
                     return;
                 }
             }
             handler.playURL("Notification", url,
                     AudioFormat.MP3.isCompatible(audioStream.getFormat()) ? MIME_TYPE_AUDIO_MPEG : MIME_TYPE_AUDIO_WAV);
+        }
+    }
+
+    private void tryClose(@Nullable InputStream is) {
+        if (is != null) {
+            try {
+                is.close();
+            } catch (IOException ignored) {
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/action/ChromecastActions.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/action/ChromecastActions.java
@@ -50,7 +50,7 @@ public class ChromecastActions implements ThingActions {
             logger.warn("Handler is null, cannot play.");
             return false;
         } else {
-            return handler.playURL(url, null);
+            return handler.playURL(null, url, null);
         }
     }
 
@@ -68,7 +68,7 @@ public class ChromecastActions implements ThingActions {
             logger.warn("Handler is null, cannot tweet.");
             return false;
         } else {
-            return handler.playURL(url, mediaType);
+            return handler.playURL(null, url, mediaType);
         }
     }
 

--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/factory/ChromecastHandlerFactory.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/factory/ChromecastHandlerFactory.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.chromecast.internal.ChromecastAudioSink;
 import org.openhab.binding.chromecast.internal.handler.ChromecastHandler;
 import org.openhab.core.audio.AudioHTTPServer;
 import org.openhab.core.audio.AudioSink;
@@ -77,11 +78,12 @@ public class ChromecastHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
-        ChromecastHandler handler = new ChromecastHandler(thing, audioHTTPServer, createCallbackUrl());
+        ChromecastHandler handler = new ChromecastHandler(thing);
+        ChromecastAudioSink audioSink = new ChromecastAudioSink(handler, audioHTTPServer, createCallbackUrl());
 
         @SuppressWarnings("unchecked")
         ServiceRegistration<AudioSink> reg = (ServiceRegistration<AudioSink>) bundleContext
-                .registerService(AudioSink.class.getName(), handler, null);
+                .registerService(AudioSink.class.getName(), audioSink, null);
         audioSinkRegistrations.put(thing.getUID().toString(), reg);
 
         return handler;


### PR DESCRIPTION
Following some rewrite with openhab/openhab-core#3461

Fix volume change/restoration and temporary files handling by using the new core capabilities.
In order to do this properly (by using an async base class), I also separated audiosink in its own class.
