### PR TITLE
[kodi] Support for more audio streams through the HTTP audio servlet

### DIFF
--- a/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiAudioSink.java
+++ b/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiAudioSink.java
@@ -118,7 +118,9 @@ public class KodiAudioSink extends AudioSinkSync {
                     handler.playNotificationSoundURI(new StringType(url), false);
                 } catch (IOException e) {
                     tryClose(audioStream);
-                    logger.warn("Kodi binding was not able to handle the audio stream (cache on disk failed)", e);
+                    throw new UnsupportedAudioStreamException(
+                            "Kodi binding was not able to handle the audio stream (cache on disk failed)",
+                            audioStream.getClass(), e);
                 }
             } else {
                 tryClose(audioStream);

--- a/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiAudioSink.java
+++ b/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiAudioSink.java
@@ -12,18 +12,17 @@
  */
 package org.openhab.binding.kodi.internal;
 
-import java.util.Collections;
+import java.io.IOException;
 import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.openhab.binding.kodi.internal.handler.KodiHandler;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioHTTPServer;
 import org.openhab.core.audio.AudioSink;
+import org.openhab.core.audio.AudioSinkAsync;
 import org.openhab.core.audio.AudioStream;
-import org.openhab.core.audio.FixedLengthAudioStream;
+import org.openhab.core.audio.StreamServed;
 import org.openhab.core.audio.URLAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
 import org.openhab.core.audio.UnsupportedAudioStreamException;
@@ -39,16 +38,14 @@ import org.slf4j.LoggerFactory;
  * @author Paul Frank - Adapted for Kodi
  * @author Christoph Weitkamp - Improvements for playing audio notifications
  */
-public class KodiAudioSink implements AudioSink {
+public class KodiAudioSink extends AudioSinkAsync {
 
     private final Logger logger = LoggerFactory.getLogger(KodiAudioSink.class);
 
-    private static final Set<AudioFormat> SUPPORTED_AUDIO_FORMATS = Collections
-            .unmodifiableSet(Stream.of(AudioFormat.MP3, AudioFormat.WAV).collect(Collectors.toSet()));
-    private static final Set<Class<? extends AudioStream>> SUPPORTED_AUDIO_STREAMS = Collections
-            .unmodifiableSet(Stream.of(FixedLengthAudioStream.class, URLAudioStream.class).collect(Collectors.toSet()));
+    private static final Set<AudioFormat> SUPPORTED_AUDIO_FORMATS = Set.of(AudioFormat.MP3, AudioFormat.WAV);
+    private static final Set<Class<? extends AudioStream>> SUPPORTED_AUDIO_STREAMS = Set.of(AudioStream.class);
     // Needed because Kodi does multiple requests for the stream
-    private static final int STREAM_TIMEOUT = 30;
+    private static final int STREAM_TIMEOUT = 10;
 
     private final KodiHandler handler;
     private final AudioHTTPServer audioHTTPServer;
@@ -71,7 +68,7 @@ public class KodiAudioSink implements AudioSink {
     }
 
     @Override
-    public void process(AudioStream audioStream)
+    public void processAsynchronously(AudioStream audioStream)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         if (audioStream == null) {
             // in case the audioStream is null, this should be interpreted as a request to end any currently playing
@@ -89,20 +86,22 @@ public class KodiAudioSink implements AudioSink {
                 String url = ((URLAudioStream) audioStream).getURL();
                 logger.trace("Processing audioStream URL {} of format {}.", url, format);
                 handler.playURI(new StringType(url));
-            } else if (audioStream instanceof FixedLengthAudioStream) {
-                if (callbackUrl != null) {
-                    // we serve it on our own HTTP server for 30 seconds as Kodi requests the stream several times
-                    // Form the URL for streaming the notification from the OH2 web server
-                    String url = callbackUrl
-                            + audioHTTPServer.serve((FixedLengthAudioStream) audioStream, STREAM_TIMEOUT);
+            } else if (callbackUrl != null) {
+                // we serve it on our own HTTP server for 10 seconds as Kodi requests the stream several times
+                // Form the URL for streaming the notification from the OH web server
+                try {
+                    StreamServed streamServed = audioHTTPServer.serve(audioStream, STREAM_TIMEOUT, true);
+                    // note : KODI is not very compatible with our HTTP server. It keeps requesting the URL again and
+                    // again, resetting the time we label as the "start". Our server cannot reliably detect duration.
+                    streamServed.playEnd().thenRun(() -> this.playbackFinished(audioStream));
+                    String url = callbackUrl + streamServed.url();
                     logger.trace("Processing audioStream URL {} of format {}.", url, format);
-                    handler.playNotificationSoundURI(new StringType(url));
-                } else {
-                    logger.warn("We do not have any callback url, so Kodi cannot play the audio stream!");
+                    handler.playNotificationSoundURI(new StringType(url), false);
+                } catch (IOException e) {
+                    logger.warn("Kodi binding was not able to handle the audio stream (cache on disk failed)", e);
                 }
             } else {
-                throw new UnsupportedAudioStreamException(
-                        "Kodi can only handle URLAudioStream or FixedLengthAudioStreams.", audioStream.getClass());
+                logger.warn("We do not have any callback url, so Kodi cannot play the audio stream!");
             }
         }
     }

--- a/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/handler/KodiHandler.java
+++ b/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/handler/KodiHandler.java
@@ -558,10 +558,10 @@ public class KodiHandler extends BaseThingHandler implements KodiEventListener {
      */
     private boolean waitForState(KodiState state) {
         int timeoutMaxCount = getConfigAs(KodiConfig.class).getNotificationTimeout().intValue(), timeoutCount = 0;
-        logger.trace("Waiting up to {} ms for state '{}' to be set ...", timeoutMaxCount * 100, state);
+        logger.trace("Waiting up to {} ms for state '{}' to be set ...", timeoutMaxCount * 1000, state);
         while (!state.equals(connection.getState()) && timeoutCount < timeoutMaxCount) {
             try {
-                Thread.sleep(100);
+                Thread.sleep(1000);
             } catch (InterruptedException e) {
                 break;
             }


### PR DESCRIPTION
Kodi audio sink supporting more audio streams, with the help of the HTTP audio servlet new capabilities.
Also (slightly) better volume restoration from openHAB.

Related to #15113

Note : The previous system for volume restoration (inside kodi binding) doesn't seem to work. It seems to try to guess when play ends by waiting for state that doesn't happen, and/or for not enough time ?
Plus, when openHAB tried to handle volume, both of them modified it at different time, leading to a mess. I added a boolean to avoid conflict.

So I replace it with the sound duration analysis from the servlet.
It's better but it is not reliable either, because Kodi keep requesting the stream again and again, resetting the time we consider as the "start".