### PR TITLE
[Unifi] Fix logic in README

### DIFF
--- a/bundles/org.openhab.binding.unifi/README.md
+++ b/bundles/org.openhab.binding.unifi/README.md
@@ -92,7 +92,7 @@ Additionally, you may use friendly site names as they appear in the controller U
 #### `considerHome`
 
 The `considerHome` parameter allows you to control how quickly the binding marks a client as away.
-For example, using the default of `180` (seconds), the binding will report a client away as soon as `lastSeen` + `180` (seconds) < `now`.
+For example, using the default of `180` (seconds), the binding will report a client away as soon as `lastSeen` + `180` (seconds) > `now`.
 
 ### `poePort`
 


### PR DESCRIPTION
# Title

[Unifi] Fix logic of comparison in README

# Description

The comparison sign was the wrong way around
- `<`: would be true until 180 seconds passed
- `>`: is true after 180 seconds passed (this is what is intended)