### PR TITLE
[rustpotterks] Upgrade library, fixes gain normalizer

### DIFF
--- a/bundles/org.openhab.voice.rustpotterks/pom.xml
+++ b/bundles/org.openhab.voice.rustpotterks/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.github.givimad</groupId>
       <artifactId>rustpotter-java</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Hi openHAB maintainers, I discovered a couple of days ago a miscalculation on the gain normalizer that made the feature inconsistent. I had to release a new library version.

Already tested over the latest snapshot.