### PR TITLE
[androidtv] Fixes log flooding from protocol error

### DIFF
--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/googletv/GoogleTVConnectionManager.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/googletv/GoogleTVConnectionManager.java
@@ -184,6 +184,10 @@ public class GoogleTVConnectionManager {
         initialize();
     }
 
+    public AndroidTVHandler getHandler() {
+        return handler;
+    }
+
     public String getThingID() {
         return handler.getThingID();
     }

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/googletv/GoogleTVMessageParser.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/googletv/GoogleTVMessageParser.java
@@ -56,6 +56,7 @@ public class GoogleTVMessageParser {
         try {
             if (msg.startsWith(DELIMITER_1A)) {
                 logger.warn("{} - GoogleTV Error Message: {}", thingId, msg);
+                callback.getHandler().dispose();
             } else if (msg.startsWith(DELIMITER_0A)) {
                 // First message on connection from GTV
                 //


### PR DESCRIPTION
As seen in #15153 when the GoogleTV protocol stack has an unrecoverable error it causes a loop of login/fail/repeat.  These errors are unrecoverable by the end user and require developer intervention.  Rather than run up the CPU and flood the log, we need to take that thing offline completely.  This triggers the handler to dispose entirely when that message comes in to avoid an endless loop.  

To note, this should NOT close #15153, this only fixes the log flooding issue, not the actual issue that caused the failure in the first place.