### PR TITLE
[openwebnet] Fix README for Sitemap AUX configuration  to the correct mapping

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -456,10 +456,10 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     
     Frame label="Alarm"
     {
-         Switch    item=iAlarm_System_State      label="Alarm state"
-         Switch    item=iAlarm_Control           label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
-         Switch    item=iAlarm_System_Armed      label="Armed"              icon="shield"
-         Switch    item=iAlarm_System_Network    label="Network"            icon="network"
+         Switch  item=iAlarm_System_State        label="Alarm state"
+         Switch  item=iAlarm_Control             label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
+         Switch  item=iAlarm_System_Armed        label="Armed"              icon="shield"
+         Switch  item=iAlarm_System_Network      label="Network"            icon="network"
          Default item=iAlarm_System_Battery      label="Battery"            icon="battery"
          Switch  item=iAlarm_Zone_3_State        label="Zone 3 state"
          Default item=iAlarm_Zone_3_Alarm        label="Zone 3 alarm"       icon="siren"

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -456,7 +456,8 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     
     Frame label="Alarm"
     {
-         Selection item=iAlarm_Control            label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarm", ON="Arm"] 
+         Switch    item=iAlarm_System_State       label="Alarm state"
+         Switch    item=iAlarm_Control            label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
          Switch    item=iAlarm_System_Armed       label="Armed"              icon="shield"
          Switch    item=iAlarm_System_Network     label="Network"            icon="network"
          Default   item=iAlarm_System_Battery     label="Battery"            icon="battery"

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -457,7 +457,7 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     Frame label="Alarm"
     {
          Switch  item=iAlarm_System_State       label="Alarm state"
-         Switch  item=iAlarm_Control             label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
+         Switch  item=iAlarm_Control            label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
          Switch  item=iAlarm_System_Armed       label="Armed"              icon="shield"
          Switch  item=iAlarm_System_Network     label="Network"            icon="network"
          Default item=iAlarm_System_Battery     label="Battery"            icon="battery"

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -460,9 +460,9 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
          Switch    item=iAlarm_Control           label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
          Switch    item=iAlarm_System_Armed      label="Armed"              icon="shield"
          Switch    item=iAlarm_System_Network    label="Network"            icon="network"
-         Default   item=iAlarm_System_Battery    label="Battery"            icon="battery"
-         Switch    item=iAlarm_Zone_3_State      label="Zone 3 state"
-         Default   item=iAlarm_Zone_3_Alarm      label="Zone 3 alarm"       icon="siren"
+         Default item=iAlarm_System_Battery      label="Battery"            icon="battery"
+         Switch  item=iAlarm_Zone_3_State        label="Zone 3 state"
+         Default item=iAlarm_Zone_3_Alarm        label="Zone 3 alarm"       icon="siren"
     }
 }
 ```

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -456,7 +456,7 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     
     Frame label="Alarm"
     {
-         Switch  item=iAlarm_System_State        label="Alarm state"
+         Switch  item=iAlarm_System_State       label="Alarm state"
          Switch  item=iAlarm_Control             label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
          Switch  item=iAlarm_System_Armed       label="Armed"              icon="shield"
          Switch  item=iAlarm_System_Network     label="Network"            icon="network"

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -458,11 +458,11 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     {
          Switch  item=iAlarm_System_State        label="Alarm state"
          Switch  item=iAlarm_Control             label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
-         Switch  item=iAlarm_System_Armed        label="Armed"              icon="shield"
-         Switch  item=iAlarm_System_Network      label="Network"            icon="network"
-         Default item=iAlarm_System_Battery      label="Battery"            icon="battery"
-         Switch  item=iAlarm_Zone_3_State        label="Zone 3 state"
-         Default item=iAlarm_Zone_3_Alarm        label="Zone 3 alarm"       icon="siren"
+         Switch  item=iAlarm_System_Armed       label="Armed"              icon="shield"
+         Switch  item=iAlarm_System_Network     label="Network"            icon="network"
+         Default item=iAlarm_System_Battery     label="Battery"            icon="battery"
+         Switch  item=iAlarm_Zone_3_State       label="Zone 3 state"
+         Default item=iAlarm_Zone_3_Alarm       label="Zone 3 alarm"       icon="siren"
     }
 }
 ```

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -456,13 +456,12 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     
     Frame label="Alarm"
     {
-         Switch  item=iAlarm_System_State       label="Alarm state"
-         Switch  item=iAlarm_Control            label="Arm/Disarm alarm"   icon="shield"
-         Switch  item=iAlarm_System_Armed       label="Armed"              icon="shield"
-         Switch  item=iAlarm_System_Network     label="Network"            icon="network"
-         Default item=iAlarm_System_Battery     label="Battery"            icon="battery"
-         Switch  item=iAlarm_Zone_3_State       label="Zone 3 state"
-         Default item=iAlarm_Zone_3_Alarm       label="Zone 3 alarm"       icon="siren"
+         Selection item=iAlarm_Control            label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarm", ON="Arm"] 
+         Switch    item=iAlarm_System_Armed       label="Armed"              icon="shield"
+         Switch    item=iAlarm_System_Network     label="Network"            icon="network"
+         Default   item=iAlarm_System_Battery     label="Battery"            icon="battery"
+         Switch    item=iAlarm_Zone_3_State       label="Zone 3 state"
+         Default   item=iAlarm_Zone_3_Alarm       label="Zone 3 alarm"       icon="siren"
     }
 }
 ```

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -456,13 +456,13 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
     
     Frame label="Alarm"
     {
-         Switch    item=iAlarm_System_State       label="Alarm state"
-         Switch    item=iAlarm_Control            label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
-         Switch    item=iAlarm_System_Armed       label="Armed"              icon="shield"
-         Switch    item=iAlarm_System_Network     label="Network"            icon="network"
-         Default   item=iAlarm_System_Battery     label="Battery"            icon="battery"
-         Switch    item=iAlarm_Zone_3_State       label="Zone 3 state"
-         Default   item=iAlarm_Zone_3_Alarm       label="Zone 3 alarm"       icon="siren"
+         Switch    item=iAlarm_System_State      label="Alarm state"
+         Switch    item=iAlarm_Control           label="Arm/Disarm alarm"   icon="shield" mappings=[OFF="Disarmed",ON="Armed"]
+         Switch    item=iAlarm_System_Armed      label="Armed"              icon="shield"
+         Switch    item=iAlarm_System_Network    label="Network"            icon="network"
+         Default   item=iAlarm_System_Battery    label="Battery"            icon="battery"
+         Switch    item=iAlarm_Zone_3_State      label="Zone 3 state"
+         Default   item=iAlarm_Zone_3_Alarm      label="Zone 3 alarm"       icon="siren"
     }
 }
 ```


### PR DESCRIPTION
# Description

Current sitemap configuration suggested on README does not work with  AUX items. in the past a user pointed out that the aux had a problem  with sitemaps. I confirm that   when the item is set as Switch on sitemap it does not work, in fact programmatically the aux command is defined as StringType.

https://community.openhab.org/t/openwebnet-bticino-legrand-binding-beta-4-0-0-0-4-1-0-0/129775/30?u=giovanni_fabiani

Finally a solution has been found 

The rest remains unchanged

 # Testing

Tested on Bticino Alarm unit 3486
closes #15254