### PR TITLE
[androidtv] Fix log flood when physical device is not online

### DIFF
--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/AndroidTVHandler.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/AndroidTVHandler.java
@@ -136,10 +136,12 @@ public class AndroidTVHandler extends BaseThingHandler {
             }
         }
 
-        if (failed && !currentThingStatus.equals(statusMessage)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, statusMessage);
-        } else {
-            updateStatus(ThingStatus.ONLINE);
+        if (!currentThingStatus.equals(statusMessage)) {
+            if (failed) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, statusMessage);
+            } else {
+                updateStatus(ThingStatus.ONLINE);
+            }
         }
 
         this.currentThingStatus = statusMessage;

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/AndroidTVHandler.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/AndroidTVHandler.java
@@ -66,6 +66,7 @@ public class AndroidTVHandler extends BaseThingHandler {
     private final String thingID;
 
     private String currentThingStatus = "";
+    private boolean currentThingFailed = false;
 
     public AndroidTVHandler(Thing thing, AndroidTVDynamicCommandDescriptionProvider commandDescriptionProvider,
             AndroidTVTranslationProvider translationProvider, ThingTypeUID thingTypeUID) {
@@ -114,6 +115,8 @@ public class AndroidTVHandler extends BaseThingHandler {
 
     public void checkThingStatus() {
         String currentThingStatus = this.currentThingStatus;
+        boolean currentThingFailed = this.currentThingFailed;
+
         String statusMessage = "";
         boolean failed = false;
 
@@ -136,7 +139,7 @@ public class AndroidTVHandler extends BaseThingHandler {
             }
         }
 
-        if (!currentThingStatus.equals(statusMessage)) {
+        if (!currentThingStatus.equals(statusMessage) || (currentThingFailed != failed)) {
             if (failed) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, statusMessage);
             } else {
@@ -145,6 +148,7 @@ public class AndroidTVHandler extends BaseThingHandler {
         }
 
         this.currentThingStatus = statusMessage;
+        this.currentThingFailed = failed;
     }
 
     @Override

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/AndroidTVHandler.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/AndroidTVHandler.java
@@ -65,6 +65,8 @@ public class AndroidTVHandler extends BaseThingHandler {
     private final ThingTypeUID thingTypeUID;
     private final String thingID;
 
+    private String currentThingStatus = "";
+
     public AndroidTVHandler(Thing thing, AndroidTVDynamicCommandDescriptionProvider commandDescriptionProvider,
             AndroidTVTranslationProvider translationProvider, ThingTypeUID thingTypeUID) {
         super(thing);
@@ -111,6 +113,7 @@ public class AndroidTVHandler extends BaseThingHandler {
     }
 
     public void checkThingStatus() {
+        String currentThingStatus = this.currentThingStatus;
         String statusMessage = "";
         boolean failed = false;
 
@@ -133,11 +136,13 @@ public class AndroidTVHandler extends BaseThingHandler {
             }
         }
 
-        if (failed) {
+        if (failed && !currentThingStatus.equals(statusMessage)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, statusMessage);
         } else {
             updateStatus(ThingStatus.ONLINE);
         }
+
+        this.currentThingStatus = statusMessage;
     }
 
     @Override


### PR DESCRIPTION
As reported on the forum, if the device is physically offline for a prolonged time the developer sidebar on the UI can have a log flood event.  This adds an additional check to make sure we aren't updating the thing status unless it actually changes.

Example flood:

```
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
* openhab/things/androidtv:googletv:E89EB43854BA/status
ThingStatusInfoEvent
{"status":"OFFLINE","statusDetail":"NONE","description":"GoogleTV: Error opening SSL connection. Check log."}
```