### PR TITLE
[jrubyscripting] loosen default gem version constraint

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/README.md
+++ b/bundles/org.openhab.automation.jrubyscripting/README.md
@@ -99,7 +99,7 @@ Additional [example rules are available](https://openhab.github.io/openhab-jruby
    following the [openHAB instructions](https://www.openhab.org/docs/configuration/addons.html).
    In openHAB 4.0+ the defaults are set so the next step can be skipped.
 1. Go to `Settings -> Other Services -> JRuby Scripting`:
-   - **Ruby Gems**: `openhab-scripting=~>5.0.0`
+   - **Ruby Gems**: `openhab-scripting=~>5.0`
    - **Require Scripts**: `openhab/dsl` (not required, but recommended)
 
 ### Using Files
@@ -112,7 +112,7 @@ Additional [example rules are available](https://openhab.github.io/openhab-jruby
    Create a file called `jruby.cfg` in `<OPENHAB_CONF>/services/` with the following content:
 
    ```ini
-   org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>5.0.0
+   org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>5.0
    org.openhab.automation.jrubyscripting:require=openhab/dsl
    ```
 
@@ -129,7 +129,7 @@ Simply change the `gems` and `require` configuration settings.
 | Parameter             | Description                                                                                              |
 | --------------------- | -------------------------------------------------------------------------------------------------------- |
 | `gem_home`            | The path to store Ruby Gems. <br/><br/>Default: `$OPENHAB_CONF/automation/ruby/.gem/RUBY_ENGINE_VERSION` |
-| `gems`                | A list of gems to install. <br/><br/>Default: `openhab-scripting=~>5.0.0`                                |
+| `gems`                | A list of gems to install. <br/><br/>Default: `openhab-scripting=~>5.0`                                  |
 | `check_update`        | Check for updated version of `gems` on start up or settings change. <br/><br/>Default: `true`            |
 | `require`             | List of scripts to be required automatically. <br/><br/>Default: `openhab/dsl`                           |
 | `rubylib`             | Search path for user libraries. <br/><br/>Default: `$OPENHAB_CONF/automation/ruby/lib`                   |

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -79,7 +79,7 @@ public class JRubyScriptEngineConfiguration {
                     new OptionalConfigurationElement(OptionalConfigurationElement.Type.RUBY_ENVIRONMENT,
                             DEFAULT_RUBYLIB, "RUBYLIB")),
 
-            Map.entry(GEMS_CONFIG_KEY, new OptionalConfigurationElement("openhab-scripting=~>5.0.0")),
+            Map.entry(GEMS_CONFIG_KEY, new OptionalConfigurationElement("openhab-scripting=~>5.0")),
 
             Map.entry(REQUIRE_CONFIG_KEY, new OptionalConfigurationElement("openhab/dsl")),
 

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
@@ -26,7 +26,7 @@
 		<parameter name="gems" type="text" required="false" groupName="gems">
 			<label>Ruby Gems</label>
 			<description><![CDATA[A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an
-			    <tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0.0</tt>".
+			    <tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0</tt>".
 				]]></description>
 			<default>openhab-scripting=~>5.0.0</default>
 		</parameter>

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jruby.properties
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jruby.properties
@@ -5,7 +5,7 @@ automation.config.jruby.dependency_tracking.description = Dependency tracking al
 automation.config.jruby.gem_home.label = GEM_HOME
 automation.config.jruby.gem_home.description = Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary. You can use <tt>{RUBY_ENGINE_VERSION}</tt>, <tt>{RUBY_ENGINE}</tt> and/or <tt>{RUBY_VERSION}</tt> replacements in this value to automatically point to a new directory when the addon is updated with a new version of JRuby. Defaults to "<tt>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</tt>" when not specified.
 automation.config.jruby.gems.label = Ruby Gems
-automation.config.jruby.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0.0</tt>".
+automation.config.jruby.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0</tt>".
 automation.config.jruby.group.environment.label = Ruby Environment
 automation.config.jruby.group.environment.description = This group defines Ruby's environment.
 automation.config.jruby.group.gems.label = Ruby Gems


### PR DESCRIPTION
so that the helper library compatible with 4.0.0.M3+ will be used

See also https://github.com/openhab/openhab-jruby/issues/84
