### PR TITLE
[googletts] Avoid UnsupportedOperationException during dispose

### DIFF
--- a/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleTTSService.java
+++ b/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleTTSService.java
@@ -136,8 +136,8 @@ public class GoogleTTSService extends AbstractCachedTTSService {
     @Deactivate
     protected void dispose() {
         apiImpl.dispose();
-        audioFormats.clear();
-        allVoices.clear();
+        audioFormats = new HashSet<>();
+        allVoices = new HashSet<>();
     }
 
     /**


### PR DESCRIPTION
Fix #15303

It is not allowed to clear an unmodified hash set.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>