### PR TITLE
fix(sec): upgrade com.squareup.okio:okio to 3.4.0

### DIFF
--- a/bundles/org.openhab.voice.watsonstt/pom.xml
+++ b/bundles/org.openhab.voice.watsonstt/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
-      <version>2.8.0</version>
+      <version>3.4.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.squareup.okio:okio 2.8.0
- [CVE-2023-3635](https://www.oscs1024.com/hd/CVE-2023-3635)


### What did I do？
Upgrade com.squareup.okio:okio from 2.8.0 to 3.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS