### PR TITLE
[jsscripting] Fix incorrect cast

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/GraalJSScriptEngineFactory.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.config.core.ConfigurableService;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
@@ -97,9 +98,7 @@ public final class GraalJSScriptEngineFactory implements ScriptEngineFactory {
 
     @Modified
     protected void modified(Map<String, ?> config) {
-        Object injectionEnabled = config.get(CFG_INJECTION_ENABLED);
-        this.injectionEnabled = injectionEnabled == null || (boolean) injectionEnabled;
-        Object useIncludedLibrary = config.get(CFG_USE_INCLUDED_LIBRARY);
-        this.useIncludedLibrary = useIncludedLibrary == null || (boolean) useIncludedLibrary;
+        this.injectionEnabled = ConfigParser.valueAsOrElse(config.get(CFG_INJECTION_ENABLED), Boolean.class, true);
+        this.useIncludedLibrary = ConfigParser.valueAsOrElse(config.get(CFG_USE_INCLUDED_LIBRARY), Boolean.class, true);
     }
 }


### PR DESCRIPTION
Fixes casting String to Boolean error when using file base configuration:

In my setup, I'm configuring the jsscripting automation via a file based .cfg file: `OPENHAB_CONF/services/jsscripting.cfg`. This config file is read as String, which leads to the ClassCastException:
```
	...
Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')
	at org.openhab.automation.jsscripting.internal.GraalJSScriptEngineFactory.modified(GraalJSScriptEngineFactory.java:101) ~[?:?]
	at org.openhab.automation.jsscripting.internal.GraalJSScriptEngineFactory.<init>(GraalJSScriptEngineFactory.java:71) ~[?:?]
	... 103 more
```
I have looked up how https://github.com/openhab/openhab-core is reading in config files and added it in the same way here.

A build of this fix is running on my instance, working as intended.

https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.automation.jsscripting/4.1.0-SNAPSHOT/