### PR TITLE
[microtik] Fix changed date format in firmware v7.10

### DIFF
--- a/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
+++ b/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
@@ -39,8 +39,13 @@ public class Converter {
         if (dateTimeString == null) {
             return null;
         }
-        String fixedTs = dateTimeString.substring(0, 1).toUpperCase() + dateTimeString.substring(1);
-        return LocalDateTime.parse(fixedTs, ROUTEROS_FORMAT);
+        // As of Firmware 7.10 the date format has changed to "yyyy-MM-dd HH:mm:SS"
+        if (dateTimeString.length() == 19) {
+            return LocalDateTime.parse(dateTimeString.replace(" ", "T"));
+        } else {
+            String fixedTs = dateTimeString.substring(0, 1).toUpperCase() + dateTimeString.substring(1);
+            return LocalDateTime.parse(fixedTs, ROUTEROS_FORMAT);
+        }
     }
 
     public @Nullable static LocalDateTime routerosPeriodBack(@Nullable String durationString) {

--- a/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
+++ b/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
@@ -33,17 +33,19 @@ import org.eclipse.jdt.annotation.Nullable;
 public class Converter {
     private static final DateTimeFormatter ROUTEROS_FORMAT = DateTimeFormatter.ofPattern("MMM/dd/yyyy kk:mm:ss",
             Locale.ENGLISH);
+    private static final DateTimeFormatter ROUTEROS_FORMAT_NEW = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss",
+            Locale.ENGLISH);
 
     private static final Pattern PERIOD_PATTERN = Pattern.compile("(\\d+)([a-z]+){1,3}");
 
     public @Nullable static LocalDateTime fromRouterosTime(@Nullable String dateTimeString) {
-        if (dateTimeString == null || dateTimeString.length() < 19) {
+        if (dateTimeString == null ) {
             return null;
         }
         try {
-            // As of Firmware 7.10 the date format has changed to "yyyy-MM-dd HH:mm:SS"
+            // As of Firmware 7.10 the date format has changed to "yyyy-MM-dd HH:mm:ss"
             if (dateTimeString.length() == 19) {
-                return LocalDateTime.parse(dateTimeString.replace(" ", "T"));
+                return LocalDateTime.parse(dateTimeString, ROUTEROS_FORMAT_NEW);
             } else {
                 String fixedTs = dateTimeString.substring(0, 1).toUpperCase() + dateTimeString.substring(1);
                 return LocalDateTime.parse(fixedTs, ROUTEROS_FORMAT);

--- a/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
+++ b/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mikrotik.internal.util;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -36,15 +37,19 @@ public class Converter {
     private static final Pattern PERIOD_PATTERN = Pattern.compile("(\\d+)([a-z]+){1,3}");
 
     public @Nullable static LocalDateTime fromRouterosTime(@Nullable String dateTimeString) {
-        if (dateTimeString == null) {
+        if (dateTimeString == null || dateTimeString.length() < 19) {
             return null;
         }
-        // As of Firmware 7.10 the date format has changed to "yyyy-MM-dd HH:mm:SS"
-        if (dateTimeString.length() == 19) {
-            return LocalDateTime.parse(dateTimeString.replace(" ", "T"));
-        } else {
-            String fixedTs = dateTimeString.substring(0, 1).toUpperCase() + dateTimeString.substring(1);
-            return LocalDateTime.parse(fixedTs, ROUTEROS_FORMAT);
+        try {
+            // As of Firmware 7.10 the date format has changed to "yyyy-MM-dd HH:mm:SS"
+            if (dateTimeString.length() == 19) {
+                return LocalDateTime.parse(dateTimeString.replace(" ", "T"));
+            } else {
+                String fixedTs = dateTimeString.substring(0, 1).toUpperCase() + dateTimeString.substring(1);
+                return LocalDateTime.parse(fixedTs, ROUTEROS_FORMAT);
+            }
+        } catch (DateTimeParseException e) {
+            return null;
         }
     }
 

--- a/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
+++ b/bundles/org.openhab.binding.mikrotik/src/main/java/org/openhab/binding/mikrotik/internal/util/Converter.java
@@ -39,7 +39,7 @@ public class Converter {
     private static final Pattern PERIOD_PATTERN = Pattern.compile("(\\d+)([a-z]+){1,3}");
 
     public @Nullable static LocalDateTime fromRouterosTime(@Nullable String dateTimeString) {
-        if (dateTimeString == null ) {
+        if (dateTimeString == null || dateTimeString.length() < 19) {
             return null;
         }
         try {

--- a/bundles/org.openhab.binding.mikrotik/src/test/java/org/openhab/binding/mikrotik/internal/util/ConverterTest.java
+++ b/bundles/org.openhab.binding.mikrotik/src/test/java/org/openhab/binding/mikrotik/internal/util/ConverterTest.java
@@ -36,6 +36,18 @@ public class ConverterTest {
                 is(equalTo(LocalDateTime.of(2021, 1, 7, 9, 14, 11, 0))));
         assertThat(Converter.fromRouterosTime("feb/13/2021 23:59:59"),
                 is(equalTo(LocalDateTime.of(2021, 2, 13, 23, 59, 59, 0))));
+
+        assertThat(Converter.fromRouterosTime("2021-02-13 23:59:59"),
+                is(equalTo(LocalDateTime.of(2021, 2, 13, 23, 59, 59, 0))));
+        assertThat(Converter.fromRouterosTime("2020-12-11 20:45:40"),
+                is(equalTo(LocalDateTime.of(2020, 12, 11, 20, 45, 40, 0))));
+        assertThat(Converter.fromRouterosTime("2021-01-07 09:14:11"),
+                is(equalTo(LocalDateTime.of(2021, 1, 7, 9, 14, 11, 0))));
+
+        assertNull(Converter.fromRouterosTime(null));
+        assertNull(Converter.fromRouterosTime(""));
+        assertNull(Converter.fromRouterosTime("2021-18-07 09:14:11"));
+        assertNull(Converter.fromRouterosTime("feb/41/2021 23:59:59"));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/15100

Since routerOs 7.10 the returned dateformat has changed. This PR ads old/new format detection and parsing. 

Test jar 4.x here : https://1drv.ms/u/s!AnMcxmvEeupwjq5eM322cplpF5bAaQ?e=0UZZ4e

Tests confirmed the fix