### PR TITLE
[renault] Small logging improvements.

### DIFF
--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/Car.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/Car.java
@@ -196,7 +196,7 @@ public class Car {
                 }
             }
         } catch (IllegalStateException | ClassCastException e) {
-            logger.warn("Error {} parsing Location: {}", e.getMessage(), responseJson);
+            logger.warn("Error {} parsing Lock Status: {}", e.getMessage(), responseJson);
         }
     }
 

--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/MyRenaultHttpSession.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/MyRenaultHttpSession.java
@@ -331,8 +331,8 @@ public class MyRenaultHttpSession {
                         response.getStatus(), response.getReason(), response.getContentAsString());
             }
         } else {
-            logger.warn("Kamereon Request: {} Response: [{}] {}\n{}", request.getURI().toString(), response.getStatus(),
-                    response.getReason(), response.getContentAsString());
+            logger.debug("Kamereon Request: {} Response: [{}] {}\n{}", request.getURI().toString(),
+                    response.getStatus(), response.getReason(), response.getContentAsString());
         }
     }
 


### PR DESCRIPTION
As requested the HTTP != 200 responses are set to debug logging level.  This cleans up the init log of the binding for cars that do not support lock status.

Details of this request are here;
https://community.openhab.org/t/betatest-renault-ze-services-binding/72226/240?u=doug_culnane