### PR TITLE
[sonnen] Fix channel types, Energy should be Power

### DIFF
--- a/bundles/org.openhab.binding.sonnen/README.md
+++ b/bundles/org.openhab.binding.sonnen/README.md
@@ -23,15 +23,13 @@ The following channels are yet supported:
 | Channel                        | Type          | Access | Description                                                                             |
 | ------------------------------ | ------------- | ------ | --------------------------------------------------------------------------------------- |
 | batteryChargingState           | Switch        | read   | Indicates if the Battery is charging at that moment                                     |
-| batteryCharging                | Number:Energy | read   | Indicates the actual current charging the Battery. Otherwise 0.                         |
+| batteryCharging                | Number:Power  | read   | Indicates the actual current charging the Battery. Otherwise 0.                         |
 | batteryDischargingState        | Switch        | read   | Indicates if the Battery is discharging at that moment                                  |
-| batteryDischarging             | Number:Energy | read   | Indicates the actual current discharging the Battery. Otherwise 0.                      |
-| batteryFeedIn                  | Number:Energy | read   | Indicates the actual charging current of the Battery in watt                            |
-| batteryDischarging             | Number:Energy | read   | Indicates the actual current discharging the Battery in watt                            |
-| consumption                    | Number:Energy | read   | Indicates the actual consumption of the consumer in watt                                |
-| gridFeedIn                     | Number:Energy | read   | Indicates the actual current feeding to the Grid in watt.0 if nothing is feeded         |
-| gridConsumption                | Number:Energy | read   | Indicates the actual current consumption from the Grid in watt.0 if nothing is received |
-| solarProduction                | Number:Energy | read   | Indicates the actual production of the Solar system in watt                             |
+| batteryDischarging             | Number:Power  | read   | Indicates the actual current discharging the Battery. Otherwise 0.                      |
+| consumption                    | Number:Power  | read   | Indicates the actual consumption of the consumer in watt                                |
+| gridFeedIn                     | Number:Power  | read   | Indicates the actual current feeding to the Grid in watt.0 if nothing is feeded         |
+| gridConsumption                | Number:Power  | read   | Indicates the actual current consumption from the Grid in watt.0 if nothing is received |
+| solarProduction                | Number:Power  | read   | Indicates the actual production of the Solar system in watt                             |
 | batteryLevel                   | Number        | read   | Indicates the actual Battery Level in % from 0 - 100                                    |
 | flowConsumptionBatteryState    | Switch        | read   | Indicates if there is a current flow from Battery towards Consumption                   |
 | flowConsumptionGridState       | Switch        | read   | Indicates if there is a current flow from Grid towards Consumption                      |

--- a/bundles/org.openhab.binding.sonnen/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sonnen/src/main/resources/OH-INF/thing/thing-types.xml
@@ -71,37 +71,37 @@
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="batteryCharging">
-		<item-type>Number:Energy</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Battery Charging</label>
 		<description>Indicates the actual current charging the Battery. Otherwise 0.</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="batteryDischarging">
-		<item-type>Number:Energy</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Battery Discharging</label>
 		<description>Indicates the actual current discharging the Battery. Otherwise 0.</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="consumption">
-		<item-type>Number:Energy</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Consumption</label>
 		<description>Indicates the actual consumption of the House.</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="gridFeedIn">
-		<item-type>Number:Energy</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Grid Feed In</label>
 		<description>Indicates the actual current feeding to the Grid. Otherwise 0.</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="gridConsumption">
-		<item-type>Number:Energy</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Grid Consumption</label>
 		<description>Indicates the actual current consumption from the the Grid. Otherwise 0.</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="solarProduction">
-		<item-type>Number:Energy</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Solar Production</label>
 		<description>Indicates the actual production of the Solar system.</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>

--- a/bundles/org.openhab.binding.sonnen/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sonnen/src/main/resources/OH-INF/thing/thing-types.xml
@@ -32,7 +32,7 @@
 		</channels>
 		<properties>
 			<property name="vendor">sonnen</property>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 
 		<config-description>

--- a/bundles/org.openhab.binding.sonnen/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.sonnen/src/main/resources/OH-INF/update/instructions.xml
@@ -19,5 +19,26 @@
 				<type>sonnen:energyExportedStateConsumption</type>
 			</add-channel>
 		</instruction-set>
+
+		<instruction-set targetVersion="2">
+			<update-channel id="batteryCharging">
+				<type>sonnen:batteryCharging</type>
+			</update-channel>
+			<update-channel id="batteryDischarging">
+				<type>sonnen:batteryDischarging</type>
+			</update-channel>
+			<update-channel id="consumption">
+				<type>sonnen:consumption</type>
+			</update-channel>
+			<update-channel id="gridFeedIn">
+				<type>sonnen:gridFeedIn</type>
+			</update-channel>
+			<update-channel id="gridConsumption">
+				<type>sonnen:gridConsumption</type>
+			</update-channel>
+			<update-channel id="solarProduction">
+				<type>sonnen:solarProduction</type>
+			</update-channel>
+		</instruction-set>
 	</thing-type>
 </update:update-descriptions>


### PR DESCRIPTION
Also adapt the documentation and drop the batteryFeedIn in the documentation, which is not part of the binding.

Fix #15365 / https://github.com/openhab/openhab-addons/issues/15365

The binding define different things/channels in "Number:Energy" but these are regular "W" entries in the binding. So "Number:Power" is the right channel type. This fix should avoid the warnings in the log, that the binding try to put a "W" into the "Number:Energy" item: `Failed to update item 'Sonnen_Battery_Consumption' because '721 W' could not be converted to the item unit 'kWh'`

