### PR TITLE
Disable "Improved ZIP64 Extra Field Validation" in itests

### DIFF
--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -23,7 +23,9 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 
 # An unused random HTTP port is used during tests to prevent resource conflicts
 # This property is set by the build-helper-maven-plugin in the itests pom.xml
--runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
+-runvm: \
+	-Djdk.util.zip.disableZip64ExtraFieldValidation=true,\
+	-Dorg.osgi.service.http.port=${org.osgi.service.http.port}
 
 # The integration test itself does not export anything.
 Export-Package: 


### PR DESCRIPTION
This prevents ZipException stacktraces when running the itests on JDK 17.0.8 or newer.

Related to:

* openhab/openhab-core#3718
* openhab/openhab-core#3747