### PR TITLE
[opensprinkler] Fix Program names and add new features for firmware 2.2.0

### DIFF
--- a/bundles/org.openhab.binding.opensprinkler/README.md
+++ b/bundles/org.openhab.binding.opensprinkler/README.md
@@ -79,7 +79,7 @@ NOTE: Some channels will only show up if the hardware has the required sensor an
 |                 |                        |    | in the `nextDuration` channel.                                                  |
 | waterlevel      | Number:Dimensionless   | RO | This channel shows the current water level in percent (0-250%). The water level is |
 |                 |                        |    | calculated based on the weather and influences the duration of the water programs. |
-| queuedZones     | Number:Dimensionless   | RO | A count of how many zones are running and also waiting to run in the queue.        |
+| queuedZones     | Number                 | RO | A count of how many zones are running and also waiting to run in the queue.        |
 
 ## Textual Example
 

--- a/bundles/org.openhab.binding.opensprinkler/README.md
+++ b/bundles/org.openhab.binding.opensprinkler/README.md
@@ -61,22 +61,25 @@ NOTE: Some channels will only show up if the hardware has the required sensor an
 
 | Channel Type ID | Item Type              |    | Description                                                                        |
 |-----------------|------------------------|----|------------------------------------------------------------------------------------|
-| rainsensor      | Switch                 | RO | This channel indicates whether rain is detected by the device or not.              |
-| sensor2         | Switch                 | RO | This channel is for the second sensor (if your hardware supports it).              |
+| cloudConnected  | Switch                 | RO | If the device is fully connected to the OpenSprinkler cloud this will show as 'ON'.|
 | currentDraw     | Number:ElectricCurrent | RO | Shows the current draw of the device.                                              |
-| waterlevel      | Number:Dimensionless   | RO | This channel shows the current water level in percent (0-250%). The water level is |
-|                 |                        |    | calculated based on the weather and influences the duration of the water programs. |
-| signalStrength  | Number                 | RO | Shows how strong the WiFi Signal is.     |
+| enablePrograms  | Switch                 | RW | Allow programs to auto run. When OFF, manually started stations will still work.   |
 | flowSensorCount | Number:Dimensionless   | RO | Shows the number of pulses the optional water flow sensor has reported.            |
-| programs        | String                 | RW | Displays a list of the programs that are setup in your OpenSprinkler and when      |
-|                 |                        |    | selected will start that program for you.                                          |
-| stations        | String                 | RW | Display a list of stations that can be run when selected to the length of time set |
-|                 |                        |    | in the `nextDuration` channel.                                                  |
 | nextDuration    | Number:Time            | RW | The time the station will open for when any stations are selected from the         |
 |                 |                        |    | `stations` channel. Defaults to 30 minutes if not set.                           |
-| resetStations   | Switch                 | RW | The ON command will stop all stations immediately, including those waiting to run. |
-| enablePrograms  | Switch                 | RW | Allow programs to auto run. When OFF, manually started stations will still work.   |
+| pausePrograms   | Number:Time            | RW | Sets/Shows the amount of time that programs will be paused for.                    |
+| programs        | String                 | RW | Displays a list of the programs that are setup in your OpenSprinkler and when      |
+|                 |                        |    | selected will start that program for you.                                          |
 | rainDelay       | Number:Time            | RW | Sets/Shows the amount of time (hours) that rain has caused programs to be delayed. |
+| rainsensor      | Switch                 | RO | This channel indicates whether rain is detected by the device or not.              |
+| resetStations   | Switch                 | RW | The ON command will stop all stations immediately, including those waiting to run. |
+| sensor2         | Switch                 | RO | This channel is for the second sensor (if your hardware supports it).              |
+| signalStrength  | Number                 | RO | Shows how strong the WiFi Signal is.     |
+| stations        | String                 | RW | Display a list of stations that can be run when selected to the length of time set |
+|                 |                        |    | in the `nextDuration` channel.                                                  |
+| waterlevel      | Number:Dimensionless   | RO | This channel shows the current water level in percent (0-250%). The water level is |
+|                 |                        |    | calculated based on the weather and influences the duration of the water programs. |
+| queuedZones     | Number:Dimensionless   | RO | A count of how many zones are running and also waiting to run in the queue.        |
 
 ## Textual Example
 

--- a/bundles/org.openhab.binding.opensprinkler/pom.xml
+++ b/bundles/org.openhab.binding.opensprinkler/pom.xml
@@ -13,12 +13,4 @@
   <artifactId>org.openhab.binding.opensprinkler</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: OpenSprinkler Binding</name>
-  <dependencies>
-    <dependency>
-      <groupId>javax.measure</groupId>
-      <artifactId>unit-api</artifactId>
-      <version>2.2</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
 </project>

--- a/bundles/org.openhab.binding.opensprinkler/pom.xml
+++ b/bundles/org.openhab.binding.opensprinkler/pom.xml
@@ -13,5 +13,12 @@
   <artifactId>org.openhab.binding.opensprinkler</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: OpenSprinkler Binding</name>
-
+  <dependencies>
+    <dependency>
+      <groupId>javax.measure</groupId>
+      <artifactId>unit-api</artifactId>
+      <version>2.2</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/feature/feature.xml
@@ -3,7 +3,6 @@
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 	<feature name="openhab-binding-opensprinkler" description="OpenSprinkler Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">javax.measure.unit-api</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.opensprinkler/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/feature/feature.xml
@@ -3,6 +3,7 @@
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 	<feature name="openhab-binding-opensprinkler" description="OpenSprinkler Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<feature dependency="true">javax.measure.unit-api</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.opensprinkler/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBindingConstants.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBindingConstants.java
@@ -82,4 +82,7 @@ public class OpenSprinklerBindingConstants {
     public static final String NEXT_DURATION = "nextDuration";
     public static final String CHANNEL_IGNORE_RAIN = "ignoreRain";
     public static final String CHANNEL_RAIN_DELAY = "rainDelay";
+    public static final String CHANNEL_QUEUED_ZONES = "queuedZones";
+    public static final String CHANNEL_CLOUD_CONNECTED = "cloudConnected";
+    public static final String CHANNEL_PAUSE_PROGRAMS = "pausePrograms";
 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerState.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerState.java
@@ -63,6 +63,11 @@ public class OpenSprinklerState {
         public int rssi = 1;
         public int flcrt = -1;
         public int curr = -1;
+        public int pq = -1;
+        public int pt = -1;
+        public int nq = -1;
+        public int otcs = -1;
+        public String dname = "";
     }
 
     public static class JnResponse {

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerState.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerState.java
@@ -63,11 +63,9 @@ public class OpenSprinklerState {
         public int rssi = 1;
         public int flcrt = -1;
         public int curr = -1;
-        public int pq = -1;
         public int pt = -1;
         public int nq = -1;
         public int otcs = -1;
-        public String dname = "";
     }
 
     public static class JnResponse {

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApi.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApi.java
@@ -278,7 +278,7 @@ public interface OpenSprinklerApi {
     /**
      * Sets the amount of time that the OpenSprinkler will stop/pause zones.
      *
-     * @param 0 to 600 seconds
+     * @param seconds for the pause duration in seconds (0 to 600)
      * @throws UnauthorizedApiException
      * @throws CommunicationApiException
      */

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApi.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApi.java
@@ -253,4 +253,34 @@ public interface OpenSprinklerApi {
      * @return {@code QuantityType<Time>}
      */
     QuantityType<Time> getRainDelay();
+
+    /**
+     * Returns the Number of zones in the queue as an int.
+     *
+     * @return Number of zones in the queue as an int.
+     */
+    int getQueuedZones();
+
+    /**
+     * Returns the connection status of the OpenSprinkler Cloud.
+     *
+     * @return Connection state 0: not enabled, 1: connecting, 2: disconnected, 3: connected
+     */
+    int getCloudConnected();
+
+    /**
+     * Returns the paused status of the OpenSprinkler.
+     *
+     * @return int 0 to 600 seconds
+     */
+    int getPausedState();
+
+    /**
+     * Sets the amount of time that the OpenSprinkler will stop/pause zones.
+     *
+     * @param 0 to 600 seconds
+     * @throws UnauthorizedApiException
+     * @throws CommunicationApiException
+     */
+    void setPausePrograms(int seconds) throws UnauthorizedApiException, CommunicationApiException;
 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApiFactory.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerApiFactory.java
@@ -70,8 +70,10 @@ public class OpenSprinklerApiFactory {
             return new OpenSprinklerHttpApiV213(this.httpClient, config);
         } else if (version >= 217 && version < 219) {
             return new OpenSprinklerHttpApiV217(this.httpClient, config);
-        } else if (version >= 219) {
+        } else if (version >= 219 && version < 220) {
             return new OpenSprinklerHttpApiV219(this.httpClient, config);
+        } else if (version >= 220) {
+            return new OpenSprinklerHttpApiV220(this.httpClient, config);
         } else {
             /* Need to make sure we have an older OpenSprinkler device by checking the first station. */
             try {

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
@@ -432,4 +432,23 @@ class OpenSprinklerHttpApiV100 implements OpenSprinklerApi {
             return response.getContentAsString();
         }
     }
+
+    @Override
+    public int getQueuedZones() {
+        return state.jcReply.nq;
+    }
+
+    @Override
+    public int getCloudConnected() {
+        return state.jcReply.otcs;
+    }
+
+    @Override
+    public int getPausedState() {
+        return state.jcReply.pt;
+    }
+
+    @Override
+    public void setPausePrograms(int seconds) throws UnauthorizedApiException, CommunicationApiException {
+    }
 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV219.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV219.java
@@ -21,7 +21,7 @@ import org.openhab.binding.opensprinkler.internal.config.OpenSprinklerHttpInterf
 
 /**
  * The {@link OpenSprinklerHttpApiV219} class is used for communicating with
- * the firmware versions 2.1.9 and up.
+ * the firmware versions 2.1.9
  *
  * @author Matthew Skinner - Initial contribution
  */

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
@@ -67,7 +67,7 @@ public class OpenSprinklerHttpApiV220 extends OpenSprinklerHttpApiV219 {
                 }
             }
         } catch (JsonParseException e) {
-            logger.debug("Following json could not be parsed:{} due to {}", returnContent, e);
+            logger.debug("Following json could not be parsed:{}", returnContent);
         }
     }
 

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
@@ -67,6 +67,6 @@ public class OpenSprinklerHttpApiV220 extends OpenSprinklerHttpApiV219 {
 
     @Override
     public void setPausePrograms(int seconds) throws UnauthorizedApiException, CommunicationApiException {
-        http.sendHttpGet(getBaseUrl() + "pq", "dur=" + seconds);
+        http.sendHttpGet(getBaseUrl() + "pq", getRequestRequiredOptions() + "&dur=" + seconds);
     }
 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.opensprinkler.internal.api;
+
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_PROGRAM_DATA;
+
+import java.util.ArrayList;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.opensprinkler.internal.OpenSprinklerState.JpResponse;
+import org.openhab.binding.opensprinkler.internal.api.exception.CommunicationApiException;
+import org.openhab.binding.opensprinkler.internal.api.exception.GeneralApiException;
+import org.openhab.binding.opensprinkler.internal.api.exception.UnauthorizedApiException;
+import org.openhab.binding.opensprinkler.internal.config.OpenSprinklerHttpInterfaceConfig;
+import org.openhab.core.types.StateOption;
+
+/**
+ * The {@link OpenSprinklerHttpApiV220} class is used for communicating with
+ * the firmware versions 2.2.0 and up.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class OpenSprinklerHttpApiV220 extends OpenSprinklerHttpApiV219 {
+
+    OpenSprinklerHttpApiV220(HttpClient httpClient, OpenSprinklerHttpInterfaceConfig config)
+            throws GeneralApiException, CommunicationApiException {
+        super(httpClient, config);
+    }
+
+    @Override
+    public void getProgramData() throws CommunicationApiException, UnauthorizedApiException {
+        String returnContent;
+        try {
+            returnContent = http.sendHttpGet(getBaseUrl() + CMD_PROGRAM_DATA, getRequestRequiredOptions());
+        } catch (CommunicationApiException exp) {
+            throw new CommunicationApiException(
+                    "There was a problem in the HTTP communication with the OpenSprinkler API: " + exp.getMessage());
+        }
+        JpResponse resp = gson.fromJson(returnContent, JpResponse.class);
+        if (resp != null && resp.pd.length > 0) {
+            state.programs = new ArrayList<>();
+            int counter = 0;
+            for (Object x : resp.pd) {
+                String temp = x.toString();
+                logger.trace("Program Data:{}", temp);
+                int end = temp.lastIndexOf('[') - 2;
+                int start = temp.lastIndexOf((','), end - 1) + 2;
+                if (start > -1 && end > -1) {
+                    temp = temp.substring(start, end);
+                    state.programs.add(new StateOption(Integer.toString(counter++), temp));
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV220.java
@@ -64,4 +64,9 @@ public class OpenSprinklerHttpApiV220 extends OpenSprinklerHttpApiV219 {
             }
         }
     }
+
+    @Override
+    public void setPausePrograms(int seconds) throws UnauthorizedApiException, CommunicationApiException {
+        http.sendHttpGet(getBaseUrl() + "pq", "dur=" + seconds);
+    }
 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerDeviceHandler.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerDeviceHandler.java
@@ -120,11 +120,7 @@ public class OpenSprinklerDeviceHandler extends OpenSprinklerBaseHandler {
                 updateState(channel, new DecimalType(localAPI.getQueuedZones()));
                 break;
             case CHANNEL_CLOUD_CONNECTED:
-                if (localAPI.getCloudConnected() == 3) {
-                    updateState(channel, OnOffType.ON);
-                } else {
-                    updateState(channel, OnOffType.OFF);
-                }
+                updateState(channel, OnOffType.from(localAPI.getCloudConnected() == 3));
                 break;
             case CHANNEL_PAUSE_PROGRAMS:
                 updateState(channel, new QuantityType<>(localAPI.getPausedState(), Units.SECOND));
@@ -269,7 +265,6 @@ public class OpenSprinklerDeviceHandler extends OpenSprinklerBaseHandler {
                             if (quantity != null) {
                                 api.setPausePrograms(quantity.toBigDecimal().intValue());
                             }
-                            api.setPausePrograms(((BigDecimal) command).intValue());
                         } else {
                             logger.warn(
                                     "The CHANNEL_PAUSE_PROGRAMS only supports QuanityType in seconds, DecimalType and OFF");

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerDeviceHandler.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerDeviceHandler.java
@@ -117,7 +117,7 @@ public class OpenSprinklerDeviceHandler extends OpenSprinklerBaseHandler {
             case CHANNEL_RESET_STATIONS:
                 break;
             case CHANNEL_QUEUED_ZONES:
-                updateState(channel, new QuantityType<Dimensionless>(localAPI.getQueuedZones(), Units.ONE));
+                updateState(channel, new DecimalType(localAPI.getQueuedZones()));
                 break;
             case CHANNEL_CLOUD_CONNECTED:
                 if (localAPI.getCloudConnected() == 3) {
@@ -261,15 +261,11 @@ public class OpenSprinklerDeviceHandler extends OpenSprinklerBaseHandler {
                     case CHANNEL_PAUSE_PROGRAMS:
                         if (command == OnOffType.OFF) {
                             api.setPausePrograms(0);
-                        } else if (!(command instanceof QuantityType<?>)) {
-                            logger.warn("Ignoring implausible non-QuantityType command for CHANNEL_PAUSE_PROGRAMS");
+                        } else if (!(command instanceof DecimalType)) {
+                            logger.warn("The CHANNEL_PAUSE_PROGRAMS only supports DecimalType and OFF");
                             return;
                         } else {
-                            QuantityType<?> quantity = (QuantityType<?>) command;
-                            quantity = quantity.toUnit(Units.SECOND);
-                            if (quantity != null) {
-                                api.setPausePrograms(quantity.toBigDecimal().intValue());
-                            }
+                            api.setPausePrograms(((BigDecimal) command).intValue());
                         }
                         break;
                 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerDeviceHandler.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerDeviceHandler.java
@@ -261,11 +261,19 @@ public class OpenSprinklerDeviceHandler extends OpenSprinklerBaseHandler {
                     case CHANNEL_PAUSE_PROGRAMS:
                         if (command == OnOffType.OFF) {
                             api.setPausePrograms(0);
-                        } else if (!(command instanceof DecimalType)) {
-                            logger.warn("The CHANNEL_PAUSE_PROGRAMS only supports DecimalType and OFF");
-                            return;
-                        } else {
+                        } else if (command instanceof DecimalType) {
                             api.setPausePrograms(((BigDecimal) command).intValue());
+                        } else if (command instanceof QuantityType<?>) {
+                            QuantityType<?> quantity = (QuantityType<?>) command;
+                            quantity = quantity.toUnit(Units.SECOND);
+                            if (quantity != null) {
+                                api.setPausePrograms(quantity.toBigDecimal().intValue());
+                            }
+                            api.setPausePrograms(((BigDecimal) command).intValue());
+                        } else {
+                            logger.warn(
+                                    "The CHANNEL_PAUSE_PROGRAMS only supports QuanityType in seconds, DecimalType and OFF");
+                            return;
                         }
                         break;
                 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/i18n/opensprinkler.properties
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/i18n/opensprinkler.properties
@@ -31,6 +31,8 @@ thing-type.config.opensprinkler.station.stationIndex.description = The index of 
 
 # channel types
 
+channel-type.opensprinkler.cloudConnected.label = Cloud Connected
+channel-type.opensprinkler.cloudConnected.description = If the device is fully connected to the OpenSprinkler cloud this will show as 'ON'.
 channel-type.opensprinkler.currentDraw.label = Current Draw
 channel-type.opensprinkler.currentDraw.description = The current draw in mA
 channel-type.opensprinkler.enablePrograms.label = Enable Programs
@@ -56,10 +58,23 @@ channel-type.opensprinkler.nextDuration.state.option.90min = 1.5 Hours
 channel-type.opensprinkler.nextDuration.state.option.2h = 2 Hours
 channel-type.opensprinkler.nextDuration.state.option.3h = 3 Hours
 channel-type.opensprinkler.nextDuration.state.option.4h = 4 Hours
+channel-type.opensprinkler.pausePrograms.label = Pause Programs
+channel-type.opensprinkler.pausePrograms.description = The duration that all zones will be paused for before resuming the watering.
+channel-type.opensprinkler.pausePrograms.state.option.0s = Not Paused
+channel-type.opensprinkler.pausePrograms.state.option.15s = 15 Seconds
+channel-type.opensprinkler.pausePrograms.state.option.30s = 30 Seconds
+channel-type.opensprinkler.pausePrograms.state.option.1min = 1 Minute
+channel-type.opensprinkler.pausePrograms.state.option.2min = 2 Minutes
+channel-type.opensprinkler.pausePrograms.state.option.3min = 3 Minutes
+channel-type.opensprinkler.pausePrograms.state.option.4min = 4 Minutes
+channel-type.opensprinkler.pausePrograms.state.option.5min = 5 Minutes
+channel-type.opensprinkler.pausePrograms.state.option.10min = 10 Minutes
 channel-type.opensprinkler.programs.label = Run Program
 channel-type.opensprinkler.programs.description = Run a program that is saved inside the OpenSprinkler Device.
 channel-type.opensprinkler.queued.label = Queued
 channel-type.opensprinkler.queued.description = Indicates if the station is queued to be turned on. Can be removed from the queue by turning off. ON is read-only.
+channel-type.opensprinkler.queuedZones.label = Number Of Queued Zones
+channel-type.opensprinkler.queuedZones.description = A count of how many zones are running and also waiting to run in the queue.
 channel-type.opensprinkler.rainDelay.label = Rain Delay
 channel-type.opensprinkler.rainDelay.description = The amount of time in hours to delay the running of any program.
 channel-type.opensprinkler.rainDelay.state.option.0s = Off

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -135,7 +135,7 @@
 	</channel-type>
 
 	<channel-type id="queuedZones">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number</item-type>
 		<label>Number Of Queued Zones</label>
 		<description>A count of how many zones are running and also waiting to run in the queue.</description>
 		<state readOnly="true"/>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -60,10 +60,6 @@
 			<channel id="ignoreRain" typeId="ignoreRain"></channel>
 		</channels>
 
-		<properties>
-			<property name="thingTypeVersion">1</property>
-		</properties>
-
 		<config-description>
 			<parameter name="stationIndex" type="integer" required="true">
 				<label>Station Index</label>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -60,6 +60,10 @@
 			<channel id="ignoreRain" typeId="ignoreRain"></channel>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
 		<config-description>
 			<parameter name="stationIndex" type="integer" required="true">
 				<label>Station Index</label>
@@ -93,6 +97,11 @@
 			<channel id="cloudConnected" typeId="cloudConnected"></channel>
 			<channel id="pausePrograms" typeId="pausePrograms"></channel>
 		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
 	</thing-type>
 
 	<channel-type id="rainsensor">

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -89,6 +89,9 @@
 			<channel id="resetStations" typeId="resetStations"></channel>
 			<channel id="enablePrograms" typeId="enablePrograms"></channel>
 			<channel id="rainDelay" typeId="rainDelay"></channel>
+			<channel id="queuedZones" typeId="queuedZones"></channel>
+			<channel id="cloudConnected" typeId="cloudConnected"></channel>
+			<channel id="pausePrograms" typeId="pausePrograms"></channel>			
 		</channels>
 	</thing-type>
 
@@ -107,7 +110,15 @@
 		<category>Sensor</category>
 		<state readOnly="true"/>
 	</channel-type>
-
+	
+    <channel-type id="cloudConnected">
+        <item-type>Switch</item-type>
+        <label>Cloud Connected</label>
+        <description>If the device is fully connected to the OpenSprinkler cloud this will show as 'ON'.</description>
+        <category>Sensor</category>
+        <state readOnly="true"/>
+    </channel-type>
+    
 	<channel-type id="waterlevel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Water Level</label>
@@ -122,6 +133,13 @@
 		<category>Flow</category>
 		<state readOnly="true"/>
 	</channel-type>
+	
+	<channel-type id="queuedZones">
+        <item-type>Number:Dimensionless</item-type>
+        <label>Number Of Queued Zones</label>
+        <description>A count of how many zones are running and also waiting to run in the queue.</description>
+        <state readOnly="true"/>
+    </channel-type>
 
 	<channel-type id="currentDraw">
 		<item-type>Number:ElectricCurrent</item-type>
@@ -175,6 +193,26 @@
 		<category>Time</category>
 		<state readOnly="true" pattern="%.0f min"/>
 	</channel-type>
+	
+	   <channel-type id="pausePrograms">
+        <item-type>Number:Time</item-type>
+        <label>Pause Programs</label>
+        <description>The duration that all zones will be paused for before resuming the watering.</description>
+        <category>Time</category>
+        <state>
+            <options>
+                <option value="0s">Not Paused</option>
+                <option value="15s">15 Seconds</option>
+                <option value="30s">30 Seconds</option>
+                <option value="1min">1 Minute</option>
+                <option value="2min">2 Minutes</option>
+                <option value="3min">3 Minutes</option>
+                <option value="4min">4 Minutes</option>
+                <option value="5min">5 Minutes</option>
+                <option value="10min">10 Minutes</option>
+            </options>
+        </state>
+    </channel-type>
 
 	<channel-type id="nextDuration">
 		<item-type>Number:Time</item-type>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -91,7 +91,7 @@
 			<channel id="rainDelay" typeId="rainDelay"></channel>
 			<channel id="queuedZones" typeId="queuedZones"></channel>
 			<channel id="cloudConnected" typeId="cloudConnected"></channel>
-			<channel id="pausePrograms" typeId="pausePrograms"></channel>			
+			<channel id="pausePrograms" typeId="pausePrograms"></channel>
 		</channels>
 	</thing-type>
 
@@ -110,15 +110,15 @@
 		<category>Sensor</category>
 		<state readOnly="true"/>
 	</channel-type>
-	
-    <channel-type id="cloudConnected">
-        <item-type>Switch</item-type>
-        <label>Cloud Connected</label>
-        <description>If the device is fully connected to the OpenSprinkler cloud this will show as 'ON'.</description>
-        <category>Sensor</category>
-        <state readOnly="true"/>
-    </channel-type>
-    
+
+	<channel-type id="cloudConnected">
+		<item-type>Switch</item-type>
+		<label>Cloud Connected</label>
+		<description>If the device is fully connected to the OpenSprinkler cloud this will show as 'ON'.</description>
+		<category>Sensor</category>
+		<state readOnly="true"/>
+	</channel-type>
+
 	<channel-type id="waterlevel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Water Level</label>
@@ -133,13 +133,13 @@
 		<category>Flow</category>
 		<state readOnly="true"/>
 	</channel-type>
-	
+
 	<channel-type id="queuedZones">
-        <item-type>Number:Dimensionless</item-type>
-        <label>Number Of Queued Zones</label>
-        <description>A count of how many zones are running and also waiting to run in the queue.</description>
-        <state readOnly="true"/>
-    </channel-type>
+		<item-type>Number:Dimensionless</item-type>
+		<label>Number Of Queued Zones</label>
+		<description>A count of how many zones are running and also waiting to run in the queue.</description>
+		<state readOnly="true"/>
+	</channel-type>
 
 	<channel-type id="currentDraw">
 		<item-type>Number:ElectricCurrent</item-type>
@@ -193,26 +193,26 @@
 		<category>Time</category>
 		<state readOnly="true" pattern="%.0f min"/>
 	</channel-type>
-	
-	   <channel-type id="pausePrograms">
-        <item-type>Number:Time</item-type>
-        <label>Pause Programs</label>
-        <description>The duration that all zones will be paused for before resuming the watering.</description>
-        <category>Time</category>
-        <state>
-            <options>
-                <option value="0s">Not Paused</option>
-                <option value="15s">15 Seconds</option>
-                <option value="30s">30 Seconds</option>
-                <option value="1min">1 Minute</option>
-                <option value="2min">2 Minutes</option>
-                <option value="3min">3 Minutes</option>
-                <option value="4min">4 Minutes</option>
-                <option value="5min">5 Minutes</option>
-                <option value="10min">10 Minutes</option>
-            </options>
-        </state>
-    </channel-type>
+
+	<channel-type id="pausePrograms">
+		<item-type>Number:Time</item-type>
+		<label>Pause Programs</label>
+		<description>The duration that all zones will be paused for before resuming the watering.</description>
+		<category>Time</category>
+		<state>
+			<options>
+				<option value="0s">Not Paused</option>
+				<option value="15s">15 Seconds</option>
+				<option value="30s">30 Seconds</option>
+				<option value="1min">1 Minute</option>
+				<option value="2min">2 Minutes</option>
+				<option value="3min">3 Minutes</option>
+				<option value="4min">4 Minutes</option>
+				<option value="5min">5 Minutes</option>
+				<option value="10min">10 Minutes</option>
+			</options>
+		</state>
+	</channel-type>
 
 	<channel-type id="nextDuration">
 		<item-type>Number:Time</item-type>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="opensprinkler:device">
+
+		<instruction-set targetVersion="1">
+			<add-channel id="queuedZones">
+				<type>opensprinkler:queuedZones</type>
+			</add-channel>
+			<add-channel id="cloudConnected">
+				<type>opensprinkler:cloudConnected</type>
+			</add-channel>
+			<add-channel id="pausePrograms">
+				<type>opensprinkler:pausePrograms</type>
+			</add-channel>
+		</instruction-set>
+
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
This change fixes the bindings ability to scrape the program names of the sprinkler controllers internal automated programs that a user can select to run. More information is found that the issue this fixes here closes #15260

The newer firmware uses JSON with this structure and the "pd" now has an extra element over previous firmware which causes the update to break the old code. The JSON is an Array that contains mixed types including further arrays. Details are included in case a better method exists.

```
{
	"nprogs": 3,
	"nboards": 1,
	"mnp": 40,
	"mnst": 4,
	"pnsize": 32,
	"pd": [
		[3, 68, 0, [20540, 0, 120, 0],
			[0, 2700, 2700, 0, 0, 0, 0, 0], Water Lawn, [0, 33, 415]
		],
		[3, 1, 0, [16384, 0, 0, 0],
			[0, 0, 0, 2700, 0, 0, 0, 0], Water Citrus, [0, 33, 415]
		],
		[3, 18, 0, [16384, 0, 0, 0],
			[2700, 0, 0, 0, 0, 0, 0, 0], Water Fruit Trees, [0, 33, 415]
		]
	]
}
```

This pull request will automatically be built and available under the following links if anyone wants to test:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.opensprinkler/4.1.0-SNAPSHOT/org.openhab.binding.opensprinkler-4.1.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>