### PR TITLE
[jdbc] Upgrade SQLite JDBC driver to 3.42.0.0

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -15,7 +15,7 @@ The following databases are currently supported and tested:
 | [MariaDB](https://mariadb.org/)              | [mariadb-java-client-3.0.8.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client) |
 | [MySQL](https://www.mysql.com/)              | [mysql-connector-j-8.0.33.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j) |
 | [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.4.3.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
-| [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.16.1.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
+| [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.42.0.0.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
 | [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.4.3.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
 
 ## Table of Contents

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -31,7 +31,7 @@
     <mariadb.version>3.0.8</mariadb.version>
     <mysql.version>8.0.33</mysql.version>
     <postgresql.version>42.4.3</postgresql.version>
-    <sqlite.version>3.40.0.0</sqlite.version>
+    <sqlite.version>3.42.0.0</sqlite.version>
   </properties>
 
   <dependencies>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -48,7 +48,7 @@
 	<feature name="openhab-persistence-jdbc-sqlite" description="JDBC Persistence SQLite" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.xerial/sqlite-jdbc/3.40.0.0</bundle>
+		<bundle start-level="80">mvn:org.xerial/sqlite-jdbc/3.42.0.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -336,7 +336,7 @@ public class JdbcConfiguration {
                         warn += "\tPostgreSQL:version >= 42.4.3 from             https://mvnrepository.com/artifact/org.postgresql/postgresql\n";
                         break;
                     case "sqlite":
-                        warn += "\tSQLite:    version >= 3.40.0.0 from           https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
+                        warn += "\tSQLite:    version >= 3.42.0.0 from           https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
                         break;
                 }
             }


### PR DESCRIPTION
Replaces #15022

Release notes:
- [3.42.0.0](https://github.com/xerial/sqlite-jdbc/releases/tag/3.42.0.0)
- [3.41.2.2](https://github.com/xerial/sqlite-jdbc/releases/tag/3.41.2.2)
- [3.41.2.1](https://github.com/xerial/sqlite-jdbc/releases/tag/3.41.2.1)
- [3.41.0.1](https://github.com/xerial/sqlite-jdbc/releases/tag/3.41.0.1)
- [3.41.0.0](https://github.com/xerial/sqlite-jdbc/releases/tag/3.41.0.0)
- [3.40.1.0](https://github.com/xerial/sqlite-jdbc/releases/tag/3.40.1.0)

Fixed vulnerabilities:
- [CVE-2023-32697](https://nvd.nist.gov/vuln/detail/CVE-2023-32697)

Artifacts:
- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc/3.42.0.0
- [org.openhab.persistence.jdbc-4.1.0-SNAPSHOT.jar](https://drive.google.com/file/d/1QzvLhmUC75J8VLn9w3v2wF4KsEmeoYso/view?usp=sharing)