### PR TITLE
[mqtt.homeassistant] handle null component name

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -224,7 +224,7 @@ public class ComponentChannel {
             ChannelType type;
             ChannelTypeUID channelTypeUID;
 
-            channelUID = new ChannelUID(component.getGroupUID(), channelID);
+            channelUID = component.buildChannelUID(channelID);
             channelTypeUID = new ChannelTypeUID(MqttBindingConstants.BINDING_ID,
                     channelUID.getGroupId() + "_" + channelID);
             channelState = new HomeAssistantChannelState(

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -32,6 +32,7 @@ import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.HaID;
 import org.openhab.binding.mqtt.homeassistant.internal.component.ComponentFactory.ComponentConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
+import org.openhab.binding.mqtt.homeassistant.internal.config.dto.Device;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
@@ -198,8 +199,9 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     public String getName() {
         String result = channelConfiguration.getName();
 
-        if (result == null && channelConfiguration.getDevice() != null) {
-            result = channelConfiguration.getDevice().getName();
+        Device device = channelConfiguration.getDevice();
+        if (result == null && device != null) {
+            result = device.getName();
         }
         if (result == null) {
             result = haID.objectID;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -181,7 +181,7 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     /**
      * Each HomeAssistant component corresponds to a Channel Group Type.
      */
-    protected @Nullable ChannelGroupTypeUID getGroupTypeUID() {
+    public @Nullable ChannelGroupTypeUID getGroupTypeUID() {
         return channelGroupTypeUID;
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,6 +34,7 @@ import org.openhab.binding.mqtt.homeassistant.internal.component.ComponentFactor
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.thing.ChannelGroupUID;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.type.ChannelDefinition;
 import org.openhab.core.thing.type.ChannelGroupDefinition;
 import org.openhab.core.thing.type.ChannelGroupType;
@@ -54,8 +56,8 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
 
     // Component location fields
     private final ComponentConfiguration componentConfiguration;
-    protected final ChannelGroupTypeUID channelGroupTypeUID;
-    protected final ChannelGroupUID channelGroupUID;
+    protected final @Nullable ChannelGroupTypeUID channelGroupTypeUID;
+    protected final @Nullable ChannelGroupUID channelGroupUID;
     protected final HaID haID;
 
     // Channels and configuration
@@ -83,10 +85,15 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
 
         this.haID = componentConfiguration.getHaID();
 
-        String groupId = this.haID.getGroupId(channelConfiguration.getUniqueId());
+        if (channelConfiguration.getName() != null) {
+            String groupId = this.haID.getGroupId(channelConfiguration.getUniqueId());
 
-        this.channelGroupTypeUID = new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID, groupId);
-        this.channelGroupUID = new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);
+            this.channelGroupTypeUID = new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID, groupId);
+            this.channelGroupUID = new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);
+        } else {
+            this.channelGroupTypeUID = null;
+            this.channelGroupUID = null;
+        }
 
         this.configSeen = false;
 
@@ -142,7 +149,10 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
      * @param channelTypeProvider The channel type provider
      */
     public void addChannelTypes(MqttChannelTypeProvider channelTypeProvider) {
-        channelTypeProvider.setChannelGroupType(getGroupTypeUID(), getType());
+        ChannelGroupTypeUID groupTypeUID = channelGroupTypeUID;
+        if (groupTypeUID != null) {
+            channelTypeProvider.setChannelGroupType(groupTypeUID, Objects.requireNonNull(getType()));
+        }
         channels.values().forEach(v -> v.addChannelTypes(channelTypeProvider));
     }
 
@@ -154,20 +164,31 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
      */
     public void removeChannelTypes(MqttChannelTypeProvider channelTypeProvider) {
         channels.values().forEach(v -> v.removeChannelTypes(channelTypeProvider));
-        channelTypeProvider.removeChannelGroupType(getGroupTypeUID());
+        ChannelGroupTypeUID groupTypeUID = channelGroupTypeUID;
+        if (groupTypeUID != null) {
+            channelTypeProvider.removeChannelGroupType(groupTypeUID);
+        }
+    }
+
+    public ChannelUID buildChannelUID(String channelID) {
+        final ChannelGroupUID groupUID = channelGroupUID;
+        if (groupUID != null) {
+            return new ChannelUID(groupUID, channelID);
+        }
+        return new ChannelUID(componentConfiguration.getThingUID(), channelID);
     }
 
     /**
      * Each HomeAssistant component corresponds to a Channel Group Type.
      */
-    public ChannelGroupTypeUID getGroupTypeUID() {
+    protected @Nullable ChannelGroupTypeUID getGroupTypeUID() {
         return channelGroupTypeUID;
     }
 
     /**
      * The unique id of this component.
      */
-    public ChannelGroupUID getGroupUID() {
+    public @Nullable ChannelGroupUID getGroupUID() {
         return channelGroupUID;
     }
 
@@ -175,7 +196,15 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
      * Component (Channel Group) name.
      */
     public String getName() {
-        return channelConfiguration.getName();
+        String result = channelConfiguration.getName();
+
+        if (result == null && channelConfiguration.getDevice() != null) {
+            result = channelConfiguration.getDevice().getName();
+        }
+        if (result == null) {
+            result = haID.objectID;
+        }
+        return result;
     }
 
     /**
@@ -207,11 +236,19 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     /**
      * Return the channel group type.
      */
-    public ChannelGroupType getType() {
+    public @Nullable ChannelGroupType getType() {
+        ChannelGroupTypeUID groupTypeUID = channelGroupTypeUID;
+        if (groupTypeUID == null) {
+            return null;
+        }
         final List<ChannelDefinition> channelDefinitions = channels.values().stream().map(ComponentChannel::type)
                 .collect(Collectors.toList());
-        return ChannelGroupTypeBuilder.instance(channelGroupTypeUID, getName())
-                .withChannelDefinitions(channelDefinitions).build();
+        return ChannelGroupTypeBuilder.instance(groupTypeUID, getName()).withChannelDefinitions(channelDefinitions)
+                .build();
+    }
+
+    public List<ChannelDefinition> getChannels() {
+        return channels.values().stream().map(ComponentChannel::type).collect(Collectors.toList());
     }
 
     /**
@@ -225,8 +262,12 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     /**
      * Return the channel group definition for this component.
      */
-    public ChannelGroupDefinition getGroupDefinition() {
-        return new ChannelGroupDefinition(channelGroupUID.getId(), getGroupTypeUID(), getName(), null);
+    public @Nullable ChannelGroupDefinition getGroupDefinition() {
+        ChannelGroupTypeUID groupTypeUID = channelGroupTypeUID;
+        if (groupTypeUID == null) {
+            return null;
+        }
+        return new ChannelGroupDefinition(channelGroupUID.getId(), groupTypeUID, getName(), null);
     }
 
     public HaID getHaID() {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -74,24 +74,23 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
         final String[] stateEnum = { channelConfiguration.stateDisarmed, channelConfiguration.stateArmedHome,
                 channelConfiguration.stateArmedAway, channelConfiguration.statePending,
                 channelConfiguration.stateTriggered };
-        buildChannel(STATE_CHANNEL_ID, new TextValue(stateEnum), channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener())
+        buildChannel(STATE_CHANNEL_ID, new TextValue(stateEnum), getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
                 .build();
 
         String commandTopic = channelConfiguration.commandTopic;
         if (commandTopic != null) {
             buildChannel(SWITCH_DISARM_CHANNEL_ID, new TextValue(new String[] { channelConfiguration.payloadDisarm }),
-                    channelConfiguration.getName(), componentConfiguration.getUpdateListener())
+                    getName(), componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
 
             buildChannel(SWITCH_ARM_HOME_CHANNEL_ID,
-                    new TextValue(new String[] { channelConfiguration.payloadArmHome }), channelConfiguration.getName(),
+                    new TextValue(new String[] { channelConfiguration.payloadArmHome }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
 
             buildChannel(SWITCH_ARM_AWAY_CHANNEL_ID,
-                    new TextValue(new String[] { channelConfiguration.payloadArmAway }), channelConfiguration.getName(),
+                    new TextValue(new String[] { channelConfiguration.payloadArmAway }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
@@ -43,7 +43,7 @@ public class Camera extends AbstractComponent<Camera.ChannelConfiguration> {
 
         ImageValue value = new ImageValue();
 
-        buildChannel(CAMERA_CHANNEL_ID, value, channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener()).stateTopic(channelConfiguration.topic).build();
+        buildChannel(CAMERA_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
+                .stateTopic(channelConfiguration.topic).build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -286,7 +286,7 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
             @Nullable String commandTopic, @Nullable String stateTemplate, @Nullable String stateTopic,
             @Nullable Predicate<Command> commandFilter) {
         if ((commandTopic != null && !commandTopic.isBlank()) || (stateTopic != null && !stateTopic.isBlank())) {
-            return buildChannel(channelId, valueState, channelConfiguration.getName(), channelStateUpdateListener)
+            return buildChannel(channelId, valueState, getName(), channelStateUpdateListener)
                     .stateTopic(stateTopic, stateTemplate, channelConfiguration.getValueTemplate())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos(),
                             commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
@@ -56,8 +56,7 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
         RollershutterValue value = new RollershutterValue(channelConfiguration.payloadOpen,
                 channelConfiguration.payloadClose, channelConfiguration.payloadStop);
 
-        buildChannel(SWITCH_CHANNEL_ID, value, channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener())
+        buildChannel(SWITCH_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -281,7 +281,7 @@ public class DefaultSchemaLight extends Light {
                         colorValue.update(newOnState);
                     }
 
-                    listener.updateChannelState(new ChannelUID(getGroupUID(), COLOR_CHANNEL_ID),
+                    listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID),
                             state.equals(OnOffType.ON) ? newOnState : HSBType.BLACK);
                 } else if (brightnessChannel != null) {
                     listener.updateChannelState(new ChannelUID(channel.getThingUID(), BRIGHTNESS_CHANNEL_ID),
@@ -301,8 +301,7 @@ public class DefaultSchemaLight extends Light {
                         colorValue.update(new HSBType(DecimalType.ZERO, PercentType.ZERO,
                                 (PercentType) brightnessValue.getChannelState()));
                     }
-                    listener.updateChannelState(new ChannelUID(getGroupUID(), COLOR_CHANNEL_ID),
-                            colorValue.getChannelState());
+                    listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
                 } else {
                     listener.updateChannelState(channel, state);
                 }
@@ -330,13 +329,11 @@ public class DefaultSchemaLight extends Light {
                     HSBType xyColor = HSBType.fromXY(x, y);
                     colorValue.update(new HSBType(xyColor.getHue(), xyColor.getSaturation(), brightness));
                 }
-                listener.updateChannelState(new ChannelUID(getGroupUID(), COLOR_CHANNEL_ID),
-                        colorValue.getChannelState());
+                listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
                 return;
             case RGB_CHANNEL_ID:
                 colorValue.update((HSBType) state);
-                listener.updateChannelState(new ChannelUID(getGroupUID(), COLOR_CHANNEL_ID),
-                        colorValue.getChannelState());
+                listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
                 break;
             case RGBW_CHANNEL_ID:
             case RGBWW_CHANNEL_ID:

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
@@ -65,8 +65,7 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
             value = new TextValue();
         }
 
-        buildChannel(channelConfiguration.type, value, channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener())
+        buildChannel(channelConfiguration.type, value, getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.topic, channelConfiguration.getValueTemplate()).trigger(true).build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -54,8 +54,7 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> {
         super(componentConfiguration, ChannelConfiguration.class);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
-        buildChannel(SWITCH_CHANNEL_ID, value, channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener())
+        buildChannel(SWITCH_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -225,12 +225,11 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
         }
 
         if (hasColorChannel) {
-            listener.updateChannelState(new ChannelUID(getGroupUID(), COLOR_CHANNEL_ID), colorValue.getChannelState());
+            listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
         } else if (brightnessChannel != null) {
-            listener.updateChannelState(new ChannelUID(getGroupUID(), BRIGHTNESS_CHANNEL_ID),
-                    brightnessValue.getChannelState());
+            listener.updateChannelState(buildChannelUID(BRIGHTNESS_CHANNEL_ID), brightnessValue.getChannelState());
         } else {
-            listener.updateChannelState(new ChannelUID(getGroupUID(), ON_OFF_CHANNEL_ID), onOffValue.getChannelState());
+            listener.updateChannelState(buildChannelUID(ON_OFF_CHANNEL_ID), onOffValue.getChannelState());
         }
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
@@ -58,8 +58,8 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
         }
 
         buildChannel(SWITCH_CHANNEL_ID,
-                new OnOffValue(channelConfiguration.payloadLock, channelConfiguration.payloadUnlock),
-                channelConfiguration.getName(), componentConfiguration.getUpdateListener())
+                new OnOffValue(channelConfiguration.payloadLock, channelConfiguration.payloadUnlock), getName(),
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
@@ -82,8 +82,7 @@ public class Number extends AbstractComponent<Number.ChannelConfiguration> {
         NumberValue value = new NumberValue(channelConfiguration.min, channelConfiguration.max,
                 channelConfiguration.step, UnitUtils.parseUnit(channelConfiguration.unitOfMeasurement));
 
-        buildChannel(NUMBER_CHANNEL_ID, value, channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener())
+        buildChannel(NUMBER_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
@@ -66,8 +66,7 @@ public class Select extends AbstractComponent<Select.ChannelConfiguration> {
 
         TextValue value = new TextValue(channelConfiguration.options);
 
-        buildChannel(SELECT_CHANNEL_ID, value, channelConfiguration.getName(),
-                componentConfiguration.getUpdateListener())
+        buildChannel(SELECT_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
@@ -88,8 +88,7 @@ public class Sensor extends AbstractComponent<Sensor.ChannelConfiguration> {
 
         boolean trigger = TRIGGER_ICONS.matcher(icon).matches();
 
-        buildChannel(SENSOR_CHANNEL_ID, value, channelConfiguration.getName(),
-                getListener(componentConfiguration, value))
+        buildChannel(SENSOR_CHANNEL_ID, value, getName(), getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
                 .trigger(trigger).build();
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -294,7 +294,7 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             ChannelStateUpdateListener channelStateUpdateListener, @Nullable String commandTemplate,
             @Nullable String commandTopic, @Nullable String stateTemplate, @Nullable String stateTopic) {
         if ((commandTopic != null && !commandTopic.isBlank()) || (stateTopic != null && !stateTopic.isBlank())) {
-            return buildChannel(channelId, valueState, channelConfiguration.getName(), channelStateUpdateListener)
+            return buildChannel(channelId, valueState, getName(), channelStateUpdateListener)
                     .stateTopic(stateTopic, stateTemplate, channelConfiguration.getValueTemplate())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos(),
                             commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/config/dto/AbstractChannelConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/config/dto/AbstractChannelConfiguration.java
@@ -33,8 +33,9 @@ import com.google.gson.annotations.SerializedName;
 @NonNullByDefault
 public abstract class AbstractChannelConfiguration {
     public static final char PARENT_TOPIC_PLACEHOLDER = '~';
+    private static final String DEFAULT_THING_NAME = "Home Assistant Device";
 
-    protected String name;
+    protected @Nullable String name;
 
     protected String icon = "";
     protected int qos; // defaults to 0 according to HA specification
@@ -93,6 +94,9 @@ public abstract class AbstractChannelConfiguration {
         if (result == null) {
             result = name;
         }
+        if (result == null) {
+            result = DEFAULT_THING_NAME;
+        }
         return result;
     }
 
@@ -127,7 +131,7 @@ public abstract class AbstractChannelConfiguration {
         return properties;
     }
 
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -160,7 +161,8 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         ComponentDiscovered cd = (haID, c) -> {
             haComponents.put(c.getGroupUID().getId(), c);
             c.addChannelTypes(channelTypeProvider);
-            channelTypeProvider.setChannelGroupType(c.getGroupTypeUID(), c.getType());
+            channelTypeProvider.setChannelGroupType(Objects.requireNonNull(c.getGroupTypeUID()),
+                    Objects.requireNonNull(c.getType()));
             latch.countDown();
         };
 


### PR DESCRIPTION
Channels from such components will not have a group. this is now done by zigbee2mqtt for the "default" component of a device, such as the light. HASS encourages this as of release 2023.8

Fixes #15634
