### PR TITLE
[paradoxalarm] Fix Paradox EVOHD zone parsing fail #10572

### DIFF
--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
@@ -193,7 +193,7 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
     private void createZoneOpenedFlags(ZoneStateFlags result, byte[] firstPage, byte[] secondPage) {
         int pageOffset = panelType == PanelType.EVO48 ? 34 : 40;
         byte[] firstBlock = Arrays.copyOfRange(firstPage, 28, pageOffset);
-        if (panelType != PanelType.EVO192) {
+        if (!PanelType.isBigRamEvo(panelType)) {
             result.setZonesOpened(firstBlock);
         } else {
             byte[] secondBlock = Arrays.copyOfRange(secondPage, 0, 12);
@@ -205,7 +205,7 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
     private void createZoneTamperedFlags(ZoneStateFlags result, byte[] firstPage, byte[] secondPage) {
         int pageOffset = panelType == PanelType.EVO48 ? 46 : 52;
         byte[] firstBlock = Arrays.copyOfRange(firstPage, 40, pageOffset);
-        if (panelType != PanelType.EVO192) {
+        if (!PanelType.isBigRamEvo(panelType)) {
             result.setZonesTampered(firstBlock);
         } else {
             byte[] secondBlock = Arrays.copyOfRange(secondPage, 12, 24);
@@ -217,7 +217,7 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
     private void createZoneLowbatteryFlags(ZoneStateFlags result, byte[] firstPage, byte[] secondPage) {
         int pageOffset = panelType == PanelType.EVO48 ? 58 : 64;
         byte[] firstBlock = Arrays.copyOfRange(firstPage, 52, pageOffset);
-        if (panelType != PanelType.EVO192) {
+        if (PanelType.isBigRamEvo(panelType)) {
             result.setZonesLowBattery(firstBlock);
         } else {
             byte[] secondBlock = Arrays.copyOfRange(secondPage, 24, 36);

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/communication/EvoCommunicator.java
@@ -217,7 +217,7 @@ public class EvoCommunicator extends GenericCommunicator implements IParadoxComm
     private void createZoneLowbatteryFlags(ZoneStateFlags result, byte[] firstPage, byte[] secondPage) {
         int pageOffset = panelType == PanelType.EVO48 ? 58 : 64;
         byte[] firstBlock = Arrays.copyOfRange(firstPage, 52, pageOffset);
-        if (PanelType.isBigRamEvo(panelType)) {
+        if (!PanelType.isBigRamEvo(panelType)) {
             result.setZonesLowBattery(firstBlock);
         } else {
             byte[] secondBlock = Arrays.copyOfRange(secondPage, 24, 36);

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/model/PanelType.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/model/PanelType.java
@@ -59,6 +59,10 @@ public enum PanelType {
         }
     }
 
+    public static boolean isBigRamEvo(PanelType panelType) {
+        return panelType == EVO192 || panelType == EVOHD;
+    }
+
     public int getPartitions() {
         return partitions;
     }


### PR DESCRIPTION
Root cause is that EVOHD and EVO192 have much more zones which are stored in a different memory map model. They should be treated the same way. The root cause was a wrong if that treats EVOHD as EVO48/96.

Fix is simple and can be downported to 3.x if decided by the maintainers.

fixes #10572 