### PR TITLE
[somfytahoma] fix NPE in case that HttpClient fails to start

### DIFF
--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
@@ -195,7 +195,7 @@ public class SomfyTahomaBridgeHandler extends BaseBridgeHandler {
         try {
             httpClient.start();
         } catch (Exception e) {
-            logger.debug("Cannot start http client for: {}", thing.getBridgeUID().getId(), e);
+            logger.debug("Cannot start http client for: {}", thing.getUID(), e);
             return;
         }
         // Remove the WWWAuth protocol handler since Tahoma is not fully compliant


### PR DESCRIPTION
This PR fixes the issue discussed here https://community.openhab.org/t/nullpointerexception-while-initializing-somfytahoma-bridge/148752
