### PR TITLE
[daikin] Support BRP069A81 adapter

### DIFF
--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -1,12 +1,16 @@
 # Daikin Binding
 
 The Daikin binding allows you to control your Daikin air conditioning units with openHAB.
-In order to do so, your Daikin air conditioning unit must have a BRP072A42, BRP072C42 or BRP15B61 WiFi adapter installed.
+
+In order to do so, your Daikin air conditioning unit must have a supported WiFi adapter installed.
+This may work with the older KRP series of wired adapters, but has not been tested with them.
 
 ## Supported Things
 
-Daikin air conditioning units with a BRP069B41, BRP072A42, BRP072C42 or BRP15B61 installed.
-This may work with the older KRP series of wired adapters, but has not been tested with them.
+| Thing             | Daikin Wifi Adapter Model                  |
+| ----------------- | ------------------------------------------ |
+| `ac_unit`         | BRP069A81, BRP069B41, BRP072A42, BRP072C42 |
+| `airbase_ac_unit` | BRP15B61                                   |
 
 ## Discovery
 

--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -2,12 +2,12 @@
 
 The Daikin binding allows you to control your Daikin air conditioning units with openHAB.
 
-In order to do so, your Daikin air conditioning unit must have a supported WiFi adapter installed.
+In order to do so, your Daikin air conditioning unit must have a supported Wi-Fi adapter installed.
 This may work with the older KRP series of wired adapters, but has not been tested with them.
 
 ## Supported Things
 
-| Thing             | Daikin Wifi Adapter Model                  |
+| Thing             | Daikin Wi-Fi Adapter Model                 |
 | ----------------- | ------------------------------------------ |
 | `ac_unit`         | BRP069A81, BRP069B41, BRP072A42, BRP072C42 |
 | `airbase_ac_unit` | BRP15B61                                   |

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinWebTargets.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinWebTargets.java
@@ -15,6 +15,7 @@ package org.openhab.binding.daikin.internal;
 import java.io.EOFException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -31,6 +32,7 @@ import org.openhab.binding.daikin.internal.api.ControlInfo;
 import org.openhab.binding.daikin.internal.api.EnergyInfoDayAndWeek;
 import org.openhab.binding.daikin.internal.api.EnergyInfoYear;
 import org.openhab.binding.daikin.internal.api.Enums.SpecialMode;
+import org.openhab.binding.daikin.internal.api.InfoParser;
 import org.openhab.binding.daikin.internal.api.SensorInfo;
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseBasicInfo;
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseControlInfo;
@@ -110,9 +112,11 @@ public class DaikinWebTargets {
         return ControlInfo.parse(response);
     }
 
-    public void setControlInfo(ControlInfo info) throws DaikinCommunicationException {
+    public boolean setControlInfo(ControlInfo info) throws DaikinCommunicationException {
         Map<String, String> queryParams = info.getParamString();
-        invoke(setControlInfoUri, queryParams);
+        String result = invoke(setControlInfoUri, queryParams);
+        Map<String, String> responseMap = InfoParser.parse(result);
+        return Optional.ofNullable(responseMap.get("ret")).orElse("").equals("OK");
     }
 
     public SensorInfo getSensorInfo() throws DaikinCommunicationException {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
@@ -38,14 +38,14 @@ public class ControlInfo {
 
     public String ret = "";
     public boolean power = false;
-    // Some models (e.g. BRP069A81) uses `1` for its Auto mode instead of `0`
+    // Store the accepted auto mode for later use.
     public int autoModeValue = Mode.AUTO.getValue();
     public Mode mode = Mode.AUTO;
-    /** Degrees in Celsius. */
+    // Degrees in Celsius.
     public Optional<Double> temp = Optional.empty();
     public FanSpeed fanSpeed = FanSpeed.AUTO;
     public FanMovement fanMovement = FanMovement.STOPPED;
-    /* Not supported by all units. Sets the target humidity for dehumidifying. */
+    // Not supported by all units. Sets the target humidity for dehumidifying.
     public Optional<Integer> targetHumidity = Optional.empty();
     public AdvancedMode advancedMode = AdvancedMode.UNKNOWN;
     public boolean separatedDirectionParams = false;
@@ -63,9 +63,8 @@ public class ControlInfo {
         info.power = "1".equals(responseMap.get("pow"));
         info.mode = Optional.ofNullable(responseMap.get("mode")).flatMap(value -> InfoParser.parseInt(value))
                 .map(value -> Mode.fromValue(value)).orElse(Mode.AUTO);
-        // Normalize AUTO1 and AUTO7 to AUTO, but remember the actual value to be sent back to the adapter
+        // Normalize AUTO1 and AUTO7 to AUTO
         if (info.mode == Mode.AUTO1 || info.mode == Mode.AUTO7) {
-            info.autoModeValue = info.mode.getValue();
             info.mode = Mode.AUTO;
         }
         info.temp = Optional.ofNullable(responseMap.get("stemp")).flatMap(value -> InfoParser.parseDouble(value));

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
@@ -61,13 +61,13 @@ public class ControlInfo {
         ControlInfo info = new ControlInfo();
         info.ret = Optional.ofNullable(responseMap.get("ret")).orElse("");
         info.power = "1".equals(responseMap.get("pow"));
-        int modeValue = Optional.ofNullable(responseMap.get("mode")).flatMap(value -> InfoParser.parseInt(value))
-                .orElse(Mode.AUTO.getValue());
-        if (modeValue == Mode.AUTO_ALT) {
-            info.autoModeValue = Mode.AUTO_ALT;
-            modeValue = Mode.AUTO.getValue();
+        info.mode = Optional.ofNullable(responseMap.get("mode")).flatMap(value -> InfoParser.parseInt(value))
+                .map(value -> Mode.fromValue(value)).orElse(Mode.AUTO);
+        // Normalize AUTO1 and AUTO7 to AUTO, but remember the actual value to be sent back to the adapter
+        if (info.mode == Mode.AUTO1 || info.mode == Mode.AUTO7) {
+            info.autoModeValue = info.mode.getValue();
+            info.mode = Mode.AUTO;
         }
-        info.mode = Mode.fromValue(modeValue);
         info.temp = Optional.ofNullable(responseMap.get("stemp")).flatMap(value -> InfoParser.parseDouble(value));
         info.fanSpeed = Optional.ofNullable(responseMap.get("f_rate")).map(value -> FanSpeed.fromValue(value))
                 .orElse(FanSpeed.AUTO);

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/ControlInfo.java
@@ -65,6 +65,7 @@ public class ControlInfo {
                 .map(value -> Mode.fromValue(value)).orElse(Mode.AUTO);
         // Normalize AUTO1 and AUTO7 to AUTO
         if (info.mode == Mode.AUTO1 || info.mode == Mode.AUTO7) {
+            info.autoModeValue = info.mode.getValue();
             info.mode = Mode.AUTO;
         }
         info.temp = Optional.ofNullable(responseMap.get("stemp")).flatMap(value -> InfoParser.parseDouble(value));

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -28,8 +28,8 @@ public class Enums {
     public enum Mode {
         UNKNOWN(-1),
         AUTO(0),
-        AUTO1(1),
-        AUTO7(7),
+        AUTO1(1), // BRP069A81 only accepts mode=1 for AUTO mode. 0 and 7 are rejected.
+        AUTO7(7), // Some adapters may return 7 as auto (heating)
         DEHUMIDIFIER(2),
         COLD(3),
         HEAT(4),

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -33,6 +33,8 @@ public class Enums {
         HEAT(4),
         FAN(6);
 
+        public final static int AUTO_ALT = 1;
+
         private static final Logger LOGGER = LoggerFactory.getLogger(Mode.class);
         private final int value;
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -28,12 +28,12 @@ public class Enums {
     public enum Mode {
         UNKNOWN(-1),
         AUTO(0),
+        AUTO1(1),
+        AUTO7(7),
         DEHUMIDIFIER(2),
         COLD(3),
         HEAT(4),
         FAN(6);
-
-        public final static int AUTO_ALT = 1;
 
         private static final Logger LOGGER = LoggerFactory.getLogger(Mode.class);
         private final int value;

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -218,9 +218,8 @@ public class DaikinAcUnitHandler extends DaikinBaseHandler {
         if (newMode == Mode.AUTO && autoModeValue.isEmpty()) {
             // When setting the mode to AUTO, perform an automatic deduction of autoModeValue and save it for future use
             info = webTargets.getControlInfo();
-
             if (info.mode != Mode.AUTO) {
-                info.autoModeValue = Mode.AUTO_ALT; // try the alternative autoModeValue
+                info.autoModeValue = Mode.AUTO1.getValue(); // try the alternative autoModeValue
                 webTargets.setControlInfo(info);
             }
         }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -213,15 +213,12 @@ public class DaikinAcUnitHandler extends DaikinBaseHandler {
         if (autoModeValue.isPresent()) {
             info.autoModeValue = autoModeValue.get();
         }
-        webTargets.setControlInfo(info);
+        boolean accepted = webTargets.setControlInfo(info);
 
-        if (newMode == Mode.AUTO && autoModeValue.isEmpty()) {
-            // When setting the mode to AUTO, perform an automatic deduction of autoModeValue and save it for future use
-            info = webTargets.getControlInfo();
-            if (info.mode != Mode.AUTO) {
-                info.autoModeValue = Mode.AUTO1.getValue(); // try the alternative autoModeValue
-                webTargets.setControlInfo(info);
-            }
+        // If mode=0 is not accepted try AUTO1 (mode=1)
+        if (!accepted && newMode == Mode.AUTO && autoModeValue.isEmpty()) {
+            info.autoModeValue = Mode.AUTO1.getValue();
+            webTargets.setControlInfo(info);
         }
     }
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -71,11 +71,6 @@ public class DaikinAcUnitHandler extends DaikinBaseHandler {
             throw new DaikinCommunicationException("Invalid response from host");
         }
 
-        if (controlInfo.mode == Mode.AUTO && autoModeValue.isEmpty()) {
-            autoModeValue = Optional.of(controlInfo.autoModeValue);
-            logger.debug("AUTO uses mode={}", controlInfo.autoModeValue);
-        }
-
         updateState(DaikinBindingConstants.CHANNEL_AC_POWER, OnOffType.from(controlInfo.power));
         updateTemperatureChannel(DaikinBindingConstants.CHANNEL_AC_TEMP, controlInfo.temp);
 
@@ -218,7 +213,12 @@ public class DaikinAcUnitHandler extends DaikinBaseHandler {
         // If mode=0 is not accepted try AUTO1 (mode=1)
         if (!accepted && newMode == Mode.AUTO && autoModeValue.isEmpty()) {
             info.autoModeValue = Mode.AUTO1.getValue();
-            webTargets.setControlInfo(info);
+            if (webTargets.setControlInfo(info)) {
+                autoModeValue = Optional.of(info.autoModeValue);
+                logger.debug("AUTO uses mode={}", info.autoModeValue);
+            } else {
+                logger.warn("AUTO mode not accepted with mode=0 or mode=1");
+            }
         }
     }
 


### PR DESCRIPTION
Daikin BRP069A81 adapter uses mode=1 for its AUTO mode. This PR makes the binding adaptively uses the correct mode=0 or mode=1 depending on what the adapter reports back.

Resolve #15375