### PR TITLE
[hue] Fix exception text in bridge status description

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
@@ -232,7 +232,7 @@ offline.group-removed = Hue Bridge reports group as removed.
 # api v2 offline configuration error descriptions
 
 offline.api2.comm-error.zigbee-connectivity-issue = Zigbee connectivity issue.
-offline.api2.comm-error.exception = An unexpected exception '{}' occurred.
+offline.api2.comm-error.exception = An unexpected exception ''{0}'' occurred.
 offline.api2.conf-error.certificate-load = Certificate loading failed. Please check your configuration settings (network address, type of certificate).
 offline.api2.conf-error.assets-not-loaded = Bridge/Thing handler assets not loaded.
 offline.api2.conf-error.press-pairing-button = Not authenticated. Press pairing button on the Hue Bridge or set a valid application key in configuration.


### PR DESCRIPTION
Related to #15460

Usages:
https://github.com/openhab/openhab-addons/blob/fef05c33220bc368fd9d0166dc403410f21aa880/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java#L470-L471

https://github.com/openhab/openhab-addons/blob/fef05c33220bc368fd9d0166dc403410f21aa880/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java#L494-L495

https://github.com/openhab/openhab-addons/blob/fef05c33220bc368fd9d0166dc403410f21aa880/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java#L687-L688

Documentation: https://www.openhab.org/javadoc/latest/org/openhab/core/thing/i18n/thingstatusinfoi18nlocalizationservice