### PR TITLE
[feed] Upgrade jdom2 to 2.0.6.1

### DIFF
--- a/bundles/org.openhab.binding.feed/pom.xml
+++ b/bundles/org.openhab.binding.feed/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.6.1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This addresses CVE-2021-33813

See: http://www.jdom.org/news/index.html