### PR TITLE
[avmfritz] Fix NPE when Fritz!Box sends empty alert state element

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/AlertModel.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/AlertModel.java
@@ -42,15 +42,15 @@ public class AlertModel {
     }
 
     public boolean hasObstructionAlarmOccurred() {
-        return (state.intValue() & 1) != 0;
+        return state != null && (state.intValue() & 1) != 0;
     }
 
     public boolean hasTemperaturAlarmOccurred() {
-        return (state.intValue() & 2) != 0;
+        return state != null && (state.intValue() & 2) != 0;
     }
 
     public boolean hasUnknownAlarmOccurred() {
-        return ((state.intValue() & 255) >> 2) != 0;
+        return state != null && ((state.intValue() & 255) >> 2) != 0;
     }
 
     @Override


### PR DESCRIPTION
Lately my Fritz!Box with Fritz!OS 7.56 sends empty alert state tags (`<state/>`) instead of a zero value (`<state>0</state>`) for **some** blinds, resulting in a NullPointerException when the binding tries to interpret the value. I fixed this by performing null checks before numerical operations take place.