### PR TITLE
[radiothermostat] Disable Remote Temp and Message Area on shutdown

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -66,6 +66,7 @@ curl http://$THERMOSTAT_IP/cloud -d '{"authkey":""}' -X POST
 - The `override` flag is not reported correctly on older thermostat versions (i.e. /tstat/model reports v1.09)
 - The 'Program Mode' command is untested and according to the published API is only available on a CT80 Rev B.
 - Humidity information is available only when using a CT80 thermostat.
+- If `remote_temp` or `message` channels are used, their values in the thermostat will be removed during binding shutdown.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -66,7 +66,7 @@ curl http://$THERMOSTAT_IP/cloud -d '{"authkey":""}' -X POST
 - The `override` flag is not reported correctly on older thermostat versions (i.e. /tstat/model reports v1.09)
 - The 'Program Mode' command is untested and according to the published API is only available on a CT80 Rev B.
 - Humidity information is available only when using a CT80 thermostat.
-- If `remote_temp` or `message` channels are used, their values in the thermostat will be removed during binding shutdown.
+- If `remote_temp` or `message` channels are used, their values in the thermostat will be cleared during binding shutdown.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -257,8 +257,13 @@ when
 then
   // Display up to 5 numbers in the thermostat's Price Message Area (PMA)
   // A decimal point can be used. CT80 can display a negative '-' number
-  // Send null or empty string to clear the number and restore the time display
-  var Number temp = Math.round((OutsideTemp.state as DecimalType).doubleValue).intValue
+  // Sends empty string to clear the number and restore the time display if OutsideTemp is undefined
+  var temp = ""
+
+  if (newState != null && newState != UNDEF) {
+      temp = Math.round((newState as DecimalType).doubleValue).intValue.toString
+  }
+
   Therm_Message.sendCommand(temp)
 end
 ```

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatBindingConstants.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatBindingConstants.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.radiothermostat.internal;
 
-import java.util.Collections;
 import java.util.Set;
 
 import javax.measure.Unit;
@@ -79,7 +78,7 @@ public class RadioThermostatBindingConstants {
     public static final String REMOTE_TEMP = "remote_temp";
     public static final String MESSAGE = "message";
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_RTHERM);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_RTHERM);
 
     public static final Set<String> SUPPORTED_CHANNEL_IDS = Set.of(TEMPERATURE, HUMIDITY, MODE, FAN_MODE, PROGRAM_MODE,
             SET_POINT, OVERRIDE, HOLD, STATUS, FAN_STATUS, DAY, HOUR, MINUTE, DATE_STAMP, TODAY_HEAT_RUNTIME,

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatHandlerFactory.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatHandlerFactory.java
@@ -14,7 +14,6 @@ package org.openhab.binding.radiothermostat.internal;
 
 import static org.openhab.binding.radiothermostat.internal.RadioThermostatBindingConstants.THING_TYPE_RTHERM;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -41,7 +40,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.radiothermostat")
 public class RadioThermostatHandlerFactory extends BaseThingHandlerFactory {
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_RTHERM);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_RTHERM);
     private final RadioThermostatStateDescriptionProvider stateDescriptionProvider;
     private final HttpClient httpClient;
 

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -20,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -185,7 +184,7 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
 
     @Override
     public Collection<Class<? extends ThingHandlerService>> getServices() {
-        return Collections.singletonList(RadioThermostatThingActions.class);
+        return List.of(RadioThermostatThingActions.class);
     }
 
     /**
@@ -287,6 +286,15 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
     public void dispose() {
         logger.debug("Disposing the RadioThermostat handler.");
         connector.removeEventListener(this);
+
+        // Disable Remote Temp and Message Area on shutdown
+        if (isLinked(REMOTE_TEMP)) {
+            connector.sendCommand("rem_mode", "0", REMOTE_TEMP_RESOURCE);
+        }
+
+        if (isLinked(MESSAGE)) {
+            connector.sendCommand("mode", "0", PMA_RESOURCE);
+        }
 
         ScheduledFuture<?> refreshJob = this.refreshJob;
         if (refreshJob != null) {


### PR DESCRIPTION
Clear the remote temp and message area values in the thermostat when dispose() is called. Also minor refactoring to use immutable list/set convenience methods.
