### PR TITLE
[hue] Fix and improve error logging and status descriptions for API v2

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/connection/Clip2Bridge.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/connection/Clip2Bridge.java
@@ -1106,7 +1106,7 @@ public class Clip2Bridge implements Closeable {
             String contentType = contentStreamListener.getContentType();
             int status = contentStreamListener.getStatus();
             LOGGER.trace("HTTP/2 {} (Content-Type: {}) << {}", status, contentType, contentJson);
-            if (status != HttpStatus.OK_200) {
+            if (!HttpStatus.isSuccess(status)) {
                 throw new ApiException(String.format("Unexpected HTTP status '%d'", status));
             }
             if (!MediaType.APPLICATION_JSON.equals(contentType)) {
@@ -1114,8 +1114,8 @@ public class Clip2Bridge implements Closeable {
             }
             try {
                 Resources resources = Objects.requireNonNull(jsonParser.fromJson(contentJson, Resources.class));
-                if (LOGGER.isDebugEnabled()) {
-                    resources.getErrors().forEach(error -> LOGGER.debug("putResource() resources error:{}", error));
+                if (resources.hasErrors()) {
+                    throw new ApiException(String.join("; ", resources.getErrors()));
                 }
             } catch (JsonParseException e) {
                 LOGGER.debug("putResource() parsing error json:{}", contentJson, e);

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Resources.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Resources.java
@@ -14,6 +14,7 @@ package org.openhab.binding.hue.internal.dto.clip2;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -28,7 +29,7 @@ public class Resources {
     private List<Resource> data = new ArrayList<>();
 
     public List<String> getErrors() {
-        return errors.stream().map(Error::getDescription).toList();
+        return errors.stream().map(Error::getDescription).collect(Collectors.toList());
     }
 
     public boolean hasErrors() {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Resources.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Resources.java
@@ -14,7 +14,6 @@ package org.openhab.binding.hue.internal.dto.clip2;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -29,7 +28,11 @@ public class Resources {
     private List<Resource> data = new ArrayList<>();
 
     public List<String> getErrors() {
-        return errors.stream().map(Error::getDescription).collect(Collectors.toList());
+        return errors.stream().map(Error::getDescription).toList();
+    }
+
+    public boolean hasErrors() {
+        return !errors.isEmpty();
     }
 
     public List<Resource> getResources() {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -161,71 +161,48 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
     private synchronized void checkConnection() {
         logger.debug("checkConnection()");
 
-        // check connection to the hub
-        ThingStatusDetail thingStatus;
+        boolean retryApplicationKey = false;
+        boolean retryConnection = false;
+
         try {
             checkAssetsLoaded();
             getClip2Bridge().testConnectionState();
-            thingStatus = ThingStatusDetail.NONE;
-        } catch (HttpUnauthorizedException e) {
-            logger.debug("checkConnection() {}", e.getMessage(), e);
-            thingStatus = ThingStatusDetail.CONFIGURATION_ERROR;
+            updateSelf(); // go online
+        } catch (HttpUnauthorizedException unauthorizedException) {
+            logger.debug("checkConnection() {}", unauthorizedException.getMessage(), unauthorizedException);
+            if (applKeyRetriesRemaining > 0) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/offline.api2.conf-error.press-pairing-button");
+                try {
+                    registerApplicationKey();
+                    retryApplicationKey = true;
+                } catch (HttpUnauthorizedException e) {
+                    retryApplicationKey = true;
+                } catch (ApiException e) {
+                    setStatusOfflineWithCommunicationError(e);
+                } catch (IllegalStateException e) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                            "@text/offline.api2.conf-error.read-only");
+                } catch (AssetNotLoadedException e) {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            "@text/offline.api2.conf-error.assets-not-loaded");
+                } catch (InterruptedException e) {
+                    return;
+                }
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/offline.api2.conf-error.not-authorized");
+            }
         } catch (ApiException e) {
             logger.debug("checkConnection() {}", e.getMessage(), e);
-            thingStatus = ThingStatusDetail.COMMUNICATION_ERROR;
+            setStatusOfflineWithCommunicationError(e);
+            retryConnection = connectRetriesRemaining > 0;
         } catch (AssetNotLoadedException e) {
             logger.debug("checkConnection() {}", e.getMessage(), e);
-            thingStatus = ThingStatusDetail.HANDLER_INITIALIZING_ERROR;
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.api2.conf-error.assets-not-loaded");
         } catch (InterruptedException e) {
             return;
-        }
-
-        // update the thing status
-        boolean retryApplicationKey = false;
-        boolean retryConnection = false;
-        switch (thingStatus) {
-            case CONFIGURATION_ERROR:
-                if (applKeyRetriesRemaining > 0) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                            "@text/offline.api2.conf-error.press-pairing-button");
-                    try {
-                        registerApplicationKey();
-                        retryApplicationKey = true;
-                    } catch (HttpUnauthorizedException e) {
-                        retryApplicationKey = true;
-                    } catch (ApiException e) {
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                                "@text/offline.communication-error");
-                    } catch (IllegalStateException e) {
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                                "@text/offline.api2.conf-error.read-only");
-                    } catch (AssetNotLoadedException e) {
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                                "@text/offline.api2.conf-error.assets-not-loaded");
-                    } catch (InterruptedException e) {
-                        return;
-                    }
-                } else {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                            "@text/offline.api2.conf-error.not-authorized");
-                }
-                break;
-
-            case COMMUNICATION_ERROR:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "@text/offline.communication-error");
-                retryConnection = connectRetriesRemaining > 0;
-                break;
-
-            case HANDLER_INITIALIZING_ERROR:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "@text/offline.api2.conf-error.assets-not-loaded");
-                break;
-
-            case NONE:
-            default:
-                updateSelf(); // go online
-                break;
         }
 
         int milliSeconds;
@@ -248,6 +225,18 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
         // this method schedules itself to be called again in a loop..
         cancelTask(checkConnectionTask, false);
         checkConnectionTask = scheduler.schedule(() -> checkConnection(), milliSeconds, TimeUnit.MILLISECONDS);
+    }
+
+    private void setStatusOfflineWithCommunicationError(Exception e) {
+        Throwable cause = e.getCause();
+        String causeMessage = cause == null ? null : cause.getMessage();
+        if (causeMessage == null || causeMessage.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.api2.comm-error.exception [\"" + e.getMessage() + "\"]");
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.api2.comm-error.exception [\"" + e.getMessage() + " -> " + causeMessage + "\"]");
+        }
     }
 
     /**
@@ -467,8 +456,7 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
                 }
             } catch (IOException e) {
                 logger.trace("initializeAssets() communication error on '{}'", ipAddress, e);
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "@text/offline.api2.comm-error.exception [\"" + e.getMessage() + "\"]");
+                setStatusOfflineWithCommunicationError(e);
                 return;
             }
 
@@ -491,8 +479,7 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
                 clip2Bridge = new Clip2Bridge(httpClientFactory, this, ipAddress, applicationKey);
             } catch (ApiException e) {
                 logger.trace("initializeAssets() communication error on '{}'", ipAddress, e);
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "@text/offline.api2.comm-error.exception [\"" + e.getMessage() + "\"]");
+                setStatusOfflineWithCommunicationError(e);
                 return;
             }
 
@@ -685,8 +672,7 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
             getClip2Bridge().open();
         } catch (ApiException e) {
             logger.trace("updateSelf() {}", e.getMessage(), e);
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "@text/offline.api2.comm-error.exception [\"" + e.getMessage() + "\"]");
+            setStatusOfflineWithCommunicationError(e);
             onConnectionOffline();
         } catch (AssetNotLoadedException e) {
             logger.trace("updateSelf() {}", e.getMessage(), e);

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -555,14 +555,15 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
      * Execute an HTTP PUT to send a Resource object to the server.
      *
      * @param resource the resource to put.
+     * @return the resource, which may contain errors.
      * @throws ApiException if a communication error occurred.
      * @throws AssetNotLoadedException if one of the assets is not loaded.
      * @throws InterruptedException
      */
-    public void putResource(Resource resource) throws ApiException, AssetNotLoadedException, InterruptedException {
+    public Resources putResource(Resource resource) throws ApiException, AssetNotLoadedException, InterruptedException {
         logger.debug("putResource() {}", resource);
         checkAssetsLoaded();
-        getClip2Bridge().putResource(resource);
+        return getClip2Bridge().putResource(resource);
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -44,6 +44,7 @@ import org.openhab.binding.hue.internal.dto.clip2.MirekSchema;
 import org.openhab.binding.hue.internal.dto.clip2.ProductData;
 import org.openhab.binding.hue.internal.dto.clip2.Resource;
 import org.openhab.binding.hue.internal.dto.clip2.ResourceReference;
+import org.openhab.binding.hue.internal.dto.clip2.Resources;
 import org.openhab.binding.hue.internal.dto.clip2.enums.ActionType;
 import org.openhab.binding.hue.internal.dto.clip2.enums.EffectType;
 import org.openhab.binding.hue.internal.dto.clip2.enums.RecallAction;
@@ -507,7 +508,11 @@ public class Clip2ThingHandler extends BaseThingHandler {
         logger.debug("{} -> handleCommand() put resource {}", resourceId, putResource);
 
         try {
-            getBridgeHandler().putResource(putResource);
+            Resources resources = getBridgeHandler().putResource(putResource);
+            if (resources.hasErrors()) {
+                logger.info("Command '{}' for thing '{}', channel '{}' succeeded with errors: {}", command,
+                        thing.getUID(), channelUID, String.join("; ", resources.getErrors()));
+            }
         } catch (ApiException | AssetNotLoadedException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("{} -> handleCommand() error {}", resourceId, e.getMessage(), e);

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
@@ -232,7 +232,7 @@ offline.group-removed = Hue Bridge reports group as removed.
 # api v2 offline configuration error descriptions
 
 offline.api2.comm-error.zigbee-connectivity-issue = Zigbee connectivity issue.
-offline.api2.comm-error.exception = An unexpected exception ''{0}'' occurred.
+offline.api2.comm-error.exception = An unexpected exception occurred: {0}
 offline.api2.conf-error.certificate-load = Certificate loading failed. Please check your configuration settings (network address, type of certificate).
 offline.api2.conf-error.assets-not-loaded = Bridge/Thing handler assets not loaded.
 offline.api2.conf-error.press-pairing-button = Not authenticated. Press pairing button on the Hue Bridge or set a valid application key in configuration.


### PR DESCRIPTION
When sending a command to an unreachable bulb this **warning** was logged:
```
[WARN] Command 'OFF' for thing 'hue:device:home:innr3', channel 'hue:device:home:innr3:switch' failed with error 'Unexpected HTTP status '207''.
```

This has been changed to log level **information** with the errors provided in the response:
```
[INFO] Command 'OFF' for thing 'hue:device:home:innr3', channel 'hue:device:home:innr3:switch' succeeded with errors: device (light) has communication issues, command (.on.on) may not have effect
```

Or this, in case of multiple errors:
```
[INFO] Command 'ON' for thing 'hue:device:home:traadfri_color_bulb2', channel 'hue:device:home:traadfri_color_bulb2:color' succeeded with errors: device (light) has communication issues, command (.on.on) may not have effect; device (light) has communication issues, command (.dimming.brightness) may not have effect; device (light) has communication issues, command (.color.xy) may not have effect
```

Prior to #15477 nothing was logged with default log level (log level **debug** required).

The reason why these errors are not strictly treated as errors is that the PUT request actually succeeds, at least partially (hence "may not have effect"). For example, for `dimming-only`, the requested level is immediately visible in the Hue app even when the bulb is off. For some supported bulb types the new values might be sent to the bulb when it will come online again.

Fixes #15511
Regression of #15477

Also improves generic error messages to obtain more information in case of issues - see https://github.com/openhab/openhab-addons/issues/15460#issuecomment-1699839595