### PR TITLE
[keba] Split channel ENABLED to USER and SYSTEM channels

### DIFF
--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -42,7 +42,8 @@ public class KebaBindingConstants {
     public static final String CHANNEL_WALLBOX = "wallbox";
     public static final String CHANNEL_VEHICLE = "vehicle";
     public static final String CHANNEL_PLUG_LOCKED = "locked";
-    public static final String CHANNEL_ENABLED = "enabled";
+    public static final String CHANNEL_ENABLED_SYSTEM = "enabledsystem";
+    public static final String CHANNEL_ENABLED_USER = "enableduser";
     public static final String CHANNEL_PILOT_CURRENT = "maxpilotcurrent";
     public static final String CHANNEL_PILOT_PWM = "maxpilotcurrentdutycyle";
     public static final String CHANNEL_MAX_SYSTEM_CURRENT = "maxsystemcurrent";

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -325,11 +325,25 @@ public class KeContactHandler extends BaseThingHandler {
                         int state = entry.getValue().getAsInt();
                         switch (state) {
                             case 1: {
-                                updateState(CHANNEL_ENABLED, OnOffType.ON);
+                                updateState(CHANNEL_ENABLED_SYSTEM, OnOffType.ON);
                                 break;
                             }
                             default: {
-                                updateState(CHANNEL_ENABLED, OnOffType.OFF);
+                                updateState(CHANNEL_ENABLED_SYSTEM, OnOffType.OFF);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case "Enable user": {
+                        int state = entry.getValue().getAsInt();
+                        switch (state) {
+                            case 1: {
+                                updateState(CHANNEL_ENABLED_USER, OnOffType.ON);
+                                break;
+                            }
+                            default: {
+                                updateState(CHANNEL_ENABLED_USER, OnOffType.OFF);
                                 break;
                             }
                         }
@@ -559,7 +573,7 @@ public class KeContactHandler extends BaseThingHandler {
                     }
                     break;
                 }
-                case CHANNEL_ENABLED: {
+                case CHANNEL_ENABLED_USER: {
                     if (command instanceof OnOffType) {
                         if (command == OnOffType.ON) {
                             transceiver.send("ena 1", this);

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
@@ -9,7 +9,8 @@
 		<description>A KeContact EV Charging Station</description>
 
 		<channels>
-			<channel id="enabled" typeId="enabled"/>
+			<channel id="enabledsystem" typeId="enabled"/>
+			<channel id="enableduser" typeId="enabled"/>
 			<channel id="state" typeId="state"/>
 			<channel id="maxpresetcurrent" typeId="current_settable"/>
 			<channel id="maxpresetcurrentrange" typeId="range"/>
@@ -119,7 +120,7 @@
 		<item-type>Switch</item-type>
 		<label>Enabled</label>
 		<description>Activation state of the wallbox</description>
-		<state readOnly="false"></state>
+		<state readOnly="true"></state>
 	</channel-type>
 	<channel-type id="x1" advanced="true">
 		<item-type>Switch</item-type>


### PR DESCRIPTION
This PR split the two channels for enabled_system and enabled_user state of the wallbox.
See https://github.com/openhab/openhab-addons/issues/15521
