### PR TITLE
[easee] simplified determination of start/stop status due to recent API changes

### DIFF
--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/EaseeBindingConstants.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/EaseeBindingConstants.java
@@ -156,9 +156,6 @@ public class EaseeBindingConstants {
 
     public static final String GENERIC_YES = "Yes";
     public static final String GENERIC_NO = "No";
-    public static final int CHARGER_OP_STATE_WAITING = 2;
-    public static final int CHARGER_OP_STATE_CHARGING = 3;
-    public static final int CHARGER_OP_STATE_NOT_AUTHENTICATED = 7;
     public static final double CHARGER_DYNAMIC_CURRENT_PAUSE = 0;
     public static final int CHARGER_REASON_FOR_NO_CURRENT_CIRCUIT_LIMIT = 2;
     public static final int CHARGER_REASON_FOR_NO_CURRENT_CHARGER_LIMIT = 52;

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/ChargerOpState.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/ChargerOpState.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.easee.internal.model;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * this enum represents the charger operation states as documented by https://developer.easee.cloud/docs/enumerations
@@ -32,6 +34,7 @@ public enum ChargerOpState {
     DEAUTHENTICATING(8),
     UNKNOWN_STATE(-1);
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChargerOpState.class);
     private final int code;
 
     private ChargerOpState(int code) {
@@ -51,7 +54,13 @@ public enum ChargerOpState {
     }
 
     public static ChargerOpState fromCode(String code) {
-        return ChargerOpState.fromCode(Integer.parseInt(code));
+        try {
+            return ChargerOpState.fromCode(Integer.parseInt(code));
+        } catch (NumberFormatException ex) {
+            LOGGER.warn("caught exception while parsing ChargerOpState code: '{}' - exception: {}", code,
+                    ex.getMessage());
+            return UNKNOWN_STATE;
+        }
     }
 
     public static ChargerOpState fromCode(int code) {
@@ -60,6 +69,7 @@ public enum ChargerOpState {
                 return state;
             }
         }
+        LOGGER.info("unknown ChargerOpState code: '{}'", code);
         return UNKNOWN_STATE;
     }
 }

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/ChargerOpState.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/ChargerOpState.java
@@ -1,0 +1,49 @@
+package org.openhab.binding.easee.internal.model;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+@NonNullByDefault
+public enum ChargerOpState {
+    OFFLINE(0),
+    DISCONNECTED(1),
+    WAITING(2),
+    CHARGING(3),
+    COMPLETED(4),
+    ERROR(5),
+    READY_TO_CHARGE(6),
+    NOT_AUTHENTICATED(7),
+    DEAUTHENTICATING(8),
+    UNKNOWN_STATE(-1);
+
+    private final int code;
+
+    private ChargerOpState(int code) {
+        this.code = code;
+    }
+
+    public boolean isAuthenticatedState() {
+        switch (this) {
+            case WAITING:
+            case CHARGING:
+            case COMPLETED:
+            case ERROR:
+            case READY_TO_CHARGE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static ChargerOpState fromCode(String code) {
+        return ChargerOpState.fromCode(Integer.parseInt(code));
+    }
+
+    public static ChargerOpState fromCode(int code) {
+        for (ChargerOpState state : ChargerOpState.values()) {
+            if (state.code == code) {
+                return state;
+            }
+        }
+        return UNKNOWN_STATE;
+    }
+}

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/ChargerOpState.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/ChargerOpState.java
@@ -1,7 +1,24 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.easee.internal.model;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
+/**
+ * this enum represents the charger operation states as documented by https://developer.easee.cloud/docs/enumerations
+ *
+ * @author Alexander Friese - initial contribution
+ */
 @NonNullByDefault
 public enum ChargerOpState {
     OFFLINE(0),
@@ -26,7 +43,6 @@ public enum ChargerOpState {
             case WAITING:
             case CHARGING:
             case COMPLETED:
-            case ERROR:
             case READY_TO_CHARGE:
                 return true;
             default:

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
@@ -81,7 +81,7 @@ class CustomResponseTransformer {
     private void updateChargerStartStop(Map<Channel, State> result, String value, JsonObject rawData) {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_START_STOP);
         if (channel != null) {
-            int val = Integer.parseInt(value);
+            int state = Integer.parseInt(value);
             // 2 <= state < 7 will mean car is connected and session is authenticated
             boolean authenticated = val >= CHARGER_OP_STATE_WAITING && val < CHARGER_OP_STATE_NOT_AUTHENTICATED;
             result.put(channel, OnOffType.from(authenticated));

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
@@ -82,24 +82,9 @@ class CustomResponseTransformer {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_START_STOP);
         if (channel != null) {
             int val = Integer.parseInt(value);
-            // state >= 3 && state < 7 will mean charging, ready to charge or charging finished
-            boolean charging = val >= CHARGER_OP_STATE_CHARGING && val < CHARGER_OP_STATE_NOT_AUTHENTICATED;
-
-            String rfnc = Utils.getAsString(rawData, CHANNEL_CHARGER_REASON_FOR_NO_CURRENT);
-            int reasonForNoCurrent = Integer.valueOf(rfnc == null ? "-1" : rfnc);
-            boolean paused = false;
-            if (val == CHARGER_OP_STATE_WAITING) {
-                switch (reasonForNoCurrent) {
-                    case CHARGER_REASON_FOR_NO_CURRENT_CHARGER_LIMIT:
-                    case CHARGER_REASON_FOR_NO_CURRENT_CIRCUIT_LIMIT:
-                        paused = true;
-                        break;
-                    default:
-                        paused = false;
-                        break;
-                }
-            }
-            result.put(channel, OnOffType.from(charging || paused));
+            // 2 <= state < 7 will mean car is connected and session is authenticated
+            boolean authenticated = val >= CHARGER_OP_STATE_WAITING && val < CHARGER_OP_STATE_NOT_AUTHENTICATED;
+            result.put(channel, OnOffType.from(authenticated));
         }
     }
 

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
@@ -53,7 +53,7 @@ class CustomResponseTransformer {
 
         switch (triggerChannel.getUID().getId()) {
             case CHANNEL_GROUP_CHARGER_STATE + "#" + CHANNEL_CHARGER_OP_MODE:
-                updateChargerStartStop(result, value, rawData);
+                updateChargerStartStop(result, value);
                 break;
             case CHANNEL_GROUP_CHARGER_STATE + "#" + CHANNEL_CHARGER_DYNAMIC_CURRENT:
                 updateChargerPauseResume(result, value);
@@ -78,7 +78,7 @@ class CustomResponseTransformer {
         return result;
     }
 
-    private void updateChargerStartStop(Map<Channel, State> result, String value, JsonObject rawData) {
+    private void updateChargerStartStop(Map<Channel, State> result, String value) {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_START_STOP);
         if (channel != null) {
             ChargerOpState state = ChargerOpState.fromCode(value);

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
@@ -82,9 +82,9 @@ class CustomResponseTransformer {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_START_STOP);
         if (channel != null) {
             int state = Integer.parseInt(value);
-            // 2 <= state < 7 will mean car is connected and session is authenticated
-            boolean authenticated = val >= CHARGER_OP_STATE_WAITING && val < CHARGER_OP_STATE_NOT_AUTHENTICATED;
-            result.put(channel, OnOffType.from(authenticated));
+            boolean connectedAndAuthenticated = state >= CHARGER_OP_STATE_WAITING
+                    && state < CHARGER_OP_STATE_NOT_AUTHENTICATED;
+            result.put(channel, OnOffType.from(connectedAndAuthenticated));
         }
     }
 

--- a/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
+++ b/bundles/org.openhab.binding.easee/src/main/java/org/openhab/binding/easee/internal/model/CustomResponseTransformer.java
@@ -81,10 +81,8 @@ class CustomResponseTransformer {
     private void updateChargerStartStop(Map<Channel, State> result, String value, JsonObject rawData) {
         Channel channel = channelProvider.getChannel(CHANNEL_GROUP_CHARGER_COMMANDS, CHANNEL_CHARGER_START_STOP);
         if (channel != null) {
-            int state = Integer.parseInt(value);
-            boolean connectedAndAuthenticated = state >= CHARGER_OP_STATE_WAITING
-                    && state < CHARGER_OP_STATE_NOT_AUTHENTICATED;
-            result.put(channel, OnOffType.from(connectedAndAuthenticated));
+            ChargerOpState state = ChargerOpState.fromCode(value);
+            result.put(channel, OnOffType.from(state.isAuthenticatedState()));
         }
     }
 


### PR DESCRIPTION
Since Easse has introduced new status values (7+8) to map different states related to authentication it is now much easier to determine start/stop status.