### PR TITLE
[SenecHome] Enable HTTPS usage for Senec Binding

### DIFF
--- a/bundles/org.openhab.binding.senechome/README.md
+++ b/bundles/org.openhab.binding.senechome/README.md
@@ -24,7 +24,7 @@ Examples: Lights, pool filters, wash machines, ...
 demo.things
 
 ```java
-Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", useHttps=false, refreshInterval=60, limitationTresholdValue=70, limitationDuration=60 ]
+Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", useHttps=true, refreshInterval=60, limitationTresholdValue=70, limitationDuration=60 ]
 ```
 
 If the thing goes online then the connection to the web interface is successful.

--- a/bundles/org.openhab.binding.senechome/README.md
+++ b/bundles/org.openhab.binding.senechome/README.md
@@ -24,7 +24,7 @@ Examples: Lights, pool filters, wash machines, ...
 demo.things
 
 ```java
-Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", refreshInterval=60, limitationTresholdValue=70, limitationDuration=60 ]
+Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", useHttps=false, refreshInterval=60, limitationTresholdValue=70, limitationDuration=60 ]
 ```
 
 If the thing goes online then the connection to the web interface is successful.

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.senechome.internal;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.util.Objects;
@@ -87,7 +88,8 @@ public class SenecHomeApi {
      * POST json with empty, but expected fields, to lala.cgi of Senec webinterface
      * the response will contain the same fields, but with the corresponding values
      *
-     * To receive new values, just modify the Json objects and add them to the thing channels
+     * To receive new values, just modify the Json objects and add them to the thing
+     * channels
      *
      * @return Instance of SenecHomeResponse
      * @throws MalformedURLException Configuration/URL is wrong
@@ -101,6 +103,7 @@ public class SenecHomeApi {
         }
 
         Request request = httpClient.newRequest(location);
+        logger.debug("Senec URL: {}", location);
         request.header(HttpHeader.ACCEPT, MimeTypes.Type.APPLICATION_JSON.asString());
         request.header(HttpHeader.CONTENT_TYPE, MimeTypes.Type.FORM_ENCODED.asString());
 
@@ -115,7 +118,7 @@ public class SenecHomeApi {
                 throw new IOException("Got unexpected response code " + response.getStatus());
             }
         } catch (MalformedJsonException | JsonSyntaxException | InterruptedException | TimeoutException
-                | ExecutionException | UnknownHostException e) {
+                | ExecutionException | UnknownHostException | ConnectException e) {
             String errorMessage = "\nlocation: " + location;
             errorMessage += "\nrequest: " + request.toString();
             errorMessage += "\nrequest.getHeaders: " + request.getHeaders();
@@ -130,7 +133,7 @@ public class SenecHomeApi {
                     errorMessage += "\nresponse.getContentAsString: " + response.getContentAsString();
                 }
             }
-            logger.trace("Issue with getting SenecHomeResponse\n{}", errorMessage);
+            logger.error("Issue with getting SenecHomeResponse\n{}", errorMessage);
             throw e;
         }
     }

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -71,14 +71,11 @@ public class SenecHomeApi {
         // Apply SSL context factory to the HttpClient builder
         httpClient = new HttpClient(sslContextFactory);
 
-        // Other configuration settings can be applied here if needed
-        // For example: httpClient.setConnectTimeout(5000);
-
         // Start the HttpClient
         try {
             httpClient.start();
         } catch (Exception e) {
-            // Handle exception
+            logger.error("Issue with starting the http client", e);
         }
 
         return httpClient;
@@ -103,10 +100,8 @@ public class SenecHomeApi {
         }
 
         Request request = httpClient.newRequest(location);
-        logger.debug("Senec URL: {}", location);
         request.header(HttpHeader.ACCEPT, MimeTypes.Type.APPLICATION_JSON.asString());
         request.header(HttpHeader.CONTENT_TYPE, MimeTypes.Type.FORM_ENCODED.asString());
-
         ContentResponse response = null;
         try {
             response = request.method(HttpMethod.POST)

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeConfigurationDTO.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeConfigurationDTO.java
@@ -20,7 +20,7 @@ package org.openhab.binding.senechome.internal;
  */
 public class SenecHomeConfigurationDTO {
     public String hostname;
-    public Boolean useHttps = false;
+    public Boolean useHttps = true;
     public int refreshInterval = 15;
     public int limitationTresholdValue = 95;
     public int limitationDuration = 120;

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeConfigurationDTO.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeConfigurationDTO.java
@@ -13,12 +13,14 @@
 package org.openhab.binding.senechome.internal;
 
 /**
- * The {@link SenecHomeConfigurationDTO} class contains fields mapping thing configuration parameters.
+ * The {@link SenecHomeConfigurationDTO} class contains fields mapping thing
+ * configuration parameters.
  *
  * @author Steven Schwarznau - Initial contribution
  */
 public class SenecHomeConfigurationDTO {
     public String hostname;
+    public Boolean useHttps = false;
     public int refreshInterval = 15;
     public int limitationTresholdValue = 95;
     public int limitationDuration = 120;

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -136,7 +136,7 @@ public class SenecHomeHandler extends BaseThingHandler {
     public @Nullable Boolean refreshState() {
         SenecHomeResponse response = null;
         try {
-            response = senecHomeApi.getStatistics();
+            response = senecHomeApi.getStatistics(true);
             logger.trace("received {}", response);
 
             BigDecimal pvLimitation = new BigDecimal(100).subtract(getSenecValue(response.power.powerLimitation))

--- a/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/i18n/senechome.properties
+++ b/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/i18n/senechome.properties
@@ -18,6 +18,8 @@ thing-type.config.senechome.senechome.limitationTresholdValue.label = Limitation
 thing-type.config.senechome.senechome.limitationTresholdValue.description = Treshold in percent, defines when limitation state is enabled
 thing-type.config.senechome.senechome.refreshInterval.label = Refresh Interval
 thing-type.config.senechome.senechome.refreshInterval.description = Rate of refreshing details (in s)
+thing-type.config.senechome.senechome.useHttps.label = Use HTTPS
+thing-type.config.senechome.senechome.useHttps.description = Use HTTPS to connect to your Senec Home device
 
 # channel types
 

--- a/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
@@ -110,7 +110,7 @@
 			<parameter name="useHttps" type="boolean" required="true">
 				<label>Use https</label>
 				<description>Only enable the usage of https if connection via http doesn't work</description>
-				<default>false</default>
+				<default>true</default>
 			</parameter>
 			<parameter name="refreshInterval" type="integer" min="1" unit="s">
 				<label>Refresh Interval</label>

--- a/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
@@ -107,6 +107,11 @@
 				<description>Enter the hostname or ip address of your Senec Home device</description>
 				<context>network-address</context>
 			</parameter>
+			<parameter name="useHttps" type="boolean" required="true">
+				<label>Use https</label>
+				<description>Only enable the usage of https if connection via http doesn't work</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="refreshInterval" type="integer" min="1" unit="s">
 				<label>Refresh Interval</label>
 				<description>Rate of refreshing details (in s)</description>


### PR DESCRIPTION
# Description

This bug shall fix #15524 . Senec currently rolls out a SW update that disables the local http page and switches to https. The roll out happens in waves with no chance of delaying or enforcing it.

This PR gives the binding a configuration parameter to enable https instead of http. By default https is enabled as soon every device will require https. For everyone where the update didn't happen yet can disable https and continue to use http.

This patch should best case be released in the next OpenHAB release 4.0.x or 4.1.x as the rollout started and one after another binding user is loosing the contact to the device. I have discussed and tested the changes here: https://community.openhab.org/t/senechome-binding/108152/20?u=kobip

Link to the automatically build jar: https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.senechome/4.1.0-SNAPSHOT/
Jars also attached: [org.openhab.binding.senechome-4.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab-addons/files/12553161/org.openhab.binding.senechome-4.1.0-SNAPSHOT.zip)

Somehow some testers and myself couldn't install the jar with OpenHAB 4.0.2 because of a too high dependency to javax.measure. Here a zip with a downgraded dependency to 1.0 that worked with 4.0.2: 
[org.openhab.binding.senechome-4.x.y-SNAPSHOT-downgraded-javax.measure.zip](https://github.com/openhab/openhab-addons/files/12553246/org.openhab.binding.senechome-4.x.y-SNAPSHOT-downgraded-javax.measure.zip)

