### PR TITLE
Fixed timeouts in tests for groupepsa bundle

### DIFF
--- a/bundles/org.openhab.binding.groupepsa/src/test/java/org/openhab/binding/groupepsa/internal/things/GroupePSAHandlerTest.java
+++ b/bundles/org.openhab.binding.groupepsa/src/test/java/org/openhab/binding/groupepsa/internal/things/GroupePSAHandlerTest.java
@@ -141,7 +141,7 @@ public class GroupePSAHandlerTest {
         bridgeHandler.initialize();
 
         // check that the bridge is online
-        verify(bridgeCallback, timeout(2000)).statusUpdated(eq(bridge),
+        verify(bridgeCallback, timeout(10000)).statusUpdated(eq(bridge),
                 argThat(arg -> arg.getStatus().equals(ThingStatus.ONLINE)));
 
         // Initialize the thing
@@ -149,7 +149,7 @@ public class GroupePSAHandlerTest {
 
         // check that the thing is offline without detail (last update time is not
         // within 15 minutes)
-        verify(thingCallback, timeout(2000)).statusUpdated(eq(thing),
+        verify(thingCallback, timeout(10000)).statusUpdated(eq(thing),
                 argThat(arg -> arg.getStatus().equals(ThingStatus.OFFLINE)
                         && arg.getStatusDetail().equals(ThingStatusDetail.NONE)));
 


### PR DESCRIPTION
# Fixed timeouts in tests for groupepsa bundle

# Description

Fix intermittent failures of tests as described in #13557. The timeouts in the verifies might be too short in certain circumstances (heavy cpu loading, etc.). It is addressed by increasing the timeout of the tests from 2 000ms to 10 000ms.


# Testing
The problem can be reproduced by decreasing the timeouts to ~ 1 000ms. Increasing from 2 000ms to 10 000ms will give ample margin.
