### PR TITLE
[openweathermap] Add JSON channels

### DIFF
--- a/bundles/org.openhab.binding.openweathermap/README.md
+++ b/bundles/org.openhab.binding.openweathermap/README.md
@@ -122,11 +122,12 @@ Once the parameter `forecastHours` will be changed, the available channel groups
 
 ### Station
 
-| Channel Group ID | Channel ID | Item Type | Description                                  |
-|------------------|------------|-----------|----------------------------------------------|
-| station          | id         | String    | Id of the weather station or the city.       |
-| station          | name       | String    | Name of the weather station or the city.     |
-| station          | location   | Location  | Location of the weather station or the city. |
+| Channel Group ID | Channel ID | Item Type | Description                                                |
+|------------------|------------|-----------|------------------------------------------------------------|
+| station          | id         | String    | Id of the weather station or the city.                     |
+| station          | name       | String    | Name of the weather station or the city.                   |
+| station          | location   | Location  | Location of the weather station or the city.               |
+| station          | json       | String    | JSON string as returned from the Weather and Forecast API. |
 
 These channels are not supported in the One Call API
 
@@ -135,6 +136,7 @@ These channels are not supported in the One Call API
 | Channel Group ID | Channel ID           | Item Type            | Description                                                             |
 |------------------|----------------------|----------------------|-------------------------------------------------------------------------|
 | current          | time-stamp           | DateTime             | Time of data observation.                                               |
+| current          | json                 | String               | One Call API only! JSON string as returned from the One Call API.       |
 | current          | sunrise              | DateTime             | Sunrise time of current day. Only available in the One Call API         |
 | current          | sunset               | DateTime             | Sunset  time of current day. Only available in the One Call API         |
 | current          | condition            | String               | Current weather condition.                                              |

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/OpenWeatherMapBindingConstants.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/OpenWeatherMapBindingConstants.java
@@ -85,6 +85,7 @@ public class OpenWeatherMapBindingConstants {
     public static final String CHANNEL_STATION_NAME = "name";
     public static final String CHANNEL_STATION_LOCATION = "location";
     public static final String CHANNEL_TIME_STAMP = "time-stamp";
+    public static final String CHANNEL_JSON = "json";
     public static final String CHANNEL_SUNRISE = "sunrise";
     public static final String CHANNEL_SUNSET = "sunset";
     public static final String CHANNEL_CONDITION = "condition";

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
@@ -134,6 +134,12 @@ public class OpenWeatherMapConnection {
                 OpenWeatherMapJsonWeatherData.class);
     }
 
+    public synchronized @Nullable String getWeatherJson(@Nullable PointType location)
+            throws CommunicationException, ConfigurationException {
+        return getResponseFromCache(
+                buildURL(WEATHER_URL, getRequestParams(handler.getOpenWeatherMapAPIConfig(), location)));
+    }
+
     /**
      * Requests the hourly forecast data for the given location (see https://openweathermap.org/forecast5).
      *
@@ -330,7 +336,8 @@ public class OpenWeatherMapConnection {
                 OpenWeatherMapOneCallAPIData.class);
     }
 
-    public synchronized @Nullable String getOneCallAPIJson(@Nullable PointType location) {
+    public synchronized @Nullable String getOneCallAPIJson(@Nullable PointType location)
+            throws CommunicationException, ConfigurationException {
         Map<String, String> params = getRequestParams(handler.getOpenWeatherMapAPIConfig(), location);
         return getResponseFromCache(buildURL(buildOneCallURL(), params));
     }

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/connection/OpenWeatherMapConnection.java
@@ -330,6 +330,11 @@ public class OpenWeatherMapConnection {
                 OpenWeatherMapOneCallAPIData.class);
     }
 
+    public synchronized @Nullable String getOneCallAPIJson(@Nullable PointType location) {
+        Map<String, String> params = getRequestParams(handler.getOpenWeatherMapAPIConfig(), location);
+        return getResponseFromCache(buildURL(buildOneCallURL(), params));
+    }
+
     /**
      * Get the historical weather data from the One Call API for the given location and the given number of days in the
      * past. As of now, OpenWeatherMap supports this function for up to 5 days in the past. However, this may change in

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapOneCallHandler.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapOneCallHandler.java
@@ -74,6 +74,7 @@ public class OpenWeatherMapOneCallHandler extends AbstractOpenWeatherMapHandler 
             .compile(CHANNEL_GROUP_ALERTS_PREFIX + "([0-9]*)");
 
     private @Nullable OpenWeatherMapOneCallAPIData weatherData;
+    private @Nullable String weatherJson;
 
     private int forecastMinutes = 60;
     private int forecastHours = 24;
@@ -219,6 +220,7 @@ public class OpenWeatherMapOneCallHandler extends AbstractOpenWeatherMapHandler 
         try {
             weatherData = connection.getOneCallAPIData(location, forecastMinutes == 0, forecastHours == 0,
                     forecastDays == 0, numberOfAlerts == 0);
+            weatherJson = connection.getOneCallAPIJson(location);
             return true;
         } catch (JsonSyntaxException e) {
             logger.debug("JsonSyntaxException occurred during execution: {}", e.getMessage(), e);
@@ -279,6 +281,7 @@ public class OpenWeatherMapOneCallHandler extends AbstractOpenWeatherMapHandler 
         String channelId = channelUID.getIdWithoutGroup();
         String channelGroupId = channelUID.getGroupId();
         OpenWeatherMapOneCallAPIData localWeatherData = weatherData;
+        String localWeatherJson = weatherJson;
         if (localWeatherData != null) {
             State state = UnDefType.UNDEF;
             switch (channelId) {
@@ -287,6 +290,9 @@ public class OpenWeatherMapOneCallHandler extends AbstractOpenWeatherMapHandler 
                     break;
                 case CHANNEL_TIME_STAMP:
                     state = getDateTimeTypeState(localWeatherData.getCurrent().getDt());
+                    break;
+                case CHANNEL_JSON:
+                    state = getStringTypeState(localWeatherJson);
                     break;
                 case CHANNEL_SUNRISE:
                     state = getDateTimeTypeState(localWeatherData.getCurrent().getSunrise());

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
@@ -74,6 +74,7 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
     private int forecastDays = 6;
 
     private @Nullable OpenWeatherMapJsonWeatherData weatherData;
+    private @Nullable String weatherJson;
     private @Nullable OpenWeatherMapJsonHourlyForecastData hourlyForecastData;
     private @Nullable OpenWeatherMapJsonDailyForecastData dailyForecastData;
 
@@ -166,6 +167,7 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
         logger.debug("Update weather and forecast data of thing '{}'.", getThing().getUID());
         try {
             weatherData = connection.getWeatherData(location);
+            weatherJson = connection.getWeatherJson(location);
             if (forecastHours > 0) {
                 hourlyForecastData = connection.getHourlyForecastData(location, forecastHours / 3);
             }
@@ -238,6 +240,7 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
         String channelId = channelUID.getIdWithoutGroup();
         String channelGroupId = channelUID.getGroupId();
         OpenWeatherMapJsonWeatherData localWeatherData = weatherData;
+        String localWeatherJson = weatherJson;
         if (localWeatherData != null) {
             State state = UnDefType.UNDEF;
             switch (channelId) {
@@ -253,6 +256,9 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     break;
                 case CHANNEL_TIME_STAMP:
                     state = getDateTimeTypeState(localWeatherData.getDt());
+                    break;
+                case CHANNEL_JSON:
+                    state = getStringTypeState(localWeatherJson);
                     break;
                 case CHANNEL_CONDITION:
                     if (!localWeatherData.getWeather().isEmpty()) {

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/i18n/openweathermap.properties
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/i18n/openweathermap.properties
@@ -74,10 +74,10 @@ thing-type.openweathermap.weather-api.description = Provides access to the OpenW
 
 # thing types config
 
-bridge-type.config.openweathermap.weather-api.apikey.label = API Key
-bridge-type.config.openweathermap.weather-api.apikey.description = API key to access the OpenWeatherMap API.
 bridge-type.config.openweathermap.weather-api.apiVersion.label = One Call API Version
 bridge-type.config.openweathermap.weather-api.apiVersion.description = One Call API version (defaults to 2.5, version 3.0 is available, but needs different subscription).
+bridge-type.config.openweathermap.weather-api.apikey.label = API Key
+bridge-type.config.openweathermap.weather-api.apikey.description = API key to access the OpenWeatherMap API.
 bridge-type.config.openweathermap.weather-api.language.label = Language
 bridge-type.config.openweathermap.weather-api.language.description = Language to be used by the OpenWeatherMap API.
 bridge-type.config.openweathermap.weather-api.language.option.af = Afrikaans
@@ -171,6 +171,7 @@ channel-group-type.openweathermap.oneCallAlerts.label = Weather Warnings
 channel-group-type.openweathermap.oneCallAlerts.description = Weather warnings issued for the requested location.
 channel-group-type.openweathermap.oneCallCurrent.label = One Call API Current Weather
 channel-group-type.openweathermap.oneCallCurrent.description = Current weather data from the One Call API.
+channel-group-type.openweathermap.oneCallCurrent.channel.location.description = Location of the weather station or the city.
 channel-group-type.openweathermap.oneCallDaily.label = One Call API Daily Forecast
 channel-group-type.openweathermap.oneCallDaily.description = Daily weather forecast delivered by the One Call API.
 channel-group-type.openweathermap.oneCallHistory.label = One Call API Historical Weather
@@ -321,6 +322,8 @@ channel-type.openweathermap.precipitation.label = Precipitation
 channel-type.openweathermap.precipitation.description = Precipitation volume of the related timespan.
 channel-type.openweathermap.rain.label = Rain
 channel-type.openweathermap.rain.description = Rain volume of the last hour.
+channel-type.openweathermap.response-json.label = JSON Response
+channel-type.openweathermap.response-json.description = JSON string as returned from the OneCall API.
 channel-type.openweathermap.snow.label = Snow
 channel-type.openweathermap.snow.description = Snow volume of the last hour.
 channel-type.openweathermap.station-id.label = Station Id

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
@@ -146,7 +146,11 @@
 		<label>One Call API Current Weather</label>
 		<description>Current weather data from the One Call API.</description>
 		<channels>
+			<channel id="location" typeId="system.location">
+				<description>Location of the weather station or the city.</description>
+			</channel>
 			<channel id="time-stamp" typeId="time-stamp"/>
+			<channel id="json" typeId="response-json"/>
 			<channel id="sunrise" typeId="sunrise"/>
 			<channel id="sunset" typeId="sunset"/>
 			<channel id="condition" typeId="condition"/>
@@ -323,6 +327,14 @@
 		<description>Time of data observation.</description>
 		<category>Time</category>
 		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
+	</channel-type>
+
+	<channel-type id="response-json" advanced="true">
+		<item-type>String</item-type>
+		<label>JSON Response</label>
+		<description>JSON string as returned from the OneCall API</description>
+		<category>Text</category>
+		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="sunrise">

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
@@ -333,7 +333,7 @@
 	<channel-type id="response-json" advanced="true">
 		<item-type>String</item-type>
 		<label>JSON Response</label>
-		<description>JSON string as returned from the OneCall API</description>
+		<description>JSON string as returned from the OneCall API.</description>
 		<category>Text</category>
 		<state readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
@@ -14,6 +14,7 @@
 			<channel id="location" typeId="system.location">
 				<description>Location of the weather station or the city.</description>
 			</channel>
+			<channel id="json" typeId="response-json"/>
 		</channels>
 	</channel-group-type>
 


### PR DESCRIPTION
This adds string channels for both for the "Weather and Forecast" and the "One Call" APIs to allow access to the raw JSON responses.

This is especially useful from JS Scripting, where you can parse that JSON and then perform operations on it as on any other JS object, which is much more straighforward than reading the state of 1000 Items.