### PR TITLE
[hue] Support new DTOs for Button and Relative Rotary sensors

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/BaseReport.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/BaseReport.java
@@ -1,0 +1,22 @@
+package org.openhab.binding.hue.internal.dto.clip2;
+
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * TODO THIS IS A PLACE HOLDER for PR #15552 (base class for a sensor report).
+ *
+ * @author Andrew Fiddian-Green - Initial contribution
+ */
+@NonNullByDefault
+public class BaseReport {
+
+    private @NonNullByDefault({}) @SerializedName(value = "changed", alternate = { "updated" }) Instant changed;
+
+    public Instant getLastChanged() {
+        return changed;
+    }
+}

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Button.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/Button.java
@@ -28,16 +28,16 @@ import com.google.gson.annotations.SerializedName;
 @NonNullByDefault
 public class Button {
     private @Nullable @SerializedName("last_event") String lastEvent;
+    private @Nullable @SerializedName("button_report") ButtonReport buttonReport;
 
     /**
      * @return the last button event as an enum.
      * @throws IllegalArgumentException if lastEvent is null or bad.
      */
     public ButtonEventType getLastEvent() throws IllegalArgumentException {
+        ButtonReport buttonReport = this.buttonReport;
         String lastEvent = this.lastEvent;
-        if (Objects.nonNull(lastEvent)) {
-            return ButtonEventType.valueOf(lastEvent.toUpperCase());
-        }
-        throw new IllegalArgumentException("lastEvent field is null");
+        return ButtonEventType.valueOf((Objects.nonNull(buttonReport) ? buttonReport.getEvent()
+                : Objects.nonNull(lastEvent) ? lastEvent : "missing field").toUpperCase());
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/ButtonReport.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/ButtonReport.java
@@ -1,0 +1,17 @@
+package org.openhab.binding.hue.internal.dto.clip2;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * DTO for CLIP 2 button report.
+ *
+ * @author Andrew Fiddian-Green - Initial contribution
+ */
+@NonNullByDefault
+public class ButtonReport extends BaseReport {
+    private @NonNullByDefault({}) String event;
+
+    public String getEvent() {
+        return event;
+    }
+}

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/RelativeRotary.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/RelativeRotary.java
@@ -28,7 +28,7 @@ import com.google.gson.annotations.SerializedName;
  */
 @NonNullByDefault
 public class RelativeRotary {
-    private @Nullable @SerializedName("last_event") RotationEvent lastEvent;
+    private @Nullable @SerializedName(value = "last_event", alternate = { "rotary_report" }) RotationEvent lastEvent;
 
     public State getActionState() {
         RotationEvent lastEvent = getLastEvent();

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/RotationEvent.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/dto/clip2/RotationEvent.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.hue.internal.dto.clip2;
 
+import java.time.Instant;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -28,6 +29,7 @@ import org.openhab.core.types.UnDefType;
  */
 @NonNullByDefault
 public class RotationEvent {
+    private @Nullable Instant updated;
     private @Nullable String action;
     private @Nullable Rotation rotation;
 
@@ -39,6 +41,10 @@ public class RotationEvent {
     public State getActionState() {
         RotationEventType action = getAction();
         return Objects.nonNull(action) ? new StringType(action.name()) : UnDefType.NULL;
+    }
+
+    public @Nullable Instant getLastChanged() {
+        return updated;
     }
 
     public @Nullable Rotation getRotation() {


### PR DESCRIPTION
Philips / Signify has deprecated the DTOs for Button and Relative Rotary sensors and replaced them with new DTOs.
This PR adds support for both new and deprecated DTOs depending on which is present.

This PR depends on some underlying infrastructure changes which are being introduced in https://github.com/openhab/openhab-addons/pull/15552

Resolves #15599
Depends on #15552

Signed-off-by: Andrew Fiddian-Green [software@whitebear.ch](mailto:software@whitebear.ch)