### PR TITLE
[miio] fix reported brightness for yeelight

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/Conversions.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/Conversions.java
@@ -61,14 +61,22 @@ public class Conversions {
      *
      * @param RGB
      * @param map with device variables containing the brightness info
+     * @param report brightness 0 on power off
      * @return HSV
      */
-    private static JsonElement addBrightToHSV(JsonElement rgbValue, @Nullable Map<String, Object> deviceVariables)
-            throws ClassCastException, IllegalStateException {
+    private static JsonElement addBrightToHSV(JsonElement rgbValue, @Nullable Map<String, Object> deviceVariables,
+            boolean powerDependent) throws ClassCastException, IllegalStateException {
         int bright = 100;
         if (deviceVariables != null) {
             JsonElement lastBright = (JsonElement) deviceVariables.getOrDefault("bright", new JsonPrimitive(100));
             bright = lastBright.getAsInt();
+            if (powerDependent) {
+                String lastPower = ((JsonElement) deviceVariables.getOrDefault("power", new JsonPrimitive("on")))
+                        .getAsString();
+                if (lastPower.toLowerCase().contentEquals("off")) {
+                    bright = 0;
+                }
+            }
         }
         if (rgbValue.isJsonPrimitive()
                 && (rgbValue.getAsJsonPrimitive().isNumber() || rgbValue.getAsString().matches("^[0-9]+$"))) {
@@ -215,7 +223,9 @@ public class Conversions {
                 case "TANKLEVEL":
                     return tankLevel(value);
                 case "ADDBRIGHTTOHSV":
-                    return addBrightToHSV(value, deviceVariables);
+                    return addBrightToHSV(value, deviceVariables, false);
+                case "ADDBRIGHTTOHSVPOWER":
+                    return addBrightToHSV(value, deviceVariables, true);
                 case "BRGBTOHSV":
                     return bRGBtoHSV(value);
                 case "DEVICEDATATAB":

--- a/bundles/org.openhab.binding.miio/src/main/resources/database/yeelink.light.color1.json
+++ b/bundles/org.openhab.binding.miio/src/main/resources/database/yeelink.light.color1.json
@@ -121,7 +121,7 @@
 				"channel": "rgbColor",
 				"type": "Color",
 				"refresh": true,
-				"transformation": "addBrightToHSV",
+				"transformation": "addBrightToHSVPower",
 				"ChannelGroup": "actions",
 				"actions": [
 					{


### PR DESCRIPTION
Fix reported brightness for yeelight when powered off. This will fix wrong power switch visualization in the OH UI.

related to issue:
https://community.openhab.org/t/miio-and-yeelight-rgb-bulbs-behavior/135788/9
