### PR TITLE
[miele] Interpret more states as appliance being switched on

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -364,7 +364,8 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
         // Switch is trigger channel, but current state can be deduced from state.
         ChannelUID channelUid = new ChannelUID(getThing().getUID(), SWITCH_CHANNEL_ID);
-        State state = OnOffType.from(dp.Value.equals(String.valueOf(STATE_RUNNING)));
+        State state = OnOffType.from(dp.Value.equals(String.valueOf(STATE_RUNNING))
+                || dp.Value.equals(String.valueOf(STATE_END)) || dp.Value.equals(String.valueOf(STATE_RINSE_HOLD)));
         logger.trace("Update state of {} to {} through '{}'", channelUid, state, dp.Name);
         updateState(channelUid, state);
     }


### PR DESCRIPTION
This allows for example to automate turning off a washing machine when entering the laundry room. This will unlock it, so that the door can be opened without stopping the appliance manually first.

This change applies to dishwashers, tumble dryers and washing machines.

Resolves #15619