### PR TITLE
[homematic] Expansion of virtual data channel for all window/door contacts

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/StateContactVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/StateContactVirtualDatapointHandler.java
@@ -21,7 +21,7 @@ import org.openhab.binding.homematic.internal.model.HmDevice;
 import org.openhab.binding.homematic.internal.model.HmValueType;
 
 /**
- * A virtual datapoint that converts the ENUM state of the HMIP-SWDO device to a contact.
+ * A virtual datapoint that converts the ENUM state of the HMIP-SWD_ devices to a contact.
  *
  * @author Gerhard Riegler - Initial contribution
  */

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/StateContactVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/StateContactVirtualDatapointHandler.java
@@ -58,7 +58,7 @@ public class StateContactVirtualDatapointHandler extends AbstractVirtualDatapoin
     }
 
     private boolean isApplicable(HmDevice device) {
-        return device.getType().toUpperCase().startsWith("HMIP-SWDO");
+        return device.getType().toUpperCase().startsWith("HMIP-SWD");
     }
 
     private Boolean convertState(Object value) {


### PR DESCRIPTION
The HomeMaticIP series includes, among other things, numerous different window and door contacts. The corresponding binding "homematic" from this repo establishes a connection to the headquarters of this product series (via an API). However, this only provides the current status (open or closed) for these sensors as a string, which is difficult to process. For example, for further integration via Openhab to Amazon Alexa, a special conversion rule is required (necessary for each sensor).

For this reason, a virtual controller was built into the add-on, which converts the strings from the API into a normal data channel (ON or OFF). This currently checks whether it is the `HMIP-SWDO` model and then adds the corresponding data channel. However, in recent years there have been significantly more variants of these sensors on the market, for example the `HMIP-SWDM` model. However, these are not assigned the virtual channel, although they have the same API return and therefore a problem-free conversion is possible (tested myself, as I own both models).

The manufacturer of HomeMatic products follows clear naming, so that all products with the model number `SWD` should also have this virtual data channel. This is why the simplification as stated in the PR.

The problem has been reported in #4614, the [german Openhab forum](https://openhabforum.de/viewtopic.php?t=5094) and other [repos](https://github.com/eclipse-archived/smarthome/issues/6869), among others.