### PR TITLE
[oppo] Update Play/Pause status to Player channel widget

### DIFF
--- a/bundles/org.openhab.binding.oppo/README.md
+++ b/bundles/org.openhab.binding.oppo/README.md
@@ -168,7 +168,9 @@ String oppo_remote_button "Remote Button [%s]" { channel="oppo:player:myoppo:rem
 secondsformat.js:
 
 ```javascript
-(function(totalSeconds) {
+(function(timestamp) {
+    var totalSeconds = Date.parse(timestamp) / 1000
+
     if (isNaN(totalSeconds)) {
         return '-';
     } else {

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -324,11 +324,11 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         }
                         break;
                     default:
-                        logger.warn("Unknown Command {} from channel {}", command, channel);
+                        logger.debug("Unknown command {} from channel {}", command, channel);
                         break;
                 }
             } catch (OppoException e) {
-                logger.warn("Command {} from channel {} failed: {}", command, channel, e.getMessage());
+                logger.debug("Command {} from channel {} failed: {}", command, channel, e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Sending command failed");
                 closeConnection();
                 scheduleReconnectJob();
@@ -492,6 +492,8 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                             updateChannelState(CHANNEL_SUBTITLE_TYPE, UNDEF);
                         }
                         updateChannelState(CHANNEL_PLAY_MODE, playStatus);
+                        updateState(CHANNEL_CONTROL,
+                                PLAY.equals(playStatus) ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
 
                         // ejecting the disc does not produce a UDT message, so clear disc type manually
                         if (OPEN.equals(playStatus) || NO_DISC.equals(playStatus)) {
@@ -716,7 +718,7 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                         }
 
                     } catch (OppoException | InterruptedException e) {
-                        logger.warn("Polling error: {}", e.getMessage());
+                        logger.debug("Polling error: {}", e.getMessage());
                     }
 
                     // if the last event received was more than 1.25 intervals ago,
@@ -835,7 +837,7 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
                 connector.sendCommand(OppoCommand.REWIND);
             }
         } else {
-            logger.warn("Unknown control command: {}", command);
+            logger.debug("Unknown control command: {}", command);
         }
     }
 


### PR DESCRIPTION
Update the state of the 'Player' channel so that the button status and its corresponding action in the UI widget will correctly reflect whether the device is in a playing or paused state.

Also some logger updates that haven been pending for a while now.