### PR TITLE
[kaleidescape] Update Play/Pause status to Player channel widget

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
@@ -112,9 +112,7 @@ public enum KaleidescapeMessageHandler {
                 handler.updateChannel(PLAY_MODE,
                         new StringType(KaleidescapeStatusCodes.PLAY_MODE.get(matcher.group(1))));
 
-                handler.updateChannel(CONTROL,
-                        (ZERO.equals(matcher.group(1)) || ONE.equals(matcher.group(1))) ? PlayPauseType.PAUSE
-                                : PlayPauseType.PLAY);
+                handler.updateChannel(CONTROL, "2".equals(matcher.group(1)) ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
 
                 handler.updateChannel(PLAY_SPEED, new StringType(matcher.group(2)));
 
@@ -318,8 +316,7 @@ public enum KaleidescapeMessageHandler {
                         new StringType(KaleidescapeStatusCodes.PLAY_MODE.get(matcher.group(1))));
 
                 handler.updateChannel(MUSIC_CONTROL,
-                        (ZERO.equals(matcher.group(1)) || ONE.equals(matcher.group(1))) ? PlayPauseType.PAUSE
-                                : PlayPauseType.PLAY);
+                        "2".equals(matcher.group(1)) ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
 
                 handler.updateChannel(MUSIC_PLAY_SPEED, new StringType(matcher.group(2)));
 

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeMessageHandler.java
@@ -34,6 +34,7 @@ import org.openhab.binding.kaleidescape.internal.communication.KaleidescapeStatu
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.PlayPauseType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.library.types.StringType;
@@ -110,6 +111,10 @@ public enum KaleidescapeMessageHandler {
             if (matcher.find()) {
                 handler.updateChannel(PLAY_MODE,
                         new StringType(KaleidescapeStatusCodes.PLAY_MODE.get(matcher.group(1))));
+
+                handler.updateChannel(CONTROL,
+                        (ZERO.equals(matcher.group(1)) || ONE.equals(matcher.group(1))) ? PlayPauseType.PAUSE
+                                : PlayPauseType.PLAY);
 
                 handler.updateChannel(PLAY_SPEED, new StringType(matcher.group(2)));
 
@@ -311,6 +316,10 @@ public enum KaleidescapeMessageHandler {
             if (matcher.find()) {
                 handler.updateChannel(MUSIC_PLAY_MODE,
                         new StringType(KaleidescapeStatusCodes.PLAY_MODE.get(matcher.group(1))));
+
+                handler.updateChannel(MUSIC_CONTROL,
+                        (ZERO.equals(matcher.group(1)) || ONE.equals(matcher.group(1))) ? PlayPauseType.PAUSE
+                                : PlayPauseType.PLAY);
 
                 handler.updateChannel(MUSIC_PLAY_SPEED, new StringType(matcher.group(2)));
 


### PR DESCRIPTION
Update the state of the 'Player' channels so that the button status and its corresponding action in the UI widget will correctly reflect whether the device is in a playing or paused state.