### PR TITLE
[netatmo] Fix typo in I18N key

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/NetatmoConstants.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/NetatmoConstants.java
@@ -445,7 +445,7 @@ public class NetatmoConstants {
         COMMAND_INVALID_PARAMS("homestatus-invalid-params"),
         @SerializedName("6")
         UNREACHABLE("device-not-connected"),
-        UNKNOWN("deserialization-unknow");
+        UNKNOWN("deserialization-unknown");
 
         // Associated error message that can be found in properties files
         public final String message;

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/i18n/netatmo.properties
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/i18n/netatmo.properties
@@ -462,7 +462,7 @@ status-bridge-offline = Bridge is not connected to Netatmo API
 device-not-connected = Thing is not reachable
 data-over-limit = Data seems quite old
 request-time-out = Request timed out - will attempt reconnection later
-deserialization-unknow = Deserialization lead to an unknown code
+deserialization-unknown = Deserialization lead to an unknown code
 
 homestatus-unknown-error = Unknown error
 homestatus-internal-error = Internal error


### PR DESCRIPTION
Manually picked from e252e993048247106046695a4819f319ce5baf99 in #15590 in order to fix this key in Crowdin faster and cause less translation regressions (see for example #15653)

See https://github.com/openhab/openhab-addons/pull/15587#discussion_r1337245481.