### PR TITLE
[energidataservice] Remove Gson 2.10 dependency

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/pom.xml
+++ b/bundles/org.openhab.binding.energidataservice/pom.xml
@@ -14,12 +14,4 @@
 
   <name>openHAB Add-ons :: Bundles :: Energi Data Service Binding</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
-  </dependencies>
-
 </project>


### PR DESCRIPTION
Dependency to Gson 2.10 is no longer needed after Gson has been upgraded from 2.9 to 2.10 in openhab/openhab-core#3817.

This reduces the resulting JAR by almost 300 kB.