### PR TITLE
[freeboxos] Remove Gson 2.10 dependency

### DIFF
--- a/bundles/org.openhab.binding.freeboxos/pom.xml
+++ b/bundles/org.openhab.binding.freeboxos/pom.xml
@@ -16,11 +16,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.seancfoley</groupId>
       <artifactId>ipaddress</artifactId>
       <version>5.4.0</version>


### PR DESCRIPTION
Dependency to Gson 2.10 is no longer needed after Gson has been upgraded from 2.9 to 2.10 in openhab/openhab-core#3817.