### PR TITLE
[e3dc] State pattern with Percent as default for QuantityType:Dimensionless

### DIFF
--- a/bundles/org.openhab.binding.modbus.e3dc/src/main/resources/OH-INF/thing/power-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/main/resources/OH-INF/thing/power-channel-types.xml
@@ -61,19 +61,19 @@
 		<item-type>Number:Dimensionless</item-type>
 		<label>Autarky</label>
 		<description>Your current Autarky Level in Percent</description>
-		<state pattern="%d %unit%" readOnly="true"/>
+		<state pattern="%d %%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="self-consumption-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Self Consumtion</label>
 		<description>Your current Photovoltaic Self Consumption Level in Percent</description>
-		<state pattern="%d %unit%" readOnly="true"/>
+		<state pattern="%d %%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="battery-soc-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Battery State Of Charge</label>
 		<description>Charge Level of your attached Battery in Percent</description>
-		<state pattern="%d %unit%" readOnly="true"/>
+		<state pattern="%d %%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="battery-charged-channel">
 		<item-type>Number:Energy</item-type>


### PR DESCRIPTION
State pattern with Percent as default for QuantityType:Dimensionless.

See https://community.openhab.org/t/e3dc-binding-strange-unit-for-powerplant-battery-soc-thing/149480