### PR TITLE
[sensorcommunity] State pattern for dB, Percent and Microgram/m3 added

### DIFF
--- a/bundles/org.openhab.binding.sensorcommunity/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sensorcommunity/src/main/resources/OH-INF/thing/thing-types.xml
@@ -76,12 +76,12 @@
 	<channel-type id="pm25-channel">
 		<item-type>Number:Density</item-type>
 		<label>Particulate Matter category 2.5</label>
-		<state pattern="%.1f %unit%" readOnly="true"/>
+		<state pattern="%.1f µg/m³" readOnly="true"/>
 	</channel-type>
 	<channel-type id="pm100-channel">
 		<item-type>Number:Density</item-type>
 		<label>Particulate Matter category 10.0</label>
-		<state pattern="%.1f %unit%" readOnly="true"/>
+		<state pattern="%.1f µg/m³" readOnly="true"/>
 	</channel-type>
 	<channel-type id="temp-channel">
 		<item-type>Number:Temperature</item-type>
@@ -93,7 +93,7 @@
 		<item-type>Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Humidity from the selected Sensor ID</description>
-		<state pattern="%.1f %unit%" readOnly="true"/>
+		<state pattern="%.1f %%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="pressure-channel">
 		<item-type>Number:Pressure</item-type>
@@ -111,18 +111,18 @@
 		<item-type>Number:Dimensionless</item-type>
 		<label>Average Noise</label>
 		<description>Average noise level from the selected Sensor ID</description>
-		<state pattern="%.1f %unit%" readOnly="true"/>
+		<state pattern="%.1f dB" readOnly="true"/>
 	</channel-type>
 	<channel-type id="noise-min-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Minimum Noise</label>
 		<description>Minimum noise level (last 2.5 minutes) from the selected Sensor ID</description>
-		<state pattern="%.1f %unit%" readOnly="true"/>
+		<state pattern="%.1f dB" readOnly="true"/>
 	</channel-type>
 	<channel-type id="noise-max-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Maximum Noise</label>
 		<description>Maximum noise level (last 2.5 minutes) from the selected Sensor ID</description>
-		<state pattern="%.1f %unit%" readOnly="true"/>
+		<state pattern="%.1f dB" readOnly="true"/>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.sensorcommunity/src/test/java/org/openhab/binding/sensorcommunity/internal/NumberTest.java
+++ b/bundles/org.openhab.binding.sensorcommunity/src/test/java/org/openhab/binding/sensorcommunity/internal/NumberTest.java
@@ -14,14 +14,9 @@ package org.openhab.binding.sensorcommunity.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.measure.quantity.Dimensionless;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensorcommunity.internal.utils.NumberUtils;
-import org.openhab.core.library.dimension.Density;
-import org.openhab.core.library.types.QuantityType;
-import org.openhab.core.library.unit.Units;
 
 /**
  * The {@link NumberTest} Test rounding and converting Numbers
@@ -62,19 +57,5 @@ public class NumberTest {
         double d1r1 = NumberUtils.round(d1, 1);
         // System.out.println("D1R1 " + d1r1);
         assertEquals("1.9", Double.toString(d1r1), "Double 1.94, 1 place");
-    }
-
-    @Test
-    public void testDecibelPattern() {
-        String d1 = "1.94 dB";
-        QuantityType<Dimensionless> dbQt = (QuantityType<Dimensionless>) QuantityType.valueOf(d1);
-        assertEquals(Units.DECIBEL, dbQt.getUnit());
-    }
-
-    @Test
-    public void testMicrogramQubicMeterPattern() {
-        String d1 = "1.94 µg/m³";
-        QuantityType<Density> pressureQt = (QuantityType<Density>) QuantityType.valueOf(d1);
-        assertEquals(Units.MICROGRAM_PER_CUBICMETRE, pressureQt.getUnit());
     }
 }

--- a/bundles/org.openhab.binding.sensorcommunity/src/test/java/org/openhab/binding/sensorcommunity/internal/NumberTest.java
+++ b/bundles/org.openhab.binding.sensorcommunity/src/test/java/org/openhab/binding/sensorcommunity/internal/NumberTest.java
@@ -14,9 +14,14 @@ package org.openhab.binding.sensorcommunity.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import javax.measure.quantity.Dimensionless;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensorcommunity.internal.utils.NumberUtils;
+import org.openhab.core.library.dimension.Density;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
 
 /**
  * The {@link NumberTest} Test rounding and converting Numbers
@@ -57,5 +62,19 @@ public class NumberTest {
         double d1r1 = NumberUtils.round(d1, 1);
         // System.out.println("D1R1 " + d1r1);
         assertEquals("1.9", Double.toString(d1r1), "Double 1.94, 1 place");
+    }
+
+    @Test
+    public void testDecibelPattern() {
+        String d1 = "1.94 dB";
+        QuantityType<Dimensionless> dbQt = (QuantityType<Dimensionless>) QuantityType.valueOf(d1);
+        assertEquals(Units.DECIBEL, dbQt.getUnit());
+    }
+
+    @Test
+    public void testMicrogramQubicMeterPattern() {
+        String d1 = "1.94 µg/m³";
+        QuantityType<Density> pressureQt = (QuantityType<Density>) QuantityType.valueOf(d1);
+        assertEquals(Units.MICROGRAM_PER_CUBICMETRE, pressureQt.getUnit());
     }
 }


### PR DESCRIPTION
State pattern for dB, Percent and Microgram/m3 added 

- to avoid "one" unit for Dimensionless units Percent and dB
- set Microgram / m3 as default particulate measure display