### PR TITLE
[tesla] Remove the minimum 5A charge current limit

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
@@ -283,9 +283,12 @@ public class TeslaVehicleHandler extends BaseThingHandler {
                             }
                         }
                         if (amps != null) {
-                            if (amps < 5 || amps > 32) {
-                                logger.warn("Charging amps can only be set in a range of 5-32A, but not to {}A.", amps);
+                            if (amps > 32) {
+                                logger.warn("Charging amps cannot be set higher than 32A, {}A was requested", amps);
                                 return;
+                            }
+                            if (amps < 5) {
+                                logger.info("Charging amps should be set higher than 5A to avoid excessive losses.");
                             }
                             setChargingAmps(amps);
                         }


### PR DESCRIPTION
While the app can't go lower than 5A, the API allows setting values down to 0A, and at least going to 2-3A can make sense if you want to put excess solar power into the car without also drawing some from the grid.

Due to the overhead this causes it can be wasteful, so keep logging the warning about going below 5A. Leave the limiting/validation of values >32A up to the API, not this addon.
