### PR TITLE
[sonos] Add Dolby Digital Plus 2.0 and fix Dolby Digital 2.0

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -1471,7 +1471,11 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                     codec = "dolbyAtmos";
                     break;
                 case "33554434":
+                case "33554488":
                     codec = "DD20";
+                    break;
+                case "33554490":
+                    codec = "DDPlus20";
                     break;
                 case "33554494":
                     codec = "PCM20";

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/channels.xml
@@ -58,6 +58,7 @@
 				<option value="DD20">Dolby Digital 2.0</option>
 				<option value="PCM20">Dolby Multichannel PCM 2.0</option>
 				<option value="DD51">Dolby Digital 5.1</option>
+				<option value="DDPlus20">Dolby Digital Plus 2.0</option>
 				<option value="DDPlus51">Dolby Digital Plus 5.1</option>
 				<option value="PCM51">Dolby Multichannel PCM 5.1</option>
 				<option value="DTS51">DTS Surround 5.1</option>


### PR DESCRIPTION
Adds Dolby Digital Plus 2.0 and a second codec ID for Dolby Digital 2.0.

Resolves #15643 