### PR TITLE
[shelly] Always try to stop WebSocketClient

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -141,10 +141,8 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
             rpcSocket.addMessageHandler(this);
             initialized = true;
         } else {
-            if (rpcSocket.isConnected()) {
-                logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
-                disconnect();
-            }
+            logger.debug("{}: Disconnect Rpc Socket on initialize", thingName);
+            disconnect();
         }
     }
 
@@ -1217,9 +1215,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     }
 
     private void disconnect() {
-        if (rpcSocket.isConnected()) {
-            rpcSocket.disconnect();
-        }
+        rpcSocket.disconnect();
     }
 
     public Shelly2RpctInterface getRpcHandler() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2RpcSocket.java
@@ -211,9 +211,7 @@ public class Shelly2RpcSocket {
                 s.close(StatusCode.NORMAL, "Socket closed");
                 session = null;
             }
-            if (client.isStarted()) {
-                client.stop();
-            }
+            client.stop();
         } catch (Exception e) {
             if (e.getCause() instanceof InterruptedException) {
                 logger.debug("{}: Unable to close socket - interrupted", thingName); // e.g. device was rebooted


### PR DESCRIPTION
If the client is not stopped it will not be garbage collected because the ShutdownThread keeps a reference to the client so it can be stopped on shutdowns.

See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java#L420-L433