### PR TITLE
[jdbc] Fix logging not working

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -39,6 +39,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-dbutils</groupId>


### PR DESCRIPTION
The dependency change in #15659 caused slf4j to be embedded into the bundle.

As a result the bundle no longer uses Pax Logging so it cannot find an SLF4J provider and logs the following when it is installed:

```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
```