### PR TITLE
[hue] Fix channels not being updated when Thing comes online (API v2)

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -900,10 +900,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
             } else if (thing.getStatus() != ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.ONLINE);
                 // issue REFRESH command to update all channels
-                Channel lastUpdateChannel = thing.getChannel(CHANNEL_2_LAST_UPDATED);
-                if (Objects.nonNull(lastUpdateChannel)) {
-                    handleCommand(lastUpdateChannel.getUID(), RefreshType.REFRESH);
-                }
+                handleCommand(new ChannelUID(thing.getUID(), "dummy"), RefreshType.REFRESH);
             }
         }
     }


### PR DESCRIPTION
Fixes #15669

The binding already executes a Refresh command when the device thing status changes from offline to online. However the command was conditional on the Last Updated channel being present. In this PR the Refresh command is issued regardless of whether the Last Updated channel exists.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
