### PR TITLE
[homematic] Adjust handling empty values in AbstractTypeConverter

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/AbstractTypeConverter.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/converter/type/AbstractTypeConverter.java
@@ -115,9 +115,9 @@ public abstract class AbstractTypeConverter<T extends State> implements TypeConv
         if (dp.getValue() == null) {
             return (T) UnDefType.NULL;
         } else if (!fromBindingValidation(dp)) {
-            String errorMessage = String.format("Can't convert %s value '%s' with %s for '%s'", dp.getType(),
-                    dp.getValue(), this.getClass().getSimpleName(), new HmDatapointInfo(dp));
-            throw new ConverterTypeException(errorMessage);
+            logger.debug("Can't convert {} value '{}' with {} for '{}'", dp.getType(), dp.getValue(),
+                    this.getClass().getSimpleName(), new HmDatapointInfo(dp));
+            return (T) UnDefType.NULL;
         }
 
         return fromBinding(dp);

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/BaseConverterTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/BaseConverterTest.java
@@ -39,5 +39,6 @@ public class BaseConverterTest {
         HmChannel stubChannel = new HmChannel("stubChannel", 0);
         stubChannel.setDevice(new HmDevice("LEQ123456", HmInterface.RF, "HM-STUB-DEVICE", "", "", ""));
         floatDp.setChannel(stubChannel);
+        integerDp.setChannel(stubChannel);
     }
 }

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
@@ -18,11 +18,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
 
 /**
  * Tests for
@@ -98,5 +100,30 @@ public class ConvertFromBindingTest extends BaseConverterTest {
         assertThat(((QuantityType<?>) convertedState).doubleValue(), is(70.0));
         assertThat(((QuantityType<?>) convertedState).getUnit(), is(Units.PERCENT));
         assertThat(((QuantityType<?>) convertedState).toUnit(Units.ONE).doubleValue(), is(0.7));
+    }
+
+    @Test
+    public void testPercentTypeConverter() throws ConverterException {
+        State convertedState;
+        TypeConverter<?> percentTypeConverter = ConverterFactory.createConverter("Dimmer");
+
+        // the binding is backwards compatible, so clients may still use DecimalType, even if a unit is used
+        integerDp.setUnit("%");
+
+        integerDp.setValue(99.9);
+        integerDp.setMaxValue(100);
+        convertedState = percentTypeConverter.convertFromBinding(integerDp);
+        assertThat(convertedState, instanceOf(PercentType.class));
+        assertThat(((PercentType) convertedState).doubleValue(), is(99.0));
+
+        integerDp.setValue(77.77777778);
+        convertedState = percentTypeConverter.convertFromBinding(integerDp);
+        assertThat(convertedState, instanceOf(PercentType.class));
+        assertThat(((PercentType) convertedState).doubleValue(), is(77.0));
+
+        integerDp.setValue("");
+        convertedState = percentTypeConverter.convertFromBinding(integerDp);
+        assertThat(convertedState, instanceOf(UnDefType.class));
+        assertThat(((UnDefType) convertedState), is(UnDefType.NULL));
     }
 }


### PR DESCRIPTION
This is a fix for #15597 

Instead of raising an exception if an empty value is received from the binding now a NULL values is return. This is incompatible but i think this is the best solution for the problem.