### PR TITLE
[miele] Rename channel `powerConsumption` to `energyConsumption` and set display unit to litres for `waterConsumption`

### DIFF
--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -116,23 +116,23 @@ Channels available for each appliance type are listed below.
 
 #### Dishwasher
 
-| Channel             | Type                 | Read/write | Description                                                         |
-|---------------------|----------------------|------------|---------------------------------------------------------------------|
-| state               | String               | Read       | Current status of the appliance                                     |
-| rawState            | Number               | Read       | Current status of the appliance as raw number                       |
-| program             | String               | Read       | Current program or function running on the appliance                |
-| rawProgram          | Number               | Read       | Current program or function running on the appliance as raw number  |
-| phase               | String               | Read       | Current phase of the program running on the appliance               |
-| rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number |
-| start               | DateTime             | Read       | Programmed start time of the program                                |
-| end                 | DateTime             | Read       | End time of the program (programmed or running)                     |
-| duration            | Number:Time          | Read       | Duration of the program running on the appliance                    |
-| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                |
-| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                 |
-| door                | Contact              | Read       | Current state of the door of the appliance                          |
-| switch              | Switch               | Write      | Switch the appliance on or off                                      |
-| powerConsumption    | Number:Energy        | Read       | Power consumption by the currently running program on the appliance |
-| waterConsumption    | Number:Volume        | Read       | Water consumption by the currently running program on the appliance |
+| Channel             | Type                 | Read/write | Description                                                          |
+|---------------------|----------------------|------------|----------------------------------------------------------------------|
+| state               | String               | Read       | Current status of the appliance                                      |
+| rawState            | Number               | Read       | Current status of the appliance as raw number                        |
+| program             | String               | Read       | Current program or function running on the appliance                 |
+| rawProgram          | Number               | Read       | Current program or function running on the appliance as raw number   |
+| phase               | String               | Read       | Current phase of the program running on the appliance                |
+| rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number  |
+| start               | DateTime             | Read       | Programmed start time of the program                                 |
+| end                 | DateTime             | Read       | End time of the program (programmed or running)                      |
+| duration            | Number:Time          | Read       | Duration of the program running on the appliance                     |
+| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                 |
+| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                  |
+| door                | Contact              | Read       | Current state of the door of the appliance                           |
+| switch              | Switch               | Write      | Switch the appliance on or off                                       |
+| energyConsumption   | Number:Energy        | Read       | Energy consumption by the currently running program on the appliance |
+| waterConsumption    | Number:Volume        | Read       | Water consumption by the currently running program on the appliance  |
 
 ##### Programs
 
@@ -336,26 +336,26 @@ See oven.
 
 #### Washing Machine
 
-| Channel             | Type                 | Read/write | Description                                                         |
-|---------------------|----------------------|------------|---------------------------------------------------------------------|
-| state               | String               | Read       | Current status of the appliance                                     |
-| rawState            | Number               | Read       | Current status of the appliance as raw number                       |
-| program             | String               | Read       | Current program or function running on the appliance                |
-| rawProgram          | Number               | Read       | Current program or function running on the appliance as raw number  |
-| type                | String               | Read       | Type of the program running on the appliance                        |
-| phase               | String               | Read       | Current phase of the program running on the appliance               |
-| rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number |
-| start               | DateTime             | Read       | Programmed start time of the program                                |
-| end                 | DateTime             | Read       | End time of the program (programmed or running)                     |
-| duration            | Number:Time          | Read       | Duration of the program running on the appliance                    |
-| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                |
-| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                 |
-| door                | Contact              | Read       | Current state of the door of the appliance                          |
-| switch              | Switch               | Write      | Switch the appliance on or off                                      |
-| target              | Number:Temperature   | Read       | Temperature of the selected program (10 °C = cold)                  |
-| spinningspeed       | String               | Read       | Spinning speed in the program running on the appliance              |
-| powerConsumption    | Number:Energy        | Read       | Power consumption by the currently running program on the appliance |
-| waterConsumption    | Number:Volume        | Read       | Water consumption by the currently running program on the appliance |
+| Channel             | Type                 | Read/write | Description                                                          |
+|---------------------|----------------------|------------|----------------------------------------------------------------------|
+| state               | String               | Read       | Current status of the appliance                                      |
+| rawState            | Number               | Read       | Current status of the appliance as raw number                        |
+| program             | String               | Read       | Current program or function running on the appliance                 |
+| rawProgram          | Number               | Read       | Current program or function running on the appliance as raw number   |
+| type                | String               | Read       | Type of the program running on the appliance                         |
+| phase               | String               | Read       | Current phase of the program running on the appliance                |
+| rawPhase            | Number               | Read       | Current phase of the program running on the appliance as raw number  |
+| start               | DateTime             | Read       | Programmed start time of the program                                 |
+| end                 | DateTime             | Read       | End time of the program (programmed or running)                      |
+| duration            | Number:Time          | Read       | Duration of the program running on the appliance                     |
+| elapsed             | Number:Time          | Read       | Time elapsed in the program running on the appliance                 |
+| finish              | Number:Time          | Read       | Time to finish the program running on the appliance                  |
+| door                | Contact              | Read       | Current state of the door of the appliance                           |
+| switch              | Switch               | Write      | Switch the appliance on or off                                       |
+| target              | Number:Temperature   | Read       | Temperature of the selected program (10 °C = cold)                   |
+| spinningspeed       | String               | Read       | Spinning speed in the program running on the appliance               |
+| energyConsumption   | Number:Energy        | Read       | Energy consumption by the currently running program on the appliance |
+| waterConsumption    | Number:Volume        | Read       | Water consumption by the currently running program on the appliance  |
 
 ##### Programs
 
@@ -432,7 +432,7 @@ String Dishwasher_Program "Program [%s]"                      {channel="miele:di
 String Dishwasher_Phase "Phase [%s]"                          {channel="miele:dishwasher:home:dishwasher:phase"}
 Number:Time Dishwasher_ElapsedTime "Elapsed time" <time>      {channel="miele:dishwasher:home:dishwasher:elapsed"}
 Number:Time Dishwasher_FinishTime "Remaining time" <time>     {channel="miele:dishwasher:home:dishwasher:finish"}
-Number:Energy Dishwasher_PowerConsumption                     {channel="miele:dishwasher:home:dishwasher:powerConsumption"}
+Number:Energy Dishwasher_EnergyConsumption                    {channel="miele:dishwasher:home:dishwasher:energyConsumption"}
 Number:Volume Dishwasher_WaterConsumption                     {channel="miele:dishwasher:home:dishwasher:waterConsumption"}
 
 String Fridge_State                                           {channel="miele:fridge:home:fridge:state"}
@@ -460,7 +460,7 @@ Number:Temperature WashingMachine_Temperature <temperature>   {channel="miele:wa
 String WashingMachine_SpinningSpeed                           {channel="miele:washingmachine:home:washingmachine:spinningspeed"}
 Number:Time WashingMachine_ElapsedTime "Elapsed time" <time>  {channel="miele:washingmachine:home:washingmachine:elapsed"}
 Number:Time WashingMachine_FinishTime "Remaining time" <time> {channel="miele:washingmachine:home:washingmachine:finish"}
-Number:Energy WashingMachine_PowerConsumption                 {channel="miele:washingmachine:home:washingmachine:powerConsumption"}
+Number:Energy WashingMachine_EnergyConsumption                {channel="miele:washingmachine:home:washingmachine:energyConsumption"}
 Number:Volume WashingMachine_WaterConsumption                 {channel="miele:washingmachine:home:washingmachine:waterConsumption"}
 
 String TumbleDryer_State                                      {channel="miele:tumbledryer:home:tumbledryer:state"}
@@ -490,7 +490,7 @@ sitemap miele label="Miele" {
             Text item=WashingMachine_Phase visibility=[WashingMachine_Phase!=UNDEF]
             Text item=WashingMachine_ElapsedTime
             Text item=WashingMachine_FinishTime
-            Text item=WashingMachine_PowerConsumption
+            Text item=WashingMachine_EnergyConsumption
             Text item=WashingMachine_WaterConsumption
         }
         Text item=TumbleDryer_State label="Tumble Dryer [%s]" icon="dryer" {
@@ -504,7 +504,7 @@ sitemap miele label="Miele" {
             Text itemDishwasher_Phase visibility=[Dishwasher_Phase!=UNDEF]
             Text item=Dishwasher_ElapsedTime
             Text item=Dishwasher_FinishTime
-            Text item=Dishwasher_PowerConsumption
+            Text item=Dishwasher_EnergyConsumption
             Text item=Dishwasher_WaterConsumption
         }
         Text item=Fridge_CurrentTemperature label="Fridge" icon="climate" {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -58,7 +58,6 @@ public class MieleBindingConstants {
     public static final String START_CHANNEL_ID = "start";
     public static final String END_CHANNEL_ID = "end";
     public static final String FINISH_CHANNEL_ID = "finish";
-    public static final String POWER_CONSUMPTION_CHANNEL_ID = "powerConsumption";
     public static final String ENERGY_CONSUMPTION_CHANNEL_ID = "energyConsumption";
     public static final String WATER_CONSUMPTION_CHANNEL_ID = "waterConsumption";
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -59,6 +59,7 @@ public class MieleBindingConstants {
     public static final String END_CHANNEL_ID = "end";
     public static final String FINISH_CHANNEL_ID = "finish";
     public static final String POWER_CONSUMPTION_CHANNEL_ID = "powerConsumption";
+    public static final String ENERGY_CONSUMPTION_CHANNEL_ID = "energyConsumption";
     public static final String WATER_CONSUMPTION_CHANNEL_ID = "waterConsumption";
 
     // List of all Thing Type UIDs

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -109,8 +109,6 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
         }
     },
     SWITCH("", "switch", OnOffType.class, false, false),
-    POWER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, POWER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
-            true),
     ENERGY_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, ENERGY_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
             true),
     WATER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, WATER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -111,6 +111,8 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     SWITCH("", "switch", OnOffType.class, false, false),
     POWER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, POWER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
             true),
+    ENERGY_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, ENERGY_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
+            true),
     WATER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, WATER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
             true);
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherHandler.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_DISHWASHER;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.math.BigDecimal;
 
@@ -49,7 +47,7 @@ import com.google.gson.JsonElement;
 public class DishwasherHandler extends MieleApplianceHandler<DishwasherChannelSelector>
         implements ExtendedDeviceStateListener {
 
-    private static final int POWER_CONSUMPTION_BYTE_POSITION = 16;
+    private static final int ENERGY_CONSUMPTION_BYTE_POSITION = 16;
     private static final int WATER_CONSUMPTION_BYTE_POSITION = 18;
     private static final int EXTENDED_STATE_MIN_SIZE_BYTES = 19;
 
@@ -130,9 +128,10 @@ public class DishwasherHandler extends MieleApplianceHandler<DishwasherChannelSe
         }
 
         BigDecimal kiloWattHoursTenths = BigDecimal
-                .valueOf(extendedDeviceState[POWER_CONSUMPTION_BYTE_POSITION] & 0xff);
+                .valueOf(extendedDeviceState[ENERGY_CONSUMPTION_BYTE_POSITION] & 0xff);
         var kiloWattHours = new QuantityType<>(kiloWattHoursTenths.divide(BigDecimal.valueOf(10)), Units.KILOWATT_HOUR);
         updateExtendedState(POWER_CONSUMPTION_CHANNEL_ID, kiloWattHours);
+        updateExtendedState(ENERGY_CONSUMPTION_CHANNEL_ID, kiloWattHours);
 
         BigDecimal decilitres = BigDecimal.valueOf(extendedDeviceState[WATER_CONSUMPTION_BYTE_POSITION] & 0xff);
         var litres = new QuantityType<>(decilitres.divide(BigDecimal.valueOf(10)), Units.LITRE);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherHandler.java
@@ -130,7 +130,6 @@ public class DishwasherHandler extends MieleApplianceHandler<DishwasherChannelSe
         BigDecimal kiloWattHoursTenths = BigDecimal
                 .valueOf(extendedDeviceState[ENERGY_CONSUMPTION_BYTE_POSITION] & 0xff);
         var kiloWattHours = new QuantityType<>(kiloWattHoursTenths.divide(BigDecimal.valueOf(10)), Units.KILOWATT_HOUR);
-        updateExtendedState(POWER_CONSUMPTION_CHANNEL_ID, kiloWattHours);
         updateExtendedState(ENERGY_CONSUMPTION_CHANNEL_ID, kiloWattHours);
 
         BigDecimal decilitres = BigDecimal.valueOf(extendedDeviceState[WATER_CONSUMPTION_BYTE_POSITION] & 0xff);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -158,7 +158,6 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             return;
         }
         initializeTranslationProvider(bridge);
-        removeDeprecatedChannels();
         updateStatus(ThingStatus.UNKNOWN);
 
         MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
@@ -182,18 +181,6 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             this.translationProvider = new MieleTranslationProvider(i18nProvider, localeProvider);
         } else {
             this.translationProvider = new MieleTranslationProvider(i18nProvider, localeProvider, locale);
-        }
-    }
-
-    private void removeDeprecatedChannels() {
-        if (this.isLinked(POWER_CONSUMPTION_CHANNEL_ID)) {
-            logger.warn("Channel '{}' for '{}' is deprecated, please use '{}' instead.", POWER_CONSUMPTION_CHANNEL_ID,
-                    thing.getUID(), ENERGY_CONSUMPTION_CHANNEL_ID);
-        } else if (thing.getChannel(POWER_CONSUMPTION_CHANNEL_ID) != null) {
-            logger.debug("Removing deprecated unlinked channel '{}' for '{}'.", POWER_CONSUMPTION_CHANNEL_ID,
-                    thing.getUID());
-            updateThing(
-                    editThing().withoutChannel(new ChannelUID(thing.getUID(), POWER_CONSUMPTION_CHANNEL_ID)).build());
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -158,6 +158,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             return;
         }
         initializeTranslationProvider(bridge);
+        removeDeprecatedChannels();
         updateStatus(ThingStatus.UNKNOWN);
 
         MieleBridgeHandler bridgeHandler = getMieleBridgeHandler();
@@ -181,6 +182,18 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             this.translationProvider = new MieleTranslationProvider(i18nProvider, localeProvider);
         } else {
             this.translationProvider = new MieleTranslationProvider(i18nProvider, localeProvider, locale);
+        }
+    }
+
+    private void removeDeprecatedChannels() {
+        if (this.isLinked(POWER_CONSUMPTION_CHANNEL_ID)) {
+            logger.warn("Channel '{}' for '{}' is deprecated, please use '{}' instead.", POWER_CONSUMPTION_CHANNEL_ID,
+                    thing.getUID(), ENERGY_CONSUMPTION_CHANNEL_ID);
+        } else if (thing.getChannel(POWER_CONSUMPTION_CHANNEL_ID) != null) {
+            logger.debug("Removing deprecated unlinked channel '{}' for '{}'.", POWER_CONSUMPTION_CHANNEL_ID,
+                    thing.getUID());
+            updateThing(
+                    editThing().withoutChannel(new ChannelUID(thing.getUID(), POWER_CONSUMPTION_CHANNEL_ID)).build());
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -543,7 +543,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                 if (cause == null) {
                     logger.debug("An exception occurred while getting the home devices: '{}'", e.getMessage());
                 } else {
-                    logger.debug("An exception occurred while getting the home devices: '{}' -> '{}", e.getMessage(),
+                    logger.debug("An exception occurred while getting the home devices: '{}' -> '{}'", e.getMessage(),
                             cause.getMessage());
                 }
             }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -130,6 +130,8 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     SWITCH("", "switch", OnOffType.class, false, false),
     POWER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, POWER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
             true),
+    ENERGY_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, ENERGY_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
+            true),
     WATER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, WATER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
             true);
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -128,8 +128,6 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
         }
     },
     SWITCH("", "switch", OnOffType.class, false, false),
-    POWER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, POWER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
-            true),
     ENERGY_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, ENERGY_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,
             true),
     WATER_CONSUMPTION(EXTENDED_DEVICE_STATE_PROPERTY_NAME, WATER_CONSUMPTION_CHANNEL_ID, QuantityType.class, false,

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -131,7 +131,6 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
         BigDecimal kiloWattHoursTenths = BigDecimal
                 .valueOf(extendedDeviceState[ENERGY_CONSUMPTION_BYTE_POSITION] & 0xff);
         var kiloWattHours = new QuantityType<>(kiloWattHoursTenths.divide(BigDecimal.valueOf(10)), Units.KILOWATT_HOUR);
-        updateExtendedState(POWER_CONSUMPTION_CHANNEL_ID, kiloWattHours);
         updateExtendedState(ENERGY_CONSUMPTION_CHANNEL_ID, kiloWattHours);
 
         var litres = new QuantityType<>(BigDecimal.valueOf(extendedDeviceState[WATER_CONSUMPTION_BYTE_POSITION] & 0xff),

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.MIELE_DEVICE_CLASS_WASHING_MACHINE;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.POWER_CONSUMPTION_CHANNEL_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.WATER_CONSUMPTION_CHANNEL_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import java.math.BigDecimal;
 
@@ -49,7 +47,7 @@ import com.google.gson.JsonElement;
 public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineChannelSelector>
         implements ExtendedDeviceStateListener {
 
-    private static final int POWER_CONSUMPTION_BYTE_POSITION = 51;
+    private static final int ENERGY_CONSUMPTION_BYTE_POSITION = 51;
     private static final int WATER_CONSUMPTION_BYTE_POSITION = 53;
     private static final int EXTENDED_STATE_MIN_SIZE_BYTES = 54;
 
@@ -131,9 +129,10 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
         }
 
         BigDecimal kiloWattHoursTenths = BigDecimal
-                .valueOf(extendedDeviceState[POWER_CONSUMPTION_BYTE_POSITION] & 0xff);
+                .valueOf(extendedDeviceState[ENERGY_CONSUMPTION_BYTE_POSITION] & 0xff);
         var kiloWattHours = new QuantityType<>(kiloWattHoursTenths.divide(BigDecimal.valueOf(10)), Units.KILOWATT_HOUR);
         updateExtendedState(POWER_CONSUMPTION_CHANNEL_ID, kiloWattHours);
+        updateExtendedState(ENERGY_CONSUMPTION_CHANNEL_ID, kiloWattHours);
 
         var litres = new QuantityType<>(BigDecimal.valueOf(extendedDeviceState[WATER_CONSUMPTION_BYTE_POSITION] & 0xff),
                 Units.LITRE);

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele.properties
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/i18n/miele.properties
@@ -70,6 +70,8 @@ channel-type.miele.elapsed.description = Time elapsed in the program running on 
 channel-type.miele.elapsed.state.pattern = %1$tR
 channel-type.miele.end.label = End Time
 channel-type.miele.end.description = End time of the program (programmed or running)
+channel-type.miele.energy-consumption.label = Energy Consumption
+channel-type.miele.energy-consumption.description = Energy consumption by the currently running program on the appliance
 channel-type.miele.finish.label = Finish Time
 channel-type.miele.finish.description = Time to finish the program running on the appliance
 channel-type.miele.finish.state.pattern = %1$tR
@@ -85,8 +87,6 @@ channel-type.miele.plates.label = Plates
 channel-type.miele.plates.description = Number of heating zones/plates on the hob
 channel-type.miele.power.label = Power Step
 channel-type.miele.power.description = Power level of the heating zone/plate
-channel-type.miele.powerConsumption.label = Power Consumption
-channel-type.miele.powerConsumption.description = Power consumption by the currently running program on the appliance
 channel-type.miele.program.label = Program
 channel-type.miele.program.description = Current program or function running on the appliance
 channel-type.miele.rawPhase.label = Raw Phase
@@ -121,8 +121,8 @@ channel-type.miele.type.label = Program Type
 channel-type.miele.type.description = Type of the program running on the appliance
 channel-type.miele.ventilation.label = Ventilation Power
 channel-type.miele.ventilation.description = Current ventilation power
-channel-type.miele.waterConsumption.label = Water Consumption
-channel-type.miele.waterConsumption.description = Water consumption by the currently running program on the appliance
+channel-type.miele.water-consumption.label = Water Consumption
+channel-type.miele.water-consumption.description = Water consumption by the currently running program on the appliance
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -224,10 +224,10 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="powerConsumption">
+	<channel-type id="energy-consumption">
 		<item-type>Number:Energy</item-type>
-		<label>Power Consumption</label>
-		<description>Power consumption by the currently running program on the appliance</description>
+		<label>Energy Consumption</label>
+		<description>Energy consumption by the currently running program on the appliance</description>
 		<category>Energy</category>
 		<tags>
 			<tag>Measurement</tag>
@@ -236,7 +236,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 
-	<channel-type id="waterConsumption">
+	<channel-type id="water-consumption">
 		<item-type>Number:Volume</item-type>
 		<label>Water Consumption</label>
 		<description>Water consumption by the currently running program on the appliance</description>
@@ -245,7 +245,7 @@
 			<tag>Measurement</tag>
 			<tag>Water</tag>
 		</tags>
-		<state readOnly="true" pattern="%.1f %unit%"/>
+		<state readOnly="true" pattern="%.1f l"/>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
@@ -27,9 +27,14 @@
 			<channel id="finish" typeId="finish"/>
 			<channel id="door" typeId="door"/>
 			<channel id="switch" typeId="switch"/>
-			<channel id="powerConsumption" typeId="powerConsumption"/>
-			<channel id="waterConsumption" typeId="waterConsumption"/>
+			<channel id="powerConsumption" typeId="energy-consumption"/>
+			<channel id="energyConsumption" typeId="energy-consumption"/>
+			<channel id="waterConsumption" typeId="water-consumption"/>
 		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 
 		<representation-property>uid</representation-property>
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
@@ -27,7 +27,6 @@
 			<channel id="finish" typeId="finish"/>
 			<channel id="door" typeId="door"/>
 			<channel id="switch" typeId="switch"/>
-			<channel id="powerConsumption" typeId="energy-consumption"/>
 			<channel id="energyConsumption" typeId="energy-consumption"/>
 			<channel id="waterConsumption" typeId="water-consumption"/>
 		</channels>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -33,7 +33,6 @@
 				<description>Temperature of the selected program (10 °C = cold)</description>
 			</channel>
 			<channel id="spinningspeed" typeId="spinningspeed"/>
-			<channel id="powerConsumption" typeId="energy-consumption"/>
 			<channel id="energyConsumption" typeId="energy-consumption"/>
 			<channel id="waterConsumption" typeId="water-consumption"/>
 		</channels>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -33,9 +33,14 @@
 				<description>Temperature of the selected program (10 °C = cold)</description>
 			</channel>
 			<channel id="spinningspeed" typeId="spinningspeed"/>
-			<channel id="powerConsumption" typeId="powerConsumption"/>
-			<channel id="waterConsumption" typeId="waterConsumption"/>
+			<channel id="powerConsumption" typeId="energy-consumption"/>
+			<channel id="energyConsumption" typeId="energy-consumption"/>
+			<channel id="waterConsumption" typeId="water-consumption"/>
 		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 
 		<representation-property>uid</representation-property>
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="miele:dishwasher">
+		<instruction-set targetVersion="1">
+			<add-channel id="energyConsumption">
+				<type>miele:energy-consumption</type>
+			</add-channel>
+			<update-channel id="powerConsumption">
+				<type>miele:energy-consumption</type>
+				<label>Power Consumption</label>
+				<description>Deprecated, please use Energy Consumption instead. This channel will be removed in a later version</description>
+			</update-channel>
+			<update-channel id="waterConsumption">
+				<type>miele:water-consumption</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="miele:washingmachine">
+		<instruction-set targetVersion="1">
+			<add-channel id="energyConsumption">
+				<type>miele:energy-consumption</type>
+			</add-channel>
+			<update-channel id="powerConsumption">
+				<type>miele:energy-consumption</type>
+				<label>Power Consumption</label>
+				<description>Deprecated, please use Energy Consumption instead. This channel will be removed in a later version</description>
+			</update-channel>
+			<update-channel id="waterConsumption">
+				<type>miele:water-consumption</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/update/instructions.xml
@@ -8,14 +8,10 @@
 			<add-channel id="energyConsumption">
 				<type>miele:energy-consumption</type>
 			</add-channel>
-			<update-channel id="powerConsumption">
-				<type>miele:energy-consumption</type>
-				<label>Power Consumption</label>
-				<description>Deprecated, please use Energy Consumption instead. This channel will be removed in a later version</description>
-			</update-channel>
 			<update-channel id="waterConsumption">
 				<type>miele:water-consumption</type>
 			</update-channel>
+			<remove-channel id="powerConsumption"/>
 		</instruction-set>
 	</thing-type>
 
@@ -24,14 +20,10 @@
 			<add-channel id="energyConsumption">
 				<type>miele:energy-consumption</type>
 			</add-channel>
-			<update-channel id="powerConsumption">
-				<type>miele:energy-consumption</type>
-				<label>Power Consumption</label>
-				<description>Deprecated, please use Energy Consumption instead. This channel will be removed in a later version</description>
-			</update-channel>
 			<update-channel id="waterConsumption">
 				<type>miele:water-consumption</type>
 			</update-channel>
+			<remove-channel id="powerConsumption"/>
 		</instruction-set>
 	</thing-type>
 


### PR DESCRIPTION
This removes channel `powerConsumption` and adds channel `energyConsumption` to rectify an old mistake.

This is a bit overdue and should probably have been done in #13930, in hindsight. This is a breaking change requiring users to relink items to the new channels. I doubt there are many users though. I will create a note for that in openhab-distro.

I tried first to do a backwards compatible deprecation (see first commit), but I think this drags too much technical debt along than can be justified, so would prefer to just take the bull by the horns now.

Additionally sets state description pattern unit to **litre** for water consumption as default unit m³ makes no sense for dishwashers and washing machines.

The upgrade will only happen after two minutes. I'm not sure if this is a known and accepted issue, or should be reported as a bug in core:
```
2023-10-17 22:24:22.980 [WARN ] [core.thing.internal.ThingManagerImpl] - Channel types or config descriptions for thing 'miele:dishwasher:Miele_XGW3000:000000000000_0' are missing in the respective registry for more than 120s. In case it does not happen immediately after an upgrade, it should be fixed in the binding.
2023-10-17 22:24:22.981 [INFO ] [core.thing.internal.ThingManagerImpl] - Updating 'miele:dishwasher:Miele_XGW3000:000000000000_0' from version 0 to 1
```