### PR TITLE
[neeo] Removes extra NEEO from thread name

### DIFF
--- a/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/NeeoApi.java
+++ b/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/NeeoApi.java
@@ -474,7 +474,7 @@ public class NeeoApi implements AutoCloseable {
         if (stackSize == 0) {
             int httpClientId = this.httpClientId + 1;
             this.httpClientId = httpClientId;
-            String httpClientIdString = "neeo-" + brainId + "-" + httpClientId;
+            String httpClientIdString = "neeo-" + brainId.substring(5) + "-" + httpClientId;
             logger.debug("getHttpClient created new client {} for brain {}", httpClientIdString, brainId);
             HttpClient httpClient = httpClientFactory.createHttpClient(httpClientIdString);
             try {


### PR DESCRIPTION
Removes double NEEO in thread name.

Before:
```
"OH-httpClient-neeo-NEEO-713af1e8-1-2054" Id=2054 in TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@31527da5
"OH-httpClient-neeo-NEEO-713af1e8-1-2060" Id=2060 in TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@31527da5
"OH-httpClient-neeo-NEEO-713af1e8-1-2061" Id=2061 in RUNNABLE (running in native)
```

After:
```
"OH-httpClient-neeo-713af1e8-1-2250" Id=2250 in RUNNABLE (running in native)
"OH-httpClient-neeo-713af1e8-1-2252" Id=2252 in TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@669e2414
"OH-httpClient-neeo-713af1e8-1-2256" Id=2256 in RUNNABLE (running in native)
```

Resolves #15777 

