### PR TITLE
[androiddebugbridge] Reconnect on max timeouts and improve volume channel

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeConfiguration.java
@@ -43,9 +43,17 @@ public class AndroidDebugBridgeConfiguration {
      */
     public int recordDuration = 5;
     /**
+     * Percent to increase/decrease volume.
+     */
+    public int volumeStepPercent = 15;
+    /**
      * Assumed max volume for devices with android versions that do not expose this value (>=android 11).
      */
     public int deviceMaxVolume = 25;
+    /**
+     * Max ADB command consecutive timeouts to force to reset the connection.
+     */
+    public int maxADBTimeouts = 10;
     /**
      * Settings key for android versions where volume is gather using settings command (>=android 11).
      */

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.NextPreviousType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.tananaev.adblib.AdbCrypto;
 
 /**
  * The {@link AndroidDebugBridgeHandler} is responsible for handling commands, which are
@@ -74,12 +76,14 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     private @Nullable ScheduledFuture<?> connectionCheckerSchedule;
     private AndroidDebugBridgeMediaStatePackageConfig @Nullable [] packageConfigs = null;
     private boolean deviceAwake = false;
+    private int consecutiveTimeouts = 0;
 
     public AndroidDebugBridgeHandler(Thing thing,
-            AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider) {
+            AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider,
+            @Nullable AdbCrypto adbCrypto) {
         super(thing);
         this.commandDescriptionProvider = commandDescriptionProvider;
-        this.adbConnection = new AndroidDebugBridgeDevice(scheduler);
+        this.adbConnection = new AndroidDebugBridgeDevice(scheduler, adbCrypto);
     }
 
     @Override
@@ -101,6 +105,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             logger.warn("{} - read error: {}", currentConfig.ip, e.getMessage());
         } catch (TimeoutException e) {
             logger.warn("{} - timeout error", currentConfig.ip);
+            disconnectOnMaxADBTimeouts();
         }
     }
 
@@ -196,6 +201,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 }
                 break;
         }
+        consecutiveTimeouts = 0;
     }
 
     private void recordDeviceInput(Command recordNameCommand)
@@ -236,6 +242,16 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             var volumeInfo = adbConnection.getMediaVolume();
             maxMediaVolume = volumeInfo.max;
             updateState(channelUID, new PercentType((int) Math.round(toPercent(volumeInfo.current, volumeInfo.max))));
+        } else if (command instanceof IncreaseDecreaseType) {
+            var volumeInfo = adbConnection.getMediaVolume();
+            var volumeStep = fromPercent(config.volumeStepPercent, volumeInfo.max);
+            logger.debug("Device {} volume step: {}", getThing().getUID(), volumeStep);
+            var targetVolume = (int) Math
+                    .round(IncreaseDecreaseType.INCREASE.equals(command) ? volumeInfo.current + volumeStep
+                            : volumeInfo.current - volumeStep);
+            var newVolume = Integer.max(0, Integer.min(targetVolume, volumeInfo.max));
+            logger.debug("Device {} new volume : {}", getThing().getUID(), newVolume);
+            adbConnection.setMediaVolume(newVolume);
         } else {
             if (maxMediaVolume == 0) {
                 return; // We can not transform percentage
@@ -250,8 +266,8 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
         return (value / maxValue) * 100;
     }
 
-    private double fromPercent(double value, double maxValue) {
-        return (value / 100) * maxValue;
+    private double fromPercent(double percent, double maxValue) {
+        return (percent / 100) * maxValue;
     }
 
     private void handleMediaControlCommand(ChannelUID channelUID, Command command)
@@ -398,8 +414,15 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
         // Add some information about the device
         try {
             Map<String, String> editProperties = editProperties();
-            editProperties.put(Thing.PROPERTY_SERIAL_NUMBER, adbConnection.getSerialNo());
-            editProperties.put(Thing.PROPERTY_MODEL_ID, adbConnection.getModel());
+            try {
+                editProperties.put(Thing.PROPERTY_SERIAL_NUMBER, adbConnection.getSerialNo());
+            } catch (AndroidDebugBridgeDeviceReadException ignored) {
+                // Allow devices without serial number.
+            }
+            try {
+                editProperties.put(Thing.PROPERTY_MODEL_ID, adbConnection.getModel());
+            } catch (AndroidDebugBridgeDeviceReadException ignored) {
+            }
             var androidVersion = adbConnection.getAndroidVersion();
             editProperties.put(Thing.PROPERTY_FIRMWARE_VERSION, androidVersion);
             // refresh android version to use
@@ -426,8 +449,10 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
         } catch (TimeoutException e) {
             // happen a lot when device is sleeping; abort refresh other channels
             logger.debug("Unable to refresh awake state: Timeout; aborting channels refresh");
+            disconnectOnMaxADBTimeouts();
             return;
         }
+        consecutiveTimeouts = 0;
         var awakeStateChannelUID = new ChannelUID(this.thing.getUID(), AWAKE_STATE_CHANNEL);
         if (isLinked(awakeStateChannelUID)) {
             updateState(awakeStateChannelUID, OnOffType.from(awakeState));
@@ -471,6 +496,16 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             logger.warn("Unable to refresh screen state: {}", e.getMessage());
         } catch (TimeoutException e) {
             logger.warn("Unable to refresh screen state: Timeout");
+        }
+    }
+
+    private void disconnectOnMaxADBTimeouts() {
+        consecutiveTimeouts++;
+        if (config.maxADBTimeouts > 0 && consecutiveTimeouts >= config.maxADBTimeouts) {
+            logger.debug("Max consecutive timeouts reached, aborting connection");
+            adbConnection.disconnect();
+            checkConnection();
+            consecutiveTimeouts = 0;
         }
     }
 

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandlerFactory.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandlerFactory.java
@@ -14,8 +14,18 @@ package org.openhab.binding.androiddebugbridge.internal;
 
 import static org.openhab.binding.androiddebugbridge.internal.AndroidDebugBridgeBindingConstants.*;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.OpenHAB;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -24,6 +34,11 @@ import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.tananaev.adblib.AdbBase64;
+import com.tananaev.adblib.AdbCrypto;
 
 /**
  * The {@link AndroidDebugBridgeHandlerFactory} is responsible for creating things and thing
@@ -32,15 +47,19 @@ import org.osgi.service.component.annotations.Reference;
  * @author Miguel Álvarez - Initial contribution
  */
 @NonNullByDefault
-@Component(configurationPid = BINDING_CONFIGURATION_PID, service = ThingHandlerFactory.class)
+@Component(configurationPid = BINDING_CONFIGURATION_PID, service = { ThingHandlerFactory.class,
+        AndroidDebugBridgeHandlerFactory.class })
 public class AndroidDebugBridgeHandlerFactory extends BaseThingHandlerFactory {
-
+    private static final Path ADB_FOLDER = Path.of(OpenHAB.getUserDataFolder(), ".adb");
+    private final Logger logger = LoggerFactory.getLogger(AndroidDebugBridgeHandlerFactory.class);
+    private @Nullable AdbCrypto adbCrypto;
     private final AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider;
 
     @Activate
     public AndroidDebugBridgeHandlerFactory(
             final @Reference AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider) {
         this.commandDescriptionProvider = commandDescriptionProvider;
+        initADBCrypto();
     }
 
     @Override
@@ -52,8 +71,45 @@ public class AndroidDebugBridgeHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
         if (THING_TYPE_ANDROID_DEVICE.equals(thingTypeUID)) {
-            return new AndroidDebugBridgeHandler(thing, commandDescriptionProvider);
+            return new AndroidDebugBridgeHandler(thing, commandDescriptionProvider, adbCrypto);
         }
         return null;
+    }
+
+    public @Nullable AdbCrypto getAdbCrypto() {
+        return adbCrypto;
+    }
+
+    private void initADBCrypto() {
+        try {
+            if (!Files.exists(ADB_FOLDER) || !Files.isDirectory(ADB_FOLDER)) {
+                Files.createDirectory(ADB_FOLDER);
+                logger.info("Binding folder {} created", ADB_FOLDER);
+            }
+            adbCrypto = loadKeyPair(ADB_FOLDER.resolve("adb_pub.key"), ADB_FOLDER.resolve("adb.key"));
+        } catch (NoSuchAlgorithmException | IOException | InvalidKeySpecException e) {
+            logger.warn("Unable to setup adb keys: {}", e.getMessage());
+        }
+    }
+
+    private static AdbCrypto loadKeyPair(Path pubKey, Path privKey)
+            throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
+        AdbCrypto adbCrypto = null;
+        Charset asciiCharset = StandardCharsets.US_ASCII;
+        AdbBase64 bytesToString = bytes -> new String(Base64.getEncoder().encode(bytes), asciiCharset);
+        // load key pair
+        if (Files.exists(pubKey) && Files.exists(privKey)) {
+            try {
+                adbCrypto = AdbCrypto.loadAdbKeyPair(bytesToString, privKey.toFile(), pubKey.toFile());
+            } catch (IOException ignored) {
+                // Keys don't exits
+            }
+        }
+        if (adbCrypto == null) {
+            // generate key pair
+            adbCrypto = AdbCrypto.generateAdbKeyPair(bytesToString);
+            adbCrypto.saveAdbKeyPair(privKey.toFile(), pubKey.toFile());
+        }
+        return adbCrypto;
     }
 }

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/i18n/androiddebugbridge.properties
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/i18n/androiddebugbridge.properties
@@ -25,6 +25,8 @@ thing-type.config.androiddebugbridge.android.deviceMaxVolume.label = Device Max 
 thing-type.config.androiddebugbridge.android.deviceMaxVolume.description = Assumed max volume for devices with android versions that do not expose this value (>=android 11).
 thing-type.config.androiddebugbridge.android.ip.label = IP Address
 thing-type.config.androiddebugbridge.android.ip.description = Device ip address.
+thing-type.config.androiddebugbridge.android.maxADBTimeouts.label = Max ADB Timeouts
+thing-type.config.androiddebugbridge.android.maxADBTimeouts.description = Max ADB command consecutive timeouts to force to reset the connection. (0 for disabled)
 thing-type.config.androiddebugbridge.android.mediaStateJSONConfig.label = Media State Config
 thing-type.config.androiddebugbridge.android.mediaStateJSONConfig.description = JSON config that allows to modify the media state detection strategy for each app. Refer to the binding documentation.
 thing-type.config.androiddebugbridge.android.port.label = Port
@@ -45,6 +47,8 @@ thing-type.config.androiddebugbridge.android.volumeSettingKey.option.volume_musi
 thing-type.config.androiddebugbridge.android.volumeSettingKey.option.volume_music_headset = volume music headset
 thing-type.config.androiddebugbridge.android.volumeSettingKey.option.volume_music_usb_headset = volume music usb headset
 thing-type.config.androiddebugbridge.android.volumeSettingKey.option.volume_system = volume system
+thing-type.config.androiddebugbridge.android.volumeStepPercent.label = Volume Step Percent
+thing-type.config.androiddebugbridge.android.volumeStepPercent.description = Percent to increase/decrease volume.
 
 # channel types
 

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
@@ -38,7 +38,7 @@
 				<description>Device port listening to adb connections.</description>
 				<default>5555</default>
 			</parameter>
-			<parameter name="refreshTime" type="integer" min="10" max="120" unit="s" required="true">
+			<parameter name="refreshTime" type="integer" min="5" max="120" unit="s" required="true">
 				<label>Refresh Time</label>
 				<description>Seconds between device status refreshes.</description>
 				<default>30</default>
@@ -75,10 +75,22 @@
 				</options>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="volumeStepPercent" type="integer" min="1" max="100">
+				<label>Volume Step Percent</label>
+				<description>Percent to increase/decrease volume.</description>
+				<default>15</default>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="deviceMaxVolume" type="integer" min="1" max="100">
 				<label>Device Max Volume</label>
 				<description>Assumed max volume for devices with android versions that do not expose this value (>=android 11).</description>
 				<default>25</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="maxADBTimeouts" type="integer" min="0">
+				<label>Max ADB Timeouts</label>
+				<description>Max ADB command consecutive timeouts to force to reset the connection. (0 for disabled)</description>
+				<default>0</default>
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
Hello,

This PR introduces an option to reset the adb connection after a configurable number of consecutive timeouts. It seems to solve an issue I was occasionally having after letting the device (Chomecast with Google TV) sleeping for a while.

Also adds support for the INCREASE and DECREASE command to the volume channel which were incorrectly handled before.

I have also moved the load  of the adb keys from the static context to the activate method of the thing handler.

Hope everything is in place, best regards.