### PR TITLE
[wemo] adapt to core StringUtils

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/WemoUtil.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/WemoUtil.java
@@ -12,11 +12,6 @@
  */
 package org.openhab.binding.wemo.internal;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.w3c.dom.CharacterData;
@@ -50,84 +45,6 @@ public class WemoUtil {
             }
         }
         return "";
-    }
-
-    public static String unescape(final String text) {
-        StringBuilder result = new StringBuilder(text.length());
-        int i = 0;
-        int n = text.length();
-        while (i < n) {
-            char charAt = text.charAt(i);
-            if (charAt != '&') {
-                result.append(charAt);
-                i++;
-            } else {
-                if (text.startsWith("&amp;", i)) {
-                    result.append('&');
-                    i += 5;
-                } else if (text.startsWith("&apos;", i)) {
-                    result.append('\'');
-                    i += 6;
-                } else if (text.startsWith("&quot;", i)) {
-                    result.append('"');
-                    i += 6;
-                } else if (text.startsWith("&lt;", i)) {
-                    result.append('<');
-                    i += 4;
-                } else if (text.startsWith("&gt;", i)) {
-                    result.append('>');
-                    i += 4;
-                } else {
-                    i++;
-                }
-            }
-        }
-        return result.toString();
-    }
-
-    public static String unescapeXml(final String xml) {
-        Pattern xmlEntityRegex = Pattern.compile("&(#?)([^;]+);");
-        // Unfortunately, Matcher requires a StringBuffer instead of a StringBuilder
-        StringBuffer unescapedOutput = new StringBuffer(xml.length());
-
-        Matcher m = xmlEntityRegex.matcher(xml);
-        Map<String, String> builtinEntities = null;
-        String entity;
-        String hashmark;
-        String ent;
-        int code;
-        while (m.find()) {
-            ent = m.group(2);
-            hashmark = m.group(1);
-            if ((hashmark != null) && (hashmark.length() > 0)) {
-                code = Integer.parseInt(ent);
-                entity = Character.toString((char) code);
-            } else {
-                // must be a non-numerical entity
-                if (builtinEntities == null) {
-                    builtinEntities = buildBuiltinXMLEntityMap();
-                }
-                entity = builtinEntities.get(ent);
-                if (entity == null) {
-                    // not a known entity - ignore it
-                    entity = "&" + ent + ';';
-                }
-            }
-            m.appendReplacement(unescapedOutput, entity);
-        }
-        m.appendTail(unescapedOutput);
-
-        return unescapedOutput.toString();
-    }
-
-    private static Map<String, String> buildBuiltinXMLEntityMap() {
-        Map<String, String> entities = new HashMap<String, String>(10);
-        entities.put("lt", "<");
-        entities.put("gt", ">");
-        entities.put("amp", "&");
-        entities.put("apos", "'");
-        entities.put("quot", "\"");
-        return entities;
     }
 
     public static String createBinaryStateContent(boolean binaryState) {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
@@ -19,6 +19,7 @@ import java.io.StringReader;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +38,7 @@ import org.openhab.core.io.transport.upnp.UpnpIOParticipant;
 import org.openhab.core.io.transport.upnp.UpnpIOService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.CharacterData;
@@ -146,7 +148,7 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
                 try {
                     String stringParser = substringBetween(endDeviceRequest, "<DeviceLists>", "</DeviceLists>");
 
-                    stringParser = unescapeXml(stringParser);
+                    stringParser = Objects.requireNonNull(StringUtils.unEscapeXml(stringParser));
 
                     // check if there are already paired devices with WeMo Link
                     if ("0".equals(stringParser)) {

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoCoffeeHandler.java
@@ -43,6 +43,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
+import org.openhab.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -203,8 +204,8 @@ public class WemoCoffeeHandler extends WemoBaseThingHandler {
                 String stringParser = substringBetween(wemoCallResponse, "<attributeList>", "</attributeList>");
 
                 // Due to Belkins bad response formatting, we need to run this twice.
-                stringParser = unescapeXml(stringParser);
-                stringParser = unescapeXml(stringParser);
+                stringParser = StringUtils.unEscapeXml(stringParser);
+                stringParser = StringUtils.unEscapeXml(stringParser);
 
                 logger.trace("CoffeeMaker response '{}' for device '{}' received", stringParser, getThing().getUID());
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHolmesHandler.java
@@ -44,6 +44,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
+import org.openhab.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -288,8 +289,8 @@ public class WemoHolmesHandler extends WemoBaseThingHandler {
             String stringParser = substringBetween(wemoCallResponse, "<attributeList>", "</attributeList>");
 
             // Due to Belkins bad response formatting, we need to run this twice.
-            stringParser = unescapeXml(stringParser);
-            stringParser = unescapeXml(stringParser);
+            stringParser = StringUtils.unEscapeXml(stringParser);
+            stringParser = StringUtils.unEscapeXml(stringParser);
 
             logger.trace("AirPurifier response '{}' for device '{}' received", stringParser, getThing().getUID());
 

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -36,6 +36,7 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
+import org.openhab.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -302,7 +303,7 @@ public class WemoLightHandler extends WemoBaseThingHandler {
                     + wemoLightID + "</DeviceIDs>" + "</u:GetDeviceStatus>" + "</s:Body>" + "</s:Envelope>";
 
             String wemoCallResponse = wemoHttpCaller.executeCall(wemoURL, soapHeader, content);
-            wemoCallResponse = unescapeXml(wemoCallResponse);
+            wemoCallResponse = StringUtils.unEscapeXml(wemoCallResponse);
             String response = substringBetween(wemoCallResponse, "<CapabilityValue>", "</CapabilityValue>");
             logger.trace("wemoNewLightState = {}", response);
             String[] splitResponse = response.split(",");

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoMakerHandler.java
@@ -37,6 +37,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
+import org.openhab.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -167,8 +168,8 @@ public class WemoMakerHandler extends WemoBaseThingHandler {
                 logger.trace("'{}'", stringParser);
 
                 // Due to Belkins bad response formatting, we need to run this twice.
-                stringParser = unescapeXml(stringParser);
-                stringParser = unescapeXml(stringParser);
+                stringParser = StringUtils.unEscapeXml(stringParser);
+                stringParser = StringUtils.unEscapeXml(stringParser);
                 logger.trace("Maker response '{}' for device '{}' received", stringParser, getThing().getUID());
 
                 stringParser = "<data>" + stringParser + "</data>";


### PR DESCRIPTION
some code deduplication now that there are some stringutils available in core.

From reading the code i think this is a drop in replacement, but the method was written totally different then elsewhere and wemo has some strange response formatting, so i would prefer that some one tests this change before merging:

Test jar: 4.1.0: https://1drv.ms/u/s!AnMcxmvEeupwjt0LqK17SvhP7E4vLA?e=wtze2p