### PR TITLE
[jdbc] Upgrade MySQL Connector/J to 8.1.0

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -13,7 +13,7 @@ The following databases are currently supported and tested:
 | [H2](https://www.h2database.com/)            | [h2-2.2.224.jar](https://mvnrepository.com/artifact/com.h2database/h2)                                   |
 | [HSQLDB](http://hsqldb.org/)                 | [hsqldb-2.3.3.jar](https://mvnrepository.com/artifact/org.hsqldb/hsqldb)                                 |
 | [MariaDB](https://mariadb.org/)              | [mariadb-java-client-3.0.8.jar](https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client) |
-| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-8.0.33.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)           |
+| [MySQL](https://www.mysql.com/)              | [mysql-connector-j-8.1.0.jar](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)            |
 | [PostgreSQL](https://www.postgresql.org/)    | [postgresql-42.4.3.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                    |
 | [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.42.0.0.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc)                    |
 | [TimescaleDB](https://www.timescale.com/)    | [postgresql-42.4.3.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql)                    |

--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -29,7 +29,7 @@
     <h2.version>2.2.224</h2.version>
     <hsqldb.version>2.3.3</hsqldb.version>
     <mariadb.version>3.0.8</mariadb.version>
-    <mysql.version>8.0.33</mysql.version>
+    <mysql.version>8.1.0</mysql.version>
     <postgresql.version>42.4.3</postgresql.version>
     <sqlite.version>3.42.0.0</sqlite.version>
   </properties>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -34,7 +34,7 @@
 	<feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
 		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/8.0.33</bundle>
+		<bundle start-level="80">mvn:com.mysql/mysql-connector-j/8.1.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -330,7 +330,7 @@ public class JdbcConfiguration {
                         warn += "\tMariaDB:   version >= 3.0.8 from              https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client\n";
                         break;
                     case "mysql":
-                        warn += "\tMySQL:     version >= 8.0.33 from             https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
+                        warn += "\tMySQL:     version >= 8.1.0 from              https://mvnrepository.com/artifact/com.mysql/mysql-connector-j\n";
                         break;
                     case "postgresql":
                         warn += "\tPostgreSQL:version >= 42.4.3 from             https://mvnrepository.com/artifact/org.postgresql/postgresql\n";


### PR DESCRIPTION
Release notes:
- https://dev.mysql.com/doc/relnotes/connector-j/8.1/en/news-8-1-0.html

Library:
- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.1.0

Tested by installing compiled bundle as well as `mysql-connector-j-8.1.0` into addons directory as `mysql-connector.jar`.

Previous upgrade: #14874