### PR TITLE
Add discovery methods xml to bindings

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,20 @@
 	<description>Controls a Kaleidescape Movie Player</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>(?i)Kaleidescape</regex>
+				</match-property>
+				<match-property>
+					<name>deviceType</name>
+					<regex>Basic</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>

--- a/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,11 @@
 	<description>Controls the Nuvo Grand Concerto or Essentia G Whole House Amplifier.</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>mdns</service-type>
+			<mdns-service-type>_ac-mcs._tcp.local.</mdns-service-type>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>

--- a/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,20 @@
 	<description>Controls Oppo UDP-203/205 and BDP-83/93/95/103/105 Blu-ray Players</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>(?i)OPPO</regex>
+				</match-property>
+				<match-property>
+					<name>deviceType</name>
+					<regex>MediaRenderer</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>


### PR DESCRIPTION
Addition to #15817
Add discovery methods xml to three bindings that I maintain where @andrewfg was unable to determine it.