### PR TITLE
[kaleidescape] Register connection in Kaleidescape System log

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/KaleidescapeBindingConstants.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/KaleidescapeBindingConstants.java
@@ -183,6 +183,7 @@ public class KaleidescapeBindingConstants {
     public static final String MUSIC_RANDOM_ON = "MUSIC_RANDOM_ON";
     public static final String MUSIC_RANDOM_OFF = "MUSIC_RANDOM_OFF";
 
+    public static final String SEND_TO_SYSLOG = "SEND_TO_SYSLOG:INFORMATION:";
     public static final String SEND_EVENT_VOLUME_CAPABILITIES_15 = "SEND_EVENT:VOLUME_CAPABILITIES=15";
     public static final String SEND_EVENT_VOLUME_LEVEL_EQ = "SEND_EVENT:VOLUME_LEVEL=";
     public static final String SEND_EVENT_MUTE = "SEND_EVENT:MUTE_";

--- a/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/java/org/openhab/binding/kaleidescape/internal/handler/KaleidescapeHandler.java
@@ -339,6 +339,11 @@ public class KaleidescapeHandler extends BaseThingHandler implements Kaleidescap
                     if (openConnection()) {
                         try {
                             cache.clear();
+
+                            // register the connection in the Kaleidescape System log
+                            connector.sendCommand(SEND_TO_SYSLOG + "openHAB Kaleidescape Binding version "
+                                    + org.openhab.core.OpenHAB.getVersion());
+
                             Set<String> initialCommands = new HashSet<>(Arrays.asList(GET_DEVICE_TYPE_NAME,
                                     GET_FRIENDLY_NAME, GET_DEVICE_INFO, GET_SYSTEM_VERSION, GET_DEVICE_POWER_STATE,
                                     GET_CINEMASCAPE_MASK, GET_CINEMASCAPE_MODE, GET_SCALE_MODE, GET_SCREEN_MASK,


### PR DESCRIPTION
Upon binding connection, register a message in the Kaleidescape server's syslog per page 61 in the control protocol manual.

https://www.kaleidescape.com/wp-content/uploads/kaleidescape-system-control-protocol-reference-manual.pdf