### PR TITLE
[sonos] Add TrueHD5.1 and normalize Atmos

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -1468,7 +1468,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                 case "59":
                 case "61":
                 case "63":
-                    codec = "dolbyAtmos";
+                    codec = "Atmos";
                     break;
                 case "33554434":
                 case "33554488":
@@ -1485,6 +1485,9 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                     break;
                 case "84934714":
                     codec = "DDPlus51";
+                    break;
+                case "84934716":
+                    codec = "TrueHD51";
                     break;
                 case "84934718":
                     codec = "PCM51";

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/i18n/sonos.properties
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/i18n/sonos.properties
@@ -91,11 +91,13 @@ channel-type.sonos.codec.description = Name of codec currently being decoded
 channel-type.sonos.codec.state.option.noSignal = No Signal
 channel-type.sonos.codec.state.option.silence = Silence
 channel-type.sonos.codec.state.option.DTS = DTS
-channel-type.sonos.codec.state.option.dolbyAtmos = Dolby Atmos
+channel-type.sonos.codec.state.option.Atmos = Dolby Atmos
 channel-type.sonos.codec.state.option.DD20 = Dolby Digital 2.0
 channel-type.sonos.codec.state.option.PCM20 = Dolby Multichannel PCM 2.0
 channel-type.sonos.codec.state.option.DD51 = Dolby Digital 5.1
+channel-type.sonos.codec.state.option.DDPlus20 = Dolby Digital Plus 2.0
 channel-type.sonos.codec.state.option.DDPlus51 = Dolby Digital Plus 5.1
+channel-type.sonos.codec.state.option.TrueHD51 = Dolby TrueHD 5.1
 channel-type.sonos.codec.state.option.PCM51 = Dolby Multichannel PCM 5.1
 channel-type.sonos.codec.state.option.DTS51 = DTS Surround 5.1
 channel-type.sonos.coordinator.label = Coordinator
@@ -198,6 +200,10 @@ channel-type.sonos.zonegroupid.label = Zone Group ID
 channel-type.sonos.zonegroupid.description = Id of the Zone Group the Sonos device belongs to
 channel-type.sonos.zonename.label = Zone Name
 channel-type.sonos.zonename.description = Name of the Zone Group associated to the Sonos device
+
+# channel types
+
+channel-type.sonos.codec.state.option.dolbyAtmos = Dolby Atmos
 
 # thing status descriptions
 

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/i18n/sonos.properties
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/i18n/sonos.properties
@@ -201,10 +201,6 @@ channel-type.sonos.zonegroupid.description = Id of the Zone Group the Sonos devi
 channel-type.sonos.zonename.label = Zone Name
 channel-type.sonos.zonename.description = Name of the Zone Group associated to the Sonos device
 
-# channel types
-
-channel-type.sonos.codec.state.option.dolbyAtmos = Dolby Atmos
-
 # thing status descriptions
 
 offline.conf-error-missing-udn = The parameter "Unique Device Name" must be configured.

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/thing/channels.xml
@@ -54,12 +54,13 @@
 				<option value="noSignal">No Signal</option>
 				<option value="silence">Silence</option>
 				<option value="DTS">DTS</option>
-				<option value="dolbyAtmos">Dolby Atmos</option>
+				<option value="Atmos">Dolby Atmos</option>
 				<option value="DD20">Dolby Digital 2.0</option>
 				<option value="PCM20">Dolby Multichannel PCM 2.0</option>
 				<option value="DD51">Dolby Digital 5.1</option>
 				<option value="DDPlus20">Dolby Digital Plus 2.0</option>
 				<option value="DDPlus51">Dolby Digital Plus 5.1</option>
+				<option value="TrueHD51">Dolby TrueHD 5.1</option>
 				<option value="PCM51">Dolby Multichannel PCM 5.1</option>
 				<option value="DTS51">DTS Surround 5.1</option>
 			</options>


### PR DESCRIPTION
Adds Dolby TrueHD 5.1 for non-Atmos streams
Normalizes dolbyAtmos to Atmos to align with the rest of the codecs (which don't have a dolby marker).

Resolves #15830 

