### PR TITLE
[wifiled] Support LED's that demand seperate white and color updates

### DIFF
--- a/bundles/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/AbstractWiFiLEDDriver.java
+++ b/bundles/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/AbstractWiFiLEDDriver.java
@@ -46,6 +46,18 @@ public abstract class AbstractWiFiLEDDriver {
         FADING
     }
 
+    public enum LevelWriteMode {
+        ALL((byte) 0x00),
+        COLORS((byte) 0xF0),
+        WHITES((byte) 0x0F);
+
+        public final byte byteValue;
+
+        private LevelWriteMode(byte byteValue) {
+            this.byteValue = byteValue;
+        }
+    }
+
     public static final Integer DEFAULT_PORT = 5577;
 
     protected static final int DEFAULT_SOCKET_TIMEOUT = 5000;
@@ -199,11 +211,15 @@ public abstract class AbstractWiFiLEDDriver {
     }
 
     protected byte[] getBytesForColor(byte r, byte g, byte b, byte w, byte w2) {
+        return getBytesForColor(r, g, b, w, w2, LevelWriteMode.ALL);
+    }
+
+    protected byte[] getBytesForColor(byte r, byte g, byte b, byte w, byte w2, LevelWriteMode writeMode) {
         byte[] bytes;
         if (protocol == Protocol.LD382 || protocol == Protocol.LD382A) {
-            bytes = new byte[] { 0x31, r, g, b, w, 0x00 };
+            bytes = new byte[] { 0x31, r, g, b, w, writeMode.byteValue };
         } else if (protocol == Protocol.LD686) {
-            bytes = new byte[] { 0x31, r, g, b, w, w2, 0x00 };
+            bytes = new byte[] { 0x31, r, g, b, w, w2, writeMode.byteValue };
         } else {
             throw new UnsupportedOperationException("Protocol " + protocol + " not yet implemented");
         }

--- a/bundles/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/ClassicWiFiLEDDriver.java
+++ b/bundles/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/ClassicWiFiLEDDriver.java
@@ -70,7 +70,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Setting color to {}", color);
 
         LEDStateDTO ledState = getLEDStateDTO().withColor(color).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.COLORS);
     }
 
     @Override
@@ -78,7 +78,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Setting brightness to {}", brightness);
 
         LEDStateDTO ledState = getLEDStateDTO().withBrightness(brightness).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.COLORS);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Changing brightness by {}", step);
 
         LEDStateDTO ledState = getLEDStateDTO().withIncrementedBrightness(step).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.COLORS);
     }
 
     @Override
@@ -94,7 +94,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Setting (warm) white LED to {}", white);
 
         LEDStateDTO ledState = getLEDStateDTO().withWhite(white).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.WHITES);
     }
 
     @Override
@@ -102,7 +102,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Changing white by {}", step);
 
         LEDStateDTO ledState = getLEDStateDTO().withIncrementedWhite(step).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.WHITES);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Setting (warm) white 2 LED to {}", white2);
 
         LEDStateDTO ledState = getLEDStateDTO().withWhite2(white2).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.WHITES);
     }
 
     @Override
@@ -118,7 +118,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
         logger.debug("Changing white by {}", step);
 
         LEDStateDTO ledState = getLEDStateDTO().withIncrementedWhite2(step).withoutProgram();
-        sendLEDData(ledState);
+        sendLEDData(ledState, LevelWriteMode.WHITES);
     }
 
     @Override
@@ -156,6 +156,10 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
     }
 
     private synchronized void sendLEDData(final LEDStateDTO ledState) {
+        this.sendLEDData(ledState, LevelWriteMode.ALL);
+    }
+
+    private synchronized void sendLEDData(final LEDStateDTO ledState, LevelWriteMode writeMode) {
         cachedLedStatus = ledState;
         if (!ledUpdateFuture.isDone()) {
             ledUpdateFuture.cancel(true);
@@ -171,7 +175,7 @@ public class ClassicWiFiLEDDriver extends AbstractWiFiLEDDriver {
             byte w = (byte) (((int) (ledState.getWhite().doubleValue() * 255 / 100)) & 0xFF);
             byte w2 = (byte) (((int) (ledState.getWhite2().doubleValue() * 255 / 100)) & 0xFF);
 
-            bytes = getBytesForColor(r, g, b, w, w2);
+            bytes = getBytesForColor(r, g, b, w, w2, writeMode);
         } else {
             // program selected
             byte p = (byte) (program & 0xFF);


### PR DESCRIPTION
When I tried the binding on my LED bulb, I encountered an issue while attempting to change its color: the changes were not applied, and after restarting the bulb, no light was emitted.

After a lot of tests, I discovered that the problem was due to the fact that the level write mode was consistently set to `0x00` in this binding.

This pull request addresses this issue, ensuring the correct updating of my bulb's color, and it should not affect other devices. Unfortunately, I am unable to test it, as the only compatible WiFi LED I have is this one... I tried the binding on my own setup and everything works fine for me with these changes.

For reference, I used this python implementation: [Danielhiversen/flux_led](https://github.com/Danielhiversen/flux_led).

I am not sure that I implemented it correctly. I also thought we could know if color or warm white values have been changed by tracking it in the `LEDStateDTO` methods... But I am not sure if it is the right way to do so. This is my first day with OpenHAB! 😄

EDIT:
Download links of the addon with the changes:
- [4.0.x](https://madeorsk.com/share/org.openhab.binding.wifiled-4.0.5-SNAPSHOT.jar)
- [4.1.0](https://madeorsk.com/share/org.openhab.binding.wifiled-4.1.0-SNAPSHOT.jar)