### PR TITLE
[energidataservice] Add support for persisting historical and upcoming prices

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/README.md
+++ b/bundles/org.openhab.binding.energidataservice/README.md
@@ -75,6 +75,13 @@ To include VAT for items linked to the `Number` channels, the [VAT profile](http
 This must be installed separately.
 Once installed, simply select "Value-Added Tax" as Profile when linking an item.
 
+#### Persisting Time Series
+
+The binding offers support for persisting both historical and upcoming prices.
+The recommended persistence strategy is `forecast`, as it ensures a clean history without redundancy.
+Prices from the past 24 hours and all forthcoming prices will be stored.
+Any changes that impact published prices (e.g. selecting or deselecting VAT Profile) will result in the replacement of persisted prices within this period.
+
 #### Net Tariff
 
 Discounts are automatically taken into account for channel `net-tariff` so that it represents the actual price.


### PR DESCRIPTION
Implement time series support introduced by openhab/openhab-core#3597.

This is transparent to users, no matter if persistence is configured or not. If persistence is configured, future prices will now also be persisted when they become available. It is recommended to configure persistence strategy `forecast` to avoid redundant updates. This has been added to the documentation. One noticeable change when looking at persisted timestamps:

Previously - last three persisted spot prices:
```csv
2023-11-09 19:00:00.005, 0.9290125275
2023-11-09 20:00:00.010, 0.77621246375
2023-11-09 21:00:00.028, 0.74480003375
```

Now:
```csv
2023-11-09 21:00:00.000, 0.74480003375
2023-11-09 22:00:00.000, 0.73518753
2023-11-09 23:00:00.000, 0.69323753375
```

As seen in the UI per 2023-11-09 with the VAT Profile applied (see #15873):
![image](https://github.com/openhab/openhab-addons/assets/19519842/9e14b81c-5e20-4113-97a5-6e5c0695aa6c)

Resolves #15863 