### PR TITLE
[boschshc] Update active profile of intrusion detection system

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/intrusion/IntrusionDetectionHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/intrusion/IntrusionDetectionHandler.java
@@ -110,6 +110,7 @@ public class IntrusionDetectionHandler extends BoschSHCHandler {
 
     private void updateChannels(IntrusionDetectionControlState controlState) {
         super.updateState(CHANNEL_ARMING_STATE, new StringType(controlState.value.toString()));
+        super.updateState(CHANNEL_ACTIVE_CONFIGURATION_PROFILE, new StringType(controlState.activeProfile));
     }
 
     private void updateChannels(SurveillanceAlarmState surveillanceAlarmState) {

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/intrusion/IntrusionDetectionHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/intrusion/IntrusionDetectionHandlerTest.java
@@ -161,6 +161,9 @@ class IntrusionDetectionHandlerTest extends AbstractBoschSHCHandlerTest<Intrusio
         verify(getCallback()).stateUpdated(
                 new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_ARMING_STATE),
                 new StringType("SYSTEM_ARMING"));
+        verify(getCallback()).stateUpdated(
+                new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_ACTIVE_CONFIGURATION_PROFILE),
+                new StringType("0"));
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue that caused the active configuration profile of the intrusion detection system not to be updated.

closes #15848