### PR TITLE
[roku] Ignore invalid elapsed/total time values

### DIFF
--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -205,6 +205,8 @@ public class RokuHandler extends BaseThingHandler {
                     } else {
                         updateState(TIME_TOTAL, UnDefType.UNDEF);
                     }
+                } catch (NumberFormatException e) {
+                    logger.debug("Unable to parse playerInfo integer value. Exception: {}", e.getMessage());
                 } catch (RokuHttpException e) {
                     logger.debug("Unable to retrieve Roku media-player info. Exception: {}", e.getMessage(), e);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);


### PR DESCRIPTION
To prevent un-handled exceptions, catch and log the NumberFormatException that happens when the position or duration numeric values returned by the Roku device exceed the amount of Integer.MAX_VALUE.

I just saw this error for the first time in my openhab.log. Since this number is supposed to represent the position or duration of a playing media stream (in milliseconds), it is safe to assume that values this large are nonsensical and should be ignored.

![image](https://github.com/openhab/openhab-addons/assets/26532542/c3d266a5-42ce-47f8-ab7f-c023194858be)
