### PR TITLE
[hdpowerview] Fix color state update

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewRepeaterHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewRepeaterHandler.java
@@ -261,7 +261,7 @@ public class HDPowerViewRepeaterHandler extends AbstractHubbedThingHandler {
                 // Light is off when RGB black, so discard brightness as otherwise it would appear on.
                 hsb = HSBType.BLACK;
             } else {
-                hsb = HSBType.fromRGB(color.red, color.green, color.red);
+                hsb = HSBType.fromRGB(color.red, color.green, color.blue);
                 hsb = new HSBType(hsb.getHue(), hsb.getSaturation(), new PercentType(color.brightness));
             }
             updateState(CHANNEL_REPEATER_COLOR, hsb);


### PR DESCRIPTION
Now, this is awkward.

I did some additional tests in context of #15880, and didn't seem to receive the correct color state. For some reason I never discovered this problem before, probably because I mostly used the same color for my tests which was not affected that much.

Technically this is not a regression of #15880. This bug was introduced with the initial contribution of repeater support in #12308. Nevertheless, I have set the label to keep only #15880 in the release notes.