### PR TITLE
[bluetooth.bluez] Fix openhab unit name

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/README.md
+++ b/bundles/org.openhab.binding.bluetooth.bluez/README.md
@@ -1,6 +1,7 @@
 # Bluetooth BlueZ Adapter
 
-This extension supports Bluetooth access via BlueZ and DBus on Linux. This is architecture agnostic and uses Unix Sockets.
+This extension supports Bluetooth access via BlueZ and DBus on Linux.
+This is architecture agnostic and uses Unix Sockets.
 
 # Setup
 
@@ -33,7 +34,7 @@ Restart running services for changes to take effect.
 ```shell
 systemctl restart dbus
 systemctl restart bluetooth
-systemctl restart openhab2
+systemctl restart openhab
 ```
 
 ## Supported Things


### PR DESCRIPTION
Unit was renamed from **openhab2** to **openhab** in openHAB 3.