### PR TITLE
[openwebnet] fix CEN/CEN+ scenario control buttons param descriptions

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/i18n/openwebnet.properties
@@ -61,11 +61,11 @@ thing-type.config.openwebnet.bus_automation.where.description = Example: A/PL ad
 thing-type.config.openwebnet.bus_aux.where.label = OpenWebNet Address (where)
 thing-type.config.openwebnet.bus_aux.where.description = Example: AUX 1 --> where="1"
 thing-type.config.openwebnet.bus_cen_scenario_control.buttons.label = Configured Buttons
-thing-type.config.openwebnet.bus_cen_scenario_control.buttons.description = List (comma separated) of buttons numbers [0-31] configured for this scenario device. Example: buttons=1,2,4
+thing-type.config.openwebnet.bus_cen_scenario_control.buttons.description = List (comma separated) of buttons numbers [0-31] configured for this scenario device. Example: buttons="1,2,4"
 thing-type.config.openwebnet.bus_cen_scenario_control.where.label = OpenWebNet Address (where)
 thing-type.config.openwebnet.bus_cen_scenario_control.where.description = Example: A/PL address: A=1 PL=3 --> where="13". On local bus: where="13#4#01"
 thing-type.config.openwebnet.bus_cenplus_scenario_control.buttons.label = Configured Buttons
-thing-type.config.openwebnet.bus_cenplus_scenario_control.buttons.description = List (comma separated) of buttons numbers [0-31] configured for this scenario device, example: buttons=1,2,4
+thing-type.config.openwebnet.bus_cenplus_scenario_control.buttons.description = List (comma separated) of buttons numbers [0-31] configured for this scenario device, example: buttons="1,2,4"
 thing-type.config.openwebnet.bus_cenplus_scenario_control.where.label = OpenWebNet Address (where)
 thing-type.config.openwebnet.bus_cenplus_scenario_control.where.description = Use 2+N[0-2047]. Example: scenario control 5 --> where="25"
 thing-type.config.openwebnet.bus_dimmer.where.label = OpenWebNet Address (where)

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
@@ -26,7 +26,7 @@
 			<parameter name="buttons" type="text">
 				<label>Configured Buttons</label>
 				<description>List (comma separated) of buttons numbers [0-31] configured for this scenario device, example:
-					buttons=1,2,4
+					buttons="1,2,4"
 				</description>
 			</parameter>
 			<parameter name="where" type="text" required="true">

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENScenarioControl.xml
@@ -27,7 +27,8 @@
 			<parameter name="buttons" type="text">
 				<label>Configured Buttons</label>
 				<description>List (comma separated) of buttons numbers [0-31] configured for this scenario device. Example:
-					buttons=1,2,4</description>
+					buttons="1,2,4"
+				</description>
 			</parameter>
 			<parameter name="where" type="text" required="true">
 				<label>OpenWebNet Address (where)</label>


### PR DESCRIPTION
Very small PR to fix description for the buttons param for bus_cen_scenario_control and bus_cenplus_scenario_control thing types.