### PR TITLE
[mqtt.homeassistant] interpret a dimmable light as OFF properly from zigbee2mqtt

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -253,8 +253,10 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
             }
         }
 
+        boolean off = false;
         if (jsonState.state != null) {
             onOffValue.update(onOffValue.parseCommand(new StringType(jsonState.state)));
+            off = onOffValue.getChannelState().equals(OnOffType.OFF);
             if (brightnessValue.getChannelState() instanceof UnDefType) {
                 brightnessValue.update(brightnessValue.parseCommand((OnOffType) onOffValue.getChannelState()));
             }
@@ -263,7 +265,7 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
             }
         }
 
-        if (jsonState.brightness != null) {
+        if (jsonState.brightness != null && !off) {
             brightnessValue.update(
                     brightnessValue.parseCommand(new DecimalType(Objects.requireNonNull(jsonState.brightness))));
             if (colorValue.getChannelState() instanceof HSBType) {
@@ -284,9 +286,14 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
         }
 
         if (jsonState.color != null) {
-            PercentType brightness = brightnessValue.getChannelState() instanceof PercentType
-                    ? (PercentType) brightnessValue.getChannelState()
-                    : PercentType.HUNDRED;
+            PercentType brightness;
+            if (off) {
+                brightness = PercentType.ZERO;
+            } else if (brightnessValue.getChannelState() instanceof PercentType) {
+                brightness = (PercentType) brightnessValue.getChannelState();
+            } else {
+                brightness = PercentType.HUNDRED;
+            }
             // This corresponds to "deprecated" color mode handling, since we're not checking which color
             // mode is currently active.
             // HS is highest priority, then XY, then RGB

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
@@ -119,6 +119,9 @@ public class JSONSchemaLightTests extends AbstractComponentTests {
         assertState(component, Light.BRIGHTNESS_CHANNEL_ID,
                 new PercentType(new BigDecimal(128 * 100).divide(new BigDecimal(255), MathContext.DECIMAL128)));
 
+        publishMessage("zigbee2mqtt/light/state", "{ \"state\": \"OFF\", \"brightness\": 128 }");
+        assertState(component, Light.BRIGHTNESS_CHANNEL_ID, PercentType.ZERO);
+
         sendCommand(component, Light.BRIGHTNESS_CHANNEL_ID, PercentType.HUNDRED);
         assertPublished("zigbee2mqtt/light/set/state", "{\"state\":\"ON\",\"brightness\":255}");
 


### PR DESCRIPTION
zigbee2mqtt can send a brightness of say 99, with a state of OFF, when a bulb is off. make sure if state is sent, it overrides all other inferences
