### PR TITLE
[mqtt.homeassistant] use Contact for certain device classes of binary_sensor

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
+import org.openhab.binding.mqtt.generic.values.OpenCloseValue;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.ExpireUpdateStateListener;
@@ -29,10 +30,29 @@ import com.google.gson.annotations.SerializedName;
  * A MQTT BinarySensor, following the https://www.home-assistant.io/components/binary_sensor.mqtt/ specification.
  *
  * @author David Graeff - Initial contribution
+ * @author Cody Cutrer - Create Contact for certain device classes
  */
 @NonNullByDefault
 public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfiguration> {
-    public static final String SENSOR_CHANNEL_ID = "sensor"; // Randomly chosen channel "ID"
+    public static final String SENSOR_CHANNEL_ID = "sensor";
+
+    private static final String DEVICE_CLASS_CARBON_MONOXIDE = "carbon_monoxide";
+    private static final String DEVICE_CLASS_DOOR = "door";
+    private static final String DEVICE_CLASS_GARAGE_DOOR = "garage_door";
+    private static final String DEVICE_CLASS_GAS = "gas";
+    private static final String DEVICE_CLASS_LOCK = "lock";
+    private static final String DEVICE_CLASS_MOISTURE = "moisture";
+    private static final String DEVICE_CLASS_MOTION = "motion";
+    private static final String DEVICE_CLASS_MOVING = "moving";
+    private static final String DEVICE_CLASS_OCCUPANCY = "occupancy";
+    private static final String DEVICE_CLASS_OPENING = "opening";
+    private static final String DEVICE_CLASS_PROBLEM = "problem";
+    private static final String DEVICE_CLASS_SAFETY = "safety";
+    private static final String DEVICE_CLASS_SMOKE = "smoke";
+    private static final String DEVICE_CLASS_SOUND = "sound";
+    private static final String DEVICE_CLASS_TAMPER = "tamper";
+    private static final String DEVICE_CLASS_VIBRATION = "vibration";
+    private static final String DEVICE_CLASS_WINDOW = "window";
 
     /**
      * Configuration class for MQTT component
@@ -69,7 +89,24 @@ public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfigur
     public BinarySensor(ComponentFactory.ComponentConfiguration componentConfiguration) {
         super(componentConfiguration, ChannelConfiguration.class);
 
-        OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
+        Value value = null;
+        String deviceClass = channelConfiguration.deviceClass;
+        if (deviceClass != null) {
+            // https://www.home-assistant.io/integrations/binary_sensor/#device-class
+            // Device classes that are obviously open/closed or secure/insecure create a Contact channel instead
+            switch (deviceClass) {
+                case DEVICE_CLASS_CARBON_MONOXIDE, DEVICE_CLASS_DOOR, DEVICE_CLASS_GARAGE_DOOR, DEVICE_CLASS_GAS,
+                        DEVICE_CLASS_LOCK, DEVICE_CLASS_MOISTURE, DEVICE_CLASS_MOTION, DEVICE_CLASS_MOVING,
+                        DEVICE_CLASS_OCCUPANCY, DEVICE_CLASS_OPENING, DEVICE_CLASS_PROBLEM, DEVICE_CLASS_SAFETY,
+                        DEVICE_CLASS_SMOKE, DEVICE_CLASS_SOUND, DEVICE_CLASS_TAMPER, DEVICE_CLASS_VIBRATION,
+                        DEVICE_CLASS_WINDOW:
+                    value = new OpenCloseValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
+                default:
+            }
+        }
+        if (value == null) {
+            value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
+        }
 
         buildChannel(SENSOR_CHANNEL_ID, value, "value", getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate()).build();


### PR DESCRIPTION
Closes #14721

I chose device classes that are obviously open/closed or secure/insecure, to match how security system bindings typically function.

Note that this is technically a breaking change; I'll add it in the release notes in openhab-distro in a separate PR.
