### PR TITLE
[ipcamera]Fix Reolink alarms not working after a reconnect.

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1424,7 +1424,7 @@ public class IpCameraHandler extends BaseThingHandler {
             }
             logger.debug("About to connect to the IP Camera using the ONVIF PORT at IP: {}:{}", cameraConfig.getIp(),
                     cameraConfig.getOnvifPort());
-            onvifCamera.connect(thing.getThingTypeUID().getId().equals(ONVIF_THING));
+            onvifCamera.connect(supportsOnvifEvents());
             return;
         }
         if ("ffmpeg".equals(snapshotUri)) {


### PR DESCRIPTION
Fixes an issue where when a Reolink camera does a reboot, or re-connects perhaps due to a wi-fi reconnection, the alarms do not work.

Signed-off-by: Matthew Skinner <matt@pcmus.com>