### PR TITLE
[lifx] Add support for new LIFX products

### DIFF
--- a/bundles/org.openhab.binding.lifx/README.md
+++ b/bundles/org.openhab.binding.lifx/README.md
@@ -28,6 +28,8 @@ The following table lists the thing types of the supported LIFX devices:
 | LIFX+ BR30                   | colorirlight  |
 |                              |               |
 | LIFX Beam                    | colormzlight  |
+| LIFX Neon                    | colormzlight  |
+| LIFX String                  | colormzlight  |
 | LIFX Z                       | colormzlight  |
 |                              |               |
 | LIFX Tile                    | tilelight     |

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxProduct.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxProduct.java
@@ -141,7 +141,11 @@ public enum LifxProduct {
     PRODUCT_135(135, "LIFX GU10", new Features(TR_1500_9000, COLOR)),
     PRODUCT_136(136, "LIFX GU10", new Features(TR_1500_9000, COLOR)),
     PRODUCT_137(137, "LIFX Candle", new Features(TR_1500_9000, COLOR, MATRIX)),
-    PRODUCT_138(138, "LIFX Candle", new Features(TR_1500_9000, COLOR, MATRIX));
+    PRODUCT_138(138, "LIFX Candle", new Features(TR_1500_9000, COLOR, MATRIX)),
+    PRODUCT_141(141, "LIFX Neon", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE)),
+    PRODUCT_142(142, "LIFX Neon", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE)),
+    PRODUCT_143(143, "LIFX String", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE)),
+    PRODUCT_144(144, "LIFX String", new Features(TR_1500_9000, COLOR, EXTENDED_MULTIZONE, MULTIZONE));
 
     /**
      * Enumerates the product features.


### PR DESCRIPTION
Allows for discovering all the new LIFX products and their features:

* LIFX Neon
* LIFX String

See:

* https://github.com/LIFX/products/blob/master/products.json
* https://www.lifx.com.au/products/neon-flex-2m-indoor
* https://www.lifx.com.au/products/lifx-string-light