### PR TITLE
[mail] Use of actions.get instead of getActions with new JS

### DIFF
--- a/bundles/org.openhab.binding.mail/README.md
+++ b/bundles/org.openhab.binding.mail/README.md
@@ -210,14 +210,9 @@ end
 ::: tab JavaScript
 
 ```javascript
-rule "Send Mail with a 'Reference' header; for threaded view in e-mail client"
-when
-    ...
-then
-    val mailActions = actions.get("mail","mail:smtp:sampleserver")
-    mailActions.addHeader("Reference", "<unique-thread-identifier>")
-    mailActions.sendMail("mail@example.com", "Test subject", "Test message text")
-end
+val mailActions = actions.get("mail","mail:smtp:sampleserver")
+mailActions.addHeader("Reference", "<unique-thread-identifier>")
+mailActions.sendMail("mail@example.com", "Test subject", "Test message text")
 ```
 
 :::

--- a/bundles/org.openhab.binding.mail/README.md
+++ b/bundles/org.openhab.binding.mail/README.md
@@ -130,7 +130,7 @@ Both functions return a boolean as the result of the operation.
 
 `recipient` can be a single address (`mail@example.com`) or a list of addresses, concatenated by a comma (`mail@example.com, mail2@example.com`).
 
-Since there is a separate rule action instance for each `smtp` thing, this needs to be retrieved through `getActions(scope, thingUID)`.
+Since there is a separate rule action instance for each `smtp` thing, this needs to be retrieved through `actions.get(scope, thingUID)` (since using ECMAScript (ECMAScript 262 Edition 11) - older JS versions need: `getActions(scope, thingUID)`).
 The first parameter always has to be `mail` and the second is the full Thing UID of the SMTP server that should be used.
 Once this action instance is retrieved, you can invoke the action method on it.
 
@@ -140,7 +140,7 @@ Using different character sets may produce unwanted results.
 Examples:
 
 ```java
-val mailActions = getActions("mail","mail:smtp:samplesmtp")
+val mailActions = actions.get("mail","mail:smtp:samplesmtp")
 val success = mailActions.sendMail("mail@example.com", "Test subject", "This is the mail content.")
 success = mailActions.sendMail("mail1@example.com, mail2@example.com", "Test subject", "This is the mail content sent to multiple recipients.")
 
@@ -152,7 +152,7 @@ import java.util.List
 val List<String> attachmentUrlList = newArrayList(
   "http://some.web/site/snap.jpg&param=value",
   "file:///tmp/201601011031.jpg")
-val mailActions = getActions("mail","mail:smtp:sampleserver")
+val mailActions = actions.get("mail","mail:smtp:sampleserver")
 mailActions.sendHtmlMailWithAttachments("mail@example.com", "Test subject", "<h1>Header</h1>This is the mail content.", attachmentUrlList)
 ```
 
@@ -168,7 +168,7 @@ rule "Send Mail with a 'Reference' header; for threaded view in e-mail client"
 when
     ...
 then
-    val mailActions = getActions("mail","mail:smtp:sampleserver")
+    val mailActions = actions.get("mail","mail:smtp:sampleserver")
     mailActions.addHeader("Reference", "<unique-thread-identifier>")
     mailActions.sendMail("mail@example.com", "Test subject", "Test message text")
 end

--- a/bundles/org.openhab.binding.mail/README.md
+++ b/bundles/org.openhab.binding.mail/README.md
@@ -130,7 +130,7 @@ Both functions return a boolean as the result of the operation.
 
 `recipient` can be a single address (`mail@example.com`) or a list of addresses, concatenated by a comma (`mail@example.com, mail2@example.com`).
 
-Since there is a separate rule action instance for each `smtp` thing, this needs to be retrieved through `actions.get(scope, thingUID)` (since using ECMAScript (ECMAScript 262 Edition 11) - older JS versions need: `getActions(scope, thingUID)`).
+Since there is a separate rule action instance for each `smtp` thing, this needs to be retrieved through `getActions(scope, thingUID)` (DSL) or `actions.get(scope, thingUID)` (Javascript).
 The first parameter always has to be `mail` and the second is the full Thing UID of the SMTP server that should be used.
 Once this action instance is retrieved, you can invoke the action method on it.
 
@@ -139,8 +139,12 @@ Using different character sets may produce unwanted results.
 
 Examples:
 
+:::: tabs
+
+::: tab DSL
+
 ```java
-val mailActions = actions.get("mail","mail:smtp:samplesmtp")
+val mailActions = getActions("mail","mail:smtp:samplesmtp")
 val success = mailActions.sendMail("mail@example.com", "Test subject", "This is the mail content.")
 success = mailActions.sendMail("mail1@example.com, mail2@example.com", "Test subject", "This is the mail content sent to multiple recipients.")
 
@@ -152,10 +156,33 @@ import java.util.List
 val List<String> attachmentUrlList = newArrayList(
   "http://some.web/site/snap.jpg&param=value",
   "file:///tmp/201601011031.jpg")
+val mailActions = getActions("mail","mail:smtp:sampleserver")
+mailActions.sendHtmlMailWithAttachments("mail@example.com", "Test subject", "<h1>Header</h1>This is the mail content.", attachmentUrlList)
+```
+:::
+
+::: tab JavaScript
+
+```javascript
+val mailActions = actions.get("mail","mail:smtp:samplesmtp")
+val success = mailActions.sendMail("mail@example.com", "Test subject", "This is the mail content.")
+success = mailActions.sendMail("mail1@example.com, mail2@example.com", "Test subject", "This is the mail content sent to multiple recipients.")
+
+```
+
+```javascript
+import java.util.List
+
+val List<String> attachmentUrlList = newArrayList(
+  "http://some.web/site/snap.jpg&param=value",
+  "file:///tmp/201601011031.jpg")
 val mailActions = actions.get("mail","mail:smtp:sampleserver")
 mailActions.sendHtmlMailWithAttachments("mail@example.com", "Test subject", "<h1>Header</h1>This is the mail content.", attachmentUrlList)
 ```
 
+:::
+
+::::
 ## Mail Headers
 
 The binding allows one to add custom e-mail headers to messages that it sends.
@@ -163,7 +190,26 @@ For example if you want e-mails sent by this binding to be grouped into a "threa
 Headers can be added inside a rule by calling the `mailActions.addHeader()` method before calling the respective `mailActions.sendMail()` method.
 See the example below.
 
+:::: tabs
+
+::: tab DSL
+
+
 ```java
+rule "Send Mail with a 'Reference' header; for threaded view in e-mail client"
+when
+    ...
+then
+    val mailActions = getActions("mail","mail:smtp:sampleserver")
+    mailActions.addHeader("Reference", "<unique-thread-identifier>")
+    mailActions.sendMail("mail@example.com", "Test subject", "Test message text")
+end
+```
+:::
+
+::: tab JavaScript
+
+```javascript
 rule "Send Mail with a 'Reference' header; for threaded view in e-mail client"
 when
     ...
@@ -174,4 +220,7 @@ then
 end
 ```
 
+:::
+
+::::
 Note: in the case of the "Reference" header, the `<unique-thread-identifier>` has to be an ASCII string enclosed in angle brackets.


### PR DESCRIPTION
Adopt doc README to newest default JS environment (ECMAScript (ECMAScript 262 Edition 11) regarding requesting mail actions via actions.get. So newbies have no longer to search in the community blog for this info.

Signed-off-by: Siggi Immel <siegmar@immels.de>
