### PR TITLE
[jpa] Do not log failure to persist item with duplicate timestamp as error

### DIFF
--- a/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
+++ b/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
@@ -164,7 +165,12 @@ public class JpaPersistenceService implements QueryablePersistenceService {
             em.getTransaction().commit();
             logger.debug("Persisting item...done");
         } catch (Exception e) {
-            logger.error("Error while persisting item! Rolling back!", e);
+            if (e.getCause() instanceof EntityExistsException) {
+                // there's a UNIQUE constraint in the database, and we tried to write
+                // a duplicate timestamp. Just ignore
+            } else {
+                logger.error("Error while persisting item! Rolling back!", e);
+            }
             em.getTransaction().rollback();
         } finally {
             em.close();

--- a/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
+++ b/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
@@ -168,6 +168,7 @@ public class JpaPersistenceService implements QueryablePersistenceService {
             if (e.getCause() instanceof EntityExistsException) {
                 // there's a UNIQUE constraint in the database, and we tried to write
                 // a duplicate timestamp. Just ignore
+                logger.debug("Skipping persistence of item... it already exists");
             } else {
                 logger.error("Error while persisting item! Rolling back!", e);
             }

--- a/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
+++ b/bundles/org.openhab.persistence.jpa/src/main/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
@@ -168,7 +168,7 @@ public class JpaPersistenceService implements QueryablePersistenceService {
             if (e.getCause() instanceof EntityExistsException) {
                 // there's a UNIQUE constraint in the database, and we tried to write
                 // a duplicate timestamp. Just ignore
-                logger.debug("Skipping persistence of item... it already exists");
+                logger.debug("Failed to persist item {} because of duplicate timestamp", name);
             } else {
                 logger.error("Error while persisting item! Rolling back!", e);
             }


### PR DESCRIPTION
in case the user manually added a UNIQUE constraint to the database, openHAB might send duplicate timestamps.

effectively this means the first attempt is kept, while others are dropped. as long as you're using sub-second timestamps, this shouldn't be an issue - the state updates truly should be duplicates

