### PR TITLE
[pilight] Add option to disable background discovery for a given pilight bridge thing

### DIFF
--- a/bundles/org.openhab.binding.pilight/README.md
+++ b/bundles/org.openhab.binding.pilight/README.md
@@ -33,11 +33,12 @@ different pilight `bridge` things.
 
 The `bridge` requires the following configuration parameters:
 
-| Parameter Label | Parameter ID | Description                                                                                                                                                                              | Required |
-|-----------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| IP Address      | ipAddress    | Host name or IP address of the pilight daemon                                                                                                                                            | yes      |
-| Port            | port         | Port number on which the pilight daemon is listening. Default: 5000                                                                                                                      | yes      |
-| Delay           | delay        | Delay (in millisecond) between consecutive commands. Recommended value without band pass filter: 1000. Recommended value with band pass filter: somewhere between 200-500. Default: 500 | no       |
+| Parameter Label      | Parameter ID        | Description                                                                                                                                                                             | Required |
+|----------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| IP Address           | ipAddress           | Host name or IP address of the pilight daemon                                                                                                                                           | yes      |
+| Port                 | port                | Port number on which the pilight daemon is listening. Default: 5000                                                                                                                     | yes      |
+| Delay                | delay               | Delay (in millisecond) between consecutive commands. Recommended value without band pass filter: 1000. Recommended value with band pass filter: somewhere between 200-500. Default: 500 | no       |
+| Background Discovery | backgroundDiscovery | Whether pilight devices for this Bridge should automatically be discovered. Default: true                                                                                               | no       |
 
 Important: you must explicitly configure the port in the pilight daemon config or otherwise a random port will be used
 and the binding will not be able to connect.
@@ -87,13 +88,13 @@ things from them.
 ### pilight.things
 
 ```java
-Bridge pilight:bridge:raspi "Pilight Daemon raspi" [ ipAddress="192.168.1.1", port=5000 ] {
+Bridge pilight:bridge:raspi "Pilight Daemon raspi" [ ipAddress="192.168.1.1", port=5000, backgroundDiscovery=false ] {
         Thing switch office "Office" [ name="office" ]
         Thing dimmer piano "Piano"  [ name="piano" ]
         Thing generic weather "Weather"  [ name="weather" ] {
             Channels:
-              State Number : temperature [ property="temperature"]
-              State Number : humidity [ property="humidity"]
+              Type number : temperature "Temperature" [ property="temperature"]
+              Type number : humidity "Humidity" [ property="humidity"]
         }
 }
 ```

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBridgeConfiguration.java
@@ -26,6 +26,7 @@ public class PilightBridgeConfiguration {
     private String ipAddress = "";
     private int port = 0;
     private int delay = 500;
+    private boolean backgroundDiscovery = true;
 
     public String getIpAddress() {
         return ipAddress;
@@ -49,5 +50,13 @@ public class PilightBridgeConfiguration {
 
     public void setDelay(Integer delay) {
         this.delay = delay;
+    }
+
+    public boolean getBackgroundDiscovery() {
+        return backgroundDiscovery;
+    }
+
+    public void setBackgroundDiscovery(boolean flag) {
+        backgroundDiscovery = flag;
     }
 }

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/discovery/PilightDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/discovery/PilightDeviceDiscoveryService.java
@@ -14,6 +14,7 @@ package org.openhab.binding.pilight.internal.discovery;
 
 import static org.openhab.binding.pilight.internal.PilightBindingConstants.*;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,9 +179,13 @@ public class PilightDeviceDiscoveryService extends AbstractDiscoveryService impl
 
     @Override
     public void activate() {
-        super.activate(null);
         final @Nullable PilightBridgeHandler pilightBridgeHandler = this.pilightBridgeHandler;
         if (pilightBridgeHandler != null) {
+            if (pilightBridgeHandler.isBackgroundDiscoveryEnabled()) {
+                super.activate(null);
+            } else {
+                removeOlderResults(new Date().getTime(), pilightBridgeHandler.getThing().getUID());
+            }
             pilightBridgeHandler.registerDiscoveryListener(this);
         }
     }

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/discovery/PilightDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/discovery/PilightDeviceDiscoveryService.java
@@ -34,6 +34,7 @@ import org.openhab.binding.pilight.internal.handler.PilightBridgeHandler;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
@@ -180,14 +181,13 @@ public class PilightDeviceDiscoveryService extends AbstractDiscoveryService impl
     @Override
     public void activate() {
         final @Nullable PilightBridgeHandler pilightBridgeHandler = this.pilightBridgeHandler;
+        boolean discoveryEnabled = false;
         if (pilightBridgeHandler != null) {
-            if (pilightBridgeHandler.isBackgroundDiscoveryEnabled()) {
-                super.activate(null);
-            } else {
-                removeOlderResults(new Date().getTime(), pilightBridgeHandler.getThing().getUID());
-            }
+            removeOlderResults(new Date().getTime(), pilightBridgeHandler.getThing().getUID());
+            discoveryEnabled = pilightBridgeHandler.isBackgroundDiscoveryEnabled();
             pilightBridgeHandler.registerDiscoveryListener(this);
         }
+        super.activate(Map.of(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY, discoveryEnabled));
     }
 
     @Override

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBridgeHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBridgeHandler.java
@@ -65,8 +65,7 @@ public class PilightBridgeHandler extends BaseBridgeHandler {
 
     private @Nullable PilightDeviceDiscoveryService discoveryService = null;
 
-    private final ExecutorService connectorExecutor = Executors
-            .newSingleThreadExecutor(new NamedThreadFactory(getThing().getUID().getAsString(), true));
+    private @Nullable ExecutorService connectorExecutor = null;
 
     public PilightBridgeHandler(Bridge bridge) {
         super(bridge);
@@ -116,7 +115,10 @@ public class PilightBridgeHandler extends BaseBridgeHandler {
 
         updateStatus(ThingStatus.UNKNOWN);
 
+        ExecutorService connectorExecutor = Executors
+                .newSingleThreadExecutor(new NamedThreadFactory(getThing().getUID().getAsString(), true));
         connectorExecutor.execute(connector);
+        this.connectorExecutor = connectorExecutor;
         this.connector = connector;
     }
 
@@ -133,7 +135,11 @@ public class PilightBridgeHandler extends BaseBridgeHandler {
             this.connector = null;
         }
 
-        connectorExecutor.shutdown();
+        final @Nullable ExecutorService connectorExecutor = this.connectorExecutor;
+        if (connectorExecutor != null) {
+            connectorExecutor.shutdown();
+            this.connectorExecutor = null;
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBridgeHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBridgeHandler.java
@@ -137,6 +137,15 @@ public class PilightBridgeHandler extends BaseBridgeHandler {
     }
 
     /**
+     * Is background discovery for this bridge enabled?
+     *
+     * @return background discovery
+     */
+    public boolean isBackgroundDiscoveryEnabled() {
+        return getConfigAs(PilightBridgeConfiguration.class).getBackgroundDiscovery();
+    }
+
+    /**
      * send action to pilight daemon
      *
      * @param action action to send

--- a/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/i18n/pilight.properties
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/i18n/pilight.properties
@@ -18,12 +18,15 @@ thing-type.pilight.switch.description = Pilight Switch
 
 # thing types config
 
+thing-type.config.pilight.bridge.backgroundDiscovery.label = Background Discovery
+thing-type.config.pilight.bridge.backgroundDiscovery.description = Whether Pilight devices for this Bridge should automatically be discovered.
 thing-type.config.pilight.bridge.delay.label = Delay between Commands
 thing-type.config.pilight.bridge.delay.description = Delay (in millisecond) between consecutive commands. Recommended value without band pass filter: 1000. Recommended value with band pass filter: somewhere between 200-500.
 thing-type.config.pilight.bridge.ipAddress.label = Network Address
 thing-type.config.pilight.bridge.ipAddress.description = The IP or host name of the Pilight instance.
 thing-type.config.pilight.bridge.port.label = Port
 thing-type.config.pilight.bridge.port.description = Port of the Pilight daemon. You must explicitly configure the port in the Pilight daemon config or otherwise a random port will be used and the binding will not be able to connect.
+
 thing-type.config.pilight.device.name.label = Name of Device
 thing-type.config.pilight.device.name.description = The name of the pilight device.
 

--- a/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/i18n/pilight_de.properties
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/i18n/pilight_de.properties
@@ -19,8 +19,6 @@ thing-type.pilight.generic.label = Generisches pilight Gerät
 thing-type.pilight.generic.description = Gerät bei dem die Kanäle dynamisch hinzugefügt werden.
 
 # thing type config description
-thing-type.config.pilight.bridge.backgroundDiscovery.label = Hintergrund-Discovery
-thing-type.config.pilight.bridge.backgroundDiscovery.description = Sollen Pilight Geräte für diese Brigde automatisch erkannt werden.
 thing-type.config.pilight.bridge.ipAddress.label = IP-Adresse
 thing-type.config.pilight.bridge.ipAddress.description = Lokale IP-Adresse oder Hostname des pilight Daemons.
 thing-type.config.pilight.bridge.port.label = Port

--- a/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/i18n/pilight_de.properties
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/i18n/pilight_de.properties
@@ -19,6 +19,8 @@ thing-type.pilight.generic.label = Generisches pilight Gerät
 thing-type.pilight.generic.description = Gerät bei dem die Kanäle dynamisch hinzugefügt werden.
 
 # thing type config description
+thing-type.config.pilight.bridge.backgroundDiscovery.label = Hintergrund-Discovery
+thing-type.config.pilight.bridge.backgroundDiscovery.description = Sollen Pilight Geräte für diese Brigde automatisch erkannt werden.
 thing-type.config.pilight.bridge.ipAddress.label = IP-Adresse
 thing-type.config.pilight.bridge.ipAddress.description = Lokale IP-Adresse oder Hostname des pilight Daemons.
 thing-type.config.pilight.bridge.port.label = Port

--- a/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/thing/bridge.xml
@@ -32,6 +32,12 @@
 				<default>500</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="backgroundDiscovery" type="boolean">
+				<label>Background Discovery</label>
+				<description>Whether Pilight devices for this bridge should be automatically discovered.</description>
+				<advanced>true</advanced>
+				<default>true</default>
+			</parameter>
 		</config-description>
 	</bridge-type>
 

--- a/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/OH-INF/thing/bridge.xml
@@ -34,7 +34,7 @@
 			</parameter>
 			<parameter name="backgroundDiscovery" type="boolean">
 				<label>Background Discovery</label>
-				<description>Whether Pilight devices for this bridge should be automatically discovered.</description>
+				<description>Whether Pilight devices for this bridge should automatically be discovered.</description>
 				<advanced>true</advanced>
 				<default>true</default>
 			</parameter>


### PR DESCRIPTION
Previously the background discovery updated periodically all channels of all devices regardless whether they have sent an update or not.  This behavior makes it impossible to decide whether a device is still alive by observing channel updates sent by a device itself.  Especially for devices running on battery, it is important to know, if it still sends updates.
