### PR TITLE
[shelly] Support for new Plus Mini Gen 3 series, Plus UNI and BLU Gateway (closing!)

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -95,13 +95,14 @@ The binding provides the same feature set across all devices as good as possible
 | shellypluswdus       | Shelly Plus Wall Dimmer US                               | SNDM-0013US                  |
 | shellywalldisplay    | Shelly Plus Wall Display                                 | SAWD-0A1XX10EU1              |
 
-### Generation 2 Plus Mini series
+### Generation 2 Plus Mini series (incl. Gen 3)
 
-| thing-type           | Model                                                    | Vendor ID                    |
-| -------------------- | -------------------------------------------------------- | ---------------------------- |
-| shellymini1          | Shelly Plus 1 Mini with 1x relay                         | SNSW-001X8EU                 |
-| shellymini1pm        | Shelly Plus 1PM Mini with 1x relay + power meter         | SNSW-001P8EU                 |
-| shellyminipm         | Shelly Plus PM Mini with 1x power meter                  | SNPM-001PCEU16               |
+| thing-type           | Model                                                    | Vendor ID                      |
+| -------------------- | -------------------------------------------------------- | ------------------------------ |
+| shellymini1          | Shelly Plus 1 Mini with 1x relay                         | SNSW-001X8EU, S3SW-001X8EU     |
+| shellymini1pm        | Shelly Plus 1PM Mini with 1x relay + power meter         | SNSW-001P8EU, S3SW-001P8EU     |
+| shellyminipm         | Shelly Plus PM Mini with 1x power meter                  | SNPM-001PCEU16, S3PM-001PCEU16 |
+
 
 ### Generation 2 Pro series
 

--- a/bundles/org.openhab.binding.shelly/pom.xml
+++ b/bundles/org.openhab.binding.shelly/pom.xml
@@ -15,6 +15,6 @@
   </properties>
 
   <artifactId>org.openhab.binding.shelly</artifactId>
-  <name>openHAB Add-ons :: Bundles :: Shelly Binding Gen1+2</name>
+  <name>openHAB Add-ons :: Bundles :: Shelly Binding</name>
 
 </project>

--- a/bundles/org.openhab.binding.shelly/pom.xml
+++ b/bundles/org.openhab.binding.shelly/pom.xml
@@ -17,4 +17,13 @@
   <artifactId>org.openhab.binding.shelly</artifactId>
   <name>openHAB Add-ons :: Bundles :: Shelly Binding Gen1+2</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-server</artifactId>
+      <version>9.4.46.v20220331</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/bundles/org.openhab.binding.shelly/pom.xml
+++ b/bundles/org.openhab.binding.shelly/pom.xml
@@ -17,13 +17,4 @@
   <artifactId>org.openhab.binding.shelly</artifactId>
   <name>openHAB Add-ons :: Bundles :: Shelly Binding Gen1+2</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-server</artifactId>
-      <version>9.4.46.v20220331</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -104,6 +104,7 @@ public class ShellyBindingConstants {
             THING_TYPE_SHELLYBLUBUTTON, //
             THING_TYPE_SHELLYBLUDW, //
             THING_TYPE_SHELLYBLUMOTION, //
+            THING_TYPE_SHELLYBLUGW, //
 
             THING_TYPE_SHELLYPROTECTED, //
             THING_TYPE_SHELLYUNKNOWN);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -403,12 +403,12 @@ public class ShellyDeviceProfile {
     }
 
     public static boolean isGeneration2(String thingType) {
-        return thingType.startsWith("shellyplus") || thingType.startsWith("shellypro")
-                || thingType.startsWith("shellymini") || isBluSeries(thingType);
+        return thingType.startsWith("shellyplus") || thingType.startsWith("shellypro") || thingType.contains("mini")
+                || isBluSeries(thingType);
     }
 
     public static boolean isBluSeries(String thingType) {
-        return thingType.startsWith("shellyblu");
+        return thingType.startsWith("shellyblu") && !thingType.startsWith(THING_TYPE_SHELLYBLUGW_STR);
     }
 
     public boolean coiotEnabled() {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -521,10 +521,25 @@ public class Shelly2ApiJsonDTO {
     }
 
     public static class Shelly2DeviceStatus {
+        public class Shelly2InputCounts {
+            public Integer total;
+            @SerializedName("by_minute")
+            public Double[] byMinute;
+            public Double xtotal;
+            @SerializedName("xby_minute")
+            public Double[] xbyMinute;
+            @SerializedName("minute_ts")
+            public Integer minuteTS;
+        }
+
         public class Shelly2InputStatus {
             public Integer id;
             public Boolean state;
             public Double percent; // analog input only
+            public Double xpercent;
+            public Shelly2InputCounts counts;
+            public Double freq;
+            public Double xfreq;
             public ArrayList<String> errors;// shown only if at least one error is present.
         }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -18,7 +18,6 @@ import static org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -56,19 +55,17 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     private ShellySettingsStatus deviceStatus = new ShellySettingsStatus();
     private int lastPid = -1;
 
-    private static final Map<String, String> MAP_INPUT_EVENT_TYPE = new HashMap<>();
-    static {
-        MAP_INPUT_EVENT_TYPE.put(SHELLY2_EVENT_1PUSH, SHELLY_BTNEVENT_1SHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put(SHELLY2_EVENT_2PUSH, SHELLY_BTNEVENT_2SHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put(SHELLY2_EVENT_3PUSH, SHELLY_BTNEVENT_3SHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put(SHELLY2_EVENT_LPUSH, SHELLY_BTNEVENT_LONGPUSH);
-        MAP_INPUT_EVENT_TYPE.put(SHELLY2_EVENT_LSPUSH, SHELLY_BTNEVENT_LONGSHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put(SHELLY2_EVENT_SLPUSH, SHELLY_BTNEVENT_SHORTLONGPUSH);
-        MAP_INPUT_EVENT_TYPE.put("1", SHELLY_BTNEVENT_1SHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put("2", SHELLY_BTNEVENT_2SHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put("3", SHELLY_BTNEVENT_3SHORTPUSH);
-        MAP_INPUT_EVENT_TYPE.put("4", SHELLY_BTNEVENT_LONGPUSH);
-    }
+    private static final Map<String, String> MAP_INPUT_EVENT_TYPE = Map.of( //
+            SHELLY2_EVENT_1PUSH, SHELLY_BTNEVENT_1SHORTPUSH, //
+            SHELLY2_EVENT_2PUSH, SHELLY_BTNEVENT_2SHORTPUSH, //
+            SHELLY2_EVENT_3PUSH, SHELLY_BTNEVENT_3SHORTPUSH, //
+            SHELLY2_EVENT_LPUSH, SHELLY_BTNEVENT_LONGPUSH, //
+            SHELLY2_EVENT_LSPUSH, SHELLY_BTNEVENT_LONGSHORTPUSH, //
+            SHELLY2_EVENT_SLPUSH, SHELLY_BTNEVENT_SHORTLONGPUSH, //
+            "1", SHELLY_BTNEVENT_1SHORTPUSH, //
+            "2", SHELLY_BTNEVENT_2SHORTPUSH, //
+            "3", SHELLY_BTNEVENT_3SHORTPUSH, //
+            "4", SHELLY_BTNEVENT_LONGPUSH);
 
     /**
      * Regular constructor - called by Thing handler

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Markus Michels - Initial contribution
  */
+@NonNullByDefault
 public class ShellyBluApi extends Shelly2ApiRpc {
     private static final Logger logger = LoggerFactory.getLogger(ShellyBluApi.class);
     private boolean connected = false; // true = BLU devices has connected

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyDiscoveryParticipant.java
@@ -157,9 +157,6 @@ public class ShellyDiscoveryParticipant implements MDNSDiscoveryParticipant {
                 devInfo = api.getDeviceInfo();
                 model = devInfo.type;
                 gen2 = !(devInfo.gen == 1); // gen 2+3
-                if (devInfo.auth == null) {
-                    int i = 1;
-                }
                 auth = getBool(devInfo.auth);
                 if (devInfo.name != null) {
                     deviceName = devInfo.name;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyDiscoveryParticipant.java
@@ -143,7 +143,11 @@ public class ShellyDiscoveryParticipant implements MDNSDiscoveryParticipant {
             config.userId = bindingConfig.defaultUserId;
             config.password = bindingConfig.defaultPassword;
 
-            boolean gen2 = "2".equals(service.getPropertyString("gen"));
+            String gen = getString(service.getPropertyString("gen"));
+            boolean gen2 = "2".equals(gen) || "3".equals(gen);
+            if ("3".equals(gen)) {
+                int j = 1;
+            }
             ShellyApiInterface api = null;
             boolean auth = false;
             ShellySettingsDevice devInfo;
@@ -152,7 +156,11 @@ public class ShellyDiscoveryParticipant implements MDNSDiscoveryParticipant {
                 api.initialize();
                 devInfo = api.getDeviceInfo();
                 model = devInfo.type;
-                auth = devInfo.auth;
+                gen2 = !(devInfo.gen == 1); // gen 2+3
+                if (devInfo.auth == null) {
+                    int i = 1;
+                }
+                auth = getBool(devInfo.auth);
                 if (devInfo.name != null) {
                     deviceName = devInfo.name;
                 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -40,6 +40,7 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_SHELLY2 = "SHSW-21";
     public static final String SHELLYDT_SHELLY25 = "SHSW-25";
     public static final String SHELLYDT_SHPRO = "SHSW-44";
+    public static final String SHELLYDT_4PRO = "SHPSW04P";
     public static final String SHELLYDT_EM = "SHEM";
     public static final String SHELLYDT_3EM = "SHEM-3";
     public static final String SHELLYDT_HT = "SHHT-1";
@@ -79,6 +80,7 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_PLUSI4DC = "SNSN-0D24X";
     public static final String SHELLYDT_PLUSHT = "SNSN-0013A";
     public static final String SHELLYDT_PLUSSMOKE = "SNSN-0031Z";
+    public static final String SHELLYDT_PLUSUNI = "SNSN-0043X";
     public static final String SHELLYDT_PLUSDIMMERUS = "SNDM-0013US";
     public static final String SHELLYDT_PLUSDIMMER10V = "SNGW-0A11WW010";
     public static final String SHELLYDT_PLUSWALLDISPLAY = "SAWD-0A1XX10EU1";
@@ -106,15 +108,19 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_PRO4PM_2 = "SPSW-104PE16EU";
 
     // Shelly Plus Mini Series
-    // Shelly Mini Series
     public static final String SHELLYDT_MINI1 = "SNSW-001X8EU";
     public static final String SHELLYDT_MINIPM = "SNPM-001PCEU16";
     public static final String SHELLYDT_MINI1PM = "SNSW-001P8EU";
+    // Mini Generation 3
+    public static final String SHELLYDT_MINI1G3_1 = "S3SW-001X8EU";
+    public static final String SHELLYDT_MINIG3_PM = "S3PM-001PCEU16";
+    public static final String SHELLYDT_MINIG3_1PM = "S3SW-001P8EU";
 
     // Shelly BLU Series
     public static final String SHELLYDT_BLUBUTTON = "SBBT";
     public static final String SHELLYDT_BLUDW = "SBDW";
     public static final String SHELLYDT_BLUMOTION = "SBMO";
+    public static final String SHELLYDT_BLUGW = "SNGW-BT01";
 
     // Thing names
     public static final String THING_TYPE_SHELLY1_STR = "shelly1";
@@ -195,6 +201,7 @@ public class ShellyThingCreator {
     public static final String THING_TYPE_SHELLYBLUBUTTON_STR = THING_TYPE_SHELLYBLU_PREFIX + "button";
     public static final String THING_TYPE_SHELLYBLUDW_STR = THING_TYPE_SHELLYBLU_PREFIX + "dw";
     public static final String THING_TYPE_SHELLYBLUMOTION_STR = THING_TYPE_SHELLYBLU_PREFIX + "motion";
+    public static final String THING_TYPE_SHELLYBLUGW_STR = THING_TYPE_SHELLYBLU_PREFIX + "gw";
 
     // Password protected or unknown device
     public static final String THING_TYPE_SHELLYPROTECTED_STR = "shellydevice";
@@ -316,6 +323,7 @@ public class ShellyThingCreator {
     public static final ThingTypeUID THING_TYPE_SHELLYBLUDW = new ThingTypeUID(BINDING_ID, THING_TYPE_SHELLYBLUDW_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUMOTION = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUMOTION_STR);
+    public static final ThingTypeUID THING_TYPE_SHELLYBLUGW = new ThingTypeUID(BINDING_ID, THING_TYPE_SHELLYBLUGW_STR);
 
     private static final Map<String, String> THING_TYPE_MAPPING = new LinkedHashMap<>();
     static {
@@ -323,6 +331,7 @@ public class ShellyThingCreator {
         THING_TYPE_MAPPING.put(SHELLYDT_1PM, THING_TYPE_SHELLY1PM_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_1L, THING_TYPE_SHELLY1L_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_1, THING_TYPE_SHELLY1_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_4PRO, THING_TYPE_SHELLY4PRO_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_3EM, THING_TYPE_SHELLY3EM_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_EM, THING_TYPE_SHELLYEM_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_SHPLG_S, THING_TYPE_SHELLYPLUGS_STR);
@@ -361,6 +370,7 @@ public class ShellyThingCreator {
         THING_TYPE_MAPPING.put(SHELLYDT_PLUSI4, THING_TYPE_SHELLYPLUSI4_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_PLUSHT, THING_TYPE_SHELLYPLUSHT_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_PLUSSMOKE, THING_TYPE_SHELLYPLUSSMOKE_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_PLUSUNI, THING_TYPE_SHELLYUNI_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_PLUSDIMMERUS, THING_TYPE_SHELLYPLUSDIMMERUS_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_PLUSDIMMER10V, THING_TYPE_SHELLYPLUSDIMMER10V_STR);
 
@@ -368,6 +378,9 @@ public class ShellyThingCreator {
         THING_TYPE_MAPPING.put(SHELLYDT_MINI1, THING_TYPE_SHELLYMINI1_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_MINIPM, THING_TYPE_SHELLYMINIPM_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_MINI1PM, THING_TYPE_SHELLYMINI1PM_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_MINI1G3_1, THING_TYPE_SHELLYMINI1_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_MINIG3_PM, THING_TYPE_SHELLYMINIPM_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_MINIG3_1PM, THING_TYPE_SHELLYMINI1PM_STR);
 
         // Pro Series
         THING_TYPE_MAPPING.put(SHELLYDT_PRO1, THING_TYPE_SHELLYPRO1_STR);
@@ -395,6 +408,7 @@ public class ShellyThingCreator {
         THING_TYPE_MAPPING.put(SHELLYDT_BLUBUTTON, THING_TYPE_SHELLYBLUBUTTON_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_BLUDW, THING_TYPE_SHELLYBLUDW_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_BLUMOTION, THING_TYPE_SHELLYBLUMOTION_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_BLUGW, THING_TYPE_SHELLYBLUGW_STR);
 
         // Wall displays
         THING_TYPE_MAPPING.put(SHELLYDT_PLUSWALLDISPLAY, THING_TYPE_SHELLYPLUSWALLDISPLAY_STR);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -154,9 +154,6 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         Map<String, String> properties = thing.getProperties();
         String gen = getString(properties.get(PROPERTY_DEV_GEN));
         String thingType = getThingType();
-        if ("3".equals(gen)) {
-            int i = 1;
-        }
         gen2 = "2".equals(gen) || "3".equals(gen) || ShellyDeviceProfile.isGeneration2(thingType);
         blu = ShellyDeviceProfile.isBluSeries(thingType);
         this.api = !blu ? !gen2 ? new Shelly1HttpApi(thingName, this) : new Shelly2ApiRpc(thingName, thingTable, this)

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -154,7 +154,10 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         Map<String, String> properties = thing.getProperties();
         String gen = getString(properties.get(PROPERTY_DEV_GEN));
         String thingType = getThingType();
-        gen2 = "2".equals(gen) || ShellyDeviceProfile.isGeneration2(thingType);
+        if ("3".equals(gen)) {
+            int i = 1;
+        }
+        gen2 = "2".equals(gen) || "3".equals(gen) || ShellyDeviceProfile.isGeneration2(thingType);
         blu = ShellyDeviceProfile.isBluSeries(thingType);
         this.api = !blu ? !gen2 ? new Shelly1HttpApi(thingName, this) : new Shelly2ApiRpc(thingName, thingTable, this)
                 : new ShellyBluApi(thingName, thingTable, this);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
@@ -20,6 +20,7 @@ import static org.openhab.core.thing.Thing.PROPERTY_MODEL_ID;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.shelly.internal.api.ShellyDeviceProfile;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Markus Michels - Initial contribution
  */
+@NonNullByDefault
 public class ShellyBluSensorHandler extends ShellyBaseHandler {
     private static final Logger logger = LoggerFactory.getLogger(ShellyBluSensorHandler.class);
 
@@ -52,7 +54,7 @@ public class ShellyBluSensorHandler extends ShellyBaseHandler {
         super.initialize();
     }
 
-    public static void addBluThing(String gateway, Shelly2NotifyEvent e, ShellyThingTable thingTable) {
+    public static void addBluThing(String gateway, Shelly2NotifyEvent e, @Nullable ShellyThingTable thingTable) {
         String model = substringBefore(getString(e.data.name), "-").toUpperCase();
         String mac = e.data.addr.replaceAll(":", "");
         String ttype = "";

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -126,13 +126,14 @@ public class ShellyChannelDefinitions {
                 // Device
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_NAME, "deviceName", ITEMT_STRING))
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_GATEWAY, "gatewayDevice", ITEMT_STRING))
-                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ITEMP, "deviceTemp", ITEMT_TEMP))
+                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ITEMP, "system:indoor-temperature", ITEMT_TEMP))
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_WAKEUP, "sensorWakeup", ITEMT_STRING))
-                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ACCUWATTS, "meterAccuWatts", ITEMT_POWER))
-                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ACCUTOTAL, "meterAccuTotal", ITEMT_ENERGY))
-                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ACCURETURNED, "meterAccuReturned", ITEMT_ENERGY))
+                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ACCUWATTS, "system:electric-power", ITEMT_POWER))
+                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ACCUTOTAL, "system:electric-current", ITEMT_ENERGY))
+                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_ACCURETURNED, "system:electric-current",
+                        ITEMT_ENERGY))
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_RESETTOTAL, "meterResetTotals", ITEMT_SWITCH))
-                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_VOLTAGE, "supplyVoltage", ITEMT_VOLT))
+                .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_VOLTAGE, "system:electric-voltage", ITEMT_VOLT))
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_DEVST_CHARGER, "charger", ITEMT_SWITCH))
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_LED_STATUS_DISABLE, "ledStatusDisable", ITEMT_SWITCH))
                 .add(new ShellyChannel(m, CHGR_DEVST, CHANNEL_LED_POWER_DISABLE, "ledPowerDisable", ITEMT_SWITCH))
@@ -154,7 +155,7 @@ public class ShellyChannelDefinitions {
                 .add(new ShellyChannel(m, CHGR_RELAY, CHANNEL_TIMER_ACTIVE, "timerActive", ITEMT_SWITCH))
 
                 // Dimmer
-                .add(new ShellyChannel(m, CHANNEL_GROUP_DIMMER_CONTROL, CHANNEL_BRIGHTNESS, "dimmerBrightness",
+                .add(new ShellyChannel(m, CHANNEL_GROUP_DIMMER_CONTROL, CHANNEL_BRIGHTNESS, "system:brightness",
                         ITEMT_DIMMER))
 
                 // Roller
@@ -190,29 +191,30 @@ public class ShellyChannelDefinitions {
                 .add(new ShellyChannel(m, CHGR_LIGHTCH, CHANNEL_TIMER_ACTIVE, "timerActive", ITEMT_SWITCH))
 
                 // Power Meter
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_METER_CURRENTWATTS, "meterWatts", ITEMT_POWER))
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_METER_TOTALKWH, "meterTotal", ITEMT_ENERGY))
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_METER_LASTMIN1, "lastPower1", ITEMT_POWER))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_METER_CURRENTWATTS, "system:electric-power", ITEMT_POWER))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_METER_TOTALKWH, "system:electric-current", ITEMT_ENERGY))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_METER_LASTMIN1, "system:electric-power", ITEMT_POWER))
                 .add(new ShellyChannel(m, CHGR_METER, CHANNEL_LAST_UPDATE, "lastUpdate", ITEMT_DATETIME))
 
                 // EMeter
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_TOTALRET, "meterReturned", ITEMT_ENERGY))
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_REACTWATTS, "meterReactive", ITEMT_POWER))
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_VOLTAGE, "meterVoltage", ITEMT_VOLT))
-                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_CURRENT, "meterCurrent", ITEMT_AMP))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_TOTALRET, "system:electric-current", ITEMT_ENERGY))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_REACTWATTS, "system:electric-power", ITEMT_POWER))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_VOLTAGE, "system:electric-voltage", ITEMT_VOLT))
+                .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_CURRENT, "system:electric-current", ITEMT_AMP))
                 .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_PFACTOR, "meterPowerFactor", ITEMT_NUMBER))
                 .add(new ShellyChannel(m, CHGR_METER, CHANNEL_EMETER_RESETTOTAL, "meterResetTotals", ITEMT_SWITCH))
 
                 // Sensors
-                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_TEMP, "sensorTemp", ITEMT_TEMP))
-                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_HUM, "sensorHumidity", ITEMT_PERCENT))
+                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_TEMP, "system:indoor-temperature", ITEMT_TEMP))
+                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_HUM, "system:atmospheric-humidity",
+                        ITEMT_PERCENT))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_LUX, "sensorLux", ITEMT_LUX))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_ILLUM, "sensorIllumination", ITEMT_STRING))
-                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_VOLTAGE, "sensorADC", ITEMT_VOLT))
+                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_VOLTAGE, "system:electric-voltage", ITEMT_VOLT))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_STATE, "sensorContact", ITEMT_CONTACT))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_SSTATE, "sensorState", ITEMT_STRING))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_TILT, "sensorTilt", ITEMT_ANGLE))
-                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_MOTION, "sensorMotion", ITEMT_SWITCH))
+                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_MOTION, "system:motion", ITEMT_SWITCH))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_MOTION_TS, "motionTimestamp", ITEMT_DATETIME))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_MOTION_ACT, "motionActive", ITEMT_SWITCH))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_SENSOR_VIBRATION, "sensorVibration", ITEMT_SWITCH))
@@ -238,7 +240,8 @@ public class ShellyChannelDefinitions {
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_TEMP1, "sensorExtTemp", ITEMT_TEMP))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_TEMP2, "sensorExtTemp", ITEMT_TEMP))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_TEMP3, "sensorExtTemp", ITEMT_TEMP))
-                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_HUMIDITY, "sensorExtHum", ITEMT_PERCENT))
+                .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_HUMIDITY, "system:atmospheric-humidity",
+                        ITEMT_PERCENT))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_VOLTAGE, "sensorExtVolt", ITEMT_VOLT))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_INPUT1, "sensorContact", ITEMT_CONTACT))
                 .add(new ShellyChannel(m, CHGR_SENSOR, CHANNEL_ESENSOR_DIGITALINPUT, "sensorExtDigitalInput",
@@ -261,8 +264,21 @@ public class ShellyChannelDefinitions {
     }
 
     public static @Nullable ShellyChannel getDefinition(String channelName) throws IllegalArgumentException {
+        return CHANNEL_DEFINITIONS.get(getDefinitionKey(channelName));
+    }
+
+    public static boolean hasDefinition(String channelName) {
+        try {
+            CHANNEL_DEFINITIONS.get(getDefinitionKey(channelName)); // may throws exception
+            return true;
+        } catch (IllegalArgumentException e) {
+        }
+        return false;
+    }
+
+    private static String getDefinitionKey(String channelName) {
         String group = substringBefore(channelName, "#");
-        String channel = substringAfter(channelName, "#");
+        String channel = channelName.contains("#") ? substringAfter(channelName, "#") : channelName;
 
         if (group.contains(CHANNEL_GROUP_METER)) {
             group = CHANNEL_GROUP_METER; // map meter1..n to meter
@@ -284,8 +300,7 @@ public class ShellyChannelDefinitions {
             channel = CHANNEL_STATUS_EVENTCOUNT;
         }
 
-        String channelId = group + "#" + channel;
-        return CHANNEL_DEFINITIONS.get(channelId);
+        return group.isEmpty() ? channel : group + "#" + channel;
     }
 
     /**
@@ -656,6 +671,7 @@ public class ShellyChannelDefinitions {
             this.itemType = itemType;
             this.typeId = typeId;
 
+            // Auto-Naming if there are multiple instances of the same group, e.g. relay, meter...
             groupLabel = getText(PREFIX_GROUP + group + ".label");
             if (groupLabel.startsWith(PREFIX_GROUP)) {
                 groupLabel = "";
@@ -664,11 +680,21 @@ public class ShellyChannelDefinitions {
             if (groupDescription.startsWith(PREFIX_GROUP)) {
                 groupDescription = "";
             }
-            label = getText(PREFIX_CHANNEL + typeId.replace(':', '.') + ".label");
-            if (label.startsWith(PREFIX_CHANNEL)) {
-                label = "";
+
+            boolean isSystem = typeId.startsWith("system:");
+            label = PREFIX_CHANNEL + (isSystem ? channel : typeId) + ".label";
+            label = getText(label);
+            if (isSystem && label.startsWith(PREFIX_CHANNEL)) {
+                label = getText(PREFIX_CHANNEL + typeId.replace(":", ".") + ".label");
             }
-            description = getText(PREFIX_CHANNEL + typeId + ".description");
+            if (label.startsWith(PREFIX_CHANNEL)) {
+                label = ""; // no resource found
+            }
+            description = PREFIX_CHANNEL + (isSystem ? channel : typeId) + ".description";
+            description = getText(description);
+            if (isSystem && description.startsWith(PREFIX_CHANNEL)) {
+                description = getText(PREFIX_CHANNEL + typeId.replace(":", ".") + ".description");
+            }
             if (description.startsWith(PREFIX_CHANNEL)) {
                 description = ""; // no resource found
             }
@@ -738,6 +764,13 @@ public class ShellyChannelDefinitions {
 
         private String getText(String key) {
             return messages.get(key);
+        }
+
+        public ChannelTypeUID getChannelTypeUID() {
+            if (typeId.contains("system:")) {
+                return new ChannelTypeUID("system", substringAfter(typeId, ":"));
+            }
+            return new ChannelTypeUID(BINDING_ID, typeId);
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/config/configblu.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/config/configblu.xml
@@ -17,4 +17,19 @@
 		</parameter>
 	</config-description>
 
+
+	<config-description uri="thing-type:shelly:blugw">
+		<parameter name="deviceIp" type="text" required="true">
+			<label>@text/thing-type.config.shelly.deviceIp.label</label>
+			<description>@text/thing-type.config.shelly.deviceIp.description</description>
+			<context>network-address</context>
+		</parameter>
+
+		<parameter name="enableBluGateway" type="boolean" required="false">
+			<label>@text/thing-type.config.shelly.enableBluGateway.label</label>
+			<description>@text/thing-type.config.shelly.enableBluGateway.description</description>
+			<default>true</default>
+		</parameter>
+	</config-description>
+
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -11,6 +11,7 @@ addon.shelly.config.autoCoIoT.label = Auto-CoIoT
 addon.shelly.config.autoCoIoT.description = If enabled CoIoT will be automatically used when the devices runs a firmware version 1.6 or newer; false: Use thing configuration to enabled/disable CoIoT events.  
 
 # Config status messages
+message.config-status.error.network-config = Invalid system / openHAB network configuration was detected.
 message.config-status.error.missing-device-address = IP/MAC Address of the Shelly device is missing.
 message.config-status.error.missing-userid = No user ID in the Thing configuration
 
@@ -125,8 +126,8 @@ thing-type.shelly.shellyblubutton.description = Shelly BLU Button 1
 thing-type.shelly.shellybludw.description = Shelly BLU Door/Window Sensor
 thing-type.shelly.shellyblumotion.description = Shelly BLU Motion Sensor
  
- # Wall Displays
- thing-type.shelly.shellywalldisplay.description = Shelly Wall Display with sensors and input/output
+# Wall Displays
+thing-type.shelly.shellywalldisplay.description = Shelly Wall Display with sensors and input/output
  
 # thing config - shellydevice
 thing-type.config.shelly.deviceIp.label = IP Address
@@ -248,7 +249,7 @@ channel-type.shelly.temperature4.description = Temperature of external Sensor #4
 channel-type.shelly.temperature5.label = Temperature 5
 channel-type.shelly.temperature5.description = Temperature of external Sensor #5
 channel-type.shelly.targetTemp.label = Target Temperature
-channel-type.shelly.targetTemp.description = Target Temperature in °C to be reached in auto-temperature mode
+channel-type.shelly.targetTemp.description = Target Temperature in \uFFFDC to be reached in auto-temperature mode
 channel-type.shelly.humidity.label = Humidity
 channel-type.shelly.humidity.description = Relative humidity (0..100%)
 channel-type.shelly.rollerShutter.label = Roller Control (0=open, 100=closed)
@@ -283,32 +284,30 @@ channel-type.shelly.inputState1.label = Input #1
 channel-type.shelly.inputState1.description = Current state of the Input #1
 channel-type.shelly.inputState2.label = Input #2
 channel-type.shelly.inputState2.description = Current state of the Input #2
-channel-type.shelly.dimmerBrightness.label = Brightness
-channel-type.shelly.dimmerBrightness.description = Light Brightness in percent (0-100%, 0=OFF)
+channel-type.shelly.brightness.label = Brightness
+channel-type.shelly.brightness.description = Light Brightness in percent (0-100%, 0=OFF)
 channel-type.shelly.whiteBrightness.label = Brightness
 channel-type.shelly.whiteBrightness.description = Brightness (0-100%, 0=OFF)
-channel-type.shelly.meterWatts.label = Power Consumption
-channel-type.shelly.meterWatts.description = Current Power Consumption in Watts
-channel-type.shelly.meterAccuWatts.label = Accumulated Power Consumption
-channel-type.shelly.meterAccuWatts.description = Accumulated Power Consumption in Watts of the device (including all meters)
-channel-type.shelly.meterAccuTotal.label = Accumulated Total Power
-channel-type.shelly.meterAccuTotal.description = Accumulated Total Power in kW/h of the device (including all meters)
-channel-type.shelly.meterAccuReturned.label = Accumulated Apparent Power
-channel-type.shelly.meterAccuReturned.description = Accumulated Apparent Power in kW/h of the device (including all meters)
-channel-type.shelly.meterReactive.label = Reactive Energy
-channel-type.shelly.meterReactive.description = Instantaneous reactive power in Watts (W)
+channel-type.shelly.currentWatts.label = Power Consumption
+channel-type.shelly.currentWatts.description = Current Power Consumption in Watts
+channel-type.shelly.accumulatedWatts.label = Accumulated Power Consumption
+channel-type.shelly.accumulatedWatts.description = Accumulated Power Consumption in Watts of the device (including all meters)
+channel-type.shelly.accumulatedWTotal.label = Accumulated Total Power
+channel-type.shelly.accumulatedWTotal.description = Accumulated Total Power in kW/h of the device (including all meters)
+channel-type.shelly.accumulatedReturned.label = Accumulated Apparent Power
+channel-type.shelly.accumulatedReturned.description = Accumulated Apparent Power in kW/h of the device (including all meters)
+channel-type.shelly.reactiveWatts.label = Reactive Energy
+channel-type.shelly.reactiveWatts.description = Instantaneous reactive power in Watts (W)
 channel-type.shelly.lastPower1.label = Last Power
 channel-type.shelly.lastPower1.description = Last power consumption #1 - one rounded minute
-channel-type.shelly.meterTotal.label = Total Energy Consumption
-channel-type.shelly.meterTotal.description = Total energy consumption in kW/h since the device powered up (resets on restart)
+channel-type.shelly.totalKWH.label = Total Energy Consumption
+channel-type.shelly.totalKWH.description = Total energy consumption in kW/h since the device powered up (resets on restart)
 channel-type.shelly.meterResetTotals.label = Reset Energy Measurements
 channel-type.shelly.meterResetTotals.description = Resets totals measurement data
-channel-type.shelly.meterReturned.label = Total Returned Energy
-channel-type.shelly.meterReturned.description = Total returned energy in kW/h
-channel-type.shelly.meterVoltage.label = Voltage
-channel-type.shelly.meterVoltage.description = RMS voltage in Volt
-channel-type.shelly.meterCurrent.label = Current
-channel-type.shelly.meterCurrent.description = Current in A
+channel-type.shelly.returnedKWH.label = Total Returned Energy
+channel-type.shelly.returnedKWH.description = Total returned energy in kW/h
+channel-type.shelly.votage.label = Voltage
+channel-type.shelly.votage.description = RMS voltage in Volt
 channel-type.shelly.meterPowerFactor.label = Power Factor
 channel-type.shelly.meterPowerFactor.description = Power Factor in percent for photovoltaic
 channel-type.shelly.timestamp.label = Last Update
@@ -353,8 +352,8 @@ channel-type.shelly.colorEffectRGBW2.option.0 = Off
 channel-type.shelly.colorEffectRGBW2.option.1 = Meteor Shower
 channel-type.shelly.colorEffectRGBW2.option.2 = Gradual Change
 channel-type.shelly.colorEffectRGBW2.option.3 = Flash
-channel-type.shelly.sensorTemp.label = Temperature
-channel-type.shelly.sensorTemp.description = Temperature from the sensor
+channel-type.shelly.temperature.label = Temperature
+channel-type.shelly.temperature.description = Temperature from the sensor
 channel-type.shelly.sensorHumidity.label = Humidity
 channel-type.shelly.sensorHumidity.description = Relative humidity in percent (0..100%)
 channel-type.shelly.sensorFlood.label = Flood Alarm
@@ -460,8 +459,8 @@ channel-type.shelly.heartBeat.label = Last Heartbeat
 channel-type.shelly.heartBeat.description = Last time we received a signal from the device (API result or sensor report), This indicates that device communication works on the network layer (WiFi + IP)
 channel-type.shelly.updateAvailable.label = Update available
 channel-type.shelly.updateAvailable.description = ON: A firmware update is available (use the Shelly App to perform update)
-channel-type.shelly.deviceTemp.label = Internal Temperature
-channel-type.shelly.deviceTemp.description = Internal device temperature, helps to detect overheating due to installation issues
+channel-type.shelly.internalTemp.label = Internal Temperature
+channel-type.shelly.internalTemp.description = Internal device temperature, helps to detect overheating due to installation issues
 channel-type.shelly.supplyVoltage.label = Supply Voltage
 channel-type.shelly.supplyVoltage.description = External voltage supplied to the device
 channel-type.shelly.lastUpdate.label = Last Update

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -106,9 +106,9 @@ thing-type.shelly.shellyplus10v.description = Shelly Plus Dimmer 10V
 thing-type.shelly.shellywalldisplay.description = Shelly Wall Display with sensors and input/output
 
 # Plus Mini Devices
-thing-type.shelly.shellyplusmini1.description = Shelly Plus Mini 1 - Single Relay Switch
-thing-type.shelly.shellyplusminipm.description =  Shelly Plus Mini PM - Power Meter
-thing-type.shelly.shellyplusmini1pm.description =  Shelly Plus Mini 1PM - Single Relay Switch with Power Meter
+thing-type.shelly.shellymini1.description = Shelly Plus Mini 1 - Single Relay Switch
+thing-type.shelly.shellyminipm.description =  Shelly Plus Mini PM - Power Meter
+thing-type.shelly.shellymini1pm.description =  Shelly Plus Mini 1PM - Single Relay Switch with Power Meter
 
 # Pro Devices
 thing-type.shelly.shellypro1.description = Shelly Pro 1 - Single Relay Switch
@@ -125,6 +125,7 @@ thing-type.shelly.shellypro4pm.description = Shelly Pro 4PM - 4xRelay Switch wit
 thing-type.shelly.shellyblubutton.description = Shelly BLU Button 1
 thing-type.shelly.shellybludw.description = Shelly BLU Door/Window Sensor
 thing-type.shelly.shellyblumotion.description = Shelly BLU Motion Sensor
+thing-type.shelly.shellyblugw.description = Shelly BLU Gateway
  
 # Wall Displays
 thing-type.shelly.shellywalldisplay.description = Shelly Wall Display with sensors and input/output
@@ -141,7 +142,7 @@ thing-type.config.shelly.password.description = Password for API access
 thing-type.config.shelly.updateInterval.label = Status Interval
 thing-type.config.shelly.updateInterval.description = Interval for the device status update
 thing-type.config.shelly.enableBluGateway.label = Enable BLU Gateway Support
-thing-type.config.shelly.enableBluGateway.description = Enables BLU Gateway support incl- auto-upload of the required script
+thing-type.config.shelly.enableBluGateway.description = Enables BLU Gateway support including auto-upload of the required script
 thing-type.config.shelly.eventsButton.label = Button Events
 thing-type.config.shelly.eventsButton.description = Activates the Button Action URLS
 thing-type.config.shelly.eventsPush.label = Push Events

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
@@ -45,4 +45,16 @@
 		<representation-property>serviceName</representation-property>
 		<config-description-ref uri="thing-type:shelly:blubattery"/>
 	</thing-type>
+
+	<thing-type id="shellyblugw">
+		<label>Shelly BLU Gateway</label>
+		<description>@text/thing-type.shelly.shellyblugw.description</description>
+		<channel-groups>
+			<channel-group id="device" typeId="deviceStatus"/>
+		</channel-groups>
+
+		<representation-property>serviceName</representation-property>
+		<config-description-ref uri="thing-type:shelly:blugw"/>
+	</thing-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen2_sensor.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen2_sensor.xml
@@ -45,4 +45,5 @@
 		<representation-property>serviceName</representation-property>
 		<config-description-ref uri="thing-type:shelly:relay-gen2"/>
 	</thing-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/scripts/oh-blu-scanner.js
@@ -1,6 +1,6 @@
 /*
  * This script uses the BLE scan functionality in scripting to pass scan reults to openHAB
- * Supported BLU Devices: SBBT , SBDW
+ * Supported BLU Devices: BLU Button 1, BLU Door/Window, BLU Motion
  * Version 0.2
  */
 
@@ -151,6 +151,7 @@ function scanCB(ev, res) {
 }
 
 // retry several times to start the scanner if script was started before
+<<<<<<< HEAD
 // BLE infrastructure was up in the Shelly
 function startBLEScan() {
     let bleScanSuccess = BLE.Scanner.Start({ duration_ms: SCAN_DURATION, active: true }, scanCB);
@@ -162,6 +163,18 @@ function startBLEScan() {
     }
  }
  
+// BLE infrastructure was up in the Shelly
+function startBLEScan() {
+    let bleScanSuccess = BLE.Scanner.Start({ duration_ms: SCAN_DURATION, active: true }, scanCB);
+    if( bleScanSuccess === null ) {
+        console.log('Unable to start OH-BLU Scanner, make sure Shelly Gateway Support is disabled in device config.');
+        Timer.set(3000, false, startBLEScan);
+    } else {
+        console.log('Success: OH-BLU Event Gateway running');
+    }
+}
+
+>>>>>>> 133e75d091 (Various channel types changed to system-defined ones; Add auto-upgrade)
 let BLEConfig = Shelly.getComponentConfig('ble');
 if(BLEConfig.enable === false) {
     console.log('Error: BLE not enabled, unable to start OH-BLU Scanner');


### PR DESCRIPTION
This PR adds support for 
- Shelly Plus Mini 1 Gen 3
- Shelly Plus Mini PM Gen 3
- Shelly Plus Mini 1PM Gen 3
- Shelly Plus UNI
- Shelly BLU Gateway

Closing
- #15990 
- #15991 
- #15992

The PR #15980 [shelly] Various channel types changed to system-defined ones, WD fix, BLU support optimized  should be merged first to have already the fixed channel types. This came in here, but relates to the other PR.