### PR TITLE
[squeezebox] Add UoM support for time channels

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -94,38 +94,38 @@ The Squeezebox server supports the following channel:
 
 All devices support some of the following channels:
 
-| Channel Type ID        | Item Type | Description                                                                                  |
-| ---------------------- | --------- | -------------------------------------------------------------------------------------------- |
-| power                  | Switch    | Power on/off your device                                                                     |
-| mute                   | Switch    | Mute/unmute your device                                                                      |
-| volume                 | Dimmer    | Volume of your device                                                                        |
-| stop                   | Switch    | Stop the current title                                                                       |
-| control                | Player    | Control the Zone Player, e.g.  play/pause/next/previous/ffward/rewind                        |
-| stream                 | String    | Play the given HTTP or file stream (file:// or http://)                                      |
-| source                 | String    | Shows the source of the currently playing playlist entry. (i.e. `http://radio.org/radio.mp3` |
-| sync                   | String    | Add another player to your device for synchronized playback (other player mac address)       |
-| playListIndex          | Number    | Playlist Index                                                                               |
-| currentPlayingTime     | Number    | Current Playing Time                                                                         |
-| duration               | Number    | Duration of currently playing track (in seconds)                                             |
-| currentPlaylistShuffle | Number    | Current playlist shuffle mode (0 No Shuffle, 1 Shuffle Songs, 2 Shuffle Albums)              |
-| currentPlaylistRepeat  | Number    | Current playlist repeat Mode (0 No Repeat, 1 Repeat Song, 2 Repeat Playlist)                 |
-| title                  | String    | Title of the current song                                                                    |
-| remotetitle            | String    | Remote Title (Radio) of the current song                                                     |
-| album                  | String    | Album name of the current song                                                               |
-| artist                 | String    | Artist name of the current song                                                              |
-| year                   | String    | Release year of the current song                                                             |
-| genre                  | String    | Genre name of the current song                                                               |
-| albumArtist            | String    | Main artist of the entire album                                                              |
-| trackArtist            | String    | Main artist of the track                                                                     |
-| band                   | String    | Band/orchestra that performed the work                                                       |
-| composer               | String    | Original composer of the work                                                                |
-| conductor              | String    | Person who conducted the performance                                                         |
-| coverartdata           | Image     | Image data of cover art of the current song                                                  |
-| ircode                 | String    | Received IR code                                                                             |
-| numberPlaylistTracks   | Number    | Number of playlist tracks                                                                    |
-| playFavorite           | String    | ID of Favorite to play (channel's state options contains available favorites)                |
-| rate                   | Switch    | "Like" or "unlike" the currently playing song (if supported by the streaming service)        |
-| sleep                  | Number    | Power off the player in the specified number of minutes. Sending 0 cancels the timer         |
+| Channel Type ID        | Item Type   | Description                                                                                  |
+| ---------------------- | ----------- | -------------------------------------------------------------------------------------------- |
+| power                  | Switch      | Power on/off your device                                                                     |
+| mute                   | Switch      | Mute/unmute your device                                                                      |
+| volume                 | Dimmer      | Volume of your device                                                                        |
+| stop                   | Switch      | Stop the current title                                                                       |
+| control                | Player      | Control the Zone Player, e.g.  play/pause/next/previous/ffward/rewind                        |
+| stream                 | String      | Play the given HTTP or file stream (file:// or http://)                                      |
+| source                 | String      | Shows the source of the currently playing playlist entry. (i.e. `http://radio.org/radio.mp3` |
+| sync                   | String      | Add another player to your device for synchronized playback (other player mac address)       |
+| playListIndex          | Number      | Playlist Index                                                                               |
+| currentPlayingTime     | Number:Time | Current Playing Time                                                                         |
+| duration               | Number:Time | Duration of currently playing track (in seconds)                                             |
+| currentPlaylistShuffle | Number      | Current playlist shuffle mode (0 No Shuffle, 1 Shuffle Songs, 2 Shuffle Albums)              |
+| currentPlaylistRepeat  | Number      | Current playlist repeat Mode (0 No Repeat, 1 Repeat Song, 2 Repeat Playlist)                 |
+| title                  | String      | Title of the current song                                                                    |
+| remotetitle            | String      | Remote Title (Radio) of the current song                                                     |
+| album                  | String      | Album name of the current song                                                               |
+| artist                 | String      | Artist name of the current song                                                              |
+| year                   | String      | Release year of the current song                                                             |
+| genre                  | String      | Genre name of the current song                                                               |
+| albumArtist            | String      | Main artist of the entire album                                                              |
+| trackArtist            | String      | Main artist of the track                                                                     |
+| band                   | String      | Band/orchestra that performed the work                                                       |
+| composer               | String      | Original composer of the work                                                                |
+| conductor              | String      | Person who conducted the performance                                                         |
+| coverartdata           | Image       | Image data of cover art of the current song                                                  |
+| ircode                 | String      | Received IR code                                                                             |
+| numberPlaylistTracks   | Number      | Number of playlist tracks                                                                    |
+| playFavorite           | String      | ID of Favorite to play (channel's state options contains available favorites)                |
+| rate                   | Switch      | "Like" or "unlike" the currently playing song (if supported by the streaming service)        |
+| sleep                  | Number      | Power off the player in the specified number of minutes. Sending 0 cancels the timer         |
 
 ## Example .Items File
 

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -39,9 +39,11 @@ import org.openhab.core.library.types.NextPreviousType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.PlayPauseType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.library.types.RewindFastforwardType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -297,7 +299,14 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                 squeezeBoxServerHandler.playPlaylistItem(mac, ((DecimalType) command).intValue());
                 break;
             case CHANNEL_CURRENT_PLAYING_TIME:
-                squeezeBoxServerHandler.setPlayingTime(mac, ((DecimalType) command).intValue());
+                if (command instanceof DecimalType decimalCommand) {
+                    squeezeBoxServerHandler.setPlayingTime(mac, decimalCommand.intValue());
+                } else if (command instanceof QuantityType<?> quantityCommand) {
+                    QuantityType<?> quantitySeconds = quantityCommand.toUnit(Units.SECOND);
+                    if (quantitySeconds != null) {
+                        squeezeBoxServerHandler.setPlayingTime(mac, quantitySeconds.intValue());
+                    }
+                }
                 break;
             case CHANNEL_CURRENT_PLAYLIST_SHUFFLE:
                 squeezeBoxServerHandler.setShuffleMode(mac, ((DecimalType) command).intValue());
@@ -390,7 +399,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
 
     @Override
     public void currentPlayingTimeEvent(String mac, int time) {
-        updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new DecimalType(time));
+        updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new QuantityType<>(time, Units.SECOND));
         if (isMe(mac)) {
             currentTime = time;
         }
@@ -402,7 +411,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
             logger.debug("Channel 'duration' does not exist.  Delete and readd player thing to pick up channel.");
             return;
         }
-        updateChannel(mac, CHANNEL_DURATION, new DecimalType(duration));
+        updateChannel(mac, CHANNEL_DURATION, new QuantityType<>(duration, Units.SECOND));
     }
 
     @Override
@@ -646,7 +655,15 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
 
     private int cachedStateAsInt(String key) {
         State state = stateMap.get(key);
-        return state instanceof DecimalType decimalValue ? decimalValue.intValue() : 0;
+        if (state instanceof DecimalType decimalValue) {
+            return decimalValue.intValue();
+        } else if (state instanceof QuantityType<?> quantityValue) {
+            QuantityType<?> quantitySeconds = quantityValue.toUnit(Units.SECOND);
+            if (quantitySeconds != null) {
+                return quantitySeconds.intValue();
+            }
+        }
+        return 0;
     }
 
     /**
@@ -655,7 +672,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     private void timeCounter() {
         timeCounterJob = scheduler.scheduleWithFixedDelay(() -> {
             if (playing) {
-                updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new DecimalType(currentTime++));
+                updateChannel(mac, CHANNEL_CURRENT_PLAYING_TIME, new QuantityType<>(currentTime++, Units.SECOND));
             }
         }, 0, 1, TimeUnit.SECONDS);
     }

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/thing/thing-types.xml
@@ -98,6 +98,7 @@
 			<property name="name"></property>
 			<property name="uid"></property>
 			<property name="ip"></property>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 
 		<representation-property>mac</representation-property>
@@ -216,14 +217,18 @@
 		<description>Playlist index</description>
 	</channel-type>
 	<channel-type id="currentPlayingTime">
-		<item-type>Number</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Current Playing Time</label>
 		<description>Current Playing Time</description>
+		<category>Time</category>
+		<state pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="duration">
-		<item-type>Number</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Track Duration</label>
 		<description>Duration of Current Track (in seconds)</description>
+		<category>Time</category>
+		<state pattern="%.0f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="currentPlaylistShuffle">
 		<item-type>Number</item-type>

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+	<thing-type uid="squeezebox:squeezeboxplayer">
+		<instruction-set targetVersion="1">
+			<update-channel id="currentPlayingTime">
+				<type>squeezebox:currentPlayingTime</type>
+			</update-channel>
+			<update-channel id="duration">
+				<type>squeezebox:duration</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
Add [Units of Measurement](https://www.openhab.org/docs/concepts/units-of-measurement.html) support for channels **currentPlayingTime** and **duration**.