### PR TITLE
[hue] Fix scene channel updates (API v2)

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -537,7 +537,7 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
         }
         getThing().getThings().forEach(thing -> {
             if (thing.getHandler() instanceof Clip2ThingHandler clip2ThingHandler) {
-                resources.forEach(resource -> clip2ThingHandler.onResource(resource));
+                clip2ThingHandler.onResources(resources);
             }
         });
     }


### PR DESCRIPTION
This is a proposal for replacing the approach in #16001.

When receiving this payload:
```json
[
	{
		"creationtime": "2023-12-07T21:39:38Z",
		"data": [
			{
				"id": "00000000-0000-0000-0000-000000000001",
				"id_v1": "/scenes/0000000000000001",
				"status": {
					"active": "static"
				},
				"type": "scene"
			},
			{
				"id": "00000000-0000-0000-0000-000000000002",
				"id_v1": "/scenes/0000000000000002",
				"status": {
					"active": "inactive"
				},
				"type": "scene"
			}
		],
		"id": "00000000-0000-0000-0000-000000000000",
		"type": "update"
	}
]
```

The correct state change is triggered:
```
2023-12-07 22:39:37.368 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Kontor_Scene' changed from Klar to Slap af
```

Also tested transition from `UNDEF` -> scene and scene -> `UNDEF`.

Since there is only one supported channel for resource type **scene**, it should be safe to skip `updateChannels()` entirely for the resource:

https://github.com/openhab/openhab-addons/blob/3814f37d9a7efae9a0d6b37e5cad4e502220ce09/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java#L933-L935

Fixes #16000