### PR TITLE
[hue] Improve handling of unknown resource ID (API v2)

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2ThingHandler.java
@@ -602,7 +602,7 @@ public class Clip2ThingHandler extends BaseThingHandler {
         String resourceId = config.resourceId;
         if (resourceId.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "@text/offline.api2.conf-error.resource-id-bad");
+                    "@text/offline.api2.conf-error.resource-id-missing");
             return;
         }
         thisResource.setId(resourceId);
@@ -700,8 +700,8 @@ public class Clip2ThingHandler extends BaseThingHandler {
                     .ifPresentOrElse(r -> onResource(r), () -> {
                         if (resourceType == thisResource.getType()) {
                             logger.debug("{} -> onResourcesList() configuration error: unknown resourceId", resourceId);
-                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                                    "@text/offline.api2.conf-error.resource-id-bad");
+                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE,
+                                    "@text/offline.api2.gone.resource-id-unknown");
                         }
                     });
         }

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/i18n/hue.properties
@@ -259,8 +259,9 @@ offline.api2.conf-error.assets-not-loaded = Bridge/Thing handler assets not load
 offline.api2.conf-error.press-pairing-button = Not authenticated. Press pairing button on the Hue Bridge or set a valid application key in configuration.
 offline.api2.conf-error.read-only = Configuration update failed. Please update the configuration manually.
 offline.api2.conf-error.clip2-not-supported = The Hue Bridge does not support API v2.
-offline.api2.conf-error.resource-id-bad = Configuration resourceId is bad.
+offline.api2.conf-error.resource-id-missing = Resource ID is not configured.
 offline.api2.conf-error.not-authorized = The application key is not authorized.
+offline.api2.gone.resource-id-unknown = Resource ID is unknown to the bridge.
 
 # scene channel description
 


### PR DESCRIPTION
This slightly improves the handling of missing and unknown resource ID's:
- **Missing:** Change the wording in the description from "bad" to "missing".
- **Unknown:** Change the working in the description from "bad" to "unknown" and mark Thing as **GONE**.

Example:

![image](https://github.com/openhab/openhab-addons/assets/19519842/7a2621f0-825c-4e1c-a74c-7f5b4051e98a)

The scenario for unknown resource ID can be one of the following:
- The resource was removed from the bridge after the Thing was created. For example, deleting a zone for which a Thing exists.
- The Thing is manually configured with an invalid resource ID.