### PR TITLE
[tesla] Fix "jumping" location updates

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/TeslaChannelSelectorProxy.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/TeslaChannelSelectorProxy.java
@@ -49,16 +49,16 @@ public class TeslaChannelSelectorProxy {
         AR_LATITUDE("active_route_latitude", "destinationlocation", DecimalType.class, false) {
             @Override
             public State getState(String s, TeslaChannelSelectorProxy proxy, Map<String, String> properties) {
-                proxy.latitude = s;
-                return new PointType(new StringType(proxy.latitude), new StringType(proxy.longitude),
+                proxy.arLatitude = s;
+                return new PointType(new StringType(proxy.arLatitude), new StringType(proxy.arLongitude),
                         new StringType(proxy.elevation));
             }
         },
         AR_LONGITUDE("active_route_longitude", "destinationlocation", DecimalType.class, false) {
             @Override
             public State getState(String s, TeslaChannelSelectorProxy proxy, Map<String, String> properties) {
-                proxy.longitude = s;
-                return new PointType(new StringType(proxy.latitude), new StringType(proxy.longitude),
+                proxy.arLongitude = s;
+                return new PointType(new StringType(proxy.arLatitude), new StringType(proxy.arLongitude),
                         new StringType(proxy.elevation));
             }
         },
@@ -1138,6 +1138,8 @@ public class TeslaChannelSelectorProxy {
     public String elevation = "0";
     public String nativeLatitude = "0";
     public String nativeLongitude = "0";
+    public String arLatitude = "0";
+    public String arLongitude = "0";
 
     public State getState(String s, TeslaChannelSelector selector, Map<String, String> properties) {
         return selector.getState(s, this, properties);


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/15878#issuecomment-1815984738

I tracked this down to a bug which used to update the location from both the location information as well as the "active route location" information, which seems to be delivered by Tesla even though no route is active while the car stays at home.

By cleanly separating these two location types now, the frequent location updates while the car is at home should not appear anymore.