### PR TITLE
[denon] Add discovery method for Denon receiver

### DIFF
--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/addon/addon.xml
@@ -10,6 +10,15 @@
 
 	<discovery-methods>
 		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>(?i)DENON</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+		<discovery-method>
 			<service-type>mdns</service-type>
 			<mdns-service-type>_raop._tcp.local.</mdns-service-type>
 			<match-properties>
@@ -20,6 +29,5 @@
 			</match-properties>
 		</discovery-method>
 	</discovery-methods>
-
 
 </addon:addon>


### PR DESCRIPTION
For my old Denon AVR-3808, the HEOS binding is now suggested. Although it's too old to support HEOS, that's fine. However, the Denon/Marantz binding is **not** suggested. This PR takes the discovery-method provided from HEOS, since this is proven to work with my receiver:
https://github.com/openhab/openhab-addons/blob/8c560a409c5a79c6f935b14b9acb64600fccd0cb/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/addon/addon.xml#L12-L20