### PR TITLE
Capture all addon xml files for finders

### DIFF
--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -35,7 +35,7 @@
                 <concat destfile="${project.build.directory}/addons.xml">
                   <header file="src/main/resources/addon-header.xml" filtering="no"/>
                   <fileset dir="${basedirRoot}/bundles">
-                    <include name="*/src/main/resources/OH-INF/addon/addon.xml"/>
+                    <include name="*/src/main/resources/OH-INF/addon/addon*.xml"/>
                   </fileset>
                   <filterchain>
                     <linecontainsRegExp negate="true">


### PR DESCRIPTION
The JDBC persistence add-on has multiple addon-*.xml files, identifying different databases.

The current addon.xml collection process does not collect these, therefore discovery criteria defined for these addons will not be used.

This PR fixes this.

See https://github.com/openhab/openhab-core/issues/3868#issuecomment-1848899824