### PR TITLE
[HEOS] more restrictive HEOS finder criteria

### DIFF
--- a/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/addon/addon.xml
@@ -14,7 +14,15 @@
 			<match-properties>
 				<match-property>
 					<name>manufacturer</name>
-					<regex>(?i)DENON</regex>
+					<regex>Denon</regex>
+				</match-property>
+				<match-property>
+					<name>modelName</name>
+					<regex>HEOS.*|.*H|.*Home.*</regex>
+				</match-property>
+				<match-property>
+					<name>deviceType</name>
+					<regex>ACT.*|Aios.*</regex>
 				</match-property>
 			</match-properties>
 		</discovery-method>


### PR DESCRIPTION
As identified in https://github.com/openhab/openhab-addons/pull/16035, with the current discovery criteria in addon.xml, Denon devices that do not support HEOS are also discovered.

This PR aligns the criteria in addon.xml with the checks in the discovery java code and should eliminate these false positives.

I don't own HEOS devices (or other Wifi enabled Denon devices), so cannot test.

@jlaur Could you check if you still see the HEOS suggestion?