### PR TITLE
[deconz] Fix discovery methods

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/addon/addon.xml
@@ -18,6 +18,11 @@
 					<name>manufacturerURI</name>
 					<regex>.*dresden.*</regex>
 				</match-property>
+			</match-properties>
+		</discovery-method>
+		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
 				<match-property>
 					<name>manufacturer</name>
 					<regex>dresden elektronik</regex>


### PR DESCRIPTION
Fixes #16036

This now corresponds to the discovery code:
https://github.com/openhab/openhab-addons/blob/f45630064a4959c294ac01f9835df68190ac875d/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/BridgeDiscoveryParticipant.java#L89-L93