### PR TITLE
[modbus] Improve error message if data thing is configured for reading but not connected to a polling bridge.

### DIFF
--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -423,8 +423,7 @@ public class ModbusDataThingHandler extends BaseThingHandler {
                 childOfEndpoint = true;
                 functionCode = null;
                 readRequest = null;
-            } else {
-                ModbusPollerThingHandler localPollerHandler = (ModbusPollerThingHandler) bridgeHandler;
+            } else if (bridgeHandler instanceof ModbusPollerThingHandler localPollerHandler) {
                 pollerHandler = localPollerHandler;
                 ModbusReadRequestBlueprint localReadRequest = localPollerHandler.getRequest();
                 if (localReadRequest == null) {
@@ -441,7 +440,12 @@ public class ModbusDataThingHandler extends BaseThingHandler {
                 comms = localPollerHandler.getCommunicationInterface();
                 pollStart = localReadRequest.getReference();
                 childOfEndpoint = false;
+            } else {
+                String errmsg = String.format("Thing %s is connected to an unsupported type of bridge.",
+                        getThing().getUID());
+                throw new ModbusConfigurationException(errmsg);
             }
+
             validateAndParseReadParameters(localConfig);
             validateAndParseWriteParameters(localConfig);
             validateMustReadOrWrite();
@@ -513,8 +517,8 @@ public class ModbusDataThingHandler extends BaseThingHandler {
         if (childOfEndpoint && readRequest == null) {
             if (!readStartMissing || !readValueTypeMissing) {
                 String errmsg = String.format(
-                        "Thing %s readStart=%s, and readValueType=%s were specified even though the data thing is child of endpoint (that is, write-only)!",
-                        getThing().getUID(), config.getReadStart(), config.getReadValueType());
+                        "Thing %s was configured for reading (readStart and/or readValueType specified) but the parent is not a polling bridge. Consider using a bridge of type 'Regular Poll'.",
+                        getThing().getUID());
                 throw new ModbusConfigurationException(errmsg);
             }
         }


### PR DESCRIPTION
The fact that a modbus `data` thing can only be used for reading if it is connected to a `polling` bridge thing (rather than to a TCP or serial bridge thing), [might not be obvious to every user](#16041). This PR improves the error message in case of a misconfiguration, i.e. if a thing is configured for reading but not connected to a polling bridge.