### PR TITLE
Change mDNS add-on discovery syntax

### DIFF
--- a/bundles/org.openhab.binding.amplipi/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.amplipi/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/addon/addon.xml
@@ -34,11 +34,21 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_androidtvremote2._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_androidtvremote2._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_amzn-wplay._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_amzn-wplay._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.androidtv/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.androidtv/src/main/resources/OH-INF/addon/addon.xml
@@ -11,11 +11,21 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_androidtvremote2._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_androidtvremote2._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_nv_shield_remote._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_nv_shield_remote._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.bondhome/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_bond._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_bond._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.bosesoundtouch/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.bosesoundtouch/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_soundtouch._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_soundtouch._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.chromecast/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.chromecast/src/main/resources/OH-INF/addon/addon.xml
@@ -18,7 +18,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_googlecast._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_googlecast._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/addon/addon.xml
@@ -20,7 +20,12 @@
 		</discovery-method>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_raop._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_raop._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.digitalstrom/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>application</name>

--- a/bundles/org.openhab.binding.dlinksmarthome/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_dhnap._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_dhnap._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.enigma2/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.enigma2/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.enphase/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.enphase/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_enphase-envoy._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_enphase-envoy._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/addon/addon.xml
@@ -24,7 +24,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_fbx-api._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_fbx-api._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/addon/addon.xml
@@ -11,11 +11,21 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_powerview-g3._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_powerview-g3._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_powerview._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_powerview._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.homeconnect/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.homeconnect/src/main/resources/OH-INF/addon/addon.xml
@@ -12,7 +12,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_homeconnect._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_homeconnect._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.hpprinter/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.hpprinter/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_printer._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_printer._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>rp</name>
@@ -25,7 +30,12 @@
 		</discovery-method>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_ipp._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_ipp._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>rp</name>

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_hue._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_hue._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 		<discovery-method>
 			<service-type>upnp</service-type>

--- a/bundles/org.openhab.binding.hyperion/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.hyperion/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_hyperiond-json._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_hyperiond-json._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.ipp/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.ipp/src/main/resources/OH-INF/addon/addon.xml
@@ -13,7 +13,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_ipp._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_ipp._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.ism8/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.ism8/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_ism7._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_ism7._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.km200/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.km200/src/main/resources/OH-INF/addon/addon.xml
@@ -14,7 +14,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>hwversion</name>

--- a/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/addon/addon.xml
@@ -12,7 +12,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_lutron._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_lutron._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.mecmeter/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.mecmeter/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_mieleathome._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_mieleathome._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>path</name>

--- a/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_mieleathome._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_mieleathome._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>path</name>

--- a/bundles/org.openhab.binding.minecraft/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.minecraft/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.mpd/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.mpd/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_mpd._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_mpd._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.mynice/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.mynice/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_nap._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_nap._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_nanoleafapi._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_nanoleafapi._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.neeo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.neeo/src/main/resources/OH-INF/addon/addon.xml
@@ -13,7 +13,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_neeo._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_neeo._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.neohub/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.neohub/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_hap._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_hap._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/addon/addon.xml
@@ -20,7 +20,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_netatmo-lcomm._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_netatmo-lcomm._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.networkupstools/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.networkupstools/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_nut._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_nut._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.nuvo/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_ac-mcs._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_ac-mcs._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/addon/addon.xml
@@ -34,7 +34,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_pulse-server._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_pulse-server._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/addon/addon.xml
@@ -35,7 +35,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/resources/OH-INF/addon/addon.xml
@@ -22,7 +22,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_sonos._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_sonos._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 		<discovery-method>
 			<service-type>upnp</service-type>

--- a/bundles/org.openhab.binding.tado/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.tado/src/main/resources/OH-INF/addon/addon.xml
@@ -12,7 +12,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_hap._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_hap._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.tivo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.tivo/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_tivo-remote._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_tivo-remote._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_coap._udp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_coap._udp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.binding.vizio/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.vizio/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_viziocast._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_viziocast._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.volumio/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.volumio/src/main/resources/OH-INF/addon/addon.xml
@@ -10,7 +10,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_Volumio._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_Volumio._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/addon/addon.xml
@@ -11,7 +11,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_http._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 			<match-properties>
 				<match-property>
 					<name>name</name>

--- a/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.io.neeo/src/main/resources/OH-INF/addon/addon.xml
@@ -15,7 +15,12 @@
 	<discovery-methods>
 		<discovery-method>
 			<service-type>mdns</service-type>
-			<mdns-service-type>_neeo._tcp.local.</mdns-service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_neeo._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
 		</discovery-method>
 	</discovery-methods>
 


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/3924

This PR modifies all mDNS discovery configurations in all addon.xml files that define mDNS discovery to an adapted format.

For this PR to build, the modified addon.xml schema file needs to be uploaded first.
