### PR TITLE
[neato] Fix things file example in Readme

### DIFF
--- a/bundles/org.openhab.binding.neato/README.md
+++ b/bundles/org.openhab.binding.neato/README.md
@@ -109,5 +109,6 @@ Frame label="Neato BotVac Connected" {
 ### neato.things
 
 ```java
-neato:vacuumcleaner:fanndamm [ serial="vacuumcleaner-serial", secret="secret-string"]
+Bridge neato:neatoaccount:neatobridge "Neato Account Bridge" [ email="yours@example.com", password="neato-account-password" ]
+Thing neato:vacuumcleaner:fanndamm "Neato BotVac" (neato:neatoaccount:neatobridge) [ serial="vacuumcleaner-serial", secret="secret-string" ]
 ```


### PR DESCRIPTION
I've updated the sample neato.things file in the Neato binding docs with an example configuration for a bridge. I've also included a link between the thing and the bridge as this was missing from the previous example.