### PR TITLE
[mqtt.espmilighthub] use ColorUtil instead of deprecated HSBType.fromXY

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -48,6 +48,7 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
+import org.openhab.core.util.ColorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -294,7 +295,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttMessag
             coefficients = KANG_Y_COEFFICIENTS[0];
         }
         BigDecimal y = polynomialFit(x, coefficients);
-        var rawHsb = HSBType.fromXY(x.floatValue() * 100.0f, y.floatValue() * 100.0f);
+        var rawHsb = ColorUtil.xyToHsb(new double[] { x.doubleValue(), y.doubleValue() });
         return new HSBType(rawHsb.getHue(), rawHsb.getSaturation(), brightness);
     }
 


### PR DESCRIPTION
and fix that it expects ranges from 0.0 to 1.0 instead of 0.0 to 100.0

this fixes the error:

```
2023-12-15 09:25:53.036 [WARN ] [nternal.handler.EspMilightHubHandler] - Failed processing Milight state {"state":"OFF","level":0,"color_temp":166,"bulb_mode":"white"} for milight/states/0x1757/fut089/3
java.lang.IllegalArgumentException: xy array only allows two or three values between 0.0 and 1.0.
```