### PR TITLE
[wemo] Fix discovery methods

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.wemo/src/main/resources/OH-INF/addon/addon.xml
@@ -14,7 +14,11 @@
 			<match-properties>
 				<match-property>
 					<name>manufacturer</name>
-					<regex>(?i)BELKIN</regex>
+					<regex>(?i).*BELKIN.*</regex>
+				</match-property>
+				<match-property>
+					<name>modelName</name>
+					<regex>(?i)(socket|outdoorplug|insight|lightswitch|motion|sensor|bridge|maker|coffee|dimmer|crockpot|airpurifier|humidifier|heater).*</regex>
 				</match-property>
 			</match-properties>
 		</discovery-method>


### PR DESCRIPTION
This should more closely match:
https://github.com/openhab/openhab-addons/blob/6763100511974badda06eb970c5bd68254722462/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/discovery/WemoDiscoveryParticipant.java#L82-L164

In the UPnP Explorer app for Android, my WeMo Insight shows as:
- **Manufacturer:** Belkin International Inc.
- **Model Name:** Insight
- **Model Number:** 1.0
- **Model Description:** Belkin Insight 1.0

Relevant XML part:
```xml
<deviceType>urn:Belkin:device:insight:1</deviceType>
<manufacturer>Belkin International Inc.</manufacturer>
<manufacturerURL>http://www.belkin.com</manufacturerURL>
<modelDescription>Belkin Insight 1.0</modelDescription>
<modelName>Insight</modelName>
<modelNumber>1.0</modelNumber>
<modelURL>http://www.belkin.com/plugin/</modelURL>
<firmwareVersion>WeMo_WW_2.00.11532.PVT-OWRT-Insight</firmwareVersion>
```

In order for the suggestion to work, a fix in core is needed also - see comments below.