### PR TITLE
[opensprinkler] Fix excessive WARN in logs due to wifi dropouts, and current displays as 0

### DIFF
--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/api/OpenSprinklerHttpApiV100.java
@@ -12,15 +12,7 @@
  */
 package org.openhab.binding.opensprinkler.internal.api;
 
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_DISABLE_MANUAL_MODE;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_ENABLE_MANUAL_MODE;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_OPTIONS_INFO;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_PASSWORD;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_STATION_INFO;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.CMD_STATUS_INFO;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.DEFAULT_STATION_COUNT;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.HTTPS_REQUEST_URL_PREFIX;
-import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.HTTP_REQUEST_URL_PREFIX;
+import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -397,7 +389,7 @@ class OpenSprinklerHttpApiV100 implements OpenSprinklerApi {
                             .timeout(config.timeout, TimeUnit.SECONDS).method(HttpMethod.GET).send();
                     connectionSuccess = true;
                 } catch (InterruptedException | TimeoutException | ExecutionException e) {
-                    logger.warn("Request to OpenSprinkler device failed (retries left: {}): {}", retriesLeft,
+                    logger.debug("Request to OpenSprinkler device failed (retries left: {}): {}", retriesLeft,
                             e.getMessage());
                 }
             }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -163,7 +163,7 @@
 		<label>Current Draw</label>
 		<description>The current draw in mA</description>
 		<category>Energy</category>
-		<state readOnly="true" pattern="%.1f A"/>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 
 	<channel-type id="stationState">

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/OH-INF/thing/thing-types.xml
@@ -163,7 +163,7 @@
 		<label>Current Draw</label>
 		<description>The current draw in mA</description>
 		<category>Energy</category>
-		<state readOnly="true"/>
+		<state readOnly="true" pattern="%.1f A"/>
 	</channel-type>
 
 	<channel-type id="stationState">


### PR DESCRIPTION
The channel will display "0" when the current draw is 300mA, so users will think this is a bug. Changing the default state description allows it to be displayed as '0.3 A'

Also the WARN that is changed to DEBUG is very annoying in the logs as the sprinkler controller is often located outside a long way from the wifi and getting multiple WARNS when it has not yet failed all the allowed retries is IMHO not inline with logging guidelines.

Signed-off-by: Matthew Skinner <matt@pcmus.com>