### PR TITLE
[surepetcare] Fix `DateTimeParseException`

### DIFF
--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/utils/GsonZonedDateTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/utils/GsonZonedDateTimeTypeAdapter.java
@@ -15,6 +15,7 @@ package org.openhab.binding.surepetcare.internal.utils;
 import java.lang.reflect.Type;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -76,6 +77,11 @@ public class GsonZonedDateTimeTypeAdapter implements JsonSerializer<ZonedDateTim
     @Override
     public @Nullable ZonedDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
             throws JsonParseException {
-        return ZONED_FORMATTER.parse(json.getAsString(), ZonedDateTime::from);
+        String content = json.getAsString();
+        try {
+            return ZonedDateTime.parse(content);
+        } catch (DateTimeParseException e) {
+            throw new JsonParseException("Could not parse as ZonedDateTime: " + content, e);
+        }
     }
 }

--- a/bundles/org.openhab.binding.surepetcare/src/test/java/org/openhab/binding/surepetcare/internal/data/SurePetcareTopologyTest.java
+++ b/bundles/org.openhab.binding.surepetcare/src/test/java/org/openhab/binding/surepetcare/internal/data/SurePetcareTopologyTest.java
@@ -14,6 +14,9 @@ package org.openhab.binding.surepetcare.internal.data;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.surepetcare.internal.SurePetcareConstants;
@@ -77,5 +80,50 @@ public class SurePetcareTopologyTest {
         } else {
             fail("GSON returned null");
         }
+    }
+
+    @Test
+    public void testDateFormats() {
+        String testResponse = """
+                {
+                    "devices": [],
+                    "households": [
+                        {
+                            "id": 0,
+                            "name": "***",
+                            "share_code": "***",
+                            "created_user_id": 0,
+                            "timezone_id": 374,
+                            "version": "MTE=",
+                            "created_at": "2021-04-24T11:41:15+00:00",
+                            "updated_at": "2023-12-16T21:08:19.637892+00:00",
+                            "invites": [],
+                            "users": [],
+                            "timezone": {
+                                "id": 374,
+                                "name": "(UTC+02:00) Europe/Zurich",
+                                "timezone": "Europe/Zurich",
+                                "utc_offset": 7200,
+                                "created_at": "2017-08-03T08:35:34+00:00",
+                                "updated_at": "2017-08-03T08:37:15+00:00"
+                            }
+                        }
+                    ],
+                    "pets": [],
+                    "photos": [],
+                    "tags": [],
+                    "user": {}
+                }
+                """;
+
+        SurePetcareTopology response = SurePetcareConstants.GSON.fromJson(testResponse, SurePetcareTopology.class);
+
+        assertNotNull(response);
+        assertNotNull(response.households);
+        assertEquals(1, response.households.size());
+        assertEquals(ZonedDateTime.of(2021, 4, 24, 11, 41, 15, 0, ZoneOffset.UTC),
+                response.households.get(0).createdAt);
+        assertEquals(ZonedDateTime.of(2023, 12, 16, 21, 8, 19, 637892000, ZoneOffset.UTC),
+                response.households.get(0).updatedAt);
     }
 }


### PR DESCRIPTION
Fixes #16082

JAR for testing: [org.openhab.binding.surepetcare-4.1.0-SNAPSHOT.jar](https://drive.google.com/file/d/1zWylM9TzlHJ-9bVPOLEwbEKQe_ZmDn8z/view?usp=sharing)