### PR TITLE
[surepetcare] Fix `NullReferenceException`

### DIFF
--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/discovery/SurePetcareDiscoveryService.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/discovery/SurePetcareDiscoveryService.java
@@ -89,6 +89,7 @@ public class SurePetcareDiscoveryService extends AbstractDiscoveryService
     @Override
     public void setThingHandler(@Nullable ThingHandler handler) {
         if (handler instanceof SurePetcareBridgeHandler bridgeHandler) {
+            this.bridgeHandler = bridgeHandler;
             bridgeUID = bridgeHandler.getUID();
         }
     }


### PR DESCRIPTION
Fixes regression from #15411:

![image](https://github.com/openhab/openhab-addons/assets/19519842/7c79619f-e61b-4b95-845e-278aad685981)
