### PR TITLE
Update OH version in skeleton scripts

### DIFF
--- a/bundles/create_openhab_binding_skeleton.cmd
+++ b/bundles/create_openhab_binding_skeleton.cmd
@@ -10,7 +10,7 @@ IF %ARGC% NEQ 3 (
 	exit /B 1
 )
 
-SET OpenhabVersion="4.1.0-SNAPSHOT"
+SET OpenhabVersion="4.2.0-SNAPSHOT"
 
 SET BindingIdInCamelCase=%~1
 SET BindingIdInLowerCase=%BindingIdInCamelCase%

--- a/bundles/create_openhab_binding_skeleton.sh
+++ b/bundles/create_openhab_binding_skeleton.sh
@@ -2,7 +2,7 @@
 
 [ $# -lt 3 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author> <GitHub Username>"; exit 1; }
 
-openHABVersion=4.1.0-SNAPSHOT
+openHABVersion=4.2.0-SNAPSHOT
 
 camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`


### PR DESCRIPTION
With these changes the correct openHAB version will be used when creating a new binding.