### PR TITLE
[sonos] prevent logging unsupported device

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosBindingConstants.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosBindingConstants.java
@@ -75,6 +75,8 @@ public class SonosBindingConstants {
             MOVE2_THING_TYPE_UID, ROAM_THING_TYPE_UID, ROAM_SL_THING_TYPE_UID, ERA_100_THING_TYPE_UID,
             ERA_300_THING_TYPE_UID);
 
+    public static final Set<String> UNSUPPORTED_KNOWN_IDS = Set.of("sub", "sonos sub mini");
+
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(SUPPORTED_KNOWN_THING_TYPES_UIDS);
     static {
         SUPPORTED_THING_TYPES_UIDS.add(ZONEPLAYER_THING_TYPE_UID);

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/discovery/ZonePlayerDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/discovery/ZonePlayerDiscoveryParticipant.java
@@ -83,7 +83,8 @@ public class ZonePlayerDiscoveryParticipant implements UpnpDiscoveryParticipant 
                 String id = SonosXMLParser
                         .buildThingTypeIdFromModelName(device.getDetails().getModelDetails().getModelName());
                 String udn = device.getIdentity().getUdn().getIdentifierString();
-                if (!id.isEmpty() && !"Sub".equalsIgnoreCase(id) && !udn.isEmpty()) {
+                if (!id.isEmpty() && !SonosBindingConstants.UNSUPPORTED_KNOWN_IDS.contains(id.toLowerCase())
+                        && !udn.isEmpty()) {
                     ThingTypeUID thingTypeUID = new ThingTypeUID(SonosBindingConstants.BINDING_ID, id);
                     if (!SonosBindingConstants.SUPPORTED_KNOWN_THING_TYPES_UIDS.contains(thingTypeUID)) {
                         // Try with the model name all in uppercase


### PR DESCRIPTION
Some devices like subs are more or less a transparant slave and are not added to openHAB as Thing. As the amount of devices slowly grows a more future proof check is needed to prevent unwanted logging. 

Fixes:  https://github.com/openhab/openhab-addons/issues/16125