### PR TITLE
[wled] Fix Playlist and Preset detection when missing bri values

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV0110.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/api/WledApiV0110.java
@@ -62,7 +62,7 @@ public class WledApiV0110 extends WledApiV084 {
             logger.trace("Preset:{} json:{}", presetEntry.getKey(), presetEntry.getValue());
             PresetState preset = gson.fromJson(presetEntry.getValue(), PresetState.class);
             if (preset != null && counter > 0) {
-                if (preset.bri == 0) {
+                if (presetEntry.getValue().toString().contains("playlist")) {
                     playlistsOptions.add(new StateOption(presetEntry.getKey(), preset.n));
                 } else {
                     presetsOptions.add(new StateOption(presetEntry.getKey(), preset.n));


### PR DESCRIPTION
Presets can have the `bri` value missing and the binding was using this to detect playlist objects from presets. This PR fixes this and should be backwards and forwards compatible with different firmwares. Reported on the forum here:

https://community.openhab.org/t/wled-0-14-doesnt-fetch-preset/152313


This pull request is available under the following links if anyone wants to test:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

Just the needed jar.
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.wled/4.2.0-SNAPSHOT/org.openhab.binding.wled-4.2.0-SNAPSHOT.jar