### PR TITLE
[shelly] Fix WebSocketServerFactory ClassNotFoundException

### DIFF
--- a/bundles/org.openhab.binding.shelly/pom.xml
+++ b/bundles/org.openhab.binding.shelly/pom.xml
@@ -10,6 +10,9 @@
     <version>4.2.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <bnd.importpackage>org.eclipse.jetty.websocket.server</bnd.importpackage>
+  </properties>
 
   <artifactId>org.openhab.binding.shelly</artifactId>
   <name>openHAB Add-ons :: Bundles :: Shelly Binding Gen1+2</name>


### PR DESCRIPTION
Adds a package import so the class can be found by the class loader.

Fixes #16118