### PR TITLE
[influxdb] Add compatibility with InfluxDB Cloud Serverless 

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>
-      !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!com.influxdb.utils.*
+      !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*
     </bnd.importpackage>
     <okhttp3.version>3.14.9</okhttp3.version>
     <retrofit.version>2.7.2</retrofit.version>

--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -16,11 +16,11 @@
 
   <properties>
     <bnd.importpackage>
-      !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*
+      !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!com.influxdb.utils.*
     </bnd.importpackage>
     <okhttp3.version>3.14.9</okhttp3.version>
     <retrofit.version>2.7.2</retrofit.version>
-    <influx2.version>1.15.0</influx2.version>
+    <influx2.version>4.3.0</influx2.version>
     <influx1.version>2.21</influx1.version>
   </properties>
 
@@ -30,6 +30,16 @@
       <groupId>com.influxdb</groupId>
       <artifactId>influxdb-client-java</artifactId>
       <version>${influx2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.influxdb</groupId>
+      <artifactId>influxdb-client-utils</artifactId>
+      <version>${influx2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>adapter-rxjava2</artifactId>
+      <version>${retrofit.version}</version>
     </dependency>
     <dependency>
       <groupId>com.influxdb</groupId>

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
@@ -122,7 +122,8 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
             if (ready != null) {
                 isUp = ready.getStatus() == Ready.StatusEnum.READY;
             } else {
-                logger.warn("Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
+                logger.warn(
+                        "Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
                 isUp = currentClient.ping();
             }
 

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
@@ -122,7 +122,8 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
             if (ready != null) {
                 isUp = ready.getStatus() == Ready.StatusEnum.READY;
             } else {
-                logger.debug("Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
+                logger.debug(
+                        "Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
                 isUp = currentClient.ping();
             }
 

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
@@ -44,7 +44,6 @@ import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.QueryApi;
 import com.influxdb.client.WriteApi;
-import com.influxdb.client.domain.HealthCheck;
 import com.influxdb.client.domain.Ready;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
@@ -78,7 +77,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
     @Override
     public boolean isConnected() {
         InfluxDBClient client = this.client;
-        return client != null && client.health().getStatus() == HealthCheck.StatusEnum.PASS;
+        return client != null && client.ping();
     }
 
     @Override
@@ -97,9 +96,10 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
         this.client = createdClient;
 
         queryAPI = createdClient.getQueryApi();
-        writeAPI = createdClient.getWriteApi();
+        writeAPI = createdClient.makeWriteApi();
         deleteAPI = createdClient.getDeleteApi();
-        logger.debug("Successfully connected to InfluxDB. Instance ready={}", createdClient.ready());
+
+        logger.debug("Successfully connected to InfluxDB. Instance pingable={}", createdClient.ping());
 
         return checkConnectionStatus();
     }
@@ -117,8 +117,15 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
     public boolean checkConnectionStatus() {
         final InfluxDBClient currentClient = client;
         if (currentClient != null) {
+            boolean isUp = false;
             Ready ready = currentClient.ready();
-            boolean isUp = ready != null && ready.getStatus() == Ready.StatusEnum.READY;
+            if (ready != null) {
+                isUp = ready.getStatus() == Ready.StatusEnum.READY;
+            } else {
+                logger.warn("Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
+                isUp = currentClient.ping();
+            }
+
             if (isUp) {
                 logger.debug("database status is OK");
             } else {

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/InfluxDB2RepositoryImpl.java
@@ -122,8 +122,7 @@ public class InfluxDB2RepositoryImpl implements InfluxDBRepository {
             if (ready != null) {
                 isUp = ready.getStatus() == Ready.StatusEnum.READY;
             } else {
-                logger.warn(
-                        "Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
+                logger.debug("Failure resolving database readiness. Falling back to ping check. This is normal when using InfluxDB Cloud Serverless.");
                 isUp = currentClient.ping();
             }
 


### PR DESCRIPTION
Update influx client to 4.3.0 and use ping endpoint to check for database availability. Fixes https://github.com/openhab/openhab-addons/issues/16147

Chose not to go to newest client version since this will resolve to some vulnerabilities in the dependency tree according to maven central (https://mvnrepository.com/artifact/com.squareup.retrofit2/adapter-rxjava3/2.9.0)

Did not run all tests since they seem to require some running influx instances and i could not find information on how to setup those. 

Resulting jar: [org.openhab.persistence.influxdb-4.2.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab-addons/files/13798883/org.openhab.persistence.influxdb-4.2.0-SNAPSHOT.jar.zip)
