### PR TITLE
[pollytts] Update AWS Java SDK

### DIFF
--- a/bundles/org.openhab.voice.pollytts/pom.xml
+++ b/bundles/org.openhab.voice.pollytts/pom.xml
@@ -18,13 +18,13 @@
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>com.amazonaws.aws-java-sdk-core</artifactId>
-      <version>1.11.490</version>
+      <version>1.12.626</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>com.amazonaws.aws-java-sdk-polly</artifactId>
-      <version>1.11.490</version>
+      <version>1.12.626</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
@@ -7,8 +7,8 @@
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.9</bundle>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.5</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.amazonaws.aws-java-sdk-core/1.11.490</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.amazonaws.aws-java-sdk-polly/1.11.490</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.amazonaws.aws-java-sdk-core/1.12.626</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.amazonaws.aws-java-sdk-polly/1.12.626</bundle>
 		<bundle dependency="true">mvn:commons-logging/commons-logging/1.2</bundle>
 		<bundle dependency="true">mvn:joda-time/joda-time/2.8.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.voice.pollytts/${project.version}</bundle>


### PR DESCRIPTION
A newer AWS Java SDK is required when using Jackson 2.16.

Fixes #16108 

Depends on https://github.com/openhab/openhab-osgiify/pull/45