### PR TITLE
Update README with sitemap Input example

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/README.md
+++ b/bundles/org.openhab.binding.kaleidescape/README.md
@@ -437,14 +437,14 @@ rule "Movie Search"
 when
     Item z1_MovieSearch received update
 then
-    if (z1_MovieSearch.state != NULL && z1_MovieSearch.state.toString.length > 0) {
+    if (newState != NULL && newState.toString.length > 0) {
         kactions.sendKCommand("GO_MOVIE_LIST")
         Thread::sleep(1000)
         kactions.sendKCommand("FILTER_LIST")
         Thread::sleep(300)
 
         var i = 0
-        var srch = z1_MovieSearch.state.toString.toUpperCase
+        var srch = newState.toString.toUpperCase
         logInfo("kaleidescape.search","Searching for: " + srch)
 
         while (i < (srch.length)) {

--- a/bundles/org.openhab.binding.kaleidescape/README.md
+++ b/bundles/org.openhab.binding.kaleidescape/README.md
@@ -224,6 +224,7 @@ String z1_Detail_ColorDescription "Color Description: [%s]" { channel="kaleidesc
 String z1_Detail_Country "Country: [%s]" { channel="kaleidescape:player:myzone1:detail#country" }
 String z1_Detail_AspectRatio "Aspect Ratio: [%s]" { channel="kaleidescape:player:myzone1:detail#aspect_ratio" }
 String z1_Detail_DiscLocation "Disc Location: [%s]" { channel="kaleidescape:player:myzone1:detail#disc_location" }
+String z1_MovieSearch "Movie Search"
 ```
 
 ksecondsformat.js:
@@ -272,6 +273,7 @@ sitemap kaleidescape label="Kaleidescape" {
         Text item=z1_Detail_Country visibility=[z1_Detail_Type=="movie"] icon="none"
         Text item=z1_Detail_AspectRatio visibility=[z1_Detail_Type=="movie"] icon="none"
         Text item=z1_Detail_DiscLocation visibility=[z1_Detail_Type=="movie", z1_Detail_Type=="album"] icon="player"
+        Input item=z1_MovieSearch label="Movie Search" staticIcon=zoom inputHint="text"
 
         Text label="Now Playing - Movie" icon="screen" {
             Switch item=z1_Ui_Power
@@ -429,5 +431,27 @@ then
       return
     }
     kactions.sendKCommand("GET_CONTENT_DETAILS:" + z1_Music_AlbumHandle.state.toString + ":")
+end
+
+rule "Movie Search"
+when
+    Item z1_MovieSearch received update
+then
+    if (z1_MovieSearch.state != NULL && z1_MovieSearch.state.toString.length > 0) {
+        kactions.sendKCommand("GO_MOVIE_LIST")
+        Thread::sleep(1000)
+        kactions.sendKCommand("FILTER_LIST")
+        Thread::sleep(300)
+
+        var i = 0
+        var srch = z1_MovieSearch.state.toString.toUpperCase
+        logInfo("kaleidescape.search","Searching for: " + srch)
+
+        while (i < (srch.length)) {
+            kactions.sendKCommand("KEYBOARD_CHARACTER:" + srch.charAt(i).toString)
+            Thread::sleep(100)
+            i++
+        }
+    }
 end
 ```

--- a/bundles/org.openhab.binding.tivo/README.md
+++ b/bundles/org.openhab.binding.tivo/README.md
@@ -203,7 +203,7 @@ rule "TiVo Search"
 when
     Item TiVo_KeyboardStr received update
 then
-    if (TiVo_KeyboardStr.state != NULL && TiVo_KeyboardStr.state.toString.length > 0) {
+    if (newState != NULL && newState.toString.length > 0) {
 
         // Command to get us to the TiVo search menu
         sendCommand(TiVo_MenuScreen, "SEARCH")
@@ -211,7 +211,7 @@ then
 
         var i = 0
         var char txt = ""
-        var srch = TiVo_KeyboardStr.state.toString.toUpperCase
+        var srch = newState.toString.toUpperCase
         logInfo("tivo.search"," Searching for: " + srch)
 
         while (i < (srch.length)) {

--- a/bundles/org.openhab.binding.tivo/README.md
+++ b/bundles/org.openhab.binding.tivo/README.md
@@ -142,7 +142,6 @@ Number      TiVo_Recording      "Recording        [MAP(tivo.map):rec-%s]" {chann
 String      TiVo_IRCmd          "Ir Cmd"          {channel="tivo:sckt:Living_Room:irCommand", autoupdate="false"}
 String      TiVo_KbdCmd         "Keyboard Cmd"    {channel="tivo:sckt:Living_Room:kbdCommand", autoupdate="false"}
 String      TiVo_KeyboardStr    "Search String"
-Switch      TiVo_Search         "Search Demo"
 ```
 
 - The item `TiVo_SetChannelName` depends upon a valid `tivo.map` file to translate channel numbers to channel names. The openHAB **MAP** transformation service must also be installed.
@@ -166,7 +165,7 @@ sitemap tivo label="Tivo Central" {
         Switch      item=TiVo_IRCmd           label="Remote"       icon="screen"   mappings=["FIND_REMOTE"="Find Remote"]
         Switch      item=TiVo_IRCmd           label="Standby"      icon="screen"   mappings=["STANDBY"="Standby","TIVO"="Wake Up"]
         Text        item=TiVo_Status          label="Status"       icon="screen"
-        Switch      item=TiVo_Search          mappings=[ON="Search Demo"]
+        Input       item=TiVo_KeyboardStr     label="Search"       staticIcon=zoom inputHint="text"
     }
 }
 ```
@@ -197,20 +196,9 @@ etc...
 
 ### tivo.rules
 
-- This rule was used to overcome limitations within the HABpanel user interface at the moment when using transform/map functionality.
-
-- The following rule shows how a string change to the item `TiVo_KeyboardStr` is split into individual characters and sent to the TiVo. The method to send a keystroke multiple times is used to simulate rapid keystrokes required to achieve number based searched.
-
-- A simple custom template widget can be used within the HABpanel user interface for tablet-based searches. See [this discussion thread] (<https://community.openhab.org/t/tivo-1-1-protocol-new-binding-contribution/5572/21?u=andymb>).
+- The following rule shows how a string change to the item `TiVo_KeyboardStr` is split into individual characters and sent to the Tivo.
 
 ```java
-rule "TiVo Search Command"
-when
-  Item TiVo_Search received command
-then
-  TiVo_KeyboardStr.sendCommand("Evening News")
-end
-
 rule "TiVo Search"
 when
     Item TiVo_KeyboardStr received update
@@ -246,5 +234,4 @@ then
         }
     }
 end
-
 ```


### PR DESCRIPTION
Update the README for kaleidescape and tivo to provide example usages of the sitemap element type 'Input'. 