### PR TITLE
[milight] Fix for failing to increas animation speed

### DIFF
--- a/bundles/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBCWWWHandler.java
+++ b/bundles/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBCWWWHandler.java
@@ -84,6 +84,6 @@ public class MilightV6RGBCWWWHandler extends AbstractLedV6Handler {
 
     @Override
     public void changeSpeed(int relativeSpeed, MilightThingState state) {
-        sendNonRepeatable(4, relativeSpeed > 1 ? 3 : 4);
+        sendNonRepeatable(4, relativeSpeed == 1 ? 3 : 4);
     }
 }

--- a/bundles/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBWHandler.java
+++ b/bundles/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/handler/MilightV6RGBWHandler.java
@@ -77,6 +77,6 @@ public class MilightV6RGBWHandler extends AbstractLedV6Handler {
 
     @Override
     public void changeSpeed(int relativeSpeed, MilightThingState state) {
-        sendNonRepeatable(4, relativeSpeed > 1 ? 3 : 4);
+        sendNonRepeatable(4, relativeSpeed == 1 ? 3 : 4);
     }
 }


### PR DESCRIPTION
Sending a "INCREASE" to a dimmer-Item on "animation_speed_relative" decreases the animation Speed.
Caused by a wrong comparison in:
org\openhab\binding\milight\internal\handler\MilightV6RGBCWWWHandler.java: line 87,
org\openhab\binding\milight\internal\handler\MilightV6RGBWHandler.java line: 80
relative Speed cannot be greater than one, as it is called with the values -1 or 1 from handleCommand() inside AbstractLedHandler.java.

Fixes #8430 