### PR TITLE
[luxtronik] Add parameter for fixed heating return temperature

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/README.md
+++ b/bundles/org.openhab.binding.luxtronikheatpump/README.md
@@ -287,26 +287,27 @@ The following channels are holding read only values:
 The usage of the numbered channels above is currently unknown. If you are able to directly match one of the values to any value reported by your heat pump, feel free to report back on the forum, so we are able to give the channel a proper name instead.
 
 The following channels are also writable:
-| channel                                  | type               | advanced | description                          |
-|------------------------------------------|--------------------|----------|--------------------------------------|
-| temperatureHeatingParallelShift          | Number:Temperature |          | Heating temperature (parallel shift) |
-| temperatureHotWaterTarget                | Number:Temperature |          | Hot water target temperature         |
-| heatingMode                              | Number             |          | Heating mode                         |
-| hotWaterMode                             | Number             |          | Hot water operating mode             |
-| thermalDisinfectionMonday                | Switch             | x        | Thermal disinfection (Monday)        |
-| thermalDisinfectionTuesday               | Switch             | x        | Thermal disinfection (Tuesday)       |
-| thermalDisinfectionWednesday             | Switch             | x        | Thermal disinfection (Wednesday)     |
-| thermalDisinfectionThursday              | Switch             | x        | Thermal disinfection (Thursday)      |
-| thermalDisinfectionFriday                | Switch             | x        | Thermal disinfection (Friday)        |
-| thermalDisinfectionSaturday              | Switch             | x        | Thermal disinfection (Saturday)      |
-| thermalDisinfectionSunday                | Switch             | x        | Thermal disinfection (Sunday)        |
-| thermalDisinfectionPermanent             | Switch             | x        | Thermal disinfection (Permanent)     |
-| comfortCoolingMode                       | Number             |          | Comfort cooling mode                 |
-| temperatureComfortCoolingATRelease       | Number:Temperature |          | Comfort cooling AT release           |
-| temperatureComfortCoolingATReleaseTarget | Number:Temperature |          | Comfort cooling AT release target    |
-| temperatureHeatingLimit                  | Number:Temperature |          | Temperature Heating Limit            |
-| comfortCoolingATExcess                   | Number:Time        |          | AT Excess                            |
-| comfortCoolingATUndercut                 | Number:Time        |          | AT undercut                          |
+| channel                                  | type               | advanced | description                                                                       |
+|------------------------------------------|--------------------|----------|-----------------------------------------------------------------------------------|
+| temperatureHeatingParallelShift          | Number:Temperature |          | Heating temperature (parallel shift)                                              |
+| temperatureHotWaterTarget                | Number:Temperature |          | Hot water target temperature                                                      |
+| temperatureHeatingFixReturn              | Number:Temperature |          | Fix return target temperature if heat pump is operating in fixed temperature mode |
+| heatingMode                              | Number             |          | Heating mode                                                                      |
+| hotWaterMode                             | Number             |          | Hot water operating mode                                                          |
+| thermalDisinfectionMonday                | Switch             | x        | Thermal disinfection (Monday)                                                     |
+| thermalDisinfectionTuesday               | Switch             | x        | Thermal disinfection (Tuesday)                                                    |
+| thermalDisinfectionWednesday             | Switch             | x        | Thermal disinfection (Wednesday)                                                  |
+| thermalDisinfectionThursday              | Switch             | x        | Thermal disinfection (Thursday)                                                   |
+| thermalDisinfectionFriday                | Switch             | x        | Thermal disinfection (Friday)                                                     |
+| thermalDisinfectionSaturday              | Switch             | x        | Thermal disinfection (Saturday)                                                   |
+| thermalDisinfectionSunday                | Switch             | x        | Thermal disinfection (Sunday)                                                     |
+| thermalDisinfectionPermanent             | Switch             | x        | Thermal disinfection (Permanent)                                                  |
+| comfortCoolingMode                       | Number             |          | Comfort cooling mode                                                              |
+| temperatureComfortCoolingATRelease       | Number:Temperature |          | Comfort cooling AT release                                                        |
+| temperatureComfortCoolingATReleaseTarget | Number:Temperature |          | Comfort cooling AT release target                                                 |
+| temperatureHeatingLimit                  | Number:Temperature |          | Temperature Heating Limit                                                         |
+| comfortCoolingATExcess                   | Number:Time        |          | AT Excess                                                                         |
+| comfortCoolingATUndercut                 | Number:Time        |          | AT undercut                                                                       |
 
 ## Example
 
@@ -368,4 +369,4 @@ This binding was initially based on the [Novelan/Luxtronik Heat Pump Binding](ht
 Luxtronik control units have an internal webserver which serves a Java applet. This applet can be used to configure some parts of the heat pump. The applet itselves uses a socket connection to fetch and send data to the heatpump.
 This socket is also used by this binding. To get some more information on how this socket works you can check out other Luxtronik tools like [Luxtronik2 for NodeJS](https://github.com/coolchip/luxtronik2).
 
-A detailed parameter descriptions for the Java Webinterface can be found in the [Loxwiki](https://loxwiki.atlassian.net/wiki/spaces/LOX/pages/1533935933/Java+Webinterface)
+A detailed parameter description for the Java Webinterface can be found in the [Loxwiki](https://loxwiki.atlassian.net/wiki/spaces/LOX/pages/1533935933/Java+Webinterface)

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
@@ -159,6 +159,7 @@ public class LuxtronikHeatpumpHandler extends BaseThingHandler {
                 break;
             case CHANNEL_EINST_WK_AKT:
             case CHANNEL_EINST_BWS_AKT:
+            case CHANNEL_EINST_HZ_FIX:
             case CHANNEL_EINST_KUCFTL_AKT:
             case CHANNEL_SOLLWERT_KUCFTL_AKT:
             case CHANNEL_SOLL_BWS_AKT:

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
@@ -1258,6 +1258,13 @@ public enum HeatpumpChannel {
      */
     CHANNEL_BA_BW_AKT(4, "hotWaterMode", NumberItem.class, null, true, HeatpumpVisibility.BRAUWASSER),
 
+   /**
+     * Target heating return temperature if heat pump is set to fixed temperature
+     * (will directly set the target return temperature, no automatic changes depending on outside temperature)
+     * (original: Rücklauf FestwerteHK)
+     */
+    CHANNEL_EINST_HZ_FIX(17, "temperatureHeatingFixReturn", NumberItem.class, SIUnits.CELSIUS, true, HeatpumpVisibility.HEIZUNG),
+
     /**
      * Thermal disinfection (Monday)
      * (original: Thermische Desinfektion (Montag))

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
@@ -1258,12 +1258,13 @@ public enum HeatpumpChannel {
      */
     CHANNEL_BA_BW_AKT(4, "hotWaterMode", NumberItem.class, null, true, HeatpumpVisibility.BRAUWASSER),
 
-   /**
+    /**
      * Target heating return temperature if heat pump is set to fixed temperature
      * (will directly set the target return temperature, no automatic changes depending on outside temperature)
      * (original: Rücklauf FestwerteHK)
      */
-    CHANNEL_EINST_HZ_FIX(17, "temperatureHeatingFixReturn", NumberItem.class, SIUnits.CELSIUS, true, HeatpumpVisibility.HEIZUNG),
+    CHANNEL_EINST_HZ_FIX(17, "temperatureHeatingFixReturn", NumberItem.class, SIUnits.CELSIUS, true, 
+            HeatpumpVisibility.HEIZUNG),
 
     /**
      * Thermal disinfection (Monday)

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump.properties
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump.properties
@@ -240,6 +240,7 @@ channel-type.luxtronikheatpump.temperatureCondensation.label = Condensation Temp
 channel-type.luxtronikheatpump.temperatureExhaustAir.label = Exhaust Air Temp.
 channel-type.luxtronikheatpump.temperatureExternalEnergySource.label = Sensor Ext. Energy Source
 channel-type.luxtronikheatpump.temperatureFlowTarget.label = Temp. Flow Target
+channel-type.luxtronikheatpump.temperatureHeatingFixReturn.label = Fixed Heating Target Return Temperature
 channel-type.luxtronikheatpump.temperatureHeatSourceInlet.label = Heat Source Inlet Temp.
 channel-type.luxtronikheatpump.temperatureHeatSourceInlet2.label = Temp. Sensor Heat Source Inlet 2
 channel-type.luxtronikheatpump.temperatureHeatSourceOutlet.label = Heat Source Outlet Temp.

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump_de.properties
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump_de.properties
@@ -240,6 +240,7 @@ channel-type.luxtronikheatpump.temperatureCondensation.label = Kondensationstemp
 channel-type.luxtronikheatpump.temperatureExhaustAir.label = Ablufttemp.
 channel-type.luxtronikheatpump.temperatureExternalEnergySource.label = Fühler externe Energiequelle
 channel-type.luxtronikheatpump.temperatureFlowTarget.label = Temp. Vorlauf Soll
+channel-type.luxtronikheatpump.temperatureHeatingFixReturn.label = Feste Rücklaufvorgabe Heizen
 channel-type.luxtronikheatpump.temperatureHeatSourceInlet.label = Wärmequellen-Eintrittstemp.
 channel-type.luxtronikheatpump.temperatureHeatSourceInlet2.label = Temp.-Fühler Wärmequelleneintritt 2
 channel-type.luxtronikheatpump.temperatureHeatSourceOutlet.label = Wärmequellen-Austrittstemp.


### PR DESCRIPTION
I run my Apha Innotec LWC heat pump in fixed temperature mode, so I can directly control the target heating return temperature via openHAB (higher temperature if solar is generating enough power, etc.). Currently upgrading from OH2, where I had made private changes to the addon, so maybe we can add this to the standard code.