### PR TITLE
[smartmeter] Prevent NumberFormatException

### DIFF
--- a/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/conformity/negate/NegateHandler.java
+++ b/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/conformity/negate/NegateHandler.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartmeter.internal.MeterValue;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class NegateHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NegateHandler.class);
 
     /**
      * Gets whether negation should be applied for the given <code>negateProperty</code> and the {@link MeterValue}
@@ -73,8 +75,7 @@ public class NegateHandler {
         try {
             longValue = format.parse(value).longValue();
         } catch (ParseException e) {
-            LoggerFactory.getLogger(NegateHandler.class)
-                    .warn("Failed to parse value: {} when determining isNegateSet, assuming false", value);
+            LOGGER.warn("Failed to parse value: {} when determining isNegateSet, assuming false", value);
             return false;
         }
         return (longValue & (1L << negatePosition)) != 0;

--- a/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/conformity/negate/NegateHandler.java
+++ b/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/conformity/negate/NegateHandler.java
@@ -12,11 +12,15 @@
  */
 package org.openhab.binding.smartmeter.internal.conformity.negate;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.smartmeter.internal.MeterValue;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the Negate Bit property for a specific meter value.
@@ -64,7 +68,15 @@ public class NegateHandler {
      * @return Whether the given bit is set or not
      */
     public static boolean isNegateSet(String value, int negatePosition) {
-        long longValue = Long.parseLong(value);
+        NumberFormat format = NumberFormat.getInstance(Locale.getDefault());
+        long longValue = 0;
+        try {
+            longValue = format.parse(value).longValue();
+        } catch (ParseException e) {
+            LoggerFactory.getLogger(NegateHandler.class)
+                    .warn("Failed to parse value: {} when determining isNegateSet, assuming false", value);
+            return false;
+        }
         return (longValue & (1L << negatePosition)) != 0;
     }
 }

--- a/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/conformity/negate/NegateHandler.java
+++ b/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/conformity/negate/NegateHandler.java
@@ -12,9 +12,6 @@
  */
 package org.openhab.binding.smartmeter.internal.conformity.negate;
 
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.util.Locale;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -70,11 +67,10 @@ public class NegateHandler {
      * @return Whether the given bit is set or not
      */
     public static boolean isNegateSet(String value, int negatePosition) {
-        NumberFormat format = NumberFormat.getInstance(Locale.getDefault());
         long longValue = 0;
         try {
-            longValue = format.parse(value).longValue();
-        } catch (ParseException e) {
+            longValue = (long) Double.parseDouble(value);
+        } catch (NumberFormatException e) {
             LOGGER.warn("Failed to parse value: {} when determining isNegateSet, assuming false", value);
             return false;
         }

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
@@ -54,11 +54,6 @@ public class TestNegateBit {
                 obis -> new MeterValue<>(obis, "49.0", null));
 
         assertTrue(negateStateDot);
-
-        boolean negateStateComma = NegateHandler.shouldNegateState(negateProperty,
-                obis -> new MeterValue<>(obis, "49,0", null));
-
-        assertTrue(negateStateComma);
     }
 
     @Test

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
@@ -47,6 +47,21 @@ public class TestNegateBit {
     }
 
     @Test
+    public void testNegateHandlingDecimalTrue() {
+        String negateProperty = "1-0_16-7-0:31:0";
+
+        boolean negateStateDot = NegateHandler.shouldNegateState(negateProperty,
+                obis -> new MeterValue<>(obis, "49.0", null));
+
+        assertTrue(negateStateDot);
+
+        boolean negateStateComma = NegateHandler.shouldNegateState(negateProperty,
+                obis -> new MeterValue<>(obis, "49,0", null));
+
+        assertTrue(negateStateComma);
+    }
+
+    @Test
     public void testNegateHandlingFalse() {
         String negateProperty = "1-0_1-8-0:5:1";
 


### PR DESCRIPTION
- Fixes #11029 by handling the way string values are converted to long. 
- Adds test to prevent regression