### PR TITLE
[chromecast] Update protobuf from 2.6.0 to protobuf-javalite 3.25.1

### DIFF
--- a/bundles/org.openhab.binding.chromecast/NOTICE
+++ b/bundles/org.openhab.binding.chromecast/NOTICE
@@ -21,5 +21,5 @@ protobuf-java
 
 chromecast-java-api-v2
 * License: Apache 2.0 License
-* Project: https://github.com/de.sfuhrm/chromecast-java-api-v2
-* Source: https://github.com/de.sfuhrm/chromecast-java-api-v2
+* Project: https://github.com/sfuhrm/chromecast-java-api-v2
+* Source: https://github.com/sfuhrm/chromecast-java-api-v2

--- a/bundles/org.openhab.binding.chromecast/NOTICE
+++ b/bundles/org.openhab.binding.chromecast/NOTICE
@@ -21,5 +21,5 @@ protobuf-java
 
 chromecast-java-api-v2
 * License: Apache 2.0 License
-* Project: https://github.com/vitalidze/chromecast-java-api-v2
-* Source: https://github.com/vitalidze/chromecast-java-api-v2
+* Project: https://github.com/de.sfuhrm/chromecast-java-api-v2
+* Source: https://github.com/de.sfuhrm/chromecast-java-api-v2

--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
+      <artifactId>protobuf-javalite</artifactId>
       <version>3.25.1</version>
       <scope>compile</scope>
     </dependency>

--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -20,9 +20,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>su.litvak.chromecast</groupId>
-      <artifactId>api-v2</artifactId>
-      <version>0.11.3</version>
+      <groupId>de.sfuhrm</groupId>
+      <artifactId>chromecast-java-api-v2</artifactId>
+      <version>0.12.3</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.6.0</version>
+      <version>3.25.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Protobuf library 2.6.0 has known issues and causes security warnings.

Try to update protobuf to a more recent release (which does not issue update warnings).
*Not sure if this works.*

@wborn You offered to do some testing on the forum, so maybe you could give it a try.