### PR TITLE
[energidataservice] Remove obsoleted advanced channel `hourly-prices`

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/EnergiDataServiceBindingConstants.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/EnergiDataServiceBindingConstants.java
@@ -52,12 +52,10 @@ public class EnergiDataServiceBindingConstants {
             + ChannelUID.CHANNEL_GROUP_SEPARATOR + "reduced-electricity-tax";
     public static final String CHANNEL_TRANSMISSION_GRID_TARIFF = CHANNEL_GROUP_ELECTRICITY
             + ChannelUID.CHANNEL_GROUP_SEPARATOR + "transmission-grid-tariff";
-    public static final String CHANNEL_HOURLY_PRICES = CHANNEL_GROUP_ELECTRICITY + ChannelUID.CHANNEL_GROUP_SEPARATOR
-            + "hourly-prices";
 
     public static final Set<String> ELECTRICITY_CHANNELS = Set.of(CHANNEL_SPOT_PRICE, CHANNEL_GRID_TARIFF,
             CHANNEL_SYSTEM_TARIFF, CHANNEL_TRANSMISSION_GRID_TARIFF, CHANNEL_ELECTRICITY_TAX,
-            CHANNEL_REDUCED_ELECTRICITY_TAX, CHANNEL_HOURLY_PRICES);
+            CHANNEL_REDUCED_ELECTRICITY_TAX);
 
     // List of all properties
     public static final String PROPERTY_REMAINING_CALLS = "remainingCalls";

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -60,7 +60,6 @@ import org.openhab.binding.energidataservice.internal.retry.RetryStrategy;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
-import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.CurrencyUnits;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -77,8 +76,6 @@ import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-
 /**
  * The {@link EnergiDataServiceHandler} is responsible for handling commands, which are
  * sent to one of the channels.
@@ -92,18 +89,11 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
     private final TimeZoneProvider timeZoneProvider;
     private final ApiController apiController;
     private final CacheManager cacheManager;
-    private final Gson gson = new Gson();
 
     private EnergiDataServiceConfiguration config;
     private RetryStrategy retryPolicy = RetryPolicyFactory.initial();
     private @Nullable ScheduledFuture<?> refreshFuture;
     private @Nullable ScheduledFuture<?> priceUpdateFuture;
-
-    private record Price(String hourStart, BigDecimal spotPrice, String spotPriceCurrency,
-            @Nullable BigDecimal gridTariff, @Nullable BigDecimal systemTariff,
-            @Nullable BigDecimal transmissionGridTariff, @Nullable BigDecimal electricityTax,
-            @Nullable BigDecimal reducedElectricityTax) {
-    }
 
     public EnergiDataServiceHandler(Thing thing, HttpClient httpClient, TimeZoneProvider timeZoneProvider) {
         super(thing);
@@ -177,12 +167,12 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
     private void refreshElectricityPrices() {
         RetryStrategy retryPolicy;
         try {
-            if (isLinked(CHANNEL_SPOT_PRICE) || isLinked(CHANNEL_HOURLY_PRICES)) {
+            if (isLinked(CHANNEL_SPOT_PRICE)) {
                 downloadSpotPrices();
             }
 
             for (DatahubTariff datahubTariff : DatahubTariff.values()) {
-                if (isLinked(datahubTariff.getChannelId()) || isLinked(CHANNEL_HOURLY_PRICES)) {
+                if (isLinked(datahubTariff.getChannelId())) {
                     downloadTariffs(datahubTariff);
                 }
             }
@@ -191,7 +181,7 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
             updatePrices();
             updateTimeSeries();
 
-            if (isLinked(CHANNEL_SPOT_PRICE) || isLinked(CHANNEL_HOURLY_PRICES)) {
+            if (isLinked(CHANNEL_SPOT_PRICE)) {
                 if (cacheManager.getNumberOfFutureSpotPrices() < 13) {
                     retryPolicy = RetryPolicyFactory.whenExpectedSpotPriceDataMissing(DAILY_REFRESH_TIME_CET,
                             NORD_POOL_TIMEZONE);
@@ -315,7 +305,6 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
         updateCurrentSpotPrice();
         Arrays.stream(DatahubTariff.values())
                 .forEach(tariff -> updateCurrentTariff(tariff.getChannelId(), cacheManager.getTariff(tariff)));
-        updateHourlyPrices();
 
         reschedulePriceUpdateJob();
     }
@@ -352,30 +341,6 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
             logger.debug("Unable to create QuantityType, falling back to DecimalType", e);
             return new DecimalType(price);
         }
-    }
-
-    private void updateHourlyPrices() {
-        if (!isLinked(CHANNEL_HOURLY_PRICES)) {
-            return;
-        }
-        Map<Instant, BigDecimal> spotPriceMap = cacheManager.getSpotPrices();
-        Price[] targetPrices = new Price[spotPriceMap.size()];
-        List<Entry<Instant, BigDecimal>> sourcePrices = spotPriceMap.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey()).toList();
-
-        int i = 0;
-        for (Entry<Instant, BigDecimal> sourcePrice : sourcePrices) {
-            Instant hourStart = sourcePrice.getKey();
-            BigDecimal gridTariff = cacheManager.getTariff(DatahubTariff.GRID_TARIFF, hourStart);
-            BigDecimal systemTariff = cacheManager.getTariff(DatahubTariff.SYSTEM_TARIFF, hourStart);
-            BigDecimal transmissionGridTariff = cacheManager.getTariff(DatahubTariff.TRANSMISSION_GRID_TARIFF,
-                    hourStart);
-            BigDecimal electricityTax = cacheManager.getTariff(DatahubTariff.ELECTRICITY_TAX, hourStart);
-            BigDecimal reducedElectricityTax = cacheManager.getTariff(DatahubTariff.REDUCED_ELECTRICITY_TAX, hourStart);
-            targetPrices[i++] = new Price(hourStart.toString(), sourcePrice.getValue(), config.currencyCode, gridTariff,
-                    systemTariff, electricityTax, reducedElectricityTax, transmissionGridTariff);
-        }
-        updateState(CHANNEL_HOURLY_PRICES, new StringType(gson.toJson(targetPrices)));
     }
 
     private void updateTimeSeries() {

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
@@ -75,8 +75,6 @@ channel-group-type.energidataservice.electricity.channel.transmission-grid-tarif
 
 channel-type.energidataservice.datahub-price.label = Datahub Price
 channel-type.energidataservice.datahub-price.description = Datahub price.
-channel-type.energidataservice.hourly-prices.label = Hourly Prices
-channel-type.energidataservice.hourly-prices.description = JSON array with hourly prices from 24 hours ago and onward.
 channel-type.energidataservice.spot-price.label = Spot Price
 channel-type.energidataservice.spot-price.description = Spot price.
 

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-groups.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-groups.xml
@@ -32,7 +32,6 @@
 				<label>Reduced Electricity Tax</label>
 				<description>Reduced electricity tax in DKK per kWh. For electric heating customers only.</description>
 			</channel>
-			<channel id="hourly-prices" typeId="hourly-prices"/>
 		</channels>
 	</channel-group-type>
 

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-types.xml
@@ -21,12 +21,4 @@
 		<config-description-ref uri="channel-type:energidataservice:datahub-price"/>
 	</channel-type>
 
-	<channel-type id="hourly-prices" advanced="true">
-		<item-type>String</item-type>
-		<label>Hourly Prices</label>
-		<description>JSON array with hourly prices from 24 hours ago and onward.</description>
-		<category>Price</category>
-		<state readOnly="true"></state>
-	</channel-type>
-
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/thing-service.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/thing-service.xml
@@ -14,7 +14,7 @@
 		</channel-groups>
 
 		<properties>
-			<property name="thingTypeVersion">3</property>
+			<property name="thingTypeVersion">4</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:energidataservice:service"/>

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/update/instructions.xml
@@ -61,6 +61,10 @@
 			</update-channel>
 		</instruction-set>
 
+		<instruction-set targetVersion="4">
+			<remove-channel id="hourly-prices" groupIds="electricity"/>
+		</instruction-set>
+
 	</thing-type>
 
 </update:update-descriptions>


### PR DESCRIPTION
With the introduction of openhab/openhab-core#3597 and #15063 in openHAB 4.1, the advanced channel `hourly-prices` is now fully obsoleted.

It was already possible to use binding-specific Thing actions for importing future prices into rules, but since 4.1.1 it's also possible to access future prices through [in-memory persistence](https://www.openhab.org/addons/persistence/inmemory/), i.e. persisted time series.

Therefore, the binding can be simplified by removing this channel.