### PR TITLE
[systeminfo] Bump OSHI to 6.4.8

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/org.openhab.binding.systeminfo/pom.xml
@@ -14,27 +14,11 @@
 
   <name>openHAB Add-ons :: Bundles :: Systeminfo Binding</name>
 
-  <properties>
-    <dep.noembedding>jna,jna-platform</dep.noembedding>
-  </properties>
-
   <dependencies>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna-platform</artifactId>
-      <version>5.12.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>5.12.1</version>
-      <scope>compile</scope>
-    </dependency>
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>6.2.2</version>
+      <version>6.4.8</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
@@ -4,9 +4,7 @@
 
 	<feature name="openhab-binding-systeminfo" description="System Info Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:net.java.dev.jna/jna/5.12.1</bundle>
-		<bundle dependency="true">mvn:net.java.dev.jna/jna-platform/5.12.1</bundle>
-		<bundle dependency="true">mvn:com.github.oshi/oshi-core/6.2.2</bundle>
+		<bundle dependency="true">mvn:com.github.oshi/oshi-core/6.4.8</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.systeminfo/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
This is the latest OSHI version that is compatible with the Karaf provided JNA 5.13.0