### PR TITLE
Remove openhab-transport-http feature dependencies

### DIFF
--- a/bundles/org.openhab.binding.bosesoundtouch/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bosesoundtouch/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-bosesoundtouch" description="Bose SoundTouch Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bosesoundtouch/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.deconz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-deconz" description="deCONZ Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<feature>openhab-transport-upnp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.deconz/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.evohome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.evohome/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-evohome" description="Evohome Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.evohome/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.hyperion/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hyperion/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-binding-hyperion" description="Hyperion Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-mdns</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hyperion/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.jablotron/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.jablotron/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-jablotron" description="Jablotron Alarm Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.jablotron/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.kodi/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.kodi/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-kodi" description="Kodi Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<feature>openhab-transport-upnp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.kodi/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.konnected/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-konnected" description="Konnected Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<feature>openhab-transport-upnp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.konnected/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-livisismarthome" description="LIVISI SmartHome Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.livisismarthome/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.mycroft/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mycroft/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-mycroft" description="mycroft Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mycroft/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.nuki/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-nuki" description="Nuki Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.nuki/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.somfytahoma/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-somfytahoma" description="Somfy Tahoma Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.somfytahoma/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.spotify/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-spotify" description="Spotify Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.spotify/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.vektiva/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.vektiva/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-vektiva" description="Vektiva Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-http</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.vektiva/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
The openhab-transport-http feature dependency is redundant since OH 2.3 when it was added to the openhab-runtime-base feature dependencies.

See:

* https://github.com/openhab/openhab-core/pull/344
* https://github.com/openhab/openhab-addons/pull/16181#issuecomment-1876015592