### PR TITLE
Remove redundant feature dependencies

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-androiddebugbridge" description="Android Debug Bridge Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.androiddebugbridge/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.androidtv/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.androidtv/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-androidtv" description="AndroidTV Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.androidtv/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-upnp</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.avmfritz/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.bosesoundtouch/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bosesoundtouch/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-bosesoundtouch" description="Bose SoundTouch Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bosesoundtouch/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.broadlinkthermostat/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.broadlinkthermostat/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-broadlinkthermostat" description="Broadlink Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.broadlinkthermostat/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.chromecast/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.chromecast/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-chromecast" description="Chromecast Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.chromecast/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.chromecast/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.chromecast/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-chromecast" description="Chromecast Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.chromecast/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.denonmarantz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-denonmarantz" description="Denon / Marantz Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.denonmarantz/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.denonmarantz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-denonmarantz" description="Denon / Marantz Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.denonmarantz/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.digitalstrom/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-digitalstrom" description="digitalSTROM Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.digitalstrom/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.dlinksmarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-dlinksmarthome" description="D-Link Smart Home Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<feature dependency="true">openhab.tp-jaxws</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.dlinksmarthome/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.freebox/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.freebox/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-freebox" description="Freebox Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.freebox/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.freeboxos/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.freeboxos/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-freeboxos" description="Freebox OS Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.freeboxos/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.groheondus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-groheondus" description="GROHE ONDUS Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.groheondus/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.hpprinter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hpprinter/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-hpprinter" description="HP Printer Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hpprinter/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.hue/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hue/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-hue" description="Hue Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<feature>openhab-transport-upnp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hue/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.hyperion/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hyperion/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-hyperion" description="Hyperion Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hyperion/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.icalendar/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.icalendar/src/main/feature/feature.xml
@@ -3,7 +3,6 @@
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 	<feature name="openhab-binding-icalendar" description="iCalendar Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.icalendar/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.ipcamera/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/feature/feature.xml
@@ -3,7 +3,6 @@
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 	<feature name="openhab-binding-ipcamera" description="ipcamera Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<feature dependency="true">openhab.tp-netty</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.ipcamera/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.ipp/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ipp/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-ipp" description="IPP Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.ipp/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.km200/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.km200/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-km200" description="KM200 Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.km200/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.miio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.miio/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-miio" description="Xiaomi Wifi devices (Mi IO) Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.miio/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.minecraft/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.minecraft/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-minecraft" description="Minecraft Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.minecraft/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.nanoleaf/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-nanoleaf" description="Nanoleaf Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.nanoleaf/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.network/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.network/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-network" description="Network Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-core-model-script</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.network/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.binding.plex/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.plex/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-plex" description="Plex Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.plex/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.pulseaudio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-pulseaudio" description="Pulseaudio Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<feature>openhab-transport-upnp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.pulseaudio/${project.version}</bundle>
 		<bundle dependency="true">mvn:com.googlecode.soundlibs/tritonus-share/0.3.7.4</bundle>

--- a/bundles/org.openhab.binding.shelly/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-binding-shelly" description="Shelly Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-coap</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.shelly/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
@@ -6,7 +6,6 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
 		<feature dependency="true">openhab.tp-netty</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle dependency="true">mvn:net.java.dev.jna/jna/4.5.2</bundle>
 		<bundle dependency="true">mvn:net.java.dev.jna/jna-platform/4.5.2</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.2.1/1.2.1_3</bundle>

--- a/bundles/org.openhab.binding.tivo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tivo/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-tivo" description="TiVo Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.tivo/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.tr064/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/feature/feature.xml
@@ -4,8 +4,6 @@
 
 	<feature name="openhab-binding-tr064" description="TR-064 Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<requirement>openhab.tp;filter:="(feature=jaxb)"</requirement>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<requirement>openhab.tp;filter:="(feature=jax-ws)"</requirement>
 		<feature dependency="true">openhab.tp-jaxws</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.tr064/${project.version}</bundle>

--- a/bundles/org.openhab.binding.tradfri/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tradfri/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-binding-tradfri" description="TRÅDFRI Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-coap</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.tradfri/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.vizio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.vizio/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-vizio" description="Vizio Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.vizio/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.webthing/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.webthing/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-webthing" description="WebThing Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.webthing/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.xmltv/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmltv/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-xmltv" description="XMLTV Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jaxb</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.xmltv/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.io.homekit/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.homekit/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-misc-homekit" description="HomeKit Integration" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-transport-mdns</feature>
 		<feature>openhab.tp-netty</feature>
 		<bundle dependency="true">mvn:org.glassfish/javax.json/1.0.4</bundle>
 		<bundle dependency="true">mvn:javax.json/javax.json-api/1.0</bundle>

--- a/bundles/org.openhab.io.metrics/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.metrics/src/main/feature/feature.xml
@@ -4,8 +4,6 @@
 
 	<feature name="openhab-misc-metrics" description="Metrics Service" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature>openhab-core-model-item</feature>
-		<feature>openhab-core-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.io.metrics/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-transformation-jinja" description="Jinja Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true">mvn:org.jsoup/jsoup/1.15.3</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>
 		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.jinja/${project.version}</bundle>

--- a/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-voice-pollytts" description="Polly Text-to-Speech" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.9</bundle>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.5</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.amazonaws.aws-java-sdk-core/1.12.626</bundle>


### PR DESCRIPTION
The following features are already dependencies of openhab-runtime-base:

* openhab-core-base
* openhab-core-model-item
* openhab-core-model-script
* openhab-transport-mdns
* openhab.tp-jackson
* openhab.tp-jaxb

See also: https://github.com/openhab/openhab-addons/pull/16202#issuecomment-1876875456