### PR TITLE
[roku] Improve TV discovery model name and add timeout

### DIFF
--- a/bundles/org.openhab.binding.roku/README.md
+++ b/bundles/org.openhab.binding.roku/README.md
@@ -54,7 +54,7 @@ The following channels are available:
 
 Some Notes:
 
-- The values for `activeApp`, `playMode`, `timeElapsed`, `timeTotal`, `activeChannel`, `signalMode`, `signalQuality`, `channelName`, `programTitle`, `programDescription` & `programRating` refresh automatically per the configured `refresh` interval (10 seconds minimum).
+- The values for `activeApp`, `playMode`, `timeElapsed`, `timeTotal`, `activeChannel`, `signalMode`, `signalQuality`, `channelName`, `programTitle`, `programDescription` & `programRating` refresh automatically per the configured `refresh` interval.
 
 **List of available button commands for Roku streaming devices:**  
 Home  
@@ -109,7 +109,7 @@ roku:roku_tv:mytv1 "My Roku TV" [ hostName="192.168.10.1", refresh=10 ]
 
 String Player_ActiveApp        "Current App: [%s]"         { channel="roku:roku_player:myplayer1:activeApp" }
 String Player_ActiveAppName    "Current App Name: [%s]"    { channel="roku:roku_player:myplayer1:activeAppName" }
-String Player_Button           "Send Command to Roku"      { channel="roku:roku_player:myplayer1:button" }
+String Player_Button           "Send Command to Roku"      { channel="roku:roku_player:myplayer1:button", autoupdate="false" }
 Player Player_Control          "Control"                   { channel="roku:roku_player:myplayer1:control" }
 String Player_PlayMode         "Status: [%s]"              { channel="roku:roku_player:myplayer1:playMode" }
 Number:Time Player_TimeElapsed "Elapsed Time: [%d %unit%]" { channel="roku:roku_player:myplayer1:timeElapsed" }
@@ -117,9 +117,11 @@ Number:Time Player_TimeTotal   "Total Time: [%d %unit%]"   { channel="roku:roku_
 
 // Roku TV items:
 
+Switch Player_Power              "Power: [%s]"               { channel="roku:roku_tv:mytv1:power" }
+String Player_PowerState         "Power State: [%s]          { channel="roku:roku_tv:mytv1:powerState" }
 String Player_ActiveApp          "Current App: [%s]"         { channel="roku:roku_tv:mytv1:activeApp" }
 String Player_ActiveAppName      "Current App Name: [%s]"    { channel="roku:roku_tv:mytv1:activeAppName" }
-String Player_Button             "Send Command to Roku"      { channel="roku:roku_tv:mytv1:button" }
+String Player_Button             "Send Command to Roku"      { channel="roku:roku_tv:mytv1:button", autoupdate="false" }
 Player Player_Control            "Control"                   { channel="roku:roku_tv:mytv1:control" }
 String Player_PlayMode           "Status: [%s]"              { channel="roku:roku_tv:mytv1:playMode" }
 Number:Time Player_TimeElapsed   "Elapsed Time: [%d %unit%]" { channel="roku:roku_tv:mytv1:timeElapsed" }
@@ -131,9 +133,6 @@ String Player_ChannelName        "Channel Name: [%s]"        { channel="roku:rok
 String Player_ProgramTitle       "Program Title: [%s]"       { channel="roku:roku_tv:mytv1:programTitle" }
 String Player_ProgramDescription "Program Description: [%s]" { channel="roku:roku_tv:mytv1:programDescription" }
 String Player_ProgramRating      "Program Rating: [%s]"      { channel="roku:roku_tv:mytv1:programRating" }
-Switch Player_Power              "Power: [%s]"               { channel="roku:roku_tv:mytv1:power" }
-String Player_PowerState         "Power State: [%s]          { channel="roku:roku_tv:mytv1:powerState" }
-
 ```
 
 ### roku.sitemap:
@@ -149,6 +148,8 @@ sitemap roku label="Roku" {
         Text item=Player_TimeElapsed icon="time"
         Text item=Player_TimeTotal icon="time"
         // The following items apply to Roku TVs only
+        Switch item=Player_Power
+        Text item=Player_PowerState
         Selection item=Player_ActiveChannel icon="screen"
         Text item=Player_SignalMode
         Text item=Player_SignalQuality
@@ -156,8 +157,6 @@ sitemap roku label="Roku" {
         Text item=Player_ProgramTitle
         Text item=Player_ProgramDescription
         Text item=Player_ProgramRating
-        Switch item=Player_Power
-        Text item=Player_PowerState
     }
 }
 ```

--- a/bundles/org.openhab.binding.roku/README.md
+++ b/bundles/org.openhab.binding.roku/README.md
@@ -54,7 +54,7 @@ The following channels are available:
 
 Some Notes:
 
-- The values for `activeApp`, `playMode`, `timeElapsed`, `timeTotal`, `activeChannel`, `signalMode`, `signalQuality`, `channelName`, `programTitle`, `programDescription` & `programRating` refresh automatically per the configured `refresh` interval.
+- The values for `activeApp`, `activeAppName`, `playMode`, `timeElapsed`, `timeTotal`, `activeChannel`, `signalMode`, `signalQuality`, `channelName`, `programTitle`, `programDescription`, `programRating`, `power` & `powerState` refresh automatically per the configured `refresh` interval.
 
 **List of available button commands for Roku streaming devices:**  
 Home  

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
@@ -15,6 +15,7 @@ package org.openhab.binding.roku.internal.communication;
 import java.io.StringReader;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import javax.xml.bind.JAXBContext;
@@ -43,6 +44,8 @@ import org.openhab.binding.roku.internal.dto.TvChannels.Channel;
  */
 @NonNullByDefault
 public class RokuCommunicator {
+    private static final int REQUEST_TIMEOUT = 5000;
+
     private final HttpClient httpClient;
 
     private final String urlKeyPress;
@@ -265,7 +268,8 @@ public class RokuCommunicator {
      */
     private String getCommand(String url) throws RokuHttpException {
         try {
-            return httpClient.GET(url).getContentAsString();
+            return httpClient.newRequest(url).method(HttpMethod.GET).timeout(REQUEST_TIMEOUT, TimeUnit.MILLISECONDS)
+                    .send().getContentAsString();
         } catch (TimeoutException | ExecutionException e) {
             throw new RokuHttpException("Error executing GET command for URL: " + url, e);
         } catch (InterruptedException e) {
@@ -282,7 +286,7 @@ public class RokuCommunicator {
      */
     private void postCommand(String url) throws RokuHttpException {
         try {
-            httpClient.POST(url).method(HttpMethod.POST).send();
+            httpClient.POST(url).method(HttpMethod.POST).timeout(REQUEST_TIMEOUT, TimeUnit.MILLISECONDS).send();
         } catch (TimeoutException | ExecutionException e) {
             throw new RokuHttpException("Error executing POST command, URL: " + url, e);
         } catch (InterruptedException e) {

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/discovery/RokuDiscoveryService.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/discovery/RokuDiscoveryService.java
@@ -253,7 +253,8 @@ public class RokuDiscoveryService extends AbstractDiscoveryService {
         try {
             RokuCommunicator communicator = new RokuCommunicator(httpClient, host, port);
             DeviceInfo device = communicator.getDeviceInfo();
-            label = device.getModelName() + " " + device.getModelNumber();
+            label = (device.getFriendlyModelName() + " " + device.getModelNumber()).replaceAll("[^a-zA-Z0-9_\\.-]",
+                    " ");
             if (device.isTv()) {
                 thingUid = new ThingUID(THING_TYPE_ROKU_TV, uuid);
             }

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/discovery/RokuDiscoveryService.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/discovery/RokuDiscoveryService.java
@@ -253,8 +253,8 @@ public class RokuDiscoveryService extends AbstractDiscoveryService {
         try {
             RokuCommunicator communicator = new RokuCommunicator(httpClient, host, port);
             DeviceInfo device = communicator.getDeviceInfo();
-            label = (device.getFriendlyModelName() + " " + device.getModelNumber()).replaceAll("[^a-zA-Z0-9_\\.-]",
-                    " ");
+            label = (device.getFriendlyModelName() + " " + device.getUserDeviceLocation())
+                    .replaceAll("[^a-zA-Z0-9_\\.-]", " ");
             if (device.isTv()) {
                 thingUid = new ThingUID(THING_TYPE_ROKU_TV, uuid);
             }

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/discovery/RokuDiscoveryService.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/discovery/RokuDiscoveryService.java
@@ -253,8 +253,10 @@ public class RokuDiscoveryService extends AbstractDiscoveryService {
         try {
             RokuCommunicator communicator = new RokuCommunicator(httpClient, host, port);
             DeviceInfo device = communicator.getDeviceInfo();
+
+            // replace extraneous characters with spaces and remove any consecutive spaces
             label = (device.getFriendlyModelName() + " " + device.getUserDeviceLocation())
-                    .replaceAll("[^a-zA-Z0-9_\\.-]", " ");
+                    .replaceAll("[^a-zA-Z0-9\\-_]", " ").trim().replaceAll("  +", " ");
             if (device.isTv()) {
                 thingUid = new ThingUID(THING_TYPE_ROKU_TV, uuid);
             }

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -114,6 +114,7 @@ public class RokuHandler extends BaseThingHandler {
             thing.setProperty(PROPERTY_SERIAL_NUMBER, deviceInfo.getSerialNumber());
             thing.setProperty(PROPERTY_DEVICE_ID, deviceInfo.getDeviceId());
             thing.setProperty(PROPERTY_SOFTWARE_VERSION, deviceInfo.getSoftwareVersion());
+            thing.setProperty(PROPERTY_UUID, deviceInfo.getSerialNumber().toLowerCase());
             updateStatus(ThingStatus.ONLINE);
         } catch (RokuHttpException e) {
             logger.debug("Unable to retrieve Roku device-info. Exception: {}", e.getMessage(), e);


### PR DESCRIPTION
Improve the label that is given to the thing by the discovery process. Previously TV things were not easily identified as a Roku device by the model name provided by the API. The `friendly-model-name` and `user-device-location` fields are now combined to help the user identify the thing in case of duplicate devices in different rooms.  The strings are formatted to remove any extraneous characters as seen in the friendly-model-name example. 

![image](https://github.com/openhab/openhab-addons/assets/26532542/0fc5d977-a769-46d4-bb97-84f8253f7dd0)

Addresses #15797 by setting a timeout on http requests sent to the roku device. Previously if the device was to crash while an http request was in progress it could cause the binding to hang.

Addresses #16164 by setting the uuid property to prevent manually added things from appearing in the inbox.