### PR TITLE
[boschshc] Cache mDNS-based bridge discovery results

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BoschHttpClient.java
@@ -56,6 +56,16 @@ public class BoschHttpClient extends HttpClient {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
+    /**
+     * Default number of seconds for HTTP request timeouts
+     */
+    public static final long DEFAULT_TIMEOUT_SECONDS = 10;
+
+    /**
+     * The time unit used for default HTTP request timeouts
+     */
+    public static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
+
     private final String ipAddress;
     private final String systemPassword;
 
@@ -299,7 +309,7 @@ public class BoschHttpClient extends HttpClient {
 
         Request request = this.newRequest(url).method(method).header("Content-Type", "application/json")
                 .header("api-version", "3.2") // see https://github.com/BoschSmartHome/bosch-shc-api-docs/issues/80
-                .timeout(10, TimeUnit.SECONDS); // Set default timeout
+                .timeout(DEFAULT_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_UNIT); // Set default timeout
 
         if (content != null) {
             final String body;

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
@@ -57,8 +57,8 @@ import com.google.gson.Gson;
 @Component(configurationPid = "discovery.boschsmarthomebridge")
 public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
     private static final String NAME_PREFIX_BOSCH_SHC = "Bosch SHC";
-    private static final Duration TTL_MINUTES = Duration.ofMinutes(10);
-    private static final long TTL_SECONDS = TTL_MINUTES.toSeconds();
+    private static final Duration TTL_DURATION = Duration.ofMinutes(10);
+    private static final long TTL_SECONDS = TTL_DURATION.toSeconds();
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(BoschSHCBindingConstants.THING_TYPE_SHC);
 
@@ -72,7 +72,7 @@ public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
      * identified at the corresponding IP address.
      */
     private ExpiringCacheMap<String, @Nullable PublicInformation> discoveryResultCache = new ExpiringCacheMap<>(
-            TTL_MINUTES);
+            TTL_DURATION);
 
     @Activate
     public BridgeDiscoveryParticipant(@Reference HttpClientFactory httpClientFactory) {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
@@ -233,7 +233,9 @@ public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
         logger.trace("Requesting SHC information via URL {}", url);
         try {
             httpClient.start();
-            ContentResponse contentResponse = httpClient.newRequest(url).method(HttpMethod.GET).send();
+            ContentResponse contentResponse = httpClient.newRequest(url).method(HttpMethod.GET)
+                    .timeout(BoschHttpClient.DEFAULT_TIMEOUT_SECONDS, BoschHttpClient.DEFAULT_TIMEOUT_UNIT).send();
+
             // check HTTP status code
             if (!HttpStatus.getCode(contentResponse.getStatus()).isSuccess()) {
                 logger.debug("Discovery failed with status code {}: {}", contentResponse.getStatus(),
@@ -244,7 +246,7 @@ public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
             String content = contentResponse.getContentAsString();
             logger.debug("Discovered SHC at IP {}, public info: {}", ipAddress, content);
             PublicInformation bridgeInfo = gson.fromJson(content, PublicInformation.class);
-            if (bridgeInfo != null && bridgeInfo.shcIpAddress != null) {
+            if (bridgeInfo != null && bridgeInfo.shcIpAddress != null && !bridgeInfo.shcIpAddress.isBlank()) {
                 return bridgeInfo;
             }
         } catch (TimeoutException | ExecutionException e) {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipant.java
@@ -15,6 +15,8 @@ package org.openhab.binding.boschshc.internal.discovery;
 import static org.openhab.binding.boschshc.internal.devices.BoschSHCBindingConstants.BINDING_ID;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -46,23 +48,33 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 
 /**
- * The {@link BridgeDiscoveryParticipant} is responsible discovering the
- * Bosch Smart Home Controller as a Bridge with the mDNS services.
+ * The {@link BridgeDiscoveryParticipant} is responsible discovering the Bosch
+ * Smart Home Controller as a Bridge with the mDNS services.
  *
  * @author Gerd Zanker - Initial contribution
+ * @author David Pace - Discovery result caching
  */
 @NonNullByDefault
 @Component(configurationPid = "discovery.boschsmarthomebridge")
 public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
+    private static final String NAME_PREFIX_BOSCH_SHC = "Bosch SHC";
     private static final long TTL_SECONDS = Duration.ofHours(1).toSeconds();
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(BoschSHCBindingConstants.THING_TYPE_SHC);
+
+    /**
+     * Special object instance representing the result that no bridge could be found
+     * for a specific IP address
+     */
+    private static final PublicInformation NO_BRIDGE_FOUND = new PublicInformation();
 
     private final Logger logger = LoggerFactory.getLogger(BridgeDiscoveryParticipant.class);
     private final HttpClient httpClient;
     private final Gson gson = new Gson();
 
-    /// SHC Bridge Information, read via public REST API if bridge is detected. Otherwise, strings are empty.
-    private PublicInformation bridgeInformation = new PublicInformation();
+    /**
+     * Cache for bridge discovery results.
+     */
+    private Map<String, PublicInformation> discoveryResultCache = new HashMap<>();
 
     @Activate
     public BridgeDiscoveryParticipant(@Reference HttpClientFactory httpClientFactory) {
@@ -89,9 +101,43 @@ public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
         return "_http._tcp.local.";
     }
 
+    /**
+     * This method is frequently called by the mDNS discovery framework in different
+     * threads with individual service info instances.
+     * <p>
+     * Different service info objects can refer to the same Bosch SHC controller,
+     * e.g. the controller may be reachable via a <code>192.168.*.*</code> IP and an
+     * IP in the <code>169.254.*.*</code> range. The response from the controller
+     * contains the actual resolved IP address.
+     * <p>
+     * We ignore mDNS events if they do not contain any IP addresses or if the name
+     * property does not start with <code>Bosch SHC</code>.
+     */
     @Override
     public @Nullable DiscoveryResult createResult(ServiceInfo serviceInfo) {
-        logger.trace("Bridge Discovery started for {}", serviceInfo);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Bridge discovery invoked with mDNS service info {}", serviceInfo);
+        }
+
+        String name = serviceInfo.getName();
+        if (name == null || !name.startsWith(NAME_PREFIX_BOSCH_SHC)) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Ignoring mDNS service event because name '{}' does not start with '{}')", name,
+                        NAME_PREFIX_BOSCH_SHC);
+            }
+            return null;
+        }
+
+        @Nullable
+        String ipAddress = getFirstIPAddress(serviceInfo);
+        if (ipAddress == null || ipAddress.isBlank()) {
+            return null;
+        }
+
+        PublicInformation publicInformation = getOrComputePublicInformation(serviceInfo, ipAddress);
+        if (publicInformation == null) {
+            return null;
+        }
 
         @Nullable
         final ThingUID uid = getThingUID(serviceInfo);
@@ -99,63 +145,115 @@ public class BridgeDiscoveryParticipant implements MDNSDiscoveryParticipant {
             return null;
         }
 
-        logger.trace("Discovered Bosch Smart Home Controller at {}", bridgeInformation.shcIpAddress);
-
         return DiscoveryResultBuilder.create(uid)
-                .withLabel("Bosch Smart Home Controller (" + bridgeInformation.shcIpAddress + ")")
-                .withProperty("ipAddress", bridgeInformation.shcIpAddress)
-                .withProperty("shcGeneration", bridgeInformation.shcGeneration)
-                .withProperty("apiVersions", bridgeInformation.apiVersions).withTTL(TTL_SECONDS).build();
+                .withLabel("Bosch Smart Home Controller (" + publicInformation.shcIpAddress + ")")
+                .withProperty("ipAddress", publicInformation.shcIpAddress)
+                .withProperty("shcGeneration", publicInformation.shcGeneration)
+                .withProperty("apiVersions", publicInformation.apiVersions).withTTL(TTL_SECONDS).build();
+    }
+
+    private @Nullable String getFirstIPAddress(ServiceInfo serviceInfo) {
+        String[] hostAddresses = serviceInfo.getHostAddresses();
+        if (hostAddresses != null && hostAddresses.length > 0 && !hostAddresses[0].isEmpty()) {
+            return hostAddresses[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * Provides a cached discovery result if available, or performs an actual
+     * communication attempt to the device with the given IP address.
+     * <p>
+     * This method is synchronized because multiple threads try to access discovery
+     * results concurrently. We only want one thread to "win" and to invoke the
+     * actual HTTP communication.
+     * 
+     * @param serviceInfo mDNS service info
+     * @param ipAddress IP address to contact if no cached result is available
+     * @return the discovery result or <code>null</code> if the device with the
+     *         given IP address could not be identified as Bosch Smart Home
+     *         Controller
+     */
+    protected synchronized @Nullable PublicInformation getOrComputePublicInformation(ServiceInfo serviceInfo,
+            String ipAddress) {
+        if (discoveryResultCache.containsKey(ipAddress)) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Providing cached bridge discovery result for IP {}", ipAddress);
+            }
+
+            PublicInformation cachedInstance = discoveryResultCache.get(ipAddress);
+            return cachedInstance == NO_BRIDGE_FOUND ? null : cachedInstance;
+        } else {
+            if (logger.isTraceEnabled()) {
+                logger.trace("No cached bridge discovery result available for IP {}, trying to contact SHC", ipAddress);
+            }
+            @Nullable
+            PublicInformation publicInformation = discoverBridge(ipAddress);
+            discoveryResultCache.put(ipAddress, publicInformation != null ? publicInformation : NO_BRIDGE_FOUND);
+            return publicInformation;
+        }
     }
 
     @Override
     public @Nullable ThingUID getThingUID(ServiceInfo serviceInfo) {
-        String ipAddress = discoverBridge(serviceInfo).shcIpAddress;
-        if (!ipAddress.isBlank()) {
-            return new ThingUID(BoschSHCBindingConstants.THING_TYPE_SHC, ipAddress.replace('.', '-'));
+        String ipAddress = getFirstIPAddress(serviceInfo);
+        if (ipAddress != null) {
+            @Nullable
+            PublicInformation publicInformation = getOrComputePublicInformation(serviceInfo, ipAddress);
+            if (publicInformation != null) {
+                String resolvedIpAddress = publicInformation.shcIpAddress;
+                return new ThingUID(BoschSHCBindingConstants.THING_TYPE_SHC, resolvedIpAddress.replace('.', '-'));
+            }
         }
         return null;
     }
 
-    protected PublicInformation discoverBridge(ServiceInfo serviceInfo) {
-        logger.trace("Discovering serviceInfo {}", serviceInfo);
-
-        if (serviceInfo.getHostAddresses() != null && serviceInfo.getHostAddresses().length > 0
-                && !serviceInfo.getHostAddresses()[0].isEmpty()) {
-            String address = serviceInfo.getHostAddresses()[0];
-            logger.trace("Discovering InetAddress {}", address);
-            // store all information for later access
-            bridgeInformation = getPublicInformationFromPossibleBridgeAddress(address);
+    protected @Nullable PublicInformation discoverBridge(String ipAddress) {
+        logger.debug("Attempting to contact Bosch Smart Home Controller at IP {}", ipAddress);
+        PublicInformation bridgeInformation = getPublicInformationFromPossibleBridgeAddress(ipAddress);
+        if (bridgeInformation != null && bridgeInformation.shcIpAddress != null
+                && !bridgeInformation.shcIpAddress.isBlank()) {
+            return bridgeInformation;
         }
 
-        return bridgeInformation;
+        return null;
     }
 
-    protected PublicInformation getPublicInformationFromPossibleBridgeAddress(String ipAddress) {
+    /**
+     * Attempts to send a HTTP request to the given IP address in order to determine
+     * if the device is a Bosch Smart Home Controller.
+     * 
+     * @param ipAddress the IP address of the potential Bosch Smart Home Controller
+     * @return a {@link PublicInformation} object if the bridge was successfully
+     *         contacted or <code>null</code> if the communication failed
+     */
+    protected @Nullable PublicInformation getPublicInformationFromPossibleBridgeAddress(String ipAddress) {
         String url = BoschHttpClient.getPublicInformationUrl(ipAddress);
-        logger.trace("Discovering ipAddress {}", url);
+        logger.trace("Requesting SHC information via URL {}", url);
         try {
             httpClient.start();
             ContentResponse contentResponse = httpClient.newRequest(url).method(HttpMethod.GET).send();
             // check HTTP status code
             if (!HttpStatus.getCode(contentResponse.getStatus()).isSuccess()) {
-                logger.debug("Discovering failed with status code: {}", contentResponse.getStatus());
-                return new PublicInformation();
+                logger.debug("Discovery failed with status code {}: {}", contentResponse.getStatus(),
+                        contentResponse.getContentAsString());
+                return null;
             }
             // get content from response
             String content = contentResponse.getContentAsString();
-            logger.trace("Discovered SHC - public info {}", content);
+            logger.debug("Discovered SHC at IP {}, public info: {}", ipAddress, content);
             PublicInformation bridgeInfo = gson.fromJson(content, PublicInformation.class);
-            if (bridgeInfo.shcIpAddress != null) {
+            if (bridgeInfo != null && bridgeInfo.shcIpAddress != null) {
                 return bridgeInfo;
             }
         } catch (TimeoutException | ExecutionException e) {
-            logger.debug("Discovering failed with exception {}", e.getMessage());
+            logger.debug("Discovery could not reach SHC at IP {}: {}", ipAddress, e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            logger.debug("Discovering failed during http client request {}", e.getMessage());
+            logger.warn("Discovery failed during HTTP client request: {}", e.getMessage(), e);
         }
-        return new PublicInformation();
+        return null;
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,22 @@
 	<description>This is the binding for Bosch Smart Home.</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>mdns</service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_http._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
+			<match-properties>
+				<match-property>
+					<name>name</name>
+					<regex>Bosch SHC.*</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipantTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/discovery/BridgeDiscoveryParticipantTest.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.boschshc.internal.discovery;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -162,7 +163,10 @@ class BridgeDiscoveryParticipantTest {
 
     @Test
     void testGetBridgeAddress() throws Exception {
-        assertThat(fixture.discoverBridge("192.168.0.123").shcIpAddress, is("192.168.0.123"));
+        @Nullable
+        PublicInformation bridgeInformation = fixture.discoverBridge("192.168.0.123");
+        assertThat(bridgeInformation, not(nullValue()));
+        assertThat(bridgeInformation.shcIpAddress, is("192.168.0.123"));
     }
 
     @Test
@@ -172,8 +176,10 @@ class BridgeDiscoveryParticipantTest {
 
     @Test
     void testGetPublicInformationFromPossibleBridgeAddress() throws Exception {
-        assertThat(fixture.getPublicInformationFromPossibleBridgeAddress("192.168.0.123").shcIpAddress,
-                is("192.168.0.123"));
+        @Nullable
+        PublicInformation bridgeInformation = fixture.getPublicInformationFromPossibleBridgeAddress("192.168.0.123");
+        assertThat(bridgeInformation, not(nullValue()));
+        assertThat(bridgeInformation.shcIpAddress, is("192.168.0.123"));
     }
 
     @Test
@@ -195,10 +201,10 @@ class BridgeDiscoveryParticipantTest {
     @Test
     void testGetOrComputePublicInformation() throws Exception {
         @Nullable
-        PublicInformation result = fixture.getOrComputePublicInformation(shcBridge, "192.168.0.123");
+        PublicInformation result = fixture.getOrComputePublicInformation("192.168.0.123");
         assertNotNull(result);
         @Nullable
-        PublicInformation result2 = fixture.getOrComputePublicInformation(shcBridge, "192.168.0.123");
+        PublicInformation result2 = fixture.getOrComputePublicInformation("192.168.0.123");
         assertSame(result, result2);
     }
 }


### PR DESCRIPTION
The bridge discovery participant receives lots of mDNS events. Previously, all events that contained IP addresses of potential bridges were actively contacted using HTTP requests. On some systems eventually the long polling stops due to too many requests.

With this change, we
* only consider mDNS events where the name property starts with "Bosch SHC"
* cache already discovered bridges so we don't have to contact them over and over again
* make sure that this happens in a thread-safe manner because the mDNS events are handled in individual concurrently running threads

closes #16174