### PR TITLE
[energidataservice] Increase robustness of UoM price updates by using currency code rather than symbol

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -340,17 +340,14 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
     }
 
     private State getEnergyPrice(BigDecimal price, Currency currency) {
-        Unit<?> unit = CurrencyUnits.getInstance().getUnit(currency.getCurrencyCode());
+        String currencyCode = currency.getCurrencyCode();
+        Unit<?> unit = CurrencyUnits.getInstance().getUnit(currencyCode);
         if (unit == null) {
             logger.trace("Currency {} is unknown, falling back to DecimalType", currency.getCurrencyCode());
             return new DecimalType(price);
         }
         try {
-            String currencyUnit = unit.getSymbol();
-            if (currencyUnit == null) {
-                currencyUnit = unit.getName();
-            }
-            return new QuantityType<>(price + " " + currencyUnit + "/kWh");
+            return new QuantityType<>(price + " " + currencyCode + "/kWh");
         } catch (IllegalArgumentException e) {
             logger.debug("Unable to create QuantityType, falling back to DecimalType", e);
             return new DecimalType(price);


### PR DESCRIPTION
This reduces the work-around provided in #16085 after the root cause has been fixed in openhab/openhab-core#4016.

Updating using currency code rather than currency symbol should be more robust since currency code is guaranteed to be unique. Therefore I'd propose to also cherry-pick this fix into 4.1.x along with openhab/openhab-core#4016 which was already cherry-picked.