### PR TITLE
[energidataservice] Reduce redundant persistence of tariffs

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -381,6 +381,7 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
     private void updateTimeSeries() {
         TimeSeries spotPriceTimeSeries = new TimeSeries(REPLACE);
         Map<DatahubTariff, TimeSeries> datahubTimeSeriesMap = new HashMap<>();
+        Map<DatahubTariff, BigDecimal> datahubPreviousTariff = new HashMap<>();
         for (DatahubTariff datahubTariff : DatahubTariff.values()) {
             datahubTimeSeriesMap.put(datahubTariff, new TimeSeries(REPLACE));
         }
@@ -401,8 +402,14 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
                 }
                 BigDecimal tariff = cacheManager.getTariff(datahubTariff, hourStart);
                 if (tariff != null) {
+                    BigDecimal previousTariff = datahubPreviousTariff.get(datahubTariff);
+                    if (previousTariff != null && tariff.equals(previousTariff)) {
+                        // Skip redundant states.
+                        continue;
+                    }
                     TimeSeries timeSeries = entry.getValue();
                     timeSeries.add(hourStart, getEnergyPrice(tariff, CURRENCY_DKK));
+                    datahubPreviousTariff.put(datahubTariff, tariff);
                 }
             }
         }


### PR DESCRIPTION
Unlike spotprices, tariffs are not updated by the hour.

The most dynamic tariff is the grid tariff which can currently change as often as four times per day. The most static one is the system tariff which is usually only changed once in very hectic years.

The time series implementation didn't take any of this into consideration. Previously when using persistence strategy **everyChange** this was not a problem (first row is an actual change, the rest are probably caused by restarts):

| Timestamp               | Value   |
|-------------------------|---------|
| 2023-07-01 00:00:00.064 | 0.87125 |
| 2023-09-30 12:51:56.487 | 0.87125 |
| 2023-11-04 20:31:20.955 | 0.87125 |
| 2023-11-18 17:25:23.032 | 0.87125 |

Now, when using persistence strategy **forecast**, this would cause many redundant updates:

| Timestamp               | Value   |
|-------------------------|---------|
| 2023-12-21 23:00:00.000 | 0.87125 |
| 2023-12-22 00:00:00.000 | 0.87125 |
| 2023-12-22 01:00:00.000 | 0.87125 |
| 2023-12-22 02:00:00.000 | 0.87125 |
| 2023-12-22 03:00:00.000 | 0.87125 |
| 2023-12-22 04:00:00.000 | 0.87125 |
| 2023-12-22 05:00:00.000 | 0.87125 |

This fix will avoid adding such redundant updates to the published time series.

As an example, for N1 grid tariffs the red marked rows will no longer be persisted:

![image](https://github.com/openhab/openhab-addons/assets/19519842/f9ad4daf-b764-43ee-8e66-06eddab7c271)
