### PR TITLE
[yamahamusiccast] Add discovery information

### DIFF
--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>Yamaha Musiccast Binding</name>
-	<description>This is the binding for Yamaha Musiccast</description>
+	<name>Yamaha MusicCast Binding</name>
+	<description>This is the binding for Yamaha MusicCast.</description>
 	<connection>local</connection>
 
 	<discovery-methods>
@@ -14,7 +14,7 @@
 			<match-properties>
 				<match-property>
 					<name>manufacturer</name>
-					<regex>(?i).*Yamaha.*</regex>
+					<regex>.*Yamaha.*</regex>
 				</match-property>
 				<match-property>
 					<name>deviceType</name>

--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,20 @@
 	<description>This is the binding for Yamaha Musiccast</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>(?i).*Yamaha.*</regex>
+				</match-property>
+				<match-property>
+					<name>deviceType</name>
+					<regex>.*MediaRenderer.*</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>

--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/i18n/yamahamusiccast.properties
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/i18n/yamahamusiccast.properties
@@ -1,7 +1,7 @@
 # add-on
 
-addon.yamahamusiccast.name = Yamaha Musiccast Binding
-addon.yamahamusiccast.description = This is the binding for Yamaha Musiccast
+addon.yamahamusiccast.name = Yamaha MusicCast Binding
+addon.yamahamusiccast.description = This is the binding for Yamaha MusicCast.
 
 # thing types
 

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/addon/addon.xml
@@ -5,7 +5,7 @@
 
 	<type>binding</type>
 	<name>YamahaReceiver Binding</name>
-	<description>For all network enabled Yamaha receivers.</description>
+	<description>This is the binding for network enabled Yamaha receivers (without MusicCast support).</description>
 	<connection>local</connection>
 
 	<discovery-methods>
@@ -14,7 +14,7 @@
 			<match-properties>
 				<match-property>
 					<name>manufacturer</name>
-					<regex>(?i).*YAMAHA.*</regex>
+					<regex>.*YAMAHA.*</regex>
 				</match-property>
 				<match-property>
 					<name>deviceType</name>

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/i18n/yamahareceiver.properties
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/i18n/yamahareceiver.properties
@@ -1,7 +1,7 @@
 # add-on
 
 addon.yamahareceiver.name = YamahaReceiver Binding
-addon.yamahareceiver.description = For all network enabled Yamaha receivers.
+addon.yamahareceiver.description = This is the binding for network enabled Yamaha receivers (without MusicCast support).
 
 # thing types
 
@@ -160,8 +160,8 @@ channel-type.yamahareceiver.surroundProgram.state.option.Sci-Fi = Sci-Fi
 channel-type.yamahareceiver.surroundProgram.state.option.Spectacle = Spectacle
 channel-type.yamahareceiver.surroundProgram.state.option.Standard = Standard
 channel-type.yamahareceiver.surroundProgram.state.option.Pro\ Logic = Pro Logic
-channel-type.yamahareceiver.surroundProgram.state.option.Neo:6 Music = Neo:6 Music
-channel-type.yamahareceiver.surroundProgram.state.option.Neo:6 Cinema = Neo:6 Cinema
+channel-type.yamahareceiver.surroundProgram.state.option.Neo\:6\ Music = Neo:6 Music
+channel-type.yamahareceiver.surroundProgram.state.option.Neo\:6\ Cinema = Neo:6 Cinema
 channel-type.yamahareceiver.surroundProgram.state.option.PLII[x]\ Game = PLII[x] Game
 channel-type.yamahareceiver.surroundProgram.state.option.PLII[x]\ Music = PLII[x] Music
 channel-type.yamahareceiver.surroundProgram.state.option.PLII[x]\ Movie = PLII[x] Movie
@@ -179,3 +179,8 @@ channel-type.yamahareceiver.volume.label = Volume
 channel-type.yamahareceiver.volume.description = Set the volume level
 channel-type.yamahareceiver.volumeDB.label = Volume in dB
 channel-type.yamahareceiver.volumeDB.description = Set the volume level (dB)
+
+# channel types
+
+channel-type.yamahareceiver.surroundProgram.state.option.Neo:6 Music = Neo:6 Music
+channel-type.yamahareceiver.surroundProgram.state.option.Neo:6 Cinema = Neo:6 Cinema

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/i18n/yamahareceiver.properties
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/resources/OH-INF/i18n/yamahareceiver.properties
@@ -179,8 +179,3 @@ channel-type.yamahareceiver.volume.label = Volume
 channel-type.yamahareceiver.volume.description = Set the volume level
 channel-type.yamahareceiver.volumeDB.label = Volume in dB
 channel-type.yamahareceiver.volumeDB.description = Set the volume level (dB)
-
-# channel types
-
-channel-type.yamahareceiver.surroundProgram.state.option.Neo:6 Music = Neo:6 Music
-channel-type.yamahareceiver.surroundProgram.state.option.Neo:6 Cinema = Neo:6 Cinema


### PR DESCRIPTION
Seems like Yamaha is using uppercase `YAMAHA CORPORATION` for the manufacturer info of non-MusicCast devices and normal case `Yamaha Corporation` for MusicCast devices.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>