### PR TITLE
[boschindego] Fix removal of discovery results

### DIFF
--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/discovery/IndegoDiscoveryService.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/discovery/IndegoDiscoveryService.java
@@ -84,6 +84,6 @@ public class IndegoDiscoveryService extends AbstractThingHandlerDiscoveryService
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().getEpochSecond());
+        removeOlderResults(Instant.now().toEpochMilli());
     }
 }


### PR DESCRIPTION
Although not very well documented (only as "timestamp"), [removeOlderResults](https://www.openhab.org/javadoc/latest/org/openhab/core/config/discovery/abstractdiscoveryservice#removeOlderResults(long)) expects number of milliseconds since epoch:

https://github.com/openhab/openhab-core/blob/9cb4b9ee1fe7c6fbc68df5db74429be7da4ccb3b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java#L222-L225