### PR TITLE
[tibber] Add time series support for Tibber prices

### DIFF
--- a/bundles/org.openhab.binding.tibber/README.md
+++ b/bundles/org.openhab.binding.tibber/README.md
@@ -102,6 +102,7 @@ Tibber API will be auto discovered if provided input is correct.
 
 ## Tomorrow and Today Prices
 
+The today and tomorrow prices are served as time series on the _Current Total_ channel and as json data on the channels _Today prices_ and _Tomorrow prices_. 
 Example of tomorrow and today prices data structure - an array of tuples:
 
 ```json

--- a/bundles/org.openhab.binding.tibber/README.md
+++ b/bundles/org.openhab.binding.tibber/README.md
@@ -81,7 +81,7 @@ Note: Tibber HomeId is retrieved from [developer.tibber.com](https://developer.t
 - If Tibber Pulse is connected, the Tibber API Explorer will report "true" for "realTimeConsumptionEnabled"
 - Copy HomeId from Tibber API Explorer, without quotation marks, and use this in the bindings configuration.
 
-```
+```json
 {
   viewer {
     homes {
@@ -214,13 +214,13 @@ Example of tomorrow and today prices data structure - an array of tuples:
 
 ### demo.things
 
-```
+```java
 Thing tibber:tibberapi:7cfae492 [ homeid="xxx", token="xxxxxxx" ]
 ```
 
 ### demo.items:
 
-```
+```java
 Number:Dimensionless       TibberAPICurrentTotal                 "Current Total Price [%.2f NOK]"            {channel="tibber:tibberapi:7cfae492:current_total"}
 DateTime                   TibberAPICurrentStartsAt              "Timestamp - Current Price"                 {channel="tibber:tibberapi:7cfae492:current_startsAt"}
 String                     TibberAPICurrentLevel                 "Price Level"                               {channel="tibber:tibberapi:7cfae492:current_level"}

--- a/bundles/org.openhab.binding.tibber/README.md
+++ b/bundles/org.openhab.binding.tibber/README.md
@@ -102,7 +102,7 @@ Tibber API will be auto discovered if provided input is correct.
 
 ## Tomorrow and Today Prices
 
-The today and tomorrow prices are served as time series on the _Current Total_ channel and as json data on the channels _Today prices_ and _Tomorrow prices_. 
+The today and tomorrow prices are served as time series on the `current_total` channel and as JSON data on the channels `today_prices` and `tomorrow_prices`.
 Example of tomorrow and today prices data structure - an array of tuples:
 
 ```json

--- a/bundles/org.openhab.binding.tibber/README.md
+++ b/bundles/org.openhab.binding.tibber/README.md
@@ -19,43 +19,47 @@ The channels (i.e. measurements) associated with the Binding:
 
 Tibber Default:
 
-| Channel ID         | Description                                             | Read-only |
-|--------------------|---------------------------------------------------------|-----------|
-| Current Total      | Current Total Price (energy + tax)                      | True      |
-| Starts At          | Current Price Timestamp                                 | True      |
-| Current Level      | Current Price Level                                     | True      |
-| Daily Cost         | Daily Cost (last/previous day)                          | True      |
-| Daily Consumption  | Daily Consumption (last/previous day)                   | True      |
-| Daily From         | Timestamp (daily from)                                  | True      |
-| Daily To           | Timestamp (daily to)                                    | True      |
-| Hourly Cost        | Hourly Cost (last/previous hour)                        | True      |
-| Hourly Consumption | Hourly Consumption (last/previous hour)                 | True      |
-| Hourly From        | Timestamp (hourly from)                                 | True      |
-| Hourly To          | Timestamp (hourly to)                                   | True      |
-| Tomorrow prices    | JSON array of tomorrow's prices. See below for example. | True      |
-| Today prices       | JSON array of today's prices. See below for example.    | True      |
+| Channel ID           | Description                                             | Read-only | Forecast |
+|----------------------|---------------------------------------------------------|-----------|----------|
+| current_total        | Current Total Price (energy + tax)                      | True      | yes      |
+| current_startsAt     | Current Price Timestamp                                 | True      | no       |
+| current_level        | Current Price Level                                     | True      | no       |
+| daily_cost           | Daily Cost (last/previous day)                          | True      | no       |
+| daily_consumption    | Daily Consumption (last/previous day)                   | True      | no       |
+| daily_from           | Timestamp (daily from)                                  | True      | no       |
+| daily_to             | Timestamp (daily to)                                    | True      | no       |
+| hourly_cost          | Hourly Cost (last/previous hour)                        | True      | no       |
+| hourly_consumption   | Hourly Consumption (last/previous hour)                 | True      | no       |
+| hourly_from          | Timestamp (hourly from)                                 | True      | no       |
+| hourly_to            | Timestamp (hourly to)                                   | True      | no       |
+| tomorrow_prices      | JSON array of tomorrow's prices. See below for example. | True      | no       |
+| today_prices         | JSON array of today's prices. See below for example.    | True      | no       |
 
 Tibber Pulse (optional):
 
-| Channel ID              | Description                              | Read-only |
-|-------------------------|------------------------------------------|-----------|
-| Timestamp               | Timestamp for live measurements          | True      |
-| Power                   | Live Power Consumption                   | True      |
-| Last Meter Consumption  | Last Recorded Meter Consumption          | True      |
-| Accumulated Consumption | Accumulated Consumption since Midnight   | True      |
-| Accumulated Cost        | Accumulated Cost since Midnight          | True      |
-| Accumulated Reward      | Accumulated Reward since Midnight        | True      |
-| Currency                | Currency of Cost                         | True      |
-| Min Power               | Min Power Consumption since Midnight     | True      |
-| Average Power           | Average Power Consumption since Midnight | True      |
-| Max Power               | Max Power Consumption since Midnight     | True      |
-| Voltage 1-3             | Voltage per Phase                        | True      |
-| Current 1-3             | Current per Phase                        | True      |
-| Power Production        | Live Power Production                    | True      |
-| Accumulated Production  | Accumulated Production since Midnight    | True      |
-| Last Meter Production   | Last Recorded Meter Production           | True      |
-| Min Power Production    | Min Power Production since Midnight      | True      |
-| Max Power Production    | Max Power Production since Midnight      | True      |
+| Channel ID                  | Description                              | Read-only |
+|-----------------------------|------------------------------------------|-----------|
+| live_timestamp              | Timestamp for live measurements          | True      |
+| live_power                  | Live Power Consumption                   | True      |
+| live_lastMeterConsumption   | Last Recorded Meter Consumption          | True      |
+| live_accumulatedConsumption | Accumulated Consumption since Midnight   | True      |
+| live_accumulatedCost        | Accumulated Cost since Midnight          | True      |
+| live_accumulatedReward      | Accumulated Reward since Midnight        | True      |
+| live_currency               | Currency of Cost                         | True      |
+| live_minPower               | Min Power Consumption since Midnight     | True      |
+| live_averagePower           | Average Power Consumption since Midnight | True      |
+| live_maxPower               | Max Power Consumption since Midnight     | True      |
+| live_voltage1               | Voltage Phase 1                          | True      |
+| live_voltage2               | Voltage Phase  2                         | True      |
+| live_voltage3               | Voltage Phase 3                          | True      |
+| live_current1               | Current Phase 1                          | True      |
+| live_current2               | Current Phase 2                          | True      |
+| live_current3               | Current Phase 3                          | True      |
+| live_powerProduction        | Live Power Production                    | True      |
+| live_accumulatedProduction  | Accumulated Production since Midnight    | True      |
+| live_lastMeterProduction    | Last Recorded Meter Production           | True      |
+| live_minPowerproduction     | Min Power Production since Midnight      | True      |
+| live_maxPowerproduction     | Max Power Production since Midnight      | True      |
 
 ## Binding Configuration
 
@@ -77,7 +81,7 @@ Note: Tibber HomeId is retrieved from [developer.tibber.com](https://developer.t
 - If Tibber Pulse is connected, the Tibber API Explorer will report "true" for "realTimeConsumptionEnabled"
 - Copy HomeId from Tibber API Explorer, without quotation marks, and use this in the bindings configuration.
 
-```json
+```
 {
   viewer {
     homes {
@@ -102,7 +106,7 @@ Tibber API will be auto discovered if provided input is correct.
 
 ## Tomorrow and Today Prices
 
-The today and tomorrow prices are served as time series on the `current_total` channel and as JSON data on the channels `today_prices` and `tomorrow_prices`.
+The today and tomorrow prices are served as forecast on the `current_total` channel and as JSON data on the channels `today_prices` and `tomorrow_prices`.
 Example of tomorrow and today prices data structure - an array of tuples:
 
 ```json
@@ -210,13 +214,13 @@ Example of tomorrow and today prices data structure - an array of tuples:
 
 ### demo.things
 
-```java
+```
 Thing tibber:tibberapi:7cfae492 [ homeid="xxx", token="xxxxxxx" ]
 ```
 
 ### demo.items:
 
-```java
+```
 Number:Dimensionless       TibberAPICurrentTotal                 "Current Total Price [%.2f NOK]"            {channel="tibber:tibberapi:7cfae492:current_total"}
 DateTime                   TibberAPICurrentStartsAt              "Timestamp - Current Price"                 {channel="tibber:tibberapi:7cfae492:current_startsAt"}
 String                     TibberAPICurrentLevel                 "Price Level"                               {channel="tibber:tibberapi:7cfae492:current_level"}

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -289,8 +289,8 @@ public class TibberHandler extends BaseThingHandler {
         return timeSeries;
     }
 
-    private static void mapTimeSeriesEntries(JsonArray today, TimeSeries timeSeries) {
-        for (JsonElement entry : today) {
+    private static void mapTimeSeriesEntries(JsonArray prices, TimeSeries timeSeries) {
+        for (JsonElement entry : prices) {
             final Instant startsAt = parseDateTime(entry.getAsJsonObject().get("startsAt"));
             final Instant endsAt = startsAt.plus(1, ChronoUnit.HOURS).minus(1, ChronoUnit.MICROS);
             final DecimalType value = new DecimalType(entry.getAsJsonObject().get("total").getAsString());

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -211,7 +211,6 @@ public class TibberHandler extends BaseThingHandler {
 
                     TimeSeries timeSeries = buildTimeSeries(today, tomorrow);
                     sendTimeSeries(CURRENT_TOTAL, timeSeries);
-
                 } catch (JsonSyntaxException e) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "Error communicating with Tibber API: " + e.getMessage());

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -22,7 +22,6 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
@@ -296,12 +295,8 @@ public class TibberHandler extends BaseThingHandler {
                 // Skip entry, if date is invalid.
                 continue;
             }
-            final Instant endsAt = startsAt.plus(1, ChronoUnit.HOURS).minus(1, ChronoUnit.MICROS);
             final DecimalType value = new DecimalType(entry.getAsJsonObject().get("total").getAsString());
-            // As the value is valid for exactly one hour and is not linear, add one entry at the beginning
-            // and one at the end of the interval, so it's a step function instead a linear one.
             timeSeries.add(startsAt, value);
-            timeSeries.add(endsAt, value);
         }
     }
 

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -297,7 +297,7 @@ public class TibberHandler extends BaseThingHandler {
             // As the value is valid for exactly one hour and is not linear, add one entry at the beginning
             // and one at the end of the interval, so it's a step function instead a linear one.
             timeSeries.add(startsAt, value);
-            timeSeries.add(endsAt,value);
+            timeSeries.add(endsAt, value);
         }
     }
 


### PR DESCRIPTION
This PR addeds time series support for future tibber prices to openhab.
The values, that are currenty served as json data, are parsed and served as time series for the current total costs channel.
