### PR TITLE
[energidataservice] Update tariff filter for NOE Net

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/api/DatahubTariffFilterFactory.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/api/DatahubTariffFilterFactory.java
@@ -124,7 +124,8 @@ public class DatahubTariffFilterFactory {
                 return new DatahubTariffFilter(Set.of(ChargeTypeCode.of("TAC")), Set.of(NOTE_NET_TARIFF_C),
                         DateQueryParameter.of(DateQueryParameterType.START_OF_DAY));
             case GLN_NORDVESTJYSK_ELFORSYNING_NOE_NET:
-                return new DatahubTariffFilter(Set.of(ChargeTypeCode.of("Net C")), Set.of(NOTE_NET_TARIFF_C));
+                return new DatahubTariffFilter(Set.of(ChargeTypeCode.of("30030")), Set.of(NOTE_NET_TARIFF_C),
+                        DateQueryParameter.of(DateQueryParameterType.START_OF_DAY));
             case GLN_RADIUS:
                 return new DatahubTariffFilter(Set.of(ChargeTypeCode.of("DT_C_01")), Set.of(NOTE_NET_TARIFF_C_HOUR),
                         DateQueryParameter.of(RADIUS_CUTOFF_DATE));


### PR DESCRIPTION
Update grid tariff filter for Nordvestjylland og Omegns Elforsyning according to new tariff model 3.0:
https://noe.dk/wp-content/uploads/2023/09/Prisblad-pr.-1.-januar-2024.pdf