### PR TITLE
[MPD] reconnect on broken idle connection should not loose pending commands

### DIFF
--- a/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnectionThread.java
+++ b/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnectionThread.java
@@ -54,6 +54,7 @@ public class MPDConnectionThread extends Thread {
 
     private final List<MPDCommand> pendingCommands = new ArrayList<>();
     private AtomicBoolean isInIdle = new AtomicBoolean(false);
+    private AtomicBoolean wakingUpFromIdle = new AtomicBoolean(false);
     private AtomicBoolean disposed = new AtomicBoolean(false);
 
     public MPDConnectionThread(MPDResponseListener listener, String address, Integer port, String password) {
@@ -70,7 +71,6 @@ public class MPDConnectionThread extends Thread {
             while (!disposed.get()) {
                 try {
                     synchronized (pendingCommands) {
-                        pendingCommands.clear();
                         pendingCommands.add(new MPDCommand("status"));
                         pendingCommands.add(new MPDCommand("currentsong"));
                     }
@@ -92,7 +92,16 @@ public class MPDConnectionThread extends Thread {
                 closeSocket();
 
                 if (!disposed.get()) {
-                    sleep(RECONNECTION_TIMEOUT_SEC * 1000);
+                    if (wakingUpFromIdle.compareAndSet(true, false)) {
+                        logger.debug("reconnecting immediately and keeping pending commands");
+                    } else {
+                        logger.debug("reconnecting in {} seconds and clearing pending commands...",
+                                RECONNECTION_TIMEOUT_SEC);
+                        sleep(RECONNECTION_TIMEOUT_SEC * 1000);
+                        synchronized (pendingCommands) {
+                            pendingCommands.clear();
+                        }
+                    }
                 }
             }
         } catch (InterruptedException ignore) {
@@ -246,6 +255,7 @@ public class MPDConnectionThread extends Thread {
 
     private void sendCommand(MPDCommand command) throws IOException {
         logger.trace("send command '{}'", command);
+        wakingUpFromIdle.set("noidle".equals(command.getCommand()));
         final Socket socket = this.socket;
         if (socket != null) {
             String line = command.asLine();


### PR DESCRIPTION
I'm using MPD on an old tablet. I wrote a rule to play music to alert when windows are open to long. It works in general. 

Unfortunately, when MPD is idle for a long time, the connection get lost. Then (when my window rule send the play command) the mpd binding automatically reconnects after 60s, but the pending commands are lost. Therefore my alert is not working most of the time.

## Expected Behavior
The mpd binding should handle reconnect on idle connections without loosing commands. (This is similar to JDBC connection pools like HikariCP handle broken idle JDBC connections.)

## Current Behavior

The mpd binding looses pending commands when reconnecting after detecting a broken connection.

Here is a trace log of such a case (formatted with extra empty lines):
```
...
2024-01-14 11:19:20.249 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'OK'
2024-01-14 11:19:20.249 [TRACE] [nternal.protocol.MPDConnectionThread] - send command 'idle'
2024-01-14 11:19:20.249 [TRACE] [nternal.protocol.MPDConnectionThread] - read response for command 'idle'

2024-01-14 15:09:11.367 [DEBUG] [nding.mpd.internal.action.MPDActions] - sendCommand called with clear
2024-01-14 15:09:11.368 [DEBUG] [nternal.protocol.MPDConnectionThread] - insert command 'clear' at position -1
2024-01-14 15:09:11.368 [TRACE] [nternal.protocol.MPDConnectionThread] - send command 'noidle'
2024-01-14 15:09:11.369 [DEBUG] [nding.mpd.internal.action.MPDActions] - sendCommand called with load
2024-01-14 15:09:11.369 [DEBUG] [nternal.protocol.MPDConnectionThread] - insert command 'load' at position -1
2024-01-14 15:09:11.371 [DEBUG] [nding.mpd.internal.action.MPDActions] - sendCommand called with play
2024-01-14 15:09:11.372 [DEBUG] [nternal.protocol.MPDConnectionThread] - insert command 'play' at position -1

2024-01-14 15:09:12.215 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'null'

2024-01-14 15:09:12.216 [DEBUG] [nternal.protocol.MPDConnectionThread] - Closing socket
2024-01-14 15:10:12.216 [DEBUG] [nternal.protocol.MPDConnectionThread] - opening connection to 192.168.178.43 port 6620

2024-01-14 15:10:12.217 [TRACE] [nternal.protocol.MPDConnectionThread] - read response for command 'connect'
2024-01-14 15:10:12.834 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'OK MPD 0.23.5'

2024-01-14 15:10:12.834 [TRACE] [nternal.protocol.MPDConnectionThread] - send command 'status'
2024-01-14 15:10:12.835 [TRACE] [nternal.protocol.MPDConnectionThread] - read response for command 'status'
2024-01-14 15:10:12.840 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'volume: 55'
2024-01-14 15:10:12.840 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'repeat: 0'
...
```

The `received line 'null'` shows the broken connection.

I looked into the code and can explain the behavior:
1. On receiving a null line, an IOException is raised [MPDConnectionThread:287](https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnectionThread.java#L287)
2. This exception is caught in the main run method  [MPDConnectionThread:85](https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnectionThread.java#L85)
3. The while loop in that run method starts the next iteration an clears the pending commands [MPDConnectionThread:73](https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnectionThread.java#L73)

Is this on purpose, especially for broken idle connections?

## Possible Solution

I think broken idle connections should be handled by a reconnect right after instead of sleeping for 60s and clearing the pending commands.
This pull request does this. It introduces a new variable wakingUpFromIdle which keeps track of whether the last command sent was a "noidle" which tries to wakeup the idle mode. If the connection reset occurs right after that, the connection is rebuilt right away.

## Steps to Reproduce (for Bugs)

I can reproduce the bug with my android tablet, if I wait long enough, but I cannot reproduce the error otherwise. If I just kill the MPD instance, the connection ist terminated properly and the MPD binding detects the closed connection. It probalby is possible using a firewall in between which silently terminates the connection, but I didn't try this.

## Context
See first paragraph

## Your Environment

I'm using openhab 4.1.0 as a docker container openhab/openhab:4.1.0. on debian bookworm. Besides the 4.1.0 binding I also used the own built MPD binding from the trunk. 