### PR TITLE
[shelly] Add check and ThingStatus for local IP issue (APIPA)

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyEventServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyEventServlet.java
@@ -75,12 +75,13 @@ public class ShellyEventServlet extends WebSocketServlet {
      * Servlet handler. Shelly1: http request, Shelly2: WebSocket call
      */
     @Override
-    protected void service(HttpServletRequest request, HttpServletResponse resp)
+    protected void service(@Nullable HttpServletRequest request, @Nullable HttpServletResponse resp)
             throws ServletException, IOException, IllegalArgumentException {
         String path = getString(request.getRequestURI()).toLowerCase();
-
         if (path.equals(SHELLY2_CALLBACK_URI)) { // Shelly2 WebSocket
-            super.service(request, resp);
+            if (request != null && resp != null) {
+                super.service(request, resp);
+            }
             return;
         }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -1008,6 +1008,13 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         config.serviceName = getString(properties.get(PROPERTY_SERVICE_NAME));
         config.localIp = bindingConfig.localIP;
         config.localPort = String.valueOf(bindingConfig.httpPort);
+        if (config.localIp.startsWith("169.254")) {
+            logger.warn("{}: An invalid local ip address {} was detected, check system and openHAB network settings",
+                    thingName, config.localIp);
+            setThingOffline(ThingStatusDetail.CONFIGURATION_ERROR, "config-status.error.network-config");
+            return;
+        }
+
         if (!profile.isGen2 && config.userId.isEmpty() && !bindingConfig.defaultUserId.isEmpty()) {
             // Gen2 has hard coded user "admin"
             config.userId = bindingConfig.defaultUserId;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -1009,9 +1009,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         config.localIp = bindingConfig.localIP;
         config.localPort = String.valueOf(bindingConfig.httpPort);
         if (config.localIp.startsWith("169.254")) {
-            logger.warn("{}: An invalid local ip address {} was detected, check system and openHAB network settings",
-                    thingName, config.localIp);
-            setThingOffline(ThingStatusDetail.CONFIGURATION_ERROR, "config-status.error.network-config");
+            setThingOffline(ThingStatusDetail.COMMUNICATION_ERROR, "config-status.error.network-config",
+                    config.localIp);
             return;
         }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerCache.java
@@ -16,7 +16,6 @@ import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -24,7 +23,6 @@ import org.eclipse.jdt.annotation.Nullable;
  *
  * @author Markus Michels - Initial contribution
  */
-@NonNullByDefault
 public class ShellyManagerCache<K, V> extends ConcurrentHashMap<K, V> {
 
     private static final long serialVersionUID = 1L;
@@ -46,7 +44,7 @@ public class ShellyManagerCache<K, V> extends ConcurrentHashMap<K, V> {
     }
 
     @Override
-    public @Nullable V put(K key, V value) {
+    public V put(K key, V value) {
         Date date = new Date();
         timeMap.put(key, date.getTime());
         return super.put(key, value);
@@ -66,7 +64,7 @@ public class ShellyManagerCache<K, V> extends ConcurrentHashMap<K, V> {
     }
 
     @Override
-    public @Nullable V putIfAbsent(K key, V value) {
+    public V putIfAbsent(K key, V value) {
         if (!containsKey(key)) {
             return put(key, value);
         } else {
@@ -86,7 +84,6 @@ public class ShellyManagerCache<K, V> extends ConcurrentHashMap<K, V> {
             }
         }
 
-        @SuppressWarnings("null")
         private void cleanMap() {
             long currentTime = new Date().getTime();
             for (K key : timeMap.keySet()) {

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -11,6 +11,7 @@ addon.shelly.config.autoCoIoT.label = Auto-CoIoT
 addon.shelly.config.autoCoIoT.description = If enabled CoIoT will be automatically used when the devices runs a firmware version 1.6 or newer; false: Use thing configuration to enabled/disable CoIoT events.  
 
 # Config status messages
+message.config-status.error.network-config = Invalid system / openHAB network configuration was detected.
 message.config-status.error.missing-device-address = IP/MAC Address of the Shelly device is missing.
 message.config-status.error.missing-userid = No user ID in the Thing configuration
 

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -11,7 +11,7 @@ addon.shelly.config.autoCoIoT.label = Auto-CoIoT
 addon.shelly.config.autoCoIoT.description = If enabled CoIoT will be automatically used when the devices runs a firmware version 1.6 or newer; false: Use thing configuration to enabled/disable CoIoT events.  
 
 # Config status messages
-message.config-status.error.network-config = Invalid system / openHAB network configuration was detected.
+message.config-status.error.network-config = Invalid system or openHAB network configuration was detected (local IP {0}).
 message.config-status.error.missing-device-address = IP/MAC Address of the Shelly device is missing.
 message.config-status.error.missing-userid = No user ID in the Thing configuration
 


### PR DESCRIPTION
The binding checks now the local ip to be != 169.254.x.x, which is the result of a failed DHCP assignment. The framework reports this in the list of interfaces and the binding had send this to the device as part of the callback url, which resulted in device functioning in general, but the binding is not receiving any events. Now the user sees a WARNING is the log, which is a clear indicator of a setup to be fixed.
