### PR TITLE
[teleinfo] Update documentation to match #16323

### DIFF
--- a/bundles/org.openhab.binding.teleinfo/README.md
+++ b/bundles/org.openhab.binding.teleinfo/README.md
@@ -253,5 +253,4 @@ The Teleinfo binding has been successfully validated with below hardware configu
 | GCE Electronics USB Teleinfo module [(more details)](https://gce-electronics.com/fr/usb/655-module-teleinfo-usb.html) | Linky | Single-phase HCHP | Standard |
 | Cartelectronic USB Teleinfo modem [(more details)](https://www.cartelectronic.fr/teleinfo-compteur-enedis/17-teleinfo-1-compteur-usb-rail-din-3760313520028.html) | Linky | Three-phase TEMPO | Standard |
 
-On Linky telemeters, only _historical_ TIC mode is currently supported.
 The method for changing the TIC mode of a Linky telemeter is explained [here](https://forum.gce-electronics.com/t/comment-passer-un-cpt-linky-en-mode-standard/8206/7).


### PR DESCRIPTION
Resolve #16323

This PR remove a sentence which implies standard TIC mode is not supported by the binding.
Standard TIC mode is supported since #11375.