### PR TITLE
[ipcamera] Improve online/offline detection for ONVIF cameras

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -514,17 +514,16 @@ public class IpCameraHandler extends BaseThingHandler {
     private void checkCameraConnection() {
         if (snapshotPolling) { // Currently polling a real URL for snapshots, so camera must be online.
             return;
-        } else if (ffmpegSnapshotGeneration) { // Use RTSP stream creating snapshots to know camera is online.
+        } else if (ffmpegSnapshotGeneration) {
             Ffmpeg localSnapshot = ffmpegSnapshot;
             if (localSnapshot != null && !localSnapshot.isAlive()) {
                 cameraCommunicationError("FFmpeg Snapshots Stopped: Check that your camera can be reached.");
             }
-            return; // ffmpeg snapshot stream is still alive
+            return; // RTSP stream is creating snapshots, so camera is online.
         }
 
-        // ONVIF cameras get regular event messages from the camera
-        if (supportsOnvifEvents() && onvifCamera.isConnected()) {
-            return;
+        if (supportsOnvifEvents() && onvifCamera.isConnected() && onvifCamera.getEventsSupported()) {
+            return;// ONVIF cameras that are getting event messages must be online
         }
 
         // Open a HTTP connection without sending any requests as we do not need a snapshot.


### PR DESCRIPTION
Add better support for checking online and offline when the camera is an ONVIF type.
Changes should now allow for edge cases where an ONVIF camera has no snapshot and hence no http server to use for checking online status.
Also should allow for cameras that do not support ONVIF events, so they fall back to the proven method of opening a HTTP connecting to the configured port.
Cameras that have working ONVIF event streams will not try additional methods as the open stream proves the camera is already online.