### PR TITLE
[knx] Correctly support state sub-types for DPTs 

### DIFF
--- a/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/channel/KNXChannelTest.java
+++ b/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/channel/KNXChannelTest.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.items.ColorItem;
+import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.UnDefType;
@@ -156,6 +158,18 @@ class KNXChannelTest {
         assertEquals(2, writeAddresses.size());
         assertTrue(writeAddresses.contains(new GroupAddress("1/2/3")));
         assertTrue(writeAddresses.contains(new GroupAddress("7/1/9")));
+    }
+
+    @Test
+    void testSubTypeMapping() throws KNXFormatException {
+        Channel channel = Objects.requireNonNull(mock(Channel.class));
+        Configuration configuration = new Configuration(Map.of("key1", "1.001:1/2/3"));
+        when(channel.getChannelTypeUID()).thenReturn(new ChannelTypeUID("a:b:c"));
+        when(channel.getConfiguration()).thenReturn(configuration);
+        when(channel.getAcceptedItemType()).thenReturn(ColorItem.class.getName());
+        MyKNXChannel knxChannel = new MyKNXChannel(channel);
+        assertNotNull(knxChannel.getCommandSpec(new HSBType("0,100,100")));
+        assertEquals(knxChannel.getCommandSpec(new HSBType("0,100,100")).getDPT(), "1.001");
     }
 
     private static class MyKNXChannel extends KNXChannel {


### PR DESCRIPTION
This fixes a problem when KNX channels are linked to items that support sub-types of what the DPTs can handle in case of "-control" channels or channels with a follow profile.

More concretely: Having a Color Item linked through the follow profile to a DPT 1.001 results in `None of the configured GAs on channel 'xxx' could handle the command`, while it would be expected that `true` is sent for anything that isn't equal to the state `OFF`.

This PR makes sure that the binding tries to check if the command is a state that can be converted to a suitable subtype for the linked DPT and then sends out the according KNX telegram.
