### PR TITLE
[boschshc] fix wrong config description references

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -340,7 +340,7 @@
 			<channel id="key-event-timestamp" typeId="key-event-timestamp"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:boschshc:user-defined-state"/>
+		<config-description-ref uri="thing-type:boschshc:device"/>
 	</thing-type>
 
 	<thing-type id="universal-switch-2">
@@ -358,7 +358,7 @@
 			<channel id="key-event-timestamp" typeId="key-event-timestamp"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:boschshc:user-defined-state"/>
+		<config-description-ref uri="thing-type:boschshc:device"/>
 	</thing-type>
 
 	<!-- Channels -->


### PR DESCRIPTION
wrong references were introduced during copy & paste from the previous thing type definition