### PR TITLE
[mqtt.generic] default STOP to null for rollershutter channel

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/OH-INF/config/rollershutter-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/OH-INF/config/rollershutter-channel-config.xml
@@ -94,7 +94,6 @@
 		<parameter name="stop" type="text">
 			<label>Stop Command</label>
 			<description>A string (like "STOP") that is sent when commanding the rollershutter to stop.</description>
-			<default>STOP</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="onState" type="text">


### PR DESCRIPTION
Closes #16276

This is how it mostly works already anyway. Sometimes core isn't persisting the default into the configuration, so we're getting null. I tried to infer that `null` should mean `"STOP"` (and empty string should mean `null`), but that resulted in weirdness where you could click the X next to the field in the UI to default it, but it would show empty until you saved and reloaded, at which point it would then show `STOP` again. Defaulting to null gets rid of that surprise, and brings it inline with how UP and DOWN already behave.