### PR TITLE
[jinja] disable failOnUnknownTokens

### DIFF
--- a/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/JinjaTransformationService.java
+++ b/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/JinjaTransformationService.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 
 /**
@@ -47,8 +46,7 @@ public class JinjaTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(JinjaTransformationService.class);
 
-    private final JinjavaConfig config = JinjavaConfig.newBuilder().withFailOnUnknownTokens(true).build();
-    private final Jinjava jinjava = new Jinjava(config);
+    private final Jinjava jinjava = new Jinjava();
 
     /**
      * Transforms the input <code>value</code> by Jinja template.

--- a/bundles/org.openhab.transform.jinja/src/test/java/org/openhab/transform/jinja/internal/JinjaTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.jinja/src/test/java/org/openhab/transform/jinja/internal/JinjaTransformationServiceTest.java
@@ -76,15 +76,13 @@ public class JinjaTransformationServiceTest {
     }
 
     @Test
-    public void testMissingVariableError() {
-        assertThrows(TransformationException.class,
-                () -> processor.transform("Hello {{ missing }}!", "{\"string\": \"world\"}"));
+    public void testMissingVariableError() throws TransformationException {
+        assertEquals("Hello !", processor.transform("Hello {{ missing }}!", "{\"string\": \"world\"}"));
     }
 
     @Test
-    public void testMissingMapKeyError() {
-        assertThrows(TransformationException.class,
-                () -> processor.transform("Hello {{ value_json.missing }}!", "{\"string\": \"world\"}"));
+    public void testMissingMapKeyError() throws TransformationException {
+        assertEquals("Hello !", processor.transform("Hello {{ value_json.missing }}!", "{\"string\": \"world\"}"));
     }
 
     @Test


### PR DESCRIPTION
Home Assistant doesn't enable strict mode, so we shouldn't either. Fixes https://github.com/Koenkk/zigbee2mqtt/issues/17395

