### PR TITLE
[jsscripting] Upgrade openhab-js to 4.8.1

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -24,7 +24,7 @@
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@4.8.0</ohjs.version>
+    <ohjs.version>openhab@4.8.1</ohjs.version>
   </properties>
 
   <build>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -24,7 +24,7 @@
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@4.7.3</ohjs.version>
+    <ohjs.version>openhab@4.8.0</ohjs.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Changelog: https://github.com/openhab/openhab-js/blob/main/CHANGELOG.md#480.
4.8.1 only contains a fix for the add-on build.

FYI @holgerfriedrich : CoreUtil actions should now be available in JS Scripting.