### PR TITLE
[http] Document translation services need to be installed before usage

### DIFF
--- a/bundles/org.openhab.binding.http/README.md
+++ b/bundles/org.openhab.binding.http/README.md
@@ -67,7 +67,7 @@ When concatenating the `baseURL` and `stateExtension` or `commandExtension` the 
 
 Transformations can be used if the supplied value (or the required value) is different from what openHAB internal types require.
 
-The relevant transformation service needs to be installed via the Main UI before use.
+The relevant transformation service needs to be installed via the Main UI or addons.cfg before use.
 
 Here are a few examples to unwrap an incoming value via `stateTransformation` from a complex response:
 

--- a/bundles/org.openhab.binding.http/README.md
+++ b/bundles/org.openhab.binding.http/README.md
@@ -66,6 +66,9 @@ When concatenating the `baseURL` and `stateExtension` or `commandExtension` the 
 ### Value Transformations (`stateTransformation`, `commandTransformation`)
 
 Transformations can be used if the supplied value (or the required value) is different from what openHAB internal types require.
+
+The relevant transformation service needs to be installed via the Main UI before use.
+
 Here are a few examples to unwrap an incoming value via `stateTransformation` from a complex response:
 
 | Received value                                                      | Tr. Service | Transformation                            |


### PR DESCRIPTION
Added "The relevant transformation service needs to be installed via the Main UI before use." (I wasted several hours trying to figure out why my JSONPATH transformation wasn't working.)

