### PR TITLE
[jsonpath] Upgrade dependencies and some cleanup

### DIFF
--- a/bundles/org.openhab.transform.jsonpath/pom.xml
+++ b/bundles/org.openhab.transform.jsonpath/pom.xml
@@ -15,32 +15,39 @@
   <name>openHAB Add-ons :: Bundles :: Transformation Service :: JSonPath</name>
 
   <properties>
-    <bnd.importpackage>!org.apache.tapestry5.json.*,!org.codehaus.jettison.json.*,!org.json.*,!com.fasterxml.jackson.*</bnd.importpackage>
+    <bnd.importpackage>!org.apache.tapestry5.json.*,!org.codehaus.jettison.json.*,!org.json.*,!com.fasterxml.jackson.*,!jakarta.json.*</bnd.importpackage>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.5.0</version>
+      <version>2.9.0</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Exclude slf4j-api to prevent its scope being changed from 'provided' to 'runtime' -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>5.0.4</version>
+      <version>9.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>accessors-smart</artifactId>
-      <version>1.2</version>
+      <version>2.5.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.3</version>
+      <version>2.5.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -30,12 +30,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 
 /**
- * <p>
- * The implementation of {@link TransformationService} which transforms the input by JSonPath Expressions.
+ * The implementation of a {@link TransformationService} which transforms the input by JSonPath Expressions.
  *
- * @author Gaël L'hopital
- * @author Sebastian Janzen
- *
+ * @author Gaël L'hopital - Initial contribution
+ * @author Sebastian Janzen - Initial contribution
  */
 @NonNullByDefault
 @Component(property = { "openhab.transform=JSONPATH" })
@@ -68,7 +66,7 @@ public class JSonPathTransformationService implements TransformationService {
             logger.debug("transformation resulted in '{}'", transformationResult);
             if (transformationResult == null) {
                 return null;
-            } else if (transformationResult instanceof List list) {
+            } else if (transformationResult instanceof List<?> list) {
                 return flattenList(list);
             } else {
                 return transformationResult.toString();
@@ -98,10 +96,10 @@ public class JSonPathTransformationService implements TransformationService {
     }
 
     private String createNumberList(List<?> list) {
-        return list.stream().map(n -> String.valueOf(n)).collect(Collectors.joining(", ", "[", "]"));
+        return list.stream().map(String::valueOf).collect(Collectors.joining(", ", "[", "]"));
     }
 
     private String createStringList(List<?> list) {
-        return list.stream().map(n -> "\"" + String.valueOf(n) + "\"").collect(Collectors.joining(", ", "[", "]"));
+        return list.stream().map(n -> "\"" + n + "\"").collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfile.java
+++ b/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfile.java
@@ -30,8 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Profile to offer the JSonPathTransformationservice on an ItemChannelLink
  *
- * @author Stefan Triller - initial contribution
- *
+ * @author Stefan Triller - Initial contribution
  */
 @NonNullByDefault
 public class JSonPathTransformationProfile implements StateProfile {
@@ -47,10 +46,8 @@ public class JSonPathTransformationProfile implements StateProfile {
     private static final String FUNCTION_PARAM = "function";
     private static final String SOURCE_FORMAT_PARAM = "sourceFormat";
 
-    @NonNullByDefault({})
-    private final String function;
-    @NonNullByDefault({})
-    private final String sourceFormat;
+    private final @NonNullByDefault({}) String function;
+    private final @NonNullByDefault({}) String sourceFormat;
 
     public JSonPathTransformationProfile(ProfileCallback callback, ProfileContext context,
             TransformationService service) {

--- a/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfileFactory.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.transform.jsonpath.internal.profiles;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -31,21 +31,19 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * Profilefactory that creates the transformation profile for the jsonpath transformation service
+ * {@link ProfileFactory} that creates the transformation profile for the jsonpath transformation service
  *
- * @author Stefan Triller - initial contribution
- *
+ * @author Stefan Triller - Initial contribution
  */
 @NonNullByDefault
 @Component(service = { ProfileFactory.class, ProfileTypeProvider.class })
 public class JSonPathTransformationProfileFactory implements ProfileFactory, ProfileTypeProvider {
 
-    @NonNullByDefault({})
-    private TransformationService service;
+    private @NonNullByDefault({}) TransformationService service;
 
     @Override
     public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
-        return Arrays.asList(ProfileTypeBuilder.newState(JSonPathTransformationProfile.PROFILE_TYPE_UID,
+        return List.of(ProfileTypeBuilder.newState(JSonPathTransformationProfile.PROFILE_TYPE_UID,
                 JSonPathTransformationProfile.PROFILE_TYPE_UID.getId()).build());
     }
 
@@ -57,7 +55,7 @@ public class JSonPathTransformationProfileFactory implements ProfileFactory, Pro
 
     @Override
     public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
-        return Arrays.asList(JSonPathTransformationProfile.PROFILE_TYPE_UID);
+        return List.of(JSonPathTransformationProfile.PROFILE_TYPE_UID);
     }
 
     @Reference(target = "(openhab.transform=JSONPATH)")

--- a/bundles/org.openhab.transform.jsonpath/src/main/resources/readme.txt
+++ b/bundles/org.openhab.transform.jsonpath/src/main/resources/readme.txt
@@ -1,1 +1,0 @@
-Bundle resources go in here!

--- a/bundles/org.openhab.transform.jsonpath/src/test/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.jsonpath/src/test/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -14,6 +14,7 @@ package org.openhab.transform.jsonpath.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;
@@ -21,9 +22,10 @@ import org.openhab.core.transform.TransformationException;
 /**
  * @author Gaël L'hopital - Initial contribution
  */
+@NonNullByDefault
 public class JSonPathTransformationServiceTest {
 
-    private JSonPathTransformationService processor;
+    private @NonNullByDefault({}) JSonPathTransformationService processor;
 
     @BeforeEach
     public void init() {
@@ -40,59 +42,59 @@ public class JSonPathTransformationServiceTest {
         assertEquals("Nigel Rees", transformedResponse);
     }
 
-    private static final String jsonArray = "[" + //
+    private static final String JSON_ARRAY = "[" + //
             "{ \"id\":1, \"name\":\"bob\", \"empty\":null }," + //
             "{ \"id\":2, \"name\":\"alice\" }" + //
             "]";
 
     @Test
     public void testValidPath1() throws TransformationException {
-        String transformedResponse = processor.transform("$[0].name", jsonArray);
+        String transformedResponse = processor.transform("$[0].name", JSON_ARRAY);
         assertEquals("bob", transformedResponse);
     }
 
     @Test
     public void testValidPath2() throws TransformationException {
-        String transformedResponse = processor.transform("$[1].id", jsonArray);
+        String transformedResponse = processor.transform("$[1].id", JSON_ARRAY);
         assertEquals("2", transformedResponse);
     }
 
     @Test
     public void testInvalidPathThrowsException() {
-        assertThrows(TransformationException.class, () -> processor.transform("$$", jsonArray));
+        assertThrows(TransformationException.class, () -> processor.transform("$$", JSON_ARRAY));
     }
 
     @Test
     public void testPathMismatchReturnNull() {
-        assertThrows(TransformationException.class, () -> processor.transform("$[5].id", jsonArray));
+        assertThrows(TransformationException.class, () -> processor.transform("$[5].id", JSON_ARRAY));
     }
 
     @Test
-    public void testInvalidJsonReturnNull() throws TransformationException {
+    public void testInvalidJsonReturnNull() {
         assertThrows(TransformationException.class, () -> processor.transform("$", "{id:"));
     }
 
     @Test
     public void testNullValue() throws TransformationException {
-        String transformedResponse = processor.transform("$[0].empty", jsonArray);
-        assertEquals(null, transformedResponse);
+        String transformedResponse = processor.transform("$[0].empty", JSON_ARRAY);
+        assertNull(transformedResponse);
     }
 
     @Test
-    public void testIndefinite_filteredToSingle() throws TransformationException {
-        String transformedResponse = processor.transform("$.*[?(@.name=='bob')].id", jsonArray);
+    public void testIndefiniteFilteredToSingle() throws TransformationException {
+        String transformedResponse = processor.transform("$.*[?(@.name=='bob')].id", JSON_ARRAY);
         assertEquals("1", transformedResponse);
     }
 
     @Test
-    public void testIndefinite_notFiltered() throws TransformationException {
-        String transformedResponse = processor.transform("$.*.id", jsonArray);
+    public void testIndefiniteNotFiltered() throws TransformationException {
+        String transformedResponse = processor.transform("$.*.id", JSON_ARRAY);
         assertEquals("[1, 2]", transformedResponse);
     }
 
     @Test
-    public void testIndefinite_noMatch() throws TransformationException {
-        String transformedResponse = processor.transform("$.*[?(@.name=='unknown')].id", jsonArray);
+    public void testIndefiniteNoMatch() throws TransformationException {
+        String transformedResponse = processor.transform("$.*[?(@.name=='unknown')].id", JSON_ARRAY);
         assertEquals("NULL", transformedResponse);
     }
 


### PR DESCRIPTION
* Upgrade json-path from 2.5.0 to 2.9.0
* Cleanup code
* Fix all SAT findings

Fixes CVE-2023-1370 and CVE-2023-51074

For json-path release notes, see:

https://github.com/json-path/JsonPath/releases