### PR TITLE
Remove readme.txt from transformation bundles

### DIFF
--- a/bundles/org.openhab.transform.exec/src/main/resources/readme.txt
+++ b/bundles/org.openhab.transform.exec/src/main/resources/readme.txt
@@ -1,1 +1,0 @@
-Bundle resources go in here!

--- a/bundles/org.openhab.transform.regex/src/main/resources/readme.txt
+++ b/bundles/org.openhab.transform.regex/src/main/resources/readme.txt
@@ -1,1 +1,0 @@
-Bundle resources go in here!

--- a/bundles/org.openhab.transform.xpath/src/main/resources/readme.txt
+++ b/bundles/org.openhab.transform.xpath/src/main/resources/readme.txt
@@ -1,1 +1,0 @@
-Bundle resources go in here!

--- a/bundles/org.openhab.transform.xslt/src/main/resources/readme.txt
+++ b/bundles/org.openhab.transform.xslt/src/main/resources/readme.txt
@@ -1,1 +1,0 @@
-Bundle resources go in here!


### PR DESCRIPTION
It's obvious and the file also ends up in the bundle JARs.