### PR TITLE
[influxdb] Standardize the label for influxdb

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/InfluxDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/InfluxDBPersistenceService.java
@@ -170,7 +170,7 @@ public class InfluxDBPersistenceService implements ModifiablePersistenceService 
 
     @Override
     public String getLabel(@Nullable Locale locale) {
-        return "InfluxDB persistence layer";
+        return "InfluxDB";
     }
 
     @Override


### PR DESCRIPTION
The label looks out of place in Blockly

Before:
<img width="560" alt="image" src="https://github.com/openhab/openhab-addons/assets/2554958/bff74ad2-0166-4aaf-b5eb-eda419001ad1">

After:
<img width="605" alt="image" src="https://github.com/openhab/openhab-addons/assets/2554958/73f80067-d7ee-437d-9abd-11f7fef298c1">

