### PR TITLE
[openwebnet] Replace gnu.io dependency with serial transport

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -14,11 +14,6 @@
 
   <name>openHAB Add-ons :: Bundles :: OpenWebNet (BTicino/Legrand) Binding</name>
 
-  <!--
-    <properties>
-    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
-    </properties>
-  -->
   <dependencies>
 
     <dependency>

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.10.1</version>
+      <version>0.12.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -14,10 +14,11 @@
 
   <name>openHAB Add-ons :: Bundles :: OpenWebNet (BTicino/Legrand) Binding</name>
 
-  <properties>
+  <!--
+    <properties>
     <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
-  </properties>
-
+    </properties>
+  -->
   <dependencies>
 
     <dependency>

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
+import org.openhab.binding.openwebnet.internal.serial.SerialTransportAdapter;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -44,9 +45,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link UsbGatewayDiscoveryService} extends {@link AbstractDiscoveryService} to detect Zigbee USB gateways
- * connected via serial port. The service will iterate over the available serial ports and open each one to test if a
- * OpenWebNet Zigbee USB gateway is connected. On successful connection, a new DiscoveryResult is created.
+ * The {@link UsbGatewayDiscoveryService} extends
+ * {@link AbstractDiscoveryService} to detect Zigbee USB gateways connected via
+ * serial port. The service will iterate over the available serial ports and
+ * open each one to test if a OpenWebNet Zigbee USB gateway is connected. On
+ * successful connection, a new DiscoveryResult is created.
  *
  * @author Massimo Valla - Initial contribution
  */
@@ -74,13 +77,21 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
     private boolean scanning;
 
     /**
-     * Constructs a new UsbGatewayDiscoveryService with the specified Zigbee USB Bridge ThingTypeUID
+     * Constructs a new UsbGatewayDiscoveryService with the specified Zigbee USB
+     * Bridge ThingTypeUID
      */
     @Activate
     public UsbGatewayDiscoveryService(final @Reference SerialPortManager spm) {
         super(Set.of(OpenWebNetBindingConstants.THING_TYPE_ZB_GATEWAY), DISCOVERY_TIMEOUT_SECONDS, false);
         // Obtain the serial port manager service using an OSGi reference
         serialPortManager = spm;
+        // FIXME
+
+        SerialTransportAdapter.setSerialPortManager(spm);
+
+        logger.debug("*********************************************************************************");
+        logger.debug("********************* set SerialPortManager: {}", SerialTransportAdapter.serialPortManager);
+        logger.debug("*********************************************************************************");
     }
 
     /**

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
-import org.openhab.binding.openwebnet.internal.serial.SerialTransportAdapter;
+import org.openhab.binding.openwebnet.internal.serial.SerialPortProviderAdapter;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -66,7 +66,7 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
     private @Nullable ScheduledFuture<?> connectTimeout;
 
     private final SerialPortManager serialPortManager;
-    private final SerialTransportAdapter transportAdapter;
+    private final SerialPortProviderAdapter transportAdapter;
 
     private @Nullable USBGateway zbGateway;
 
@@ -86,9 +86,9 @@ public class UsbGatewayDiscoveryService extends AbstractDiscoveryService impleme
         super(Set.of(OpenWebNetBindingConstants.THING_TYPE_ZB_GATEWAY), DISCOVERY_TIMEOUT_SECONDS, false);
         // Inject the SerialPortManager passed via @Reference into the adapter
         serialPortManager = spm;
-        SerialTransportAdapter.setSerialPortManager(spm);
-        this.transportAdapter = new SerialTransportAdapter();
-        logger.debug("**** -SPI- **** Set SerialPortManager to: {}", SerialTransportAdapter.serialPortManager);
+        SerialPortProviderAdapter.setSerialPortManager(spm);
+        this.transportAdapter = new SerialPortProviderAdapter();
+        logger.debug("**** -SPI- **** Set SerialPortManager to: {}", SerialPortProviderAdapter.serialPortManager);
     }
 
     /**

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/UsbGatewayDiscoveryService.java
@@ -50,7 +50,8 @@ import org.slf4j.LoggerFactory;
  * open each one to test if a OpenWebNet Zigbee USB gateway is connected. On
  * successful connection, a new DiscoveryResult is created.
  *
- * @author Massimo Valla - Initial contribution
+ * @author Massimo Valla - Initial contribution. Inject SerialPortManager to
+ *         openwebnet4j lib.
  */
 @NonNullByDefault
 @Component(service = DiscoveryService.class, configurationPid = "discovery.openwebnet")

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -391,7 +391,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     /**
      * Register a device ThingHandler to this BridgHandler
      *
-     * @param ownId        the device OpenWebNet id
+     * @param ownId the device OpenWebNet id
      * @param thingHandler the thing handler to be registered
      */
     protected void registerDevice(String ownId, OpenWebNetThingHandler thingHandler) {
@@ -682,7 +682,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     /**
      * Return a ownId string (=WHO.WHERE) from the device Where address and handler
      *
-     * @param where   the Where address (to be normalized)
+     * @param where the Where address (to be normalized)
      * @param handler the device handler
      * @return the ownId String
      */
@@ -693,7 +693,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     /**
      * Returns a ownId string (=WHO.WHERE) from a Who and Where address
      *
-     * @param who   the Who
+     * @param who the Who
      * @param where the Where address (to be normalized)
      * @return the ownId String
      */

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -180,15 +180,10 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
                     "@text/offline.conf-error-no-serial-port");
             return null;
         } else {
-
-            // FIXME modified - test no SPI
             USBGateway tmpUSBGateway = new USBGateway(serialPort);
-
             tmpUSBGateway.setSerialPortProvider(new SerialTransportAdapter());
-            logger.info("===================================================================================");
-            logger.info("===================== OpenWebNetBridgeHandler :: setSerialPortProvider to: {}",
-                    tmpUSBGateway.serialPortProvider);
-            logger.info("===================================================================================");
+            logger.debug("**** -SPI- ****  OpenWebNetBridgeHandler :: setSerialPortProvider to: {}",
+                    tmpUSBGateway.getSerialPortProvider());
             return tmpUSBGateway;
         }
     }
@@ -396,7 +391,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     /**
      * Register a device ThingHandler to this BridgHandler
      *
-     * @param ownId the device OpenWebNet id
+     * @param ownId        the device OpenWebNet id
      * @param thingHandler the thing handler to be registered
      */
     protected void registerDevice(String ownId, OpenWebNetThingHandler thingHandler) {
@@ -687,7 +682,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     /**
      * Return a ownId string (=WHO.WHERE) from the device Where address and handler
      *
-     * @param where the Where address (to be normalized)
+     * @param where   the Where address (to be normalized)
      * @param handler the device handler
      * @return the ownId String
      */
@@ -698,7 +693,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
     /**
      * Returns a ownId string (=WHO.WHERE) from a Who and Where address
      *
-     * @param who the Who
+     * @param who   the Who
      * @param where the Where address (to be normalized)
      * @return the ownId String
      */

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -32,6 +32,7 @@ import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
 import org.openhab.binding.openwebnet.internal.discovery.OpenWebNetDeviceDiscoveryService;
 import org.openhab.binding.openwebnet.internal.handler.config.OpenWebNetBusBridgeConfig;
 import org.openhab.binding.openwebnet.internal.handler.config.OpenWebNetZigBeeBridgeConfig;
+import org.openhab.binding.openwebnet.internal.serial.SerialTransportAdapter;
 import org.openhab.core.config.core.status.ConfigStatusMessage;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -179,7 +180,16 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
                     "@text/offline.conf-error-no-serial-port");
             return null;
         } else {
-            return new USBGateway(serialPort);
+
+            // FIXME modified - test no SPI
+            USBGateway tmpUSBGateway = new USBGateway(serialPort);
+
+            tmpUSBGateway.setSerialPortProvider(new SerialTransportAdapter());
+            logger.info("===================================================================================");
+            logger.info("===================== OpenWebNetBridgeHandler :: setSerialPortProvider to: {}",
+                    tmpUSBGateway.serialPortProvider);
+            logger.info("===================================================================================");
+            return tmpUSBGateway;
         }
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -32,7 +32,7 @@ import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
 import org.openhab.binding.openwebnet.internal.discovery.OpenWebNetDeviceDiscoveryService;
 import org.openhab.binding.openwebnet.internal.handler.config.OpenWebNetBusBridgeConfig;
 import org.openhab.binding.openwebnet.internal.handler.config.OpenWebNetZigBeeBridgeConfig;
-import org.openhab.binding.openwebnet.internal.serial.SerialTransportAdapter;
+import org.openhab.binding.openwebnet.internal.serial.SerialPortProviderAdapter;
 import org.openhab.core.config.core.status.ConfigStatusMessage;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -181,7 +181,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
             return null;
         } else {
             USBGateway tmpUSBGateway = new USBGateway(serialPort);
-            tmpUSBGateway.setSerialPortProvider(new SerialTransportAdapter());
+            tmpUSBGateway.setSerialPortProvider(new SerialPortProviderAdapter());
             logger.debug("**** -SPI- ****  OpenWebNetBridgeHandler :: setSerialPortProvider to: {}",
                     tmpUSBGateway.getSerialPortProvider());
             return tmpUSBGateway;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetLightingHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetLightingHandler.java
@@ -385,8 +385,7 @@ public class OpenWebNetLightingHandler extends OpenWebNetThingHandler {
      *
      * @param channelId the channelId string
      **/
-    @Nullable
-    private String toWhere(String channelId) {
+    private String toWhere(String channelId) throws OWNException {
         Where w = deviceWhere;
         if (w != null) {
             OpenWebNetBridgeHandler brH = bridgeHandler;
@@ -400,6 +399,6 @@ public class OpenWebNetLightingHandler extends OpenWebNetThingHandler {
                 }
             }
         }
-        return null;
+        throw new OWNException("Cannot select channel from WHERE " + w);
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortAdapter.java
@@ -46,12 +46,6 @@ public class SerialPortAdapter implements org.openwebnet4j.communication.serial.
     private @Nullable SerialPort sp = null;
 
     public SerialPortAdapter(final SerialPortIdentifier spid) {
-        logger.debug(
-                "*************************************************************************************************************");
-        logger.debug(
-                "************* org.openhab.binding.openwebnet.internal.serial.SerialPortAdapter *** Constructor **************");
-        logger.debug(
-                "*************************************************************************************************************");
         this.spid = spid;
     }
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortAdapter.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.openwebnet.internal.serial;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.TooManyListenersException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.io.transport.serial.PortInUseException;
+import org.openhab.core.io.transport.serial.SerialPort;
+import org.openhab.core.io.transport.serial.SerialPortEvent;
+import org.openhab.core.io.transport.serial.SerialPortEventListener;
+import org.openhab.core.io.transport.serial.SerialPortIdentifier;
+import org.openhab.core.io.transport.serial.UnsupportedCommOperationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * openwebnet4j SerialPort implementation based on
+ * org.openhab.core.io.transport.serial.SerialPort
+ *
+ * @author M. Valla - Initial contribution
+ */
+
+@NonNullByDefault
+// FIXME rename SerialPortImpl
+public class SerialPortAdapter implements org.openwebnet4j.communication.serial.spi.SerialPort {
+
+    private static final Logger logger = LoggerFactory.getLogger(SerialPortAdapter.class);
+
+    private class AdapterEvListener implements SerialPortEventListener {
+
+        org.openwebnet4j.communication.serial.spi.@Nullable SerialPortEventListener lsnr;
+
+        void subscribe(org.openwebnet4j.communication.serial.spi.SerialPortEventListener listener) {
+            lsnr = listener;
+        }
+
+        @Override
+        public void serialEvent(SerialPortEvent event) {
+            org.openwebnet4j.communication.serial.spi.SerialPortEventListener localLsnr = lsnr;
+            if (event != null && localLsnr != null) {
+                localLsnr.serialEvent(new SerialPortEventAdapter(event));
+            }
+        }
+    }
+
+    private static final int OPEN_TIMEOUT_MS = 200;
+
+    private final SerialPortIdentifier spid;
+
+    private @Nullable SerialPort sp = null;
+
+    @Nullable
+    AdapterEvListener adaptListener = null;
+
+    public SerialPortAdapter(final SerialPortIdentifier spid) {
+        logger.debug(
+                "*************************************************************************************************************");
+        logger.debug(
+                "************* org.openhab.binding.openwebnet.internal.serial.SerialPortAdapter *** Constructor **************");
+        logger.debug(
+                "*************************************************************************************************************");
+        this.spid = spid;
+    }
+
+    @Override
+    public boolean setSerialPortParams(int baudrate, int dataBits, int stopBits, int parity) {
+        @Nullable
+        SerialPort lsp = sp;
+        if (lsp != null) {
+            try {
+                lsp.setSerialPortParams(baudrate, dataBits, stopBits, parity);
+                return true;
+            } catch (UnsupportedCommOperationException e) {
+                logger.error("UnsupportedCommOperationException while setting port params in setSerialPortParams: {}",
+                        e.getMessage());
+                return false;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean addEventListener(org.openwebnet4j.communication.serial.spi.SerialPortEventListener listener) {
+        @Nullable
+        SerialPort lsp = sp;
+        if (lsp != null) {
+            adaptListener = new AdapterEvListener();
+            AdapterEvListener lsnr = adaptListener;
+            if (lsnr != null) {
+                lsnr.subscribe(listener);
+                try {
+                    lsp.notifyOnDataAvailable(true);
+                    lsp.addEventListener(lsnr);
+                    return true;
+                } catch (TooManyListenersException e) {
+                    logger.error("TooManyListenersException while adding event listener: {}", e.getMessage());
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean open() {
+        try {
+            sp = spid.open(this.getClass().getName(), OPEN_TIMEOUT_MS);
+        } catch (PortInUseException e) {
+            logger.error("PortInUseException while opening serial port {}: {}", spid.getName(), e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public @Nullable String getName() {
+        @Nullable
+        SerialPort lsp = sp;
+        if (lsp != null) {
+            return lsp.getName();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public @Nullable InputStream getInputStream() throws IOException {
+        @Nullable
+        SerialPort lsp = sp;
+        if (lsp != null) {
+            return lsp.getInputStream();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public @Nullable OutputStream getOutputStream() throws IOException {
+        @Nullable
+        SerialPort lsp = sp;
+        if (lsp != null) {
+            return lsp.getOutputStream();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() {
+        @Nullable
+        SerialPort lsp = sp;
+        if (lsp != null) {
+            lsp.close();
+        }
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.openwebnet.internal.serial;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openwebnet4j.communication.serial.spi.SerialPortEvent;
+
+/**
+ * openwebnet4j SerialPortEvent implementation based on
+ * org.openhab.core.io.transport.serial.SerialPortEvent
+ *
+ * @author M. Valla - Initial contribution
+ */
+
+@NonNullByDefault
+public class SerialPortEventAdapter implements SerialPortEvent {
+
+    private final org.openhab.core.io.transport.serial.SerialPortEvent event;
+
+    /**
+     * Constructor.
+     *
+     * @param event the underlying event implementation
+     */
+    public SerialPortEventAdapter(org.openhab.core.io.transport.serial.SerialPortEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public int getEventType() {
+        if (event.getEventType() == 11) { // TODO to be changed to constant when defined in
+                                          // org.openhab.core.io.transport.serial.SerialPortEvent
+            return SerialPortEvent.EVENT_PORT_DISCONNECTED;
+        } else {
+            return event.getEventType();
+        }
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
@@ -16,8 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openwebnet4j.communication.serial.spi.SerialPortEvent;
 
 /**
- * openwebnet4j SerialPortEvent implementation based on
- * org.openhab.core.io.transport.serial.SerialPortEvent
+ * openwebnet4j SerialPortEvent implementation based on OH serial transport
  *
  * @author M. Valla - Initial contribution
  */

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
@@ -45,5 +45,4 @@ public class SerialPortEventAdapter implements SerialPortEvent {
             return event.getEventType();
         }
     }
-
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortEventAdapter.java
@@ -37,11 +37,13 @@ public class SerialPortEventAdapter implements SerialPortEvent {
 
     @Override
     public int getEventType() {
-        if (event.getEventType() == 11) { // TODO to be changed to constant when defined in
-                                          // org.openhab.core.io.transport.serial.SerialPortEvent
+        if (event.getEventType() == org.openhab.core.io.transport.serial.SerialPortEvent.PORT_DISCONNECTED) {
             return SerialPortEvent.EVENT_PORT_DISCONNECTED;
+        } else if (event.getEventType() == org.openhab.core.io.transport.serial.SerialPortEvent.DATA_AVAILABLE) {
+            return SerialPortEvent.EVENT_DATA_AVAILABLE;
         } else {
             return event.getEventType();
         }
     }
+
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortProviderAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialPortProviderAdapter.java
@@ -33,15 +33,14 @@ import aQute.bnd.annotation.spi.ServiceProvider;
  */
 @ServiceProvider(value = SerialPortProvider.class)
 @NonNullByDefault
-// FIXME rename SerialPortProviderImpl
-public class SerialTransportAdapter implements SerialPortProvider {
+public class SerialPortProviderAdapter implements SerialPortProvider {
 
-    private Logger logger = LoggerFactory.getLogger(SerialTransportAdapter.class);
+    private Logger logger = LoggerFactory.getLogger(SerialPortProviderAdapter.class);
     @Nullable
     public static SerialPortManager serialPortManager = null;
 
     public static void setSerialPortManager(SerialPortManager serialPortManager) {
-        SerialTransportAdapter.serialPortManager = serialPortManager;
+        SerialPortProviderAdapter.serialPortManager = serialPortManager;
     }
 
     @Override

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialTransportAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialTransportAdapter.java
@@ -27,8 +27,7 @@ import org.slf4j.LoggerFactory;
 import aQute.bnd.annotation.spi.ServiceProvider;
 
 /**
- * openwebnet4j SerialPortProvider implementation based on
- * org.openhab.core.io.transport.serial.SerialPortManager
+ * openwebnet4j SerialPortProvider implementation based on OH serial transport
  *
  * @author M. Valla - Initial contribution
  */

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialTransportAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialTransportAdapter.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.openwebnet.internal.serial;
+
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.io.transport.serial.SerialPortIdentifier;
+import org.openhab.core.io.transport.serial.SerialPortManager;
+import org.openwebnet4j.communication.serial.spi.SerialPort;
+import org.openwebnet4j.communication.serial.spi.SerialPortProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import aQute.bnd.annotation.spi.ServiceProvider;
+
+/**
+ * openwebnet4j SerialPortProvider implementation based on
+ * org.openhab.core.io.transport.serial.SerialPortManager
+ *
+ * @author M. Valla - Initial contribution
+ */
+@ServiceProvider(value = SerialPortProvider.class)
+@NonNullByDefault
+// FIXME rename SerialPortProviderImpl
+
+public class SerialTransportAdapter implements SerialPortProvider {
+
+    private Logger logger = LoggerFactory.getLogger(SerialTransportAdapter.class);
+    @Nullable
+    // FIXME
+    public static SerialPortManager serialPortManager = null;
+    // @Nullable
+    // private SerialPort serialPort = null;
+
+    public SerialTransportAdapter() {
+        // FIXME remove logs
+        logger.info("#### ***********************************************");
+        logger.info("#### **** SerialTransportAdapter *** Constructor ***");
+        logger.info("#### ***********************************************");
+    }
+
+    public static void setSerialPortManager(SerialPortManager serialPortManager) {
+        SerialTransportAdapter.serialPortManager = serialPortManager;
+        // FIXME remove logs
+        System.out.println("*************************************************************************");
+        System.out.println("********* SerialTransportAdapter *** Set static SerialPortManager to: "
+                + SerialTransportAdapter.serialPortManager);
+        System.out.println("*************************************************************************");
+    }
+
+    @Override
+    public @Nullable SerialPort getSerialPort(String portName) {
+        final @Nullable SerialPortManager spm = serialPortManager;
+        if (spm == null) {
+            return null;
+        }
+        SerialPortIdentifier spid = spm.getIdentifier(portName);
+        if (spid == null) {
+            logger.debug("No SerialPort {} found", portName);
+            return null;
+        } else {
+            return new SerialPortAdapter(spid);
+        }
+    }
+
+    @Override
+    public Stream<SerialPort> getSerialPorts() {
+
+        // FIXME remove
+        // Enumeration<CommPortIdentifier> identifiers =
+        // CommPortIdentifier.getPortIdentifiers();
+        // Stream<CommPortIdentifier> ids = Collections.list(identifiers).stream();
+        // return ids.filter(id -> id.getPortType() ==
+        // CommPortIdentifier.PORT_SERIAL).map(sid -> new RxTxSerialPort(sid));
+
+        final @Nullable SerialPortManager spm = serialPortManager;
+        if (spm == null) {
+            return Stream.empty();
+        }
+        return spm.getIdentifiers().map(sid -> new SerialPortAdapter(sid));
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialTransportAdapter.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/serial/SerialTransportAdapter.java
@@ -34,30 +34,14 @@ import aQute.bnd.annotation.spi.ServiceProvider;
 @ServiceProvider(value = SerialPortProvider.class)
 @NonNullByDefault
 // FIXME rename SerialPortProviderImpl
-
 public class SerialTransportAdapter implements SerialPortProvider {
 
     private Logger logger = LoggerFactory.getLogger(SerialTransportAdapter.class);
     @Nullable
-    // FIXME
     public static SerialPortManager serialPortManager = null;
-    // @Nullable
-    // private SerialPort serialPort = null;
-
-    public SerialTransportAdapter() {
-        // FIXME remove logs
-        logger.info("#### ***********************************************");
-        logger.info("#### **** SerialTransportAdapter *** Constructor ***");
-        logger.info("#### ***********************************************");
-    }
 
     public static void setSerialPortManager(SerialPortManager serialPortManager) {
         SerialTransportAdapter.serialPortManager = serialPortManager;
-        // FIXME remove logs
-        System.out.println("*************************************************************************");
-        System.out.println("********* SerialTransportAdapter *** Set static SerialPortManager to: "
-                + SerialTransportAdapter.serialPortManager);
-        System.out.println("*************************************************************************");
     }
 
     @Override
@@ -77,14 +61,6 @@ public class SerialTransportAdapter implements SerialPortProvider {
 
     @Override
     public Stream<SerialPort> getSerialPorts() {
-
-        // FIXME remove
-        // Enumeration<CommPortIdentifier> identifiers =
-        // CommPortIdentifier.getPortIdentifiers();
-        // Stream<CommPortIdentifier> ids = Collections.list(identifiers).stream();
-        // return ids.filter(id -> id.getPortType() ==
-        // CommPortIdentifier.PORT_SERIAL).map(sid -> new RxTxSerialPort(sid));
-
         final @Nullable SerialPortManager spm = serialPortManager;
         if (spm == null) {
             return Stream.empty();


### PR DESCRIPTION
This PR uses a new version of openwebnet4j lib (0.12.0) to avoid dependency of the binding on `gnu.io`.

### Implementation

Version 0.12.0 of the openwebnet4j  lib defines a new `SerialPortProvider` interface to discover and interact with serial ports.

With this PR the binding now provides a `SerialPortProviderAdapter` implementation of openwebnet4j's `SerialPortProvider` based on OH Serial Transport to provide serial port access to the lib, thus making the binding independent from  `gnu.io`.

It has been tested extensively  in a real environment with the Zigbee serial-USB dongle integrated by the binding.

Related to #7573