### PR TITLE
[lgwebos] Increase limit to 5MB for Websocket text message

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSHandlerFactory.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSHandlerFactory.java
@@ -79,8 +79,8 @@ public class LGWebOSHandlerFactory extends BaseThingHandlerFactory {
         // reduce timeout from default 15sec
         this.webSocketClient.setConnectTimeout(1000);
 
-        // channel and app listing are json docs up to 4MB
-        this.webSocketClient.getPolicy().setMaxTextMessageSize(4 * 1024 * 1024);
+        // channel and app listing are json docs up to 5MB
+        this.webSocketClient.getPolicy().setMaxTextMessageSize(5 * 1024 * 1024);
 
         // since this is not using openHAB's shared web socket client we need to start and stop
         try {


### PR DESCRIPTION
A user reported an error with size 4 316 809 while previous max was 4 194 304.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>