### PR TITLE
[openweathermap] Finish clean-up & Fix OneCall Forecast Thing channel creation

### DIFF
--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapOneCallHandler.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/handler/OpenWeatherMapOneCallHandler.java
@@ -85,9 +85,9 @@ public class OpenWeatherMapOneCallHandler extends AbstractOpenWeatherMapHandler 
     private @Nullable OpenWeatherMapOneCallAPIData weatherData;
 
     // forecastMinutes, -Hours and -Days determine the number of channel groups to create for each type
-    private int forecastMinutes = 0;
-    private int forecastHours = 12;
-    private int forecastDays = 6;
+    private int forecastMinutes = 60;
+    private int forecastHours = 48;
+    private int forecastDays = 8;
     private int numberOfAlerts = 0;
 
     public OpenWeatherMapOneCallHandler(Thing thing, final TimeZoneProvider timeZoneProvider) {

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/config/config.xml
@@ -97,19 +97,6 @@
 		</parameter>
 	</config-description>
 
-	<config-description uri="thing-type:openweathermap:uvindex">
-		<parameter name="location" type="text" required="true">
-			<context>location</context>
-			<label>Location of Weather</label>
-			<description>Location of weather in geographical coordinates (latitude/longitude/altitude).</description>
-		</parameter>
-		<parameter name="forecastDays" type="integer" min="1" max="8" step="1">
-			<label>Number of Days</label>
-			<description>Number of days for UV Index forecast.</description>
-			<default>6</default>
-		</parameter>
-	</config-description>
-
 	<config-description uri="thing-type:openweathermap:air-pollution">
 		<parameter name="location" type="text" required="true">
 			<context>location</context>

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/thing-types.xml
@@ -108,6 +108,72 @@
 
 			<channel-group id="forecastMinutely" typeId="oneCallMinutelyTimeSeries"/>
 
+			<channel-group id="forecastMinutes01" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes02" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes03" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes04" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes05" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes06" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes07" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes08" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes09" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes10" typeId="oneCallMinutely"/>
+
+			<channel-group id="forecastMinutes11" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes12" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes13" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes14" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes15" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes16" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes17" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes18" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes19" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes20" typeId="oneCallMinutely"/>
+
+			<channel-group id="forecastMinutes21" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes22" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes23" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes24" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes25" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes26" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes27" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes28" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes29" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes30" typeId="oneCallMinutely"/>
+
+			<channel-group id="forecastMinutes31" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes32" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes33" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes34" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes35" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes36" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes37" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes38" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes39" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes40" typeId="oneCallMinutely"/>
+
+			<channel-group id="forecastMinutes41" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes42" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes43" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes44" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes45" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes46" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes47" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes48" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes49" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes50" typeId="oneCallMinutely"/>
+
+			<channel-group id="forecastMinutes51" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes52" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes53" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes54" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes55" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes56" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes57" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes58" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes59" typeId="oneCallMinutely"/>
+			<channel-group id="forecastMinutes60" typeId="oneCallMinutely"/>
+
 			<channel-group id="forecastHourly" typeId="oneCallHourlyTimeSeries"/>
 
 			<channel-group id="forecastHours01" typeId="oneCallHourly"/>
@@ -122,6 +188,18 @@
 			<channel-group id="forecastHours10" typeId="oneCallHourly"/>
 			<channel-group id="forecastHours11" typeId="oneCallHourly"/>
 			<channel-group id="forecastHours12" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours13" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours14" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours15" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours16" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours17" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours18" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours19" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours20" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours21" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours22" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours23" typeId="oneCallHourly"/>
+			<channel-group id="forecastHours24" typeId="oneCallHourly"/>
 
 			<channel-group id="forecastDaily" typeId="oneCallDailyTimeSeries"/>
 
@@ -148,6 +226,14 @@
 			<channel-group id="forecastDay5" typeId="oneCallDaily">
 				<label>One Call API 5 Day Forecast</label>
 				<description>This is the weather forecast in five days from the one call API.</description>
+			</channel-group>
+			<channel-group id="forecastDay6" typeId="oneCallDaily">
+				<label>One Call API 6 Day Forecast</label>
+				<description>This is the weather forecast in six days from the one call API.</description>
+			</channel-group>
+			<channel-group id="forecastDay7" typeId="oneCallDaily">
+				<label>One Call API 7 Day Forecast</label>
+				<description>This is the weather forecast in seven days from the one call API.</description>
 			</channel-group>
 		</channel-groups>
 

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/thing-types.xml
@@ -108,72 +108,6 @@
 
 			<channel-group id="forecastMinutely" typeId="oneCallMinutelyTimeSeries"/>
 
-			<channel-group id="forecastMinutes01" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes02" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes03" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes04" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes05" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes06" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes07" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes08" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes09" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes10" typeId="oneCallMinutely"/>
-
-			<channel-group id="forecastMinutes11" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes12" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes13" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes14" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes15" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes16" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes17" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes18" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes19" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes20" typeId="oneCallMinutely"/>
-
-			<channel-group id="forecastMinutes21" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes22" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes23" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes24" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes25" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes26" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes27" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes28" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes29" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes30" typeId="oneCallMinutely"/>
-
-			<channel-group id="forecastMinutes31" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes32" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes33" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes34" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes35" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes36" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes37" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes38" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes39" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes40" typeId="oneCallMinutely"/>
-
-			<channel-group id="forecastMinutes41" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes42" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes43" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes44" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes45" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes46" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes47" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes48" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes49" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes50" typeId="oneCallMinutely"/>
-
-			<channel-group id="forecastMinutes51" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes52" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes53" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes54" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes55" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes56" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes57" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes58" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes59" typeId="oneCallMinutely"/>
-			<channel-group id="forecastMinutes60" typeId="oneCallMinutely"/>
-
 			<channel-group id="forecastHourly" typeId="oneCallHourlyTimeSeries"/>
 
 			<channel-group id="forecastHours01" typeId="oneCallHourly"/>
@@ -188,18 +122,6 @@
 			<channel-group id="forecastHours10" typeId="oneCallHourly"/>
 			<channel-group id="forecastHours11" typeId="oneCallHourly"/>
 			<channel-group id="forecastHours12" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours13" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours14" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours15" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours16" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours17" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours18" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours19" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours20" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours21" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours22" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours23" typeId="oneCallHourly"/>
-			<channel-group id="forecastHours24" typeId="oneCallHourly"/>
 
 			<channel-group id="forecastDaily" typeId="oneCallDailyTimeSeries"/>
 
@@ -226,14 +148,6 @@
 			<channel-group id="forecastDay5" typeId="oneCallDaily">
 				<label>One Call API 5 Day Forecast</label>
 				<description>This is the weather forecast in five days from the one call API.</description>
-			</channel-group>
-			<channel-group id="forecastDay6" typeId="oneCallDaily">
-				<label>One Call API 6 Day Forecast</label>
-				<description>This is the weather forecast in six days from the one call API.</description>
-			</channel-group>
-			<channel-group id="forecastDay7" typeId="oneCallDaily">
-				<label>One Call API 7 Day Forecast</label>
-				<description>This is the weather forecast in seven days from the one call API.</description>
 			</channel-group>
 		</channel-groups>
 


### PR DESCRIPTION
- Remove config description for removed UV Index Thing. (Follow-up for #16369, where this was forgotten.)
- Fix OneCall Forecast Thing creates too many channels:
   The default setting is to create 0 minutes, 12 hours and 6 days of forecast channels.
   When creating a new OneCall Thing, actually 60 minutes, 24 hours and 8 days of forecast were created due to the thing-types, now they are removed by the Thing handler if they should not be created according to the config.
  It is important to have them in the thing-types though, because otherwise the channel groups won't be ordered correctly.