### PR TITLE
[shelly] Fix missing starting head tag in manager web ui

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/resources/sniplets/header.html
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/sniplets/header.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="Shelly Manager">
-
+<head>
     <title>Shelly Manager</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />


### PR DESCRIPTION
The header.html has a closing head tag, but no opener head tag. This commit fixes it.