### PR TITLE
[evcc] fixed channels vehicle/capacity and vehicle/vehicleName, added channels for current Vehicle/HeatingDevice per Loadpoint

### DIFF
--- a/bundles/org.openhab.binding.evcc/README.md
+++ b/bundles/org.openhab.binding.evcc/README.md
@@ -79,7 +79,6 @@ Please note that you have to replace _\<N\>_ with your loadpoint id/number.
 | loadpoint\<N\>#title                          | String                 | R          | Title of loadpoint                                                                                                |
 | loadpoint\<N\>#vehicleConnected               | Switch                 | R          | Whether vehicle is connected to loadpoint                                                                         |
 | loadpoint\<N\>#vehicleConnectedDuration       | Number:Time            | R          | Duration the vehicle is connected to loadpoint                                                                    |
-| loadpoint\<N\>#vehicleCapacity                | Number:Energy          | R          | Capacity of EV battery                                                                                            |
 | loadpoint\<N\>#vehicleOdometer                | Number:Length          | R          | Total distance travelled by EV                                                                                    |
 | loadpoint\<N\>#vehiclePresent                 | Switch                 | R          | Whether evcc is able to get data from vehicle                                                                     |
 | loadpoint\<N\>#vehicleRange                   | Number:Length          | R          | Battery range for EV                                                                                              |
@@ -105,31 +104,43 @@ Please note that you have to replace _\<N\>_ with your loadpoint id/number.
 
 ### Vehicle Channels
 
-Those channels exist per configured vehicle.
-Please note that you have to replace _\<ID\>_ with your vehicle id/name.
+Those channels exist:
 
-| Channel                          | Type                 | Read/Write | Description                                                              |
-|----------------------------------|----------------------|------------|--------------------------------------------------------------------------|
-| vehicle\<ID\>#vehicleTitle       | String               | R          | Title of vehicle                                                         |
-| vehicle\<ID\>#vehicleMinSoC      | Number:Dimensionless | RW         | Minimum state of charge (SoC) a vehicle should have                      |
-| vehicle\<ID\>#vehicleLimitSoC    | Number:Dimensionless | RW         | Until which state of charge (SoC) should the specific vehicle be charged |
-| vehicle\<ID\>#vehiclePlanEnabled | Switch               | RW         | Plan for charging enabled                                                |
-| vehicle\<ID\>#vehiclePlanSoC     | Number:Dimensionless | RW         | Until which state of charge (SoC) should vehicle be charged in plan      |
-| vehicle\<ID\>#vehiclePlanTime    | DateTime             | RW         | When the plan SoC should be reached                                      |
+* 1 per configured loadpoint with `chargerFeatureHeating = false`:
+  * These channels point to the heating device that is currently active/connected at/to the loadpoint
+  * Please note that you have to replace _\<N\>_ with your loadpoint id/number
+* 1 per configured vehicle:
+  * Please note that you have to replace _\<ID\>_ with your vehicle id/name
+
+| Channel                                            | Type                 | Read/Write | Description                                                              |
+|----------------------------------------------------|----------------------|------------|--------------------------------------------------------------------------|
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehicleTitle       | String               | R          | Title of vehicle                                                         |
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehicleMinSoC      | Number:Dimensionless | RW         | Minimum state of charge (SoC) a vehicle should have                      |
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehicleLimitSoC    | Number:Dimensionless | RW         | Until which state of charge (SoC) should the specific vehicle be charged |
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehicleCapacity    | Number:Energy        | R          | Capacity of EV battery                                                   |
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehiclePlanEnabled | Switch               | RW         | Plan for charging enabled                                                |
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehiclePlanSoC     | Number:Dimensionless | RW         | Until which state of charge (SoC) should vehicle be charged in plan      |
+| [loadpoint\<N\>\|vehicle\<ID\]>#vehiclePlanTime    | DateTime             | RW         | When the plan SoC should be reached                                      |
 
 ### Heating Channels
 
-Those channels exist per configured heating device.
-Please note that you have to replace _\<ID\>_ with your heating device id/name.
+Those channels exist:
 
-| Channel                               | Type               | Read/Write | Description                                                           |
-|---------------------------------------|--------------------|------------|-----------------------------------------------------------------------|
-| heating\<ID\>#heatingTitle            | String             | R          | Title of heating device                                               |
-| heating\<ID\>#heatingMinTemperature   | Number:Temperature | RW         | Minimum Temperature a heating device should have                      |
-| heating\<ID\>#heatingLimitTemperature | Number:Temperature | RW         | Until which Temperature should the specific heating device be charged |
-| heating\<ID\>#heatingPlanEnabled      | Switch             | RW         | Plan for charging enabled                                             |
-| heating\<ID\>#heatingPlanTemperature  | Number:Temperature | RW         | Until which Temperature should heating device be charged in plan      |
-| heating\<ID\>#heatingPlanTime         | DateTime           | RW         | When the plan Temperature should be reached                           |
+* 1 per configured loadpoint with `chargerFeatureHeating = true`:
+  * These channels point to the heating device that is currently active/connected at/to the loadpoint
+  * Please note that you have to replace _\<N\>_ with your loadpoint id/number
+* 1 per configured heating device:
+  * Please note that you have to replace _\<ID\>_ with your heating device id/name
+
+| Channel                                                 | Type               | Read/Write | Description                                                           |
+|---------------------------------------------------------|--------------------|------------|-----------------------------------------------------------------------|
+| [loadpoint\<N\>\|heating\<ID\]>#heatingTitle            | String             | R          | Title of heating device                                               |
+| [loadpoint\<N\>\|heating\<ID\]>#heatingMinTemperature   | Number:Temperature | RW         | Minimum Temperature a heating device should have                      |
+| [loadpoint\<N\>\|heating\<ID\]>#heatingLimitTemperature | Number:Temperature | RW         | Until which Temperature should the specific heating device be charged |
+| [loadpoint\<N\>\|heating\<ID\]>#heatingCapacity         | Number:Energy      | R          | Capacity of heating device                                            |
+| [loadpoint\<N\>\|heating\<ID\]>#heatingPlanEnabled      | Switch             | RW         | Plan for charging enabled                                             |
+| [loadpoint\<N\>\|heating\<ID\]>#heatingPlanTemperature  | Number:Temperature | RW         | Until which Temperature should heating device be charged in plan      |
+| [loadpoint\<N\>\|heating\<ID\]>#heatingPlanTime         | DateTime           | RW         | When the plan Temperature should be reached                           |
 
 ## Full Example
 
@@ -179,23 +190,23 @@ String                 evcc_loadpoint0_title                          "Loadpoint
 Switch                 evcc_loadpoint0_chargerFeatureHeating          "Feature: Heating [%s]"                              <switch>       {channel="evcc:device:demo:loadpoint0#chargerFeatureHeating"}
 Switch                 evcc_loadpoint0_chargerFeatureIntegratedDevice "Feature: Integrated Device [%s]"                    <switch>       {channel="evcc:device:demo:loadpoint0#chargerFeatureIntegratedDevice"}
 
-// Vehicle on loadpoint
+// Loadpoint vehicle channels
 Switch                 evcc_loadpoint0_vehicleConnected               "Vehicle connected [%s]"                             <switch>       {channel="evcc:device:demo:loadpoint0#vehicleConnected"}
 Number:Time            evcc_loadpoint0_vehicleConnectedDuration       "Vehicle connected duration [%.1f h]"                <time>         {channel="evcc:device:demo:loadpoint0#vehicleConnectedDuration"}
-Number:Energy          evcc_loadpoint0_vehicleCapacity                "Vehicle capacity [%.0f kWh]"                        <batterylevel> {channel="evcc:device:demo:loadpoint0#vehicleCapacity"}
 Number:Length          evcc_loadpoint0_vehicleOdometer                "Vehicle odometer [%.1f km]"                                        {channel="evcc:device:demo:loadpoint0#vehicleOdometer"}
 Switch                 evcc_loadpoint0_vehiclePresent                 "Vehicle present [%s]"                               <switch>       {channel="evcc:device:demo:loadpoint0#vehiclePresent"}
 Number:Length          evcc_loadpoint0_vehicleRange                   "Vehicle Range [%.0f km]"                                           {channel="evcc:device:demo:loadpoint0#vehicleRange"}
 Number:Dimensionless   evcc_loadpoint0_vehicleSoC                     "Vehicle SoC [%d %%]"                                <batterylevel> {channel="evcc:device:demo:loadpoint0#vehicleSoC"}
 String                 evcc_loadpoint0_VehicleName                    "Vehicle name [%s]"                                  <text>         {channel="evcc:device:demo:loadpoint0#vehicleName"}
 
-// Vehicle
-String                 evcc_vehicle0_vehicleTitle                     "Vehicle title [%s]"                                 <text>         {channel="evcc:device:demo:vehicle0#vehicleTitle"}
-Number:Dimensionless   evcc_vehicle0_vehicleMinSoC                    "Vehicle minimum SoC [%d %%]"                        <batterylevel> {channel="evcc:device:demo:vehicle0#vehicleMinSoC"}
-Number:Dimensionless   evcc_vehicle0_vehicleLimitSoC                  "Vehicle limit SoC [%d %%]"                          <batterylevel> {channel="evcc:device:demo:vehicle0#vehicleLimitSoC"}
-Switch                 evcc_vehicle0_vehiclePlanEnabled               "Vehicle plan enabled [%s]"                          <switch>       {channel="evcc:device:demo:vehicle0#vehiclePlanEnabled"}
-Number:Dimensionless   evcc_vehicle0_vehiclePlanSoC                   "Vehicle plan SoC [%d %%]"                           <batterylevel> {channel="evcc:device:demo:vehicle0#vehiclePlanSoC"}
-DateTime               evcc_vehicle0_vehiclePlanTime                  "Vehicle plan time [%1$td.%1$tm.%1$tY, %1$tH:%1$tM]" <time>         {channel="evcc:device:demo:vehicle0#vehiclePlanTime"}
+// Vehicle on loadpoint
+String                 evcc_loadpoint0current_vehicleTitle            "Vehicle title [%s]"                                 <text>         {channel="evcc:device:demo:loadpoint0current#vehicleTitle"}
+Number:Dimensionless   evcc_loadpoint0current_vehicleMinSoC           "Vehicle minimum SoC [%d %%]"                        <batterylevel> {channel="evcc:device:demo:loadpoint0current#vehicleMinSoC"}
+Number:Dimensionless   evcc_loadpoint0current_vehicleLimitSoC         "Vehicle limit SoC [%d %%]"                          <batterylevel> {channel="evcc:device:demo:loadpoint0current#vehicleLimitSoC"}
+Number:Energy          evcc_loadpoint0current_vehicleCapacity         "Vehicle capacity [%.0f kWh]"                        <batterylevel> {channel="evcc:device:demo:loadpoint0current#vehicleCapacity"}
+Switch                 evcc_loadpoint0current_vehiclePlanEnabled      "Vehicle plan enabled [%s]"                          <switch>       {channel="evcc:device:demo:loadpoint0current#vehiclePlanEnabled"}
+Number:Dimensionless   evcc_loadpoint0current_vehiclePlanSoC          "Vehicle plan SoC [%d %%]"                           <batterylevel> {channel="evcc:device:demo:loadpoint0current#vehiclePlanSoC"}
+DateTime               evcc_loadpoint0current_vehiclePlanTime         "Vehicle plan time [%1$td.%1$tm.%1$tY, %1$tH:%1$tM]" <time>         {channel="evcc:device:demo:loadpoint0current#vehiclePlanTime"}
 ```
 
 ### Sitemap
@@ -230,16 +241,16 @@ sitemap evcc label="evcc Demo" {
             Setpoint item=evcc_loadpoint0_phases minValue=1 maxValue=3 step=2
         }
         Text item=evcc_loadpoint0_vehicleName label="Vehicle" {
-            Text item=evcc_loadpoint0_vehicleCapacity
+            Text item=evcc_loadpoint0current_vehicleCapacity
             Text item=evcc_loadpoint0_vehicleOdometer
             Text item=evcc_loadpoint0_vehicleRange
             Text item=evcc_loadpoint0_vehicleSoC
-            Text item=evcc_vehicle0_vehicleTitle
-            Setpoint item=evcc_vehicle0_vehicleMinSoC minValue=0 maxValue=100 step=5
-            Setpoint item=evcc_vehicle0_vehicleLimitSoC minValue=5 maxValue=100 step=5
-            Switch item=evcc_vehicle0_vehiclePlanEnabled
-            Setpoint item=evcc_vehicle0_vehiclePlanSoC minValue=5 maxValue=100 step=5
-            Input item=evcc_vehicle0_vehiclePlanTime
+            Text item=evcc_loadpoint0current_vehicleTitle
+            Setpoint item=evcc_loadpoint0current_vehicleMinSoC minValue=0 maxValue=100 step=5
+            Setpoint item=evcc_loadpoint0current_vehicleLimitSoC minValue=5 maxValue=100 step=5
+            Switch item=evcc_loadpoint0current_vehiclePlanEnabled
+            Setpoint item=evcc_loadpoint0current_vehiclePlanSoC minValue=5 maxValue=100 step=5
+            Input item=evcc_loadpoint0current_vehiclePlanTime
         }
     }
 }

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccBindingConstants.java
@@ -32,6 +32,7 @@ public class EvccBindingConstants {
     public static final String CHANNEL_GROUP_ID_LOADPOINT = "loadpoint";
     public static final String CHANNEL_GROUP_ID_VEHICLE = "vehicle";
     public static final String CHANNEL_GROUP_ID_HEATING = "heating";
+    public static final String CHANNEL_GROUP_ID_CURRENT = "current";
 
     // List of all Channel ids
     public static final String CHANNEL_BATTERY_CAPACITY = "batteryCapacity";
@@ -70,7 +71,6 @@ public class EvccBindingConstants {
     public static final String CHANNEL_LOADPOINT_EFFECTIVE_LIMIT_SOC = "effectiveLimitSoC";
     public static final String CHANNEL_LOADPOINT_EFFECTIVE_LIMIT_TEMPERATURE = "effectiveLimitTemperature";
     public static final String CHANNEL_LOADPOINT_TITLE = "title";
-    public static final String CHANNEL_LOADPOINT_VEHICLE_CAPACITY = "vehicleCapacity";
     public static final String CHANNEL_LOADPOINT_VEHICLE_ODOMETER = "vehicleOdometer";
     public static final String CHANNEL_LOADPOINT_VEHICLE_PRESENT = "vehiclePresent";
     public static final String CHANNEL_LOADPOINT_VEHICLE_RANGE = "vehicleRange";
@@ -86,6 +86,8 @@ public class EvccBindingConstants {
     public static final String CHANNEL_HEATING_MIN_TEMPERATURE = "heatingMinTemperature";
     public static final String CHANNEL_VEHICLE_LIMIT_SOC = "vehicleLimitSoC";
     public static final String CHANNEL_HEATING_LIMIT_TEMPERATURE = "heatingLimitTemperature";
+    public static final String CHANNEL_VEHICLE_CAPACITY = "vehicleCapacity";
+    public static final String CHANNEL_HEATING_CAPACITY = "heatingCapacity";
     public static final String CHANNEL_VEHICLE_PLAN_ENABLED = "vehiclePlanEnabled";
     public static final String CHANNEL_HEATING_PLAN_ENABLED = "heatingPlanEnabled";
     public static final String CHANNEL_VEHICLE_PLAN_SOC = "vehiclePlanSoC";
@@ -163,8 +165,6 @@ public class EvccBindingConstants {
             BINDING_ID, CHANNEL_LOADPOINT_EFFECTIVE_LIMIT_TEMPERATURE);
     public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_TITLE = new ChannelTypeUID(BINDING_ID,
             CHANNEL_LOADPOINT_TITLE);
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_CAPACITY = new ChannelTypeUID(BINDING_ID,
-            CHANNEL_LOADPOINT_VEHICLE_CAPACITY);
     public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_ODOMETER = new ChannelTypeUID(BINDING_ID,
             CHANNEL_LOADPOINT_VEHICLE_ODOMETER);
     public static final ChannelTypeUID CHANNEL_TYPE_UID_LOADPOINT_VEHICLE_PRESENT = new ChannelTypeUID(BINDING_ID,
@@ -194,6 +194,10 @@ public class EvccBindingConstants {
             CHANNEL_VEHICLE_LIMIT_SOC);
     public static final ChannelTypeUID CHANNEL_TYPE_UID_HEATING_LIMIT_TEMPERATURE = new ChannelTypeUID(BINDING_ID,
             CHANNEL_HEATING_LIMIT_TEMPERATURE);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_VEHICLE_CAPACITY = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_VEHICLE_CAPACITY);
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_HEATING_CAPACITY = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_HEATING_CAPACITY);
     public static final ChannelTypeUID CHANNEL_TYPE_UID_VEHICLE_PLAN_ENABLED = new ChannelTypeUID(BINDING_ID,
             CHANNEL_VEHICLE_PLAN_ENABLED);
     public static final ChannelTypeUID CHANNEL_TYPE_UID_HEATING_PLAN_ENABLED = new ChannelTypeUID(BINDING_ID,

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Loadpoint.java
@@ -82,9 +82,6 @@ public class Loadpoint {
     @SerializedName("title")
     private String title;
 
-    @SerializedName("vehicleCapacity")
-    private float vehicleCapacity;
-
     @SerializedName("vehicleOdometer")
     private float vehicleOdometer;
 
@@ -240,13 +237,6 @@ public class Loadpoint {
      */
     public String getTitle() {
         return title;
-    }
-
-    /**
-     * @return vehicle's capacity
-     */
-    public float getVehicleCapacity() {
-        return vehicleCapacity;
     }
 
     /**

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Vehicle.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Vehicle.java
@@ -33,6 +33,9 @@ public class Vehicle {
     @SerializedName("limitSoc")
     private float limitSoC;
 
+    @SerializedName("capacity")
+    private float capacity;
+
     @SerializedName("plans")
     private Plan[] plans;
 
@@ -55,6 +58,13 @@ public class Vehicle {
      */
     public float getLimitSoC() {
         return limitSoC;
+    }
+
+    /**
+     * @return vehicle's capacity
+     */
+    public float getCapacity() {
+        return capacity;
     }
 
     /**

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
@@ -18,12 +18,33 @@ thing-type.config.evcc.device.url.description = URL of evcc web UI, e.g. https:/
 # channel group types
 
 channel-group-type.evcc.general.label = General Data
-channel-group-type.evcc.loadpoint.label = Loadpoint
+channel-group-type.evcc.loadpoint0.label = Loadpoint 0
+channel-group-type.evcc.loadpoint0current.label = Loadpoint 0: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint1.label = Loadpoint 1
+channel-group-type.evcc.loadpoint1current.label = Loadpoint 1: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint2.label = Loadpoint 2
+channel-group-type.evcc.loadpoint2current.label = Loadpoint 2: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint3.label = Loadpoint 3
+channel-group-type.evcc.loadpoint3current.label = Loadpoint 3: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint4.label = Loadpoint 4
+channel-group-type.evcc.loadpoint4current.label = Loadpoint 4: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint5.label = Loadpoint 5
+channel-group-type.evcc.loadpoint5current.label = Loadpoint 5: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint6.label = Loadpoint 6
+channel-group-type.evcc.loadpoint6current.label = Loadpoint 6: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint7.label = Loadpoint 7
+channel-group-type.evcc.loadpoint7current.label = Loadpoint 7: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint8.label = Loadpoint 8
+channel-group-type.evcc.loadpoint8current.label = Loadpoint 8: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint9.label = Loadpoint 9
+channel-group-type.evcc.loadpoint9current.label = Loadpoint 9: Current Vehicle/Heating
 
 # channel types
 
 channel-type.evcc.activePhases.label = Charging Active Phases
 channel-type.evcc.activePhases.description = Current number of active phases while charging
+channel-type.evcc.availableVersion.label = Available Version
+channel-type.evcc.availableVersion.description = Available evcc update version
 channel-type.evcc.batteryCapacity.label = Battery Capacity
 channel-type.evcc.batteryCapacity.description = Capacity of (home) battery
 channel-type.evcc.batteryDischargeControl.label = Battery Discharge Control
@@ -64,7 +85,7 @@ channel-type.evcc.charging.label = Charging State
 channel-type.evcc.charging.description = Loadpoint is currently charging
 channel-type.evcc.charging.state.option.ON = Charging
 channel-type.evcc.charging.state.option.OFF = Not charging
-channel-type.evcc.effectiveLimitSoC.label = Effective Charging Limit SoC
+channel-type.evcc.effectiveLimitSoC.label = Effective Charging Limit
 channel-type.evcc.effectiveLimitSoC.description = Effective state of charge (SoC) until which the vehicle will be charged
 channel-type.evcc.effectiveLimitTemperature.label = Effective Charging Limit Temperature
 channel-type.evcc.effectiveLimitTemperature.description = Effective Temperature until which the heating device will be charged
@@ -74,7 +95,9 @@ channel-type.evcc.enabled.state.option.ON = Enabled
 channel-type.evcc.enabled.state.option.OFF = Disabled
 channel-type.evcc.gridPower.label = Grid Power
 channel-type.evcc.gridPower.description = Current power from grid (negative means feed-in)
-channel-type.evcc.heatingLimitTemperature.label = Heating Charging Limit Temperature
+channel-type.evcc.heatingCapacity.label = Heating Capacity
+channel-type.evcc.heatingCapacity.description = Capacity of heating device
+channel-type.evcc.heatingLimitTemperature.label = Charging Temperature Limit
 channel-type.evcc.heatingLimitTemperature.description = Until which Temperature should the specific heating device be charged
 channel-type.evcc.heatingMinTemperature.label = Heating Min Temperature
 channel-type.evcc.heatingMinTemperature.description = Minimum Temperature a heating device should have
@@ -152,6 +175,12 @@ channel-type.evcc.vehicleTemperature.label = Temperature
 channel-type.evcc.vehicleTemperature.description = Current Temperature of the heating device
 channel-type.evcc.vehicleTitle.label = Vehicle Title
 channel-type.evcc.vehicleTitle.description = Title of vehicle
+channel-type.evcc.version.label = Version
+channel-type.evcc.version.description = Current evcc version
+
+# channel group types
+
+channel-group-type.evcc.loadpoint.label = Loadpoint
 
 # channel types
 

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/i18n/evcc.properties
@@ -19,25 +19,25 @@ thing-type.config.evcc.device.url.description = URL of evcc web UI, e.g. https:/
 
 channel-group-type.evcc.general.label = General Data
 channel-group-type.evcc.loadpoint0.label = Loadpoint 0
-channel-group-type.evcc.loadpoint0current.label = Loadpoint 0: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint0current.label = Loadpoint 0: Current
 channel-group-type.evcc.loadpoint1.label = Loadpoint 1
-channel-group-type.evcc.loadpoint1current.label = Loadpoint 1: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint1current.label = Loadpoint 1: Current
 channel-group-type.evcc.loadpoint2.label = Loadpoint 2
-channel-group-type.evcc.loadpoint2current.label = Loadpoint 2: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint2current.label = Loadpoint 2: Current
 channel-group-type.evcc.loadpoint3.label = Loadpoint 3
-channel-group-type.evcc.loadpoint3current.label = Loadpoint 3: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint3current.label = Loadpoint 3: Current
 channel-group-type.evcc.loadpoint4.label = Loadpoint 4
-channel-group-type.evcc.loadpoint4current.label = Loadpoint 4: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint4current.label = Loadpoint 4: Current
 channel-group-type.evcc.loadpoint5.label = Loadpoint 5
-channel-group-type.evcc.loadpoint5current.label = Loadpoint 5: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint5current.label = Loadpoint 5: Current
 channel-group-type.evcc.loadpoint6.label = Loadpoint 6
-channel-group-type.evcc.loadpoint6current.label = Loadpoint 6: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint6current.label = Loadpoint 6: Current
 channel-group-type.evcc.loadpoint7.label = Loadpoint 7
-channel-group-type.evcc.loadpoint7current.label = Loadpoint 7: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint7current.label = Loadpoint 7: Current
 channel-group-type.evcc.loadpoint8.label = Loadpoint 8
-channel-group-type.evcc.loadpoint8current.label = Loadpoint 8: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint8current.label = Loadpoint 8: Current
 channel-group-type.evcc.loadpoint9.label = Loadpoint 9
-channel-group-type.evcc.loadpoint9current.label = Loadpoint 9: Current Vehicle/Heating
+channel-group-type.evcc.loadpoint9current.label = Loadpoint 9: Current
 
 # channel types
 

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -82,34 +82,34 @@
 		<label>Loadpoint 9</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint0current">
-		<label>Loadpoint 0: Current Vehicle/Heating</label>
+		<label>Loadpoint 0: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint1current">
-		<label>Loadpoint 1: Current Vehicle/Heating</label>
+		<label>Loadpoint 1: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint2current">
-		<label>Loadpoint 2: Current Vehicle/Heating</label>
+		<label>Loadpoint 2: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint3current">
-		<label>Loadpoint 3: Current Vehicle/Heating</label>
+		<label>Loadpoint 3: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint4current">
-		<label>Loadpoint 4: Current Vehicle/Heating</label>
+		<label>Loadpoint 4: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint5current">
-		<label>Loadpoint 5: Current Vehicle/Heating</label>
+		<label>Loadpoint 5: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint6current">
-		<label>Loadpoint 6: Current Vehicle/Heating</label>
+		<label>Loadpoint 6: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint7current">
-		<label>Loadpoint 7: Current Vehicle/Heating</label>
+		<label>Loadpoint 7: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint8current">
-		<label>Loadpoint 8: Current Vehicle/Heating</label>
+		<label>Loadpoint 8: Current</label>
 	</channel-group-type>
 	<channel-group-type id="loadpoint9current">
-		<label>Loadpoint 9: Current Vehicle/Heating</label>
+		<label>Loadpoint 9: Current</label>
 	</channel-group-type>
 
 	<!-- Units and description on: https://docs.evcc.io/docs/reference/configuration/messaging/#msg -->

--- a/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.evcc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -11,16 +11,26 @@
 
 		<channel-groups>
 			<channel-group id="general" typeId="general"/>
-			<channel-group id="loadpoint0" typeId="loadpoint"/>
-			<channel-group id="loadpoint1" typeId="loadpoint"/>
-			<channel-group id="loadpoint2" typeId="loadpoint"/>
-			<channel-group id="loadpoint3" typeId="loadpoint"/>
-			<channel-group id="loadpoint4" typeId="loadpoint"/>
-			<channel-group id="loadpoint5" typeId="loadpoint"/>
-			<channel-group id="loadpoint6" typeId="loadpoint"/>
-			<channel-group id="loadpoint7" typeId="loadpoint"/>
-			<channel-group id="loadpoint8" typeId="loadpoint"/>
-			<channel-group id="loadpoint9" typeId="loadpoint"/>
+			<channel-group id="loadpoint0" typeId="loadpoint0"/>
+			<channel-group id="loadpoint1" typeId="loadpoint1"/>
+			<channel-group id="loadpoint2" typeId="loadpoint2"/>
+			<channel-group id="loadpoint3" typeId="loadpoint3"/>
+			<channel-group id="loadpoint4" typeId="loadpoint4"/>
+			<channel-group id="loadpoint5" typeId="loadpoint5"/>
+			<channel-group id="loadpoint6" typeId="loadpoint6"/>
+			<channel-group id="loadpoint7" typeId="loadpoint7"/>
+			<channel-group id="loadpoint8" typeId="loadpoint8"/>
+			<channel-group id="loadpoint9" typeId="loadpoint9"/>
+			<channel-group id="loadpoint0current" typeId="loadpoint0current"/>
+			<channel-group id="loadpoint1current" typeId="loadpoint1current"/>
+			<channel-group id="loadpoint2current" typeId="loadpoint2current"/>
+			<channel-group id="loadpoint3current" typeId="loadpoint3current"/>
+			<channel-group id="loadpoint4current" typeId="loadpoint4current"/>
+			<channel-group id="loadpoint5current" typeId="loadpoint5current"/>
+			<channel-group id="loadpoint6current" typeId="loadpoint6current"/>
+			<channel-group id="loadpoint7current" typeId="loadpoint7current"/>
+			<channel-group id="loadpoint8current" typeId="loadpoint8current"/>
+			<channel-group id="loadpoint9current" typeId="loadpoint9current"/>
 		</channel-groups>
 
 		<config-description>
@@ -41,8 +51,65 @@
 	<channel-group-type id="general">
 		<label>General Data</label>
 	</channel-group-type>
-	<channel-group-type id="loadpoint">
-		<label>Loadpoint</label>
+	<channel-group-type id="loadpoint0">
+		<label>Loadpoint 0</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint1">
+		<label>Loadpoint 1</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint2">
+		<label>Loadpoint 2</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint3">
+		<label>Loadpoint 3</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint4">
+		<label>Loadpoint 4</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint5">
+		<label>Loadpoint 5</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint6">
+		<label>Loadpoint 6</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint7">
+		<label>Loadpoint 7</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint8">
+		<label>Loadpoint 8</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint9">
+		<label>Loadpoint 9</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint0current">
+		<label>Loadpoint 0: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint1current">
+		<label>Loadpoint 1: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint2current">
+		<label>Loadpoint 2: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint3current">
+		<label>Loadpoint 3: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint4current">
+		<label>Loadpoint 4: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint5current">
+		<label>Loadpoint 5: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint6current">
+		<label>Loadpoint 6: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint7current">
+		<label>Loadpoint 7: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint8current">
+		<label>Loadpoint 8: Current Vehicle/Heating</label>
+	</channel-group-type>
+	<channel-group-type id="loadpoint9current">
+		<label>Loadpoint 9: Current Vehicle/Heating</label>
 	</channel-group-type>
 
 	<!-- Units and description on: https://docs.evcc.io/docs/reference/configuration/messaging/#msg -->
@@ -332,13 +399,6 @@
 		<category>Time</category>
 		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
-	<channel-type id="vehicleCapacity">
-		<item-type>Number:Energy</item-type>
-		<label>Vehicle Capacity</label>
-		<description>Capacity of EV battery</description>
-		<category>Energy</category>
-		<state pattern="%.0f %unit%" readOnly="true"/>
-	</channel-type>
 	<channel-type id="vehicleOdometer">
 		<item-type>Number:Length</item-type>
 		<label>Vehicle Odometer</label>
@@ -458,6 +518,20 @@
 		<category>Temperature</category>
 		<state min="0" step="1" max="100" pattern="%.0f %unit%" readOnly="false"/>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+	<channel-type id="vehicleCapacity">
+		<item-type>Number:Energy</item-type>
+		<label>Vehicle Capacity</label>
+		<description>Capacity of EV battery</description>
+		<category>Energy</category>
+		<state pattern="%.0f %unit%" readOnly="true"/>
+	</channel-type>
+	<channel-type id="heatingCapacity">
+		<item-type>Number:Energy</item-type>
+		<label>Heating Capacity</label>
+		<description>Capacity of heating device</description>
+		<category>Energy</category>
+		<state pattern="%.0f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="vehiclePlanEnabled">
 		<item-type>Switch</item-type>


### PR DESCRIPTION
1. Fixed channels vehicle/capacity (bugfix)
   * Capacity channel is under vehicle and no longer under loadpoint since evcc 0.123.1 
2. Fixed channel vehicle/vehicleName (bugfix)
   * Update was done using a wrong channelUID 
3. Added channels for current Vehicle/HeatingDevice per Loadpoint (enhancement)
   * The new ChannelGroup provides direct access to the vehicle/heating device connected to the loadpoint without the indirection using the `vehicleName`
   * Example:
      * Access vehicle title in a rule before this PR:
         * `const vehicleTitle = items.getItem("evcc" + items.evccLoadpoint0_VehicleName.state + "_VehicleTitle").state;`
      * Now:
         * `const vehicleTitle = items.evccLoadpoint0CurrentVehicle_VehicleTitle.state;`
         * Users with a big fleet of vehicles will benefit allot. Because they must no longer add each single vehicle as items.