### PR TITLE
[jsonpath] change code-fence so it doesn't overlap with logo

### DIFF
--- a/bundles/org.openhab.transform.jsonpath/README.md
+++ b/bundles/org.openhab.transform.jsonpath/README.md
@@ -4,9 +4,7 @@ Extracts values from a JSON string using a [JsonPath](https://github.com/jayway/
 
 Given the following JSON string:
 
-```
-[{ "device": { "location": "Outside", "status": { "temperature": 23.2 }}}]
-```
+`[{ "device": { "location": "Outside", "status": { "temperature": 23.2 }}}]`
 
 The expression `$.device.location` extracts the string `Outside`.
 The JsonPath expression `$.device.status.temperature` extracts the string `23.2`.


### PR DESCRIPTION
Avoid this problem:
<img width="1411" alt="image" src="https://github.com/openhab/openhab-addons/assets/2554958/cd1a6f47-9940-4bcb-b43d-05970afb9bd0">
