### PR TITLE
[jsscripting] Improve logging on JS error

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
@@ -15,6 +15,7 @@ package org.openhab.automation.jsscripting.internal;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.graalvm.polyglot.PolyglotException;
 import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable;
 import org.slf4j.Logger;
@@ -28,8 +29,9 @@ import org.slf4j.LoggerFactory;
 class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoCloseable>
         extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<T> {
 
-    private static final Logger STACK_LOGGER = LoggerFactory
-            .getLogger("org.openhab.automation.script.javascript.stack");
+    private static final String SCRIPT_TRANSFORMATION_ENGINE_IDENTIFIER = "openhab-transformation-script-";
+
+    private @Nullable Logger logger;
 
     public DebuggingGraalScriptEngine(T delegate) {
         super(delegate);
@@ -37,13 +39,42 @@ class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoClosea
 
     @Override
     public Exception afterThrowsInvocation(Exception e) {
+        if (logger == null) {
+            initializeLogger();
+        }
+
         Throwable cause = e.getCause();
         if (cause instanceof IllegalArgumentException) {
-            STACK_LOGGER.error("Failed to execute script:", e);
+            logger.error("Failed to execute script:", e);
         }
         if (cause instanceof PolyglotException) {
-            STACK_LOGGER.error("Failed to execute script:", cause);
+            logger.error("Failed to execute script:", cause);
         }
         return e;
+    }
+
+    /**
+     * Initializes the logger.
+     * This cannot be done upon class construction because at that moment, the context is not setup.
+     * Instead, this has to be done before the first usage of the logger.
+     */
+    private void initializeLogger() {
+        Object fileName = delegate.getContext().getAttribute("javax.script.filename");
+        Object ruleUID = delegate.getContext().getAttribute("ruleUID");
+        Object ohEngineIdentifier = delegate.getContext().getAttribute("oh.engine-identifier");
+
+        String identifier = "stack";
+        if (fileName != null) {
+            identifier = fileName.toString().replaceAll("^.*[/\\\\]", "");
+        } else if (ruleUID != null) {
+            identifier = ruleUID.toString();
+        } else if (ohEngineIdentifier != null) {
+            if (ohEngineIdentifier.toString().startsWith(SCRIPT_TRANSFORMATION_ENGINE_IDENTIFIER)) {
+                identifier = ohEngineIdentifier.toString().replaceAll(SCRIPT_TRANSFORMATION_ENGINE_IDENTIFIER,
+                        "transformation.");
+            }
+        }
+
+        logger = LoggerFactory.getLogger("org.openhab.automation.script.javascript." + identifier);
     }
 }

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
@@ -55,8 +55,8 @@ class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoClosea
 
     /**
      * Initializes the logger.
-     * This cannot be done upon class construction because at that moment, the context is not setup.
-     * Instead, this has to be done before the first usage of the logger.
+     * This cannot be done on script engine creation because the context variables are not yet initialized.
+     * Therefore, the logger needs to be initialized on the first use after script engine creation.
      */
     private void initializeLogger() {
         Object fileName = delegate.getContext().getAttribute("javax.script.filename");

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -72,7 +72,7 @@ public class OpenhabGraalJSScriptEngine
         extends InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable<GraalJSScriptEngine> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenhabGraalJSScriptEngine.class);
-    private static Source GLOBAL_SOURCE;
+    private static final Source GLOBAL_SOURCE;
     static {
         try {
             GLOBAL_SOURCE = Source.newBuilder("js", getFileAsReader("node_modules/@jsscripting-globals.js"),
@@ -82,7 +82,7 @@ public class OpenhabGraalJSScriptEngine
         }
     }
 
-    private static Source OPENHAB_JS_SOURCE;
+    private static final Source OPENHAB_JS_SOURCE;
     static {
         try {
             OPENHAB_JS_SOURCE = Source

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -78,7 +78,7 @@ public class OpenhabGraalJSScriptEngine
             GLOBAL_SOURCE = Source.newBuilder("js", getFileAsReader("node_modules/@jsscripting-globals.js"),
                     "@jsscripting-globals.js").cached(true).build();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load @jsscripting-globals.js", e);
+            throw new IllegalStateException("Failed to load @jsscripting-globals.js", e);
         }
     }
 
@@ -89,7 +89,7 @@ public class OpenhabGraalJSScriptEngine
                     .newBuilder("js", getFileAsReader("node_modules/@openhab-globals.js"), "@openhab-globals.js")
                     .cached(true).build();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load @openhab-globals.js", e);
+            throw new IllegalStateException("Failed to load @openhab-globals.js", e);
         }
     }
     private static final String OPENHAB_JS_INJECTION_CODE = "Object.assign(this, require('openhab'));";

--- a/bundles/org.openhab.automation.jsscripting/suppressions.properties
+++ b/bundles/org.openhab.automation.jsscripting/suppressions.properties
@@ -1,3 +1,2 @@
 # Please check here how to add suppressions https://maven.apache.org/plugins/maven-pmd-plugin/examples/violation-exclusions.html
 org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable=AvoidThrowingNullPointerException,AvoidCatchingNPE
-org.openhab.automation.jsscripting.internal.OpenhabGraalJSScriptEngine=AvoidThrowingRawExceptionTypes

--- a/bundles/org.openhab.automation.jsscripting/suppressions.properties
+++ b/bundles/org.openhab.automation.jsscripting/suppressions.properties
@@ -1,2 +1,3 @@
 # Please check here how to add suppressions https://maven.apache.org/plugins/maven-pmd-plugin/examples/violation-exclusions.html
 org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndAutoCloseable=AvoidThrowingNullPointerException,AvoidCatchingNPE
+org.openhab.automation.jsscripting.internal.OpenhabGraalJSScriptEngine=AvoidThrowingRawExceptionTypes


### PR DESCRIPTION
- Use the file name, rule UID or transformation UID in the stack trace printed on a JS error.
- Minor code improvements.
- Suppress a warning.