### PR TITLE
Upgrade get-changed-files GHA dependency

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Get Changed Files
         if: github.head_ref != ''
         id: files
-        uses: Ana06/get-changed-files@v2.2.0
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
 


### PR DESCRIPTION
This fixes the last remaining deprecation warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20