### PR TITLE
[tr064] Add wifiGuestEnableTriband channel

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -128,19 +128,23 @@ The call-types are the same as provided by the FritzBox, i.e. `1` (inbound), `2`
 
 ### LAN `subdeviceLan` channels
 
-| channel              | item-type                 | advanced | description                                                                                                  |
-|----------------------|---------------------------|:--------:|--------------------------------------------------------------------------------------------------------------|
-| `wifi24GHzEnable`    | `Switch`                  |          | Enable/Disable the 2.4 GHz WiFi device.                                                                      |
-| `wifi5GHzEnable`     | `Switch`                  |          | Enable/Disable the 5.0 GHz WiFi device.                                                                      |
-| `wifiGuestEnable`    | `Switch`                  |          | Enable/Disable the guest WiFi.                                                                               |
-| `macOnline`          | `Switch`                  |    x     | Online status of the device with the given MAC                                                               |
-| `macOnlineIpAddress` | `String`                  |    x     | IP of the MAC (uses same parameter as `macOnline`)                                                           |
-| `macSignalStrength1` | `Number`                  |    x     | Wifi Signal Strength of the device with the given MAC. This is set in case the Device is connected to 2.4Ghz |
-| `macSpeed1`          | `Number:DataTransferRate` |    x     | Wifi Speed of the device with the given MAC. This is set in case the Device is connected to 2.4Ghz           |
-| `macSignalStrength2` | `Number`                  |    x     | Wifi Signal Strength of the device with the given MAC. This is set in case the Device is connected to 5Ghz   |
-| `macSpeed2`          | `Number:DataTransferRate` |    x     | Wifi Speed of the device with the given MAC. This is set in case the Device is connected to 5Ghz             |
-Older FritzBox devices may not support 5 GHz WiFi.
+| channel                  | item-type                 | advanced | description                                                                                                  |
+|--------------------------|---------------------------|:--------:|--------------------------------------------------------------------------------------------------------------|
+| `wifi24GHzEnable`        | `Switch`                  |          | Enable/Disable the 2.4 GHz WiFi device.                                                                      |
+| `wifi5GHzEnable`         | `Switch`                  |          | Enable/Disable the 5.0 GHz WiFi device.                                                                      |
+| `wifiGuestEnable`        | `Switch`                  |          | Enable/Disable the guest WiFi.                                                                               |
+| `wifiGuestEnableTriband` | `Switch`                  |          | Enable/Disable the guest WiFi on triband devices.                                                                               |
+| `macOnline`              | `Switch`                  |    x     | Online status of the device with the given MAC                                                               |
+| `macOnlineIpAddress`     | `String`                  |    x     | IP of the MAC (uses same parameter as `macOnline`)                                                           |
+| `macSignalStrength1`     | `Number`                  |    x     | Wifi Signal Strength of the device with the given MAC. This is set in case the Device is connected to 2.4Ghz |
+| `macSpeed1`              | `Number:DataTransferRate` |    x     | Wifi Speed of the device with the given MAC. This is set in case the Device is connected to 2.4Ghz           |
+| `macSignalStrength2`     | `Number`                  |    x     | Wifi Signal Strength of the device with the given MAC. This is set in case the Device is connected to 5Ghz   |
+| `macSpeed2`              | `Number:DataTransferRate` |    x     | Wifi Speed of the device with the given MAC. This is set in case the Device is connected to 5Ghz             |
+
+**Note:** Older FritzBox devices may not support 5 GHz WiFi.
 In this case you have to use the `wifi5GHzEnable` channel for switching the guest WiFi.
+On triband FritzBox devices the `wifiGuestEnable` controls the second 5 GHz WiFi. 
+In this case you have to use the `wifiGuestEnableTriband` channel for switching the guest WiFi.
 
 ### WANConnection `subdevice` channels
 

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -139,7 +139,7 @@
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>
 	<channel name="wifiGuestEnableTriband" label="WiFi Guest Triband"
-	    description="Enable/Disable the guest WiFi on triband devices.">
+		description="Enable/Disable the guest WiFi on triband devices.">
 		<item type="Switch"/>
 		<service deviceType="urn:dslforum-org:device:LANDevice:1"
 			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration4"/>

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -138,6 +138,13 @@
 		<getAction name="GetInfo" argument="NewEnable"/>
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>
+	<channel name="wifiGuestEnableTriband" label="WiFi Guest Triband" description="Enable/Disable the guest WiFi on triband devices.">
+		<item type="Switch"/>
+		<service deviceType="urn:dslforum-org:device:LANDevice:1"
+			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration4"/>
+		<getAction name="GetInfo" argument="NewEnable"/>
+		<setAction name="SetEnable" argument="NewEnable"/>
+	</channel>
 	<channel name="macOnline" label="MAC Online" description="Online status of the device with the given MAC"
 		advanced="true">
 		<item type="Switch"/>

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -138,7 +138,8 @@
 		<getAction name="GetInfo" argument="NewEnable"/>
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>
-	<channel name="wifiGuestEnableTriband" label="WiFi Guest Triband" description="Enable/Disable the guest WiFi on triband devices.">
+	<channel name="wifiGuestEnableTriband" label="WiFi Guest Triband" 
+	    description="Enable/Disable the guest WiFi on triband devices.">
 		<item type="Switch"/>
 		<service deviceType="urn:dslforum-org:device:LANDevice:1"
 			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration4"/>

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -138,7 +138,7 @@
 		<getAction name="GetInfo" argument="NewEnable"/>
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>
-	<channel name="wifiGuestEnableTriband" label="WiFi Guest Triband" 
+	<channel name="wifiGuestEnableTriband" label="WiFi Guest Triband"
 	    description="Enable/Disable the guest WiFi on triband devices.">
 		<item type="Switch"/>
 		<service deviceType="urn:dslforum-org:device:LANDevice:1"


### PR DESCRIPTION
# Added support for guest Wi-Fi on tri-band routers

The guest WiFi on tri-band routers like the Fritzbox 4060 cannot be controlled. The guest WiFi channel controls the second 5GHz unit. This change adds the fourth WiFi channel (guest on tri-band routers).

Fixes #12198