### PR TITLE
Bump Kotlin, okhttp, okio, and java-telegram-bot-api libraries

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.1</version>
+      <version>${gson.version}</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.dbquery/pom.xml
+++ b/bundles/org.openhab.binding.dbquery/pom.xml
@@ -56,6 +56,13 @@
       <artifactId>okio</artifactId>
       <groupId>com.squareup.okio</groupId>
       <version>${okio.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>${okio.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <artifactId>commons-csv</artifactId>

--- a/bundles/org.openhab.binding.dbquery/pom.xml
+++ b/bundles/org.openhab.binding.dbquery/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>
-      !javax.annotation;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*
+      !javax.annotation;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*
     </bnd.importpackage>
   </properties>
 
@@ -45,7 +45,7 @@
     <dependency> <!-- also used for querydb library -->
       <artifactId>gson</artifactId>
       <groupId>com.google.code.gson</groupId>
-      <version>2.9.1</version>
+      <version>${gson.version}</version>
     </dependency>
     <dependency>
       <artifactId>gson-fire</artifactId>
@@ -55,7 +55,7 @@
     <dependency>
       <artifactId>okio</artifactId>
       <groupId>com.squareup.okio</groupId>
-      <version>1.17.3</version>
+      <version>${okio.version}</version>
     </dependency>
     <dependency>
       <artifactId>commons-csv</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <artifactId>okhttp</artifactId>
       <groupId>com.squareup.okhttp3</groupId>
-      <version>3.14.4</version>
+      <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
       <artifactId>retrofit</artifactId>
@@ -85,7 +85,7 @@
     <dependency>
       <artifactId>logging-interceptor</artifactId>
       <groupId>com.squareup.okhttp3</groupId>
-      <version>3.14.4</version>
+      <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
       <artifactId>rxjava</artifactId>

--- a/bundles/org.openhab.binding.jellyfin/pom.xml
+++ b/bundles/org.openhab.binding.jellyfin/pom.xml
@@ -84,31 +84,31 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.7.21</version>
+      <version>${kotlin.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlinx</groupId>
       <artifactId>kotlinx-coroutines-core-jvm</artifactId>
-      <version>1.6.4</version>
+      <version>1.8.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlinx</groupId>
       <artifactId>kotlinx-serialization-core-jvm</artifactId>
-      <version>1.4.1</version>
+      <version>1.6.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlinx</groupId>
       <artifactId>kotlinx-serialization-json-jvm</artifactId>
-      <version>1.4.1</version>
+      <version>1.6.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.github.microutils</groupId>
       <artifactId>kotlin-logging-jvm</artifactId>
-      <version>3.0.4</version>
+      <version>3.0.5</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.telegram/pom.xml
+++ b/bundles/org.openhab.binding.telegram/pom.xml
@@ -15,32 +15,44 @@
   <name>openHAB Add-ons :: Bundles :: Telegram Binding</name>
 
   <properties>
-    <bnd.importpackage>!android.*,!com.android.org.*,!dalvik.*,!javax.annotation.meta.*,!org.apache.harmony.*,!org.conscrypt.*,!sun.*</bnd.importpackage>
+    <bnd.importpackage>!android.*,!com.android.org.*,!dalvik.*,!javax.annotation.meta.*,!org.apache.harmony.*,!org.conscrypt.*,!sun.*,!kotlin.*,!org.bouncycastle.*,!org.openjsse.*</bnd.importpackage>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.github.pengrad</groupId>
       <artifactId>java-telegram-bot-api</artifactId>
-      <version>5.2.0</version>
+      <version>7.1.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>${okhttp.version}</version>
+      <version>${okhttp3.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
-      <version>1.15.0</version>
+      <version>${okio.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>${okio.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>${okhttp.version}</version>
+      <version>${okhttp3.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -360,7 +360,7 @@ public class TelegramHandler extends BaseThingHandler {
                 } else if (message.photo() != null) {
                     PhotoSize[] photoSizes = message.photo();
                     logger.trace("Received photos {}", Arrays.asList(photoSizes));
-                    Arrays.sort(photoSizes, Comparator.comparingInt(PhotoSize::fileSize).reversed());
+                    Arrays.sort(photoSizes, Comparator.comparingLong(PhotoSize::fileSize).reversed());
                     lastMessageURL = getFullDownloadUrl(photoSizes[0].fileId());
                 } else if (message.text() != null) {
                     lastMessageText = message.text();

--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio-jvm</artifactId>
-      <version>3.8.0</version>
+      <version>${okio.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -18,7 +18,7 @@
     <bnd.importpackage>
       !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*
     </bnd.importpackage>
-    <retrofit.version>2.9.0</retrofit.version>
+    <retrofit.version>2.10.0</retrofit.version>
     <influx2.version>7.0.0</influx2.version>
     <influx1.version>2.24</influx1.version>
     <io.reactivex.rxjava3>3.1.8</io.reactivex.rxjava3>

--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -19,8 +19,9 @@
       !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*
     </bnd.importpackage>
     <retrofit.version>2.9.0</retrofit.version>
-    <influx2.version>5.0.0</influx2.version>
+    <influx2.version>7.0.0</influx2.version>
     <influx1.version>2.24</influx1.version>
+    <io.reactivex.rxjava3>3.1.8</io.reactivex.rxjava3>
   </properties>
 
   <dependencies>
@@ -36,11 +37,6 @@
       <version>${influx2.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.retrofit2</groupId>
-      <artifactId>adapter-rxjava2</artifactId>
-      <version>${retrofit.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.influxdb</groupId>
       <artifactId>influxdb-client-core</artifactId>
       <version>${influx2.version}</version>
@@ -48,6 +44,11 @@
     <dependency>
       <groupId>com.influxdb</groupId>
       <artifactId>flux-dsl</artifactId>
+      <version>${influx2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.influxdb</groupId>
+      <artifactId>influxdb-client-flux</artifactId>
       <version>${influx2.version}</version>
     </dependency>
 
@@ -66,6 +67,11 @@
       <groupId>com.squareup.retrofit2</groupId>
       <version>${retrofit.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>adapter-rxjava3</artifactId>
+      <version>${retrofit.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
@@ -78,6 +84,19 @@
       <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>${okio.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>3.8.0</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
@@ -88,24 +107,15 @@
       <version>1.9.0</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>${okio.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-csv</artifactId>
-      <version>1.8</version>
-    </dependency>
-    <dependency>
       <artifactId>json</artifactId>
       <groupId>org.json</groupId>
       <version>20231013</version>
     </dependency>
+
     <dependency>
-      <artifactId>rxjava</artifactId>
-      <groupId>io.reactivex.rxjava2</groupId>
-      <version>2.2.21</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <artifactId>reactive-streams</artifactId>
@@ -116,6 +126,16 @@
       <artifactId>swagger-annotations</artifactId>
       <groupId>io.swagger</groupId>
       <version>1.6.13</version>
+    </dependency>
+    <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>${io.reactivex.rxjava3}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
     </dependency>
     <!--END InfluxDB 2.0 -->
 

--- a/bundles/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/org.openhab.persistence.influxdb/pom.xml
@@ -16,12 +16,11 @@
 
   <properties>
     <bnd.importpackage>
-      !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*
+      !javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*
     </bnd.importpackage>
-    <okhttp3.version>3.14.9</okhttp3.version>
-    <retrofit.version>2.7.2</retrofit.version>
-    <influx2.version>4.3.0</influx2.version>
-    <influx1.version>2.21</influx1.version>
+    <retrofit.version>2.9.0</retrofit.version>
+    <influx2.version>5.0.0</influx2.version>
+    <influx1.version>2.24</influx1.version>
   </properties>
 
   <dependencies>
@@ -81,17 +80,17 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.1</version>
+      <version>${gson.version}</version>
     </dependency>
     <dependency>
       <groupId>io.gsonfire</groupId>
       <artifactId>gson-fire</artifactId>
-      <version>1.8.4</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
-      <version>1.17.3</version>
+      <version>${okio.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -106,17 +105,17 @@
     <dependency>
       <artifactId>rxjava</artifactId>
       <groupId>io.reactivex.rxjava2</groupId>
-      <version>2.2.19</version>
+      <version>2.2.21</version>
     </dependency>
     <dependency>
       <artifactId>reactive-streams</artifactId>
       <groupId>org.reactivestreams</groupId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
       <artifactId>swagger-annotations</artifactId>
       <groupId>io.swagger</groupId>
-      <version>1.6.1</version>
+      <version>1.6.13</version>
     </dependency>
     <!--END InfluxDB 2.0 -->
 
@@ -134,7 +133,7 @@
     <dependency>
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
-      <version>1.8.0</version>
+      <version>1.15.1</version>
     </dependency>
     <!-- Okhttp & Retrofit from 2.0 are ok -->
 

--- a/bundles/org.openhab.voice.watsonstt/pom.xml
+++ b/bundles/org.openhab.voice.watsonstt/pom.xml
@@ -39,37 +39,37 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.11.0</version>
+      <version>${okhttp3.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
-      <version>4.11.0</version>
+      <version>${okhttp3.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.6.21</version>
+      <version>${kotlin.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
-      <version>3.4.0</version>
+      <version>${okio.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio-jvm</artifactId>
-      <version>3.4.0</version>
+      <version>${okio.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.1</version>
+      <version>${gson.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,10 @@
     <jackson.version>2.16.0</jackson.version>
     <karaf.version>4.4.4</karaf.version>
     <netty.version>4.1.104.Final</netty.version>
-    <okhttp.version>3.14.9</okhttp.version>
+    <okhttp3.version>4.12.0</okhttp3.version>
+    <okio.version>3.6.0</okio.version>
+    <gson.version>2.9.1</gson.version>
+    <kotlin.version>1.9.22</kotlin.version>
     <sat.version>0.15.0</sat.version>
     <slf4j.version>2.0.6</slf4j.version>
     <spotless.version>2.38.0</spotless.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <karaf.version>4.4.4</karaf.version>
     <netty.version>4.1.104.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
-    <okio.version>3.8.0</okio.version>
+    <okio.version>3.6.0</okio.version>
     <gson.version>2.9.1</gson.version>
     <kotlin.version>1.9.22</kotlin.version>
     <sat.version>0.15.0</sat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <karaf.version>4.4.4</karaf.version>
     <netty.version>4.1.104.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
-    <okio.version>3.6.0</okio.version>
+    <okio.version>3.8.0</okio.version>
     <gson.version>2.9.1</gson.version>
     <kotlin.version>1.9.22</kotlin.version>
     <sat.version>0.15.0</sat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@
     <karaf.version>4.4.4</karaf.version>
     <netty.version>4.1.104.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
-    <okio.version>3.6.0</okio.version>
+    <okio.version>3.9.0</okio.version>
     <gson.version>2.9.1</gson.version>
-    <kotlin.version>1.9.22</kotlin.version>
+    <kotlin.version>1.9.23</kotlin.version>
     <sat.version>0.15.0</sat.version>
     <slf4j.version>2.0.6</slf4j.version>
     <spotless.version>2.38.0</spotless.version>


### PR DESCRIPTION
Update various libraries to their latest versions, and also make it easier to keep multiple bindings in sync with the latest and same version. No need to use 3+ different versions of the same library.

Updating java-telegram-bot-api to tackle some of the Telegram bugs and feature requests.