### PR TITLE
Bump net.java.dev.jna lib to version 5.14.0

### DIFF
--- a/bundles/org.openhab.binding.amazondashbutton/pom.xml
+++ b/bundles/org.openhab.binding.amazondashbutton/pom.xml
@@ -16,14 +16,13 @@
 
   <properties>
     <bnd.importpackage>!org.slf4j.impl.*</bnd.importpackage>
-    <dep.noembedding>jna</dep.noembedding>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.4.0</version>
+      <version>${jna.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -37,6 +36,16 @@
       <artifactId>pcap4j-packetfactory-static</artifactId>
       <version>1.8.2</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>${jna.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.binding.amazondashbutton/pom.xml
+++ b/bundles/org.openhab.binding.amazondashbutton/pom.xml
@@ -26,6 +26,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>${jna.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.pcap4j</groupId>
       <artifactId>pcap4j-core</artifactId>
       <version>1.8.2</version>
@@ -36,16 +41,6 @@
       <artifactId>pcap4j-packetfactory-static</artifactId>
       <version>1.8.2</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>${jna.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna-platform</artifactId>
-      <version>${jna.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.binding.doorbird/pom.xml
+++ b/bundles/org.openhab.binding.doorbird/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.5.0</version>
+      <version>${jna.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 
 	<feature name="openhab-binding-doorbird" description="Doorbird Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:net.java.dev.jna/jna/5.5.0</bundle>
+		<bundle dependency="true">mvn:net.java.dev.jna/jna/${jna.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.doorbird/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/org.openhab.binding.systeminfo/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>6.4.8</version>
+      <version>6.4.12</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -26,6 +26,16 @@
           <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>${jna.version}</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/org.openhab.binding.tellstick/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.5.2</version>
+      <version>${jna.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
@@ -6,8 +6,8 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
 		<feature dependency="true">openhab.tp-netty</feature>
-		<bundle dependency="true">mvn:net.java.dev.jna/jna/4.5.2</bundle>
-		<bundle dependency="true">mvn:net.java.dev.jna/jna-platform/4.5.2</bundle>
+		<bundle dependency="true">mvn:net.java.dev.jna/jna/${jna.version}</bundle>
+		<bundle dependency="true">mvn:net.java.dev.jna/jna-platform/${jna.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.2.1/1.2.1_3</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.tellstick/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.voice.voskstt/pom.xml
+++ b/bundles/org.openhab.voice.voskstt/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.13.0</version>
+      <version>${jna.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <commons.net.version>3.9.0</commons.net.version>
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.16.0</jackson.version>
+    <jna.version>5.14.0</jna.version>
     <karaf.version>4.4.4</karaf.version>
     <netty.version>4.1.104.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>


### PR DESCRIPTION
PR will update the net.java.dev.jna library.
Updates the oshi-core lib for the system info binding, have tested it works.
Gets all bindings onto the same version. I count 5 different versions are/were in use.
Makes it easier to keep them all updated in the future.