### PR TITLE
[ecovacs] Handle invalid JSON responses properly

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/EcovacsApiException.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/EcovacsApiException.java
@@ -27,6 +27,11 @@ public class EcovacsApiException extends Exception {
         this(reason, false);
     }
 
+    public EcovacsApiException(String reason, Throwable cause) {
+        super(reason, cause);
+        isAuthFailure = false;
+    }
+
     public EcovacsApiException(String reason, boolean isAuthFailure) {
         super(reason);
         this.isAuthFailure = isAuthFailure;

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsApiImpl.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/api/impl/EcovacsApiImpl.java
@@ -345,13 +345,18 @@ public final class EcovacsApiImpl implements EcovacsApi {
     }
 
     private <T> T handleResponse(ContentResponse response, Class<T> clazz) throws EcovacsApiException {
-        @Nullable
-        T respObject = gson.fromJson(response.getContentAsString(), clazz);
-        if (respObject == null) {
-            // should not happen in practice
-            throw new EcovacsApiException("No response received");
+        try {
+            @Nullable
+            T respObject = gson.fromJson(response.getContentAsString(), clazz);
+            if (respObject == null) {
+                // should not happen in practice
+                throw new EcovacsApiException("No response received");
+            }
+            return respObject;
+        } catch (JsonSyntaxException e) {
+            throw new EcovacsApiException("Failed to parse response '" + response.getContentAsString()
+                    + "' as data class " + clazz.getSimpleName(), e);
         }
-        return respObject;
     }
 
     private Request createAuthRequest(String url, String clientKey, String clientSecret,


### PR DESCRIPTION
The API has differing responses depending on device type. If our understanding of the JSON format differs from that of the API, make sure to properly set the thing OFFLINE and to log a meaningful message.

Related to #16187

