### PR TITLE
[ecobee] Fix for error code 14 (token expired)

### DIFF
--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
@@ -356,10 +356,10 @@ public class EcobeeApi implements AccessTokenRefreshListener {
                 // Recreating the OAuthClientService seems to be the only way to handle this error
                 closeOAuthClientService();
                 createOAuthClientService();
-                try {
-                    oAuthClientService.refreshToken();
-                } catch (OAuthException | IOException | OAuthResponseException e) {
-                    logger.warn("API: Unable to refresh token after receiving error code 14");
+                if (isAuthorized()) {
+                    return true;
+                } else {
+                    logger.warn("API: isAuthorized was NOT successful on second try");
                     bridgeHandler.updateBridgeStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "Unable to refresh access token");
                 }

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/api/EcobeeApi.java
@@ -46,7 +46,6 @@ import org.openhab.binding.ecobee.internal.dto.thermostat.summary.SummaryRespons
 import org.openhab.binding.ecobee.internal.function.FunctionRequest;
 import org.openhab.binding.ecobee.internal.handler.EcobeeAccountBridgeHandler;
 import org.openhab.binding.ecobee.internal.util.ExceptionUtils;
-import org.openhab.core.auth.client.oauth2.AccessTokenRefreshListener;
 import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
 import org.openhab.core.auth.client.oauth2.OAuthClientService;
 import org.openhab.core.auth.client.oauth2.OAuthException;
@@ -69,7 +68,7 @@ import com.google.gson.JsonSyntaxException;
  * @author Mark Hilbush - Initial contribution
  */
 @NonNullByDefault
-public class EcobeeApi implements AccessTokenRefreshListener {
+public class EcobeeApi {
 
     private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantDeserializer())
             .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeDeserializer())
@@ -133,14 +132,12 @@ public class EcobeeApi implements AccessTokenRefreshListener {
     public void deleteOAuthClientService() {
         String bridgeUID = bridgeHandler.getThing().getUID().getAsString();
         logger.debug("API: Deleting OAuth Client Service for {}", bridgeUID);
-        oAuthClientService.removeAccessTokenRefreshListener(this);
         oAuthFactory.deleteServiceAndAccessToken(bridgeUID);
     }
 
     public void closeOAuthClientService() {
         String bridgeUID = bridgeHandler.getThing().getUID().getAsString();
         logger.debug("API: Closing OAuth Client Service for {}", bridgeUID);
-        oAuthClientService.removeAccessTokenRefreshListener(this);
         oAuthFactory.ungetOAuthService(bridgeUID);
     }
 
@@ -201,10 +198,6 @@ public class EcobeeApi implements AccessTokenRefreshListener {
             logger.debug("API: Exception getting access token: error='{}', description='{}'", e.getError(),
                     e.getErrorDescription());
         }
-    }
-
-    @Override
-    public void onAccessTokenResponse(AccessTokenResponse accessTokenResponse) {
     }
 
     public @Nullable SummaryResponseDTO performThermostatSummaryQuery() {


### PR DESCRIPTION
The error code 14 (token expired) returned by the Ecobee API is not handled correctly by the binding. No matter how much time passes, the AccessTokenResponse `isExpired` method never returns true. I don't know why this is the case. I can only assume there's something wrong with the access token returned from Ecobee.

Therefore, the only way to recover from this condition (short of the user manually disabling and enabling the account thing) is to close and recreate the OAuthClientService (which is essentially what happens when you disable/enable the account thing).

Also raising the log level from DEBUG to INFO to give more visibility in the log to when the condition occurs.
