### PR TITLE
[keba] Add support for additional x-series wallboxes

### DIFF
--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -4,7 +4,7 @@ This binding integrates the [Keba KeContact EV Charging Stations](https://www.ke
 
 ## Supported Things
 
-The Keba KeContact P20 and P30 stations which are providing the UDP interface (P20 LSA+ socket, P30 c-series and x-series) are supported by this binding, the thing type id is `kecontact`.
+The Keba KeContact P20 and P30 stations which are providing the UDP interface (P20 LSA+ socket, P30 c-series and x-series or BMW wallbox) are supported by this binding, the thing type id is `kecontact`.
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -87,8 +87,8 @@ public class KebaBindingConstants {
          */
         E('0'),
         B('1'),
-        C('2', 'A'),
-        A('3'),
+        C('2', '3', 'A'), // '3' is P20 c-series + PLC
+        // A('3'), // '3' is also P30 a-series - but P30 a-series doesn't support the required UDS protocol
         X('B', 'C', 'D', 'E', 'G', 'H', 'S', 'U');
 
         private final List<Character> things = new ArrayList<>();

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -81,8 +81,9 @@ public class KebaBindingConstants {
 
         E('0'),
         B('1'),
-        C('2', '3'),
-        X('A', 'B', 'C', 'D', 'E', 'G', 'H');
+        C('2'),
+        A('3'),
+        X('A', 'B', 'C', 'D', 'E', 'G', 'H', 'S', 'U');
 
         private final List<Character> things = new ArrayList<>();
 

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -79,11 +79,17 @@ public class KebaBindingConstants {
 
     public enum KebaSeries {
 
+        /*
+         * Mapping derived from:
+         * - https://www.keba.com/download/x/ea958eb797/kecontactp30_bden_web.pdf
+         * - https://www.keba.com/file/downloads/e-mobility/KeContact_KCP20_30_ih_de.pdf
+         * 'G' is still unclear
+         */
         E('0'),
         B('1'),
-        C('2'),
+        C('2', 'A'),
         A('3'),
-        X('A', 'B', 'C', 'D', 'E', 'G', 'H', 'S', 'U');
+        X('B', 'C', 'D', 'E', 'G', 'H', 'S', 'U');
 
         private final List<Character> things = new ArrayList<>();
 


### PR DESCRIPTION
Fixed https://github.com/openhab/openhab-addons/issues/16472.

The following wallboxes from the x-series are now supported as well:
- x-series 4G, w/o LM: identified via `S` in the product designation string
- x-series WLAN, w/o LM: identfied via `U` in the product designation string

Fixed type mapping for identifier 'A':
- was x-series but actually is c-series

Test Build: [org.openhab.binding.keba-4.2.0-SNAPSHOT-2024-03-01.zip](https://www.dropbox.com/scl/fi/4f10fw3d2dcgmzxfzbm7h/org.openhab.binding.keba-4.2.0-SNAPSHOT-2024-03-01.zip?rlkey=rcxs7gm5uypy6oz6aao1ybas8&dl=0)