### PR TITLE
[intesis] SESSION ID HANDLING IMPROVED

### DIFF
--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/gson/IntesisHomeJSonDTO.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/gson/IntesisHomeJSonDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2023 Contributors to the openHAB project
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -25,6 +25,7 @@ public class IntesisHomeJSonDTO {
     public static class Response {
         public boolean success;
         public JsonElement data;
+        public JsonElement error;
     }
 
     public static class Data {
@@ -34,6 +35,11 @@ public class IntesisHomeJSonDTO {
         public JsonElement config;
         public JsonElement dp;
         public JsonElement dpval;
+    }
+
+    public static class ResponseError {
+        public int code;
+        public String message;
     }
 
     public static class Id {


### PR DESCRIPTION
I have changed the login process so that the binding now only logs in at the beginning and logs out at the end. If a request fails due to a missing login or an invalid session ID, a new login attempt is made.

This ensures that
- Several requests can be sent in direct succession (if I switch the air conditioning from cooling to heating, I also want to change the slats at the same time)
- Less traffic is generated as there is not a constant logout and login again
- Ideally, the login credentials should only be visible once at startup

I am unsure whether I have used the correct levels for the logging.

The updated binding has been running without any problems for a few weeks now in my environment. First under 4.1.0, and since a few days now under 4.1.1.

Unfortunately, I completely struggle with Git, so I have no idea if I did it the correct way. Help is very much appreciated.