### PR TITLE
[inmemory] Default persistence strategy Forecast

### DIFF
--- a/bundles/org.openhab.persistence.inmemory/README.md
+++ b/bundles/org.openhab.persistence.inmemory/README.md
@@ -5,7 +5,7 @@ Because of that the `restoreOnStartup` strategy is not supported for this servic
 
 The main use-case is to store data that is needed during runtime, e.g. temporary storage of forecast data that is retrieved from a binding.
 
-Since all data is stored in memory only, there is no default strategy for this service.
+The default strategy for this service is `forecast`.
 Unlike other persistence services, you MUST add a configuration, otherwise no data will be persisted.
 To avoid excessive memory usage, it is recommended to persist only a limited number of items and use a strategy that stores only data that is actually needed.
 

--- a/bundles/org.openhab.persistence.inmemory/src/main/java/org/openhab/persistence/inmemory/internal/InMemoryPersistenceService.java
+++ b/bundles/org.openhab.persistence.inmemory/src/main/java/org/openhab/persistence/inmemory/internal/InMemoryPersistenceService.java
@@ -188,8 +188,8 @@ public class InMemoryPersistenceService implements ModifiablePersistenceService 
 
     @Override
     public List<PersistenceStrategy> getDefaultStrategies() {
-        // persist nothing by default
-        return List.of();
+        // persist only forecasts by default
+        return List.of(PersistenceStrategy.Globals.FORECAST);
     }
 
     private PersistenceItemInfo toItemInfo(Map.Entry<String, PersistItem> itemEntry) {
@@ -268,7 +268,7 @@ public class InMemoryPersistenceService implements ModifiablePersistenceService 
         }
     }
 
-    @SuppressWarnings({ "rawType", "unchecked" })
+    @SuppressWarnings("unchecked")
     private boolean applies(PersistEntry entry, FilterCriteria filter) {
         ZonedDateTime beginDate = filter.getBeginDate();
         if (beginDate != null && entry.timestamp().isBefore(beginDate)) {


### PR DESCRIPTION
The in memory persistence is especially relevant for forecasts or future value calculations.

To make it easy to configure, I propose a default strategy of Forecast. Any item with time series data will then get persisted in memory.
Memory impact is expected to be limited, as typically there are few items with time series. The most likely ones are for weather forecasts and solar predication calculated values.

See discussion: https://community.openhab.org/t/solar-forecast-pv/137681/157?u=mherwege

This would also make it possible to add it as a proposed persistence extension to the setup wizard, without further configuration required. See https://github.com/openhab/openhab-webui/pull/2431