### PR TITLE
[boschshc] Boost unit test coverage

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandler.java
@@ -657,7 +657,7 @@ public class BridgeHandler extends BaseBridgeHandler {
      *
      * @param e error during long polling
      */
-    private void handleLongPollFailure(Throwable e) {
+    void handleLongPollFailure(Throwable e) {
         logger.warn("Long polling failed, will try to reconnect", e);
         @Nullable
         BoschHttpClient localHttpClient = this.httpClient;
@@ -722,7 +722,7 @@ public class BridgeHandler extends BaseBridgeHandler {
                             return new BoschSHCException("@text/offline.conf-error.invalid-state-id");
                         } else {
                             return new BoschSHCException(String.format(
-                                    "Request for info of user-defines state %s failed with status code %d and error code %s",
+                                    "Request for info of user-defined state %s failed with status code %d and error code %s",
                                     stateId, errorResponse.statusCode, errorResponse.errorCode));
                         }
                     } else {

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/ScenarioHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/ScenarioHandler.java
@@ -96,7 +96,7 @@ public class ScenarioHandler {
         }
     }
 
-    private String prettyLogScenarios(final Scenario[] scenarios) {
+    String prettyLogScenarios(final Scenario[] scenarios) {
         final StringBuilder builder = new StringBuilder();
         builder.append("[");
         for (Scenario scenario : scenarios) {

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/console/BoschShcCommandExtensionTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/console/BoschShcCommandExtensionTest.java
@@ -17,7 +17,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,6 +40,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.boschshc.internal.devices.bridge.BridgeHandler;
@@ -87,6 +94,24 @@ class BoschShcCommandExtensionTest {
         verify(consoleMock, atLeastOnce()).print(any());
         fixture.execute(new String[] { BoschShcCommandExtension.GET_DEVICES }, consoleMock);
         verify(consoleMock, atLeastOnce()).print(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getBoschShcAndExecutionAndTimeoutExceptionArguments()")
+    void executeHandleExceptions(Exception exception)
+            throws InterruptedException, BoschSHCException, ExecutionException, TimeoutException {
+        Console console = mock(Console.class);
+        Bridge bridge = mock(Bridge.class);
+        BridgeHandler bridgeHandler = mock(BridgeHandler.class);
+        when(bridgeHandler.getThing()).thenReturn(bridge);
+        when(bridgeHandler.getPublicInformation()).thenThrow(exception);
+        when(bridge.getHandler()).thenReturn(bridgeHandler);
+        List<Thing> things = List.of(bridge);
+        when(thingRegistry.getAll()).thenReturn(things);
+
+        fixture.execute(new String[] { BoschShcCommandExtension.GET_BRIDGEINFO }, console);
+
+        verify(console).print(anyString());
     }
 
     @Test

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBatteryPoweredDeviceHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBatteryPoweredDeviceHandlerTest.java
@@ -46,13 +46,13 @@ public abstract class AbstractBatteryPoweredDeviceHandlerTest<T extends Abstract
     @BeforeEach
     @Override
     public void beforeEach() throws InterruptedException, TimeoutException, ExecutionException, BoschSHCException {
-        super.beforeEach();
-
         DeviceServiceData deviceServiceData = new DeviceServiceData();
         deviceServiceData.path = "/devices/hdm:ZigBee:000d6f0004b93361/services/BatteryLevel";
         deviceServiceData.id = "BatteryLevel";
         deviceServiceData.deviceId = "hdm:ZigBee:000d6f0004b93361";
-        lenient().when(bridgeHandler.getServiceData(anyString(), anyString())).thenReturn(deviceServiceData);
+        when(getBridgeHandler().getServiceData(anyString(), anyString())).thenReturn(deviceServiceData);
+
+        super.beforeEach();
     }
 
     @Test
@@ -137,10 +137,11 @@ public abstract class AbstractBatteryPoweredDeviceHandlerTest<T extends Abstract
                     "deviceId":"hdm:ZigBee:000d6f0004b93361" }\
                 """);
         getFixture().processUpdate("BatteryLevel", deviceServiceData);
-        verify(getCallback()).stateUpdated(
+        // state is updated twice: via short poll in initialize() and via long poll result in this test
+        verify(getCallback(), times(2)).stateUpdated(
                 new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_BATTERY_LEVEL),
                 new DecimalType(100));
-        verify(getCallback()).stateUpdated(
+        verify(getCallback(), times(2)).stateUpdated(
                 new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_LOW_BATTERY), OnOffType.OFF);
     }
 
@@ -165,19 +166,24 @@ public abstract class AbstractBatteryPoweredDeviceHandlerTest<T extends Abstract
         getFixture().processUpdate("BatteryLevel", deviceServiceData);
         verify(getCallback()).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_BATTERY_LEVEL),
                 UnDefType.UNDEF);
-        verify(getCallback()).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_LOW_BATTERY), OnOffType.OFF);
+        // state is updated twice: via short poll in initialize() and via long poll result in this test
+        verify(getCallback(), times(2)).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_LOW_BATTERY),
+                OnOffType.OFF);
     }
 
     @Test
     public void testHandleCommandRefreshBatteryLevelChannel() {
         getFixture().handleCommand(getChannelUID(BoschSHCBindingConstants.CHANNEL_BATTERY_LEVEL), RefreshType.REFRESH);
-        verify(getCallback()).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_BATTERY_LEVEL),
+        // state is updated twice: via short poll in initialize() and via long poll result in this test
+        verify(getCallback(), times(2)).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_BATTERY_LEVEL),
                 new DecimalType(100));
     }
 
     @Test
     public void testHandleCommandRefreshLowBatteryChannel() {
         getFixture().handleCommand(getChannelUID(BoschSHCBindingConstants.CHANNEL_LOW_BATTERY), RefreshType.REFRESH);
-        verify(getCallback()).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_LOW_BATTERY), OnOffType.OFF);
+        // state is updated twice: via short poll in initialize() and via long poll result in this test
+        verify(getCallback(), times(2)).stateUpdated(getChannelUID(BoschSHCBindingConstants.CHANNEL_LOW_BATTERY),
+                OnOffType.OFF);
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBoschSHCDeviceHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBoschSHCDeviceHandlerTest.java
@@ -12,9 +12,23 @@
  */
 package org.openhab.binding.boschshc.internal.devices;
 
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.Device;
+import org.openhab.binding.boschshc.internal.exceptions.BoschSHCException;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * Abstract unit test implementation for device handlers.
@@ -42,4 +56,27 @@ public abstract class AbstractBoschSHCDeviceHandlerTest<T extends BoschSHCDevice
     }
 
     protected abstract String getDeviceID();
+
+    @Test
+    void initializeInvalidDeviceId() {
+        getFixture().getThing().getConfiguration().remove("id");
+        getFixture().initialize();
+
+        verify(getCallback()).statusUpdated(eq(getThing()),
+                argThat(status -> status.getStatus().equals(ThingStatus.OFFLINE)
+                        && status.getStatusDetail().equals(ThingStatusDetail.CONFIGURATION_ERROR)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getExecutionExceptionAndInterruptedExceptionArguments()")
+    void initializeHandleExceptionDuringDeviceInfoRestCall(Exception exception)
+            throws BoschSHCException, InterruptedException, TimeoutException, ExecutionException {
+        when(getBridgeHandler().getDeviceInfo(getDeviceID())).thenThrow(exception);
+
+        getFixture().initialize();
+
+        verify(getCallback()).statusUpdated(eq(getThing()),
+                argThat(status -> status.getStatus().equals(ThingStatus.OFFLINE)
+                        && status.getStatusDetail().equals(ThingStatusDetail.CONFIGURATION_ERROR)));
+    }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBoschSHCHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/AbstractBoschSHCHandlerTest.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.boschshc.internal.devices;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -60,7 +63,7 @@ public abstract class AbstractBoschSHCHandlerTest<T extends BoschSHCHandler> {
 
     private @Mock @NonNullByDefault({}) Bridge bridge;
 
-    protected @Mock @NonNullByDefault({}) BridgeHandler bridgeHandler;
+    private @Mock @NonNullByDefault({}) BridgeHandler bridgeHandler;
 
     private @Mock @NonNullByDefault({}) ThingHandlerCallback callback;
 
@@ -128,8 +131,25 @@ public abstract class AbstractBoschSHCHandlerTest<T extends BoschSHCHandler> {
     }
 
     @Test
-    public void testInitialize() {
+    void testInitialize() {
         ThingStatusInfo expectedStatusInfo = new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
         verify(callback).statusUpdated(same(thing), eq(expectedStatusInfo));
+    }
+
+    @Test
+    void testGetBridgeHandler() throws BoschSHCException {
+        assertThat(fixture.getBridgeHandler(), sameInstance(bridgeHandler));
+    }
+
+    @Test
+    void testGetBridgeHandlerThrowExceptionIfBridgeIsNull() throws BoschSHCException {
+        when(callback.getBridge(any())).thenReturn(null);
+        assertThrows(BoschSHCException.class, () -> fixture.getBridgeHandler());
+    }
+
+    @Test
+    void testGetBridgeHandlerThrowExceptionIfBridgeHandlerIsNull() throws BoschSHCException {
+        when(bridge.getHandler()).thenReturn(null);
+        assertThrows(BoschSHCException.class, () -> fixture.getBridgeHandler());
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandlerTest.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.binding.boschshc.internal.devices.bridge;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,9 +25,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -50,16 +55,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.openhab.binding.boschshc.internal.devices.BoschSHCBindingConstants;
 import org.openhab.binding.boschshc.internal.devices.BoschSHCHandler;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.Device;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.DeviceServiceData;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.DeviceTest;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.Faults;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.LongPollResult;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.PublicInformation;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.Room;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.Scenario;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.SubscribeResult;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.UserDefinedState;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.UserDefinedStateTest;
+import org.openhab.binding.boschshc.internal.discovery.ThingDiscoveryService;
 import org.openhab.binding.boschshc.internal.exceptions.BoschSHCException;
 import org.openhab.binding.boschshc.internal.serialization.GsonUtils;
 import org.openhab.binding.boschshc.internal.services.binaryswitch.dto.BinarySwitchServiceState;
@@ -70,15 +82,21 @@ import org.openhab.binding.boschshc.internal.services.intrusion.dto.IntrusionDet
 import org.openhab.binding.boschshc.internal.services.shuttercontact.ShutterContactState;
 import org.openhab.binding.boschshc.internal.services.shuttercontact.dto.ShutterContactServiceState;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 /**
  * Unit tests for the {@link BridgeHandler}.
@@ -92,13 +110,9 @@ class BridgeHandlerTest {
     private @NonNullByDefault({}) BridgeHandler fixture;
 
     private @NonNullByDefault({}) BoschHttpClient httpClient;
-
     private @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
-
-    /**
-     * A mocked bridge instance
-     */
     private @NonNullByDefault({}) Bridge thing;
+    private @NonNullByDefault({}) Configuration bridgeConfiguration;
 
     @BeforeAll
     static void beforeAll() throws IOException {
@@ -119,7 +133,7 @@ class BridgeHandlerTest {
         thingHandlerCallback = mock(ThingHandlerCallback.class);
         fixture.setCallback(thingHandlerCallback);
 
-        Configuration bridgeConfiguration = new Configuration();
+        bridgeConfiguration = new Configuration();
         Map<@Nullable String, @Nullable Object> properties = new HashMap<>();
         properties.put("ipAddress", "localhost");
         properties.put("password", "test");
@@ -152,6 +166,19 @@ class BridgeHandlerTest {
 
         fixture.postAction(endpoint, request);
         verify(httpClient).createRequest(eq(url), same(HttpMethod.POST), same(request));
+        verify(mockRequest).send();
+    }
+
+    @Test
+    void postActionWithoutRequestBody() throws InterruptedException, TimeoutException, ExecutionException {
+        String endpoint = "/intrusion/actions/disarm";
+        String url = "https://127.0.0.1:8444/smarthome/intrusion/actions/disarm";
+        when(httpClient.getBoschSmartHomeUrl(endpoint)).thenReturn(url);
+        Request mockRequest = mock(Request.class);
+        when(httpClient.createRequest(anyString(), any(), any())).thenReturn(mockRequest);
+
+        fixture.postAction(endpoint);
+        verify(httpClient).createRequest(eq(url), same(HttpMethod.POST), isNull());
         verify(mockRequest).send();
     }
 
@@ -212,9 +239,31 @@ class BridgeHandlerTest {
         when(httpClient.createRequest(anyString(), same(HttpMethod.POST),
                 argThat((JsonRpcRequest r) -> "RE/longPoll".equals(r.method)))).thenReturn(longPollRequest);
 
+        ThingDiscoveryService thingDiscoveryListener = mock(ThingDiscoveryService.class);
+        fixture.registerDiscoveryListener(thingDiscoveryListener);
+
         fixture.initialAccess(httpClient);
+
         verify(thingHandlerCallback).statusUpdated(any(),
                 eq(ThingStatusInfoBuilder.create(ThingStatus.ONLINE, ThingStatusDetail.NONE).build()));
+        verify(thingDiscoveryListener).doScan();
+    }
+
+    @Test
+    void initialAccessNoBridgeAccess() throws InterruptedException, TimeoutException, ExecutionException {
+        when(httpClient.isOnline()).thenReturn(true);
+        when(httpClient.isAccessPossible()).thenReturn(true);
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), same(HttpMethod.GET))).thenReturn(request);
+        ContentResponse response = mock(ContentResponse.class);
+        when(request.send()).thenReturn(response);
+        when(response.getStatus()).thenReturn(400);
+
+        fixture.initialAccess(httpClient);
+
+        verify(thingHandlerCallback).statusUpdated(same(thing),
+                argThat(status -> status.getStatus().equals(ThingStatus.OFFLINE)
+                        && status.getStatusDetail().equals(ThingStatusDetail.COMMUNICATION_ERROR)));
     }
 
     @Test
@@ -469,6 +518,44 @@ class BridgeHandlerTest {
     }
 
     @Test
+    void getUserStateInfoErrorCases()
+            throws InterruptedException, TimeoutException, ExecutionException, BoschSHCException {
+        when(httpClient.getBoschSmartHomeUrl(anyString())).thenCallRealMethod();
+        when(httpClient.getBoschShcUrl(anyString())).thenCallRealMethod();
+
+        Request request = mock(Request.class);
+        when(request.header(anyString(), anyString())).thenReturn(request);
+        ContentResponse response = mock(ContentResponse.class);
+        when(response.getStatus()).thenReturn(200);
+        when(request.send()).thenReturn(response);
+        when(httpClient.createRequest(anyString(), same(HttpMethod.GET))).thenReturn(request);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<BiFunction<Integer, String, BoschSHCException>> errorResponseHandlerCaptor = ArgumentCaptor
+                .forClass(BiFunction.class);
+
+        String stateId = "abcdef";
+        when(httpClient.sendRequest(same(request), same(UserDefinedState.class), any(),
+                errorResponseHandlerCaptor.capture())).thenReturn(UserDefinedStateTest.createTestState(stateId));
+
+        fixture.getUserStateInfo(stateId);
+
+        BiFunction<Integer, String, BoschSHCException> errorResponseHandler = errorResponseHandlerCaptor.getValue();
+        Exception e = errorResponseHandler.apply(500,
+                "{\"@type\":\"JsonRestExceptionResponseEntity\",\"errorCode\": \"testErrorCode\",\"statusCode\": 500}");
+        assertEquals(
+                "Request for info of user-defined state abcdef failed with status code 500 and error code testErrorCode",
+                e.getMessage());
+
+        e = errorResponseHandler.apply(404,
+                "{\"@type\":\"JsonRestExceptionResponseEntity\",\"errorCode\": \"ENTITY_NOT_FOUND\",\"statusCode\": 404}");
+        assertNotNull(e);
+
+        e = errorResponseHandler.apply(500, "");
+        assertEquals("Request for info of user-defined state abcdef failed with status code 500", e.getMessage());
+    }
+
+    @Test
     void getUserStates() throws InterruptedException, TimeoutException, ExecutionException, BoschSHCException {
         when(httpClient.getBoschSmartHomeUrl(anyString())).thenCallRealMethod();
         when(httpClient.getBoschShcUrl(anyString())).thenCallRealMethod();
@@ -649,5 +736,348 @@ class BridgeHandlerTest {
                 """);
 
         verify(thingHandler).processChildUpdate("hdm:ZigBee:70ac08fffefead2d#3", "PowerSwitch", expectedState);
+    }
+
+    @Test
+    void handleLongPollResultScenarioTriggered() {
+        Channel channel = mock(Channel.class);
+        when(thing.getChannel(BoschSHCBindingConstants.CHANNEL_SCENARIO_TRIGGERED)).thenReturn(channel);
+        when(thingHandlerCallback.isChannelLinked(any())).thenReturn(true);
+
+        String json = """
+                {
+                  "result": [{
+                    "@type": "scenarioTriggered",
+                    "name": "My Scenario",
+                    "id": "509bd737-eed0-40b7-8caa-e8686a714399",
+                    "lastTimeTriggered": "1693758693032"
+                  }],
+                  "jsonrpc": "2.0"
+                }
+                """;
+        LongPollResult longPollResult = GsonUtils.DEFAULT_GSON_INSTANCE.fromJson(json, LongPollResult.class);
+        assertNotNull(longPollResult);
+
+        fixture.handleLongPollResult(longPollResult);
+
+        verify(thingHandlerCallback).stateUpdated(any(), eq(new StringType("My Scenario")));
+    }
+
+    @Test
+    void handleLongPollResultUserDefinedState() {
+        List<Thing> things = new ArrayList<Thing>();
+        when(thing.getThings()).thenReturn(things);
+
+        Thing thing = mock(Thing.class);
+        things.add(thing);
+
+        BoschSHCHandler thingHandler = mock(BoschSHCHandler.class);
+        when(thing.getHandler()).thenReturn(thingHandler);
+
+        when(thingHandler.getBoschID()).thenReturn("3d8023d6-69ca-4e79-89dd-7090295cefbf");
+
+        String json = """
+                {
+                    "result": [{
+                        "deleted": false,
+                        "@type": "userDefinedState",
+                        "name": "Test State",
+                        "id": "3d8023d6-69ca-4e79-89dd-7090295cefbf",
+                        "state": true
+                    }],
+                    "jsonrpc": "2.0"
+                }
+                """;
+        LongPollResult longPollResult = GsonUtils.DEFAULT_GSON_INSTANCE.fromJson(json, LongPollResult.class);
+        assertNotNull(longPollResult);
+
+        fixture.handleLongPollResult(longPollResult);
+
+        JsonElement expectedState = new JsonPrimitive(true);
+
+        verify(thingHandler).processUpdate("3d8023d6-69ca-4e79-89dd-7090295cefbf", expectedState);
+    }
+
+    @Test
+    void handleLongPollFailure() {
+        Throwable e = new RuntimeException("Test exception");
+        fixture.handleLongPollFailure(e);
+
+        ThingStatusInfo expectedStatus = ThingStatusInfoBuilder
+                .create(ThingStatus.UNKNOWN, ThingStatusDetail.UNKNOWN.NONE).build();
+        verify(thingHandlerCallback).statusUpdated(thing, expectedStatus);
+    }
+
+    @Test
+    void getDevices() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(200);
+        String devicesJson = """
+                [
+                    {
+                        "@type": "device",
+                        "rootDeviceId": "64-da-a0-3e-81-0c",
+                        "id": "hdm:ZigBee:0c4314fffea15de7",
+                        "deviceServiceIds": [
+                            "CommunicationQuality",
+                            "PowerMeter",
+                            "PowerSwitch",
+                            "PowerSwitchConfiguration",
+                            "PowerSwitchProgram"
+                        ],
+                        "manufacturer": "BOSCH",
+                        "roomId": "hz_1",
+                        "deviceModel": "PLUG_COMPACT",
+                        "serial": "0C4314FFFE802BE2",
+                        "profile": "LIGHT",
+                        "iconId": "icon_plug_lamp_table",
+                        "name": "My Lamp Plug",
+                        "status": "AVAILABLE",
+                        "childDeviceIds": [],
+                        "supportedProfiles": [
+                            "LIGHT",
+                            "GENERIC",
+                            "HEATING_RCC"
+                        ]
+                    },
+                    {
+                        "@type": "device",
+                        "rootDeviceId": "64-da-a0-3e-81-0c",
+                        "id": "hdm:ZigBee:000d6f0012f13bfa",
+                        "deviceServiceIds": [
+                            "LatestMotion",
+                            "CommunicationQuality",
+                            "WalkTest",
+                            "BatteryLevel",
+                            "MultiLevelSensor",
+                            "DeviceDefect"
+                        ],
+                        "manufacturer": "BOSCH",
+                        "roomId": "hz_5",
+                        "deviceModel": "MD",
+                        "serial": "000D6F0012F0da96",
+                        "profile": "GENERIC",
+                        "name": "My Motion Detector",
+                        "status": "AVAILABLE",
+                        "childDeviceIds": [],
+                        "supportedProfiles": []
+                    }
+                ]
+                """;
+        when(contentResponse.getContentAsString()).thenReturn(devicesJson);
+
+        List<Device> devices = fixture.getDevices();
+
+        assertEquals(2, devices.size());
+
+        Device plugDevice = devices.get(0);
+        assertEquals("hdm:ZigBee:0c4314fffea15de7", plugDevice.id);
+        assertEquals(5, plugDevice.deviceServiceIds.size());
+        assertEquals(0, plugDevice.childDeviceIds.size());
+
+        Device motionDetectorDevice = devices.get(1);
+        assertEquals("hdm:ZigBee:000d6f0012f13bfa", motionDetectorDevice.id);
+        assertEquals(6, motionDetectorDevice.deviceServiceIds.size());
+        assertEquals(0, motionDetectorDevice.childDeviceIds.size());
+    }
+
+    @Test
+    void getDevicesErrorRestResponse() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(400); // bad request
+
+        List<Device> devices = fixture.getDevices();
+
+        assertThat(devices, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getExecutionAndTimeoutExceptionArguments()")
+    void getDevicesHandleExceptions() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        when(request.send()).thenThrow(new ExecutionException(new RuntimeException("Test Exception")));
+
+        List<Device> devices = fixture.getDevices();
+
+        assertThat(devices, hasSize(0));
+    }
+
+    @Test
+    void getRooms() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(200);
+        String roomsJson = """
+                [
+                    {
+                        "@type": "room",
+                        "id": "hz_1",
+                        "iconId": "icon_room_living_room",
+                        "name": "Living Room"
+                    },
+                    {
+                        "@type": "room",
+                        "id": "hz_2",
+                        "iconId": "icon_room_dining_room",
+                        "name": "Dining Room"
+                    }
+                ]
+                """;
+        when(contentResponse.getContentAsString()).thenReturn(roomsJson);
+
+        List<Room> rooms = fixture.getRooms();
+
+        assertEquals(2, rooms.size());
+
+        Room livingRoom = rooms.get(0);
+        assertEquals("hz_1", livingRoom.id);
+        assertEquals("Living Room", livingRoom.name);
+
+        Room diningRoom = rooms.get(1);
+        assertEquals("hz_2", diningRoom.id);
+        assertEquals("Dining Room", diningRoom.name);
+    }
+
+    @Test
+    void getRoomsErrorRestResponse() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(400); // bad request
+
+        List<Room> rooms = fixture.getRooms();
+
+        assertThat(rooms, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getExecutionAndTimeoutExceptionArguments()")
+    void getRoomsHandleExceptions() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        when(request.send()).thenThrow(new ExecutionException(new RuntimeException("Test Exception")));
+
+        List<Room> rooms = fixture.getRooms();
+
+        assertThat(rooms, hasSize(0));
+    }
+
+    @Test
+    void getServices() {
+        assertTrue(fixture.getServices().contains(ThingDiscoveryService.class));
+    }
+
+    @Test
+    void handleCommandIrrelevantChannel() {
+        ChannelUID channelUID = mock(ChannelUID.class);
+        when(channelUID.getId()).thenReturn(BoschSHCBindingConstants.CHANNEL_POWER_SWITCH);
+
+        fixture.handleCommand(channelUID, OnOffType.ON);
+
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void handleCommandTriggerScenario()
+            throws InterruptedException, TimeoutException, ExecutionException, BoschSHCException {
+        ChannelUID channelUID = mock(ChannelUID.class);
+        when(channelUID.getId()).thenReturn(BoschSHCBindingConstants.CHANNEL_TRIGGER_SCENARIO);
+
+        // required to prevent NPE
+        when(httpClient.sendRequest(any(), eq(Scenario[].class), any(), any())).thenReturn(new Scenario[] {});
+
+        fixture.handleCommand(channelUID, OnOffType.ON);
+
+        verify(httpClient).sendRequest(any(), eq(Scenario[].class), any(), any());
+    }
+
+    @Test
+    void registerDiscoveryListener() {
+        ThingDiscoveryService listener = mock(ThingDiscoveryService.class);
+        assertTrue(fixture.registerDiscoveryListener(listener));
+        assertFalse(fixture.registerDiscoveryListener(listener));
+    }
+
+    @Test
+    void unregisterDiscoveryListener() {
+        assertFalse(fixture.unregisterDiscoveryListener());
+        fixture.registerDiscoveryListener(mock(ThingDiscoveryService.class));
+        assertTrue(fixture.unregisterDiscoveryListener());
+    }
+
+    @Test
+    void initializeNoIpAddress() {
+        bridgeConfiguration.setProperties(new HashMap<String, Object>());
+
+        fixture.initialize();
+
+        ThingStatusInfo expectedStatus = ThingStatusInfoBuilder
+                .create(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR)
+                .withDescription("@text/offline.conf-error-empty-ip").build();
+        verify(thingHandlerCallback).statusUpdated(thing, expectedStatus);
+    }
+
+    @Test
+    void initializeNoPassword() {
+        HashMap<String, Object> properties = new HashMap<String, Object>();
+        properties.put("ipAddress", "localhost");
+        bridgeConfiguration.setProperties(properties);
+
+        fixture.initialize();
+
+        ThingStatusInfo expectedStatus = ThingStatusInfoBuilder
+                .create(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR)
+                .withDescription("@text/offline.conf-error-empty-password").build();
+        verify(thingHandlerCallback).statusUpdated(thing, expectedStatus);
+    }
+
+    @Test
+    void checkBridgeAccess() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(200);
+
+        assertTrue(fixture.checkBridgeAccess());
+    }
+
+    @Test
+    void checkBridgeAccessRestResponseError() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(400);
+
+        assertFalse(fixture.checkBridgeAccess());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getExecutionAndTimeoutExceptionArguments()")
+    void checkBridgeAccessRestException(Exception e) throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        when(request.send()).thenThrow(e);
+
+        assertFalse(fixture.checkBridgeAccess());
+    }
+
+    @Test
+    void getPublicInformation() throws InterruptedException, BoschSHCException, ExecutionException, TimeoutException {
+        fixture.getPublicInformation();
+
+        verify(httpClient).createRequest(any(), same(HttpMethod.GET));
+        verify(httpClient).sendRequest(any(), same(PublicInformation.class), any(), isNull());
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/ScenarioTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/ScenarioTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.devices.bridge.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Scenario}.
+ * 
+ * @author David Pace - Initial contribution
+ *
+ */
+class ScenarioTest {
+
+    private Scenario fixture;
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        fixture = Scenario.createScenario("abc", "My Scenario", "1708845918493");
+    }
+
+    @Test
+    void isValid() {
+        assertTrue(Scenario.isValid(new Scenario[] { fixture }));
+        assertFalse(Scenario.isValid(new Scenario[] { fixture, new Scenario() }));
+    }
+
+    @Test
+    void testToString() {
+        assertEquals("Scenario{name='My Scenario', id='abc', lastTimeTriggered='1708845918493'}", fixture.toString());
+    }
+}

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/intrusion/IntrusionDetectionHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/intrusion/IntrusionDetectionHandlerTest.java
@@ -13,14 +13,20 @@
 package org.openhab.binding.boschshc.internal.devices.intrusion;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.openhab.binding.boschshc.internal.devices.AbstractBoschSHCHandlerTest;
@@ -29,6 +35,8 @@ import org.openhab.binding.boschshc.internal.services.intrusion.actions.arm.dto.
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
 
 import com.google.gson.JsonElement;
@@ -64,11 +72,39 @@ class IntrusionDetectionHandlerTest extends AbstractBoschSHCHandlerTest<Intrusio
         assertEquals("0", armRequest.profileId);
     }
 
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getExecutionAndTimeoutAndInterruptedExceptionArguments()")
+    void testHandleCommandArmActionHandleExceptions(Exception e)
+            throws InterruptedException, TimeoutException, ExecutionException {
+        when(getBridgeHandler().postAction(any(), any())).thenThrow(e);
+
+        getFixture().handleCommand(new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_ARM_ACTION),
+                new StringType("0"));
+
+        verify(getBridgeHandler()).postAction(eq("intrusion/actions/arm"), armActionRequestCaptor.capture());
+        ArmActionRequest armRequest = armActionRequestCaptor.getValue();
+        assertEquals("0", armRequest.profileId);
+    }
+
     @Test
     void testHandleCommandDisarmAction() throws InterruptedException, TimeoutException, ExecutionException {
         getFixture().handleCommand(new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_DISARM_ACTION),
                 OnOffType.ON);
         verify(getBridgeHandler()).postAction("intrusion/actions/disarm");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.openhab.binding.boschshc.internal.tests.common.CommonTestUtils#getExecutionAndTimeoutAndInterruptedExceptionArguments()")
+    void testHandleCommandDisarmActionHandleExceptions(Exception e)
+            throws InterruptedException, TimeoutException, ExecutionException {
+        when(getBridgeHandler().postAction(any())).thenThrow(e);
+
+        getFixture().handleCommand(new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_DISARM_ACTION),
+                OnOffType.ON);
+
+        verify(getCallback()).statusUpdated(same(getThing()),
+                argThat(status -> status.getStatus().equals(ThingStatus.OFFLINE)
+                        && status.getStatusDetail().equals(ThingStatusDetail.COMMUNICATION_ERROR)));
     }
 
     @Test

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/shuttercontrol/ShutterControl2HandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/shuttercontrol/ShutterControl2HandlerTest.java
@@ -15,6 +15,7 @@ package org.openhab.binding.boschshc.internal.devices.shuttercontrol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.ExecutionException;
@@ -139,5 +140,15 @@ class ShutterControl2HandlerTest extends ShutterControlHandlerTest {
                 childProtectionServiceStateCaptor.capture());
         ChildProtectionServiceState state = childProtectionServiceStateCaptor.getValue();
         assertTrue(state.childLockActive);
+    }
+
+    @Test
+    void testHandleCommandChildProtectionInvalidCommand()
+            throws InterruptedException, TimeoutException, ExecutionException, BoschSHCException {
+        getFixture().handleCommand(
+                new ChannelUID(getThing().getUID(), BoschSHCBindingConstants.CHANNEL_CHILD_PROTECTION),
+                DecimalType.ZERO);
+        verify(getBridgeHandler(), times(0)).putState(eq(getDeviceID()), eq("ChildProtection"),
+                childProtectionServiceStateCaptor.capture());
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/services/userstate/dto/UserStateServiceStateTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/services/userstate/dto/UserStateServiceStateTest.java
@@ -71,4 +71,9 @@ class UserStateServiceStateTest {
         subject.setState(true);
         assertEquals(OnOffType.ON, subject.toOnOffType());
     }
+
+    @Test
+    void testToString() {
+        assertEquals("UserStateServiceState{state=false, type='userdefinedstates'}", subject.toString());
+    }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/tests/common/CommonTestUtils.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/tests/common/CommonTestUtils.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.boschshc.internal.tests.common;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.boschshc.internal.exceptions.BoschSHCException;
+
+/**
+ * Common utilities used in unit tests.
+ * 
+ * @author David Pace - Initial contribution
+ *
+ */
+@NonNullByDefault
+public final class CommonTestUtils {
+
+    public static final String TEST_EXCEPTION_MESSAGE = "Test exception";
+
+    private CommonTestUtils() {
+        // Utility Class
+    }
+
+    public static List<Exception> getExecutionExceptionAndInterruptedExceptionArguments() {
+        return List.of(new ExecutionException(TEST_EXCEPTION_MESSAGE, null),
+                new InterruptedException(TEST_EXCEPTION_MESSAGE));
+    }
+
+    public static List<Exception> getExceutionExceptionAndRuntimeExceptionArguments() {
+        return List.of(new ExecutionException(TEST_EXCEPTION_MESSAGE, null),
+                new RuntimeException(TEST_EXCEPTION_MESSAGE));
+    }
+
+    public static List<Exception> getBoschShcAndExecutionAndTimeoutExceptionArguments() {
+        return List.of(new BoschSHCException(TEST_EXCEPTION_MESSAGE),
+                new ExecutionException(TEST_EXCEPTION_MESSAGE, null), new TimeoutException(TEST_EXCEPTION_MESSAGE));
+    }
+
+    public static List<Exception> getBoschShcAndExecutionAndTimeoutAndInterruptedExceptionArguments() {
+        return List.of(new BoschSHCException(TEST_EXCEPTION_MESSAGE),
+                new ExecutionException(TEST_EXCEPTION_MESSAGE, null), new TimeoutException(TEST_EXCEPTION_MESSAGE),
+                new InterruptedException(TEST_EXCEPTION_MESSAGE));
+    }
+
+    public static List<Exception> getExecutionAndTimeoutAndInterruptedExceptionArguments() {
+        return List.of(new ExecutionException(TEST_EXCEPTION_MESSAGE, null),
+                new TimeoutException(TEST_EXCEPTION_MESSAGE), new InterruptedException(TEST_EXCEPTION_MESSAGE));
+    }
+
+    public static List<Exception> getExecutionAndTimeoutExceptionArguments() {
+        return List.of(new ExecutionException(TEST_EXCEPTION_MESSAGE, null),
+                new TimeoutException(TEST_EXCEPTION_MESSAGE));
+    }
+}


### PR DESCRIPTION
Boosts the unit test coverage for the `boschshc` binding in `src/main/java`
to 94%.

Main code changes:
* made some methods package-protected in order to be testable
* fix typo in exception message (in class `BridgeHandler`)

Test code changes:
* add lots of additional tests
* refactor redundant tests to parameterized tests
* add utility class providing arguments for common parameterized tests
* fix a problem caused by wrong order of `super.beforeEach()` calls
* remove unnecessary `lenient()` configurations