### PR TITLE
[miele] Fix sticky appliance ID

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -193,7 +193,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             if (bridgeHandler != null) {
                 bridgeHandler.unregisterApplianceStatusListener(applianceId, this);
             }
-            applianceId = null;
+            this.applianceId = null;
         }
         startTimeStabilizer.clear();
         finishTimeStabilizer.clear();


### PR DESCRIPTION
Fix small corner-case bug where commands would be sent to the previously configured appliance, if the ID is blanked in the configuration.