### PR TITLE
[orbitbhyve] Handle null location attribute in devices json

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
@@ -212,7 +212,7 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                         "Get devices returned response status: " + response.getStatus());
             }
         } catch (JsonSyntaxException e) {
-            logger.info("Exception parsing devices json: {}", e.getMessage(), e);
+            logger.debug("Exception parsing devices json: {}", e.getMessage(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error parsing devices json");
         } catch (TimeoutException | ExecutionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error during getting devices");
@@ -241,6 +241,9 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Returned status: " + response.getStatus());
             }
+        } catch (JsonSyntaxException e) {
+            logger.debug("Exception parsing device json: {}", e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error parsing device json");
         } catch (TimeoutException | ExecutionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Error during getting device info: " + deviceId);

--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
@@ -64,6 +64,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The {@link OrbitBhyveBridgeHandler} is responsible for handling commands, which are
@@ -210,6 +211,9 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Get devices returned response status: " + response.getStatus());
             }
+        } catch (JsonSyntaxException e) {
+            logger.info("Exception parsing devices json: {}", e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error parsing devices json");
         } catch (TimeoutException | ExecutionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error during getting devices");
         } catch (InterruptedException e) {

--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/model/OrbitBhyveDevice.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/model/OrbitBhyveDevice.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
@@ -52,7 +54,8 @@ public class OrbitBhyveDevice {
     @SerializedName("last_connected_at")
     String lastConnectedAt = "";
 
-    JsonObject location = new JsonObject();
+    @Nullable
+    JsonElement location = null;
 
     @SerializedName("suggested_start_time")
     String suggestedStartTime = "";


### PR DESCRIPTION
Some "devices" responses contain a null value in the `location` attribute. Json parsing failed because JsonObject will not deserialize a null value. Also added a check for `JsonSyntaxException` and logged the stack trace to better be able to track down parsing issues.

BTW, I noticed that `location` is not used anywhere in the binding. So, an alternative would be to just remove it from the DTO. However, I still think it's a good idea to catch `JsonSyntaxException` and log the stack trace to be able to track down parsing issues.

This doesn't seem critical enough to cherry pick to 4.1.x.
