### PR TITLE
[hue] Shrink step size for increase/decrease commands

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/Resource.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/api/dto/clip2/Resource.java
@@ -67,7 +67,6 @@ import com.google.gson.annotations.SerializedName;
 @NonNullByDefault
 public class Resource {
 
-    public static final double PERCENT_DELTA = 30f;
     public static final MathContext PERCENT_MATH_CONTEXT = new MathContext(4, RoundingMode.HALF_UP);
 
     /**


### PR DESCRIPTION
A step size of 30 with a value range of 0..100 leads to only 4 steps, which additionally are spaced unevenly. Shrink the step size to 10, which yields 10 evenly spaced steps.
While at it, also deduplicate the increase/decrease code, which had slightly different implementation in both branches.

Fixes #16532 