### PR TITLE
[shelly] Use macaddress as a fallback name

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java
@@ -564,6 +564,9 @@ public class ShellyManagerPage {
         if (name.isEmpty()) {
             name = getString(properties.get(PROPERTY_SERVICE_NAME));
         }
+        if (name.isEmpty()) {
+            name = getString(properties.get(PROPERTY_MAC_ADDRESS));
+        }
         return name;
     }
 


### PR DESCRIPTION
I have 2 shelly plug s sockets. None of them has a device name or service name.

The function getDisplayName returns a empty string and in ShellyManagerOverviewPage.java in the sortedMap the empty string is used as the key. The result is that the overview page shows only one row.

![1](https://github.com/openhab/openhab-addons/assets/5681988/9abd7a4a-1dc6-4588-8898-d055adcfdf77)

After the fix, it shows

![2](https://github.com/openhab/openhab-addons/assets/5681988/e088d5bd-18b1-4d80-86c0-a8cbaa34c223)


