### PR TITLE
[caddx] Amend README with missing bridge configuration parameter

### DIFF
--- a/bundles/org.openhab.binding.caddx/README.md
+++ b/bundles/org.openhab.binding.caddx/README.md
@@ -66,8 +66,9 @@ The following table shows the available configuration parameters for each thing.
 |-----------|-----------------------------------------------------------------------------------------------------|
 | bridge    | `serialPort` - Serial port for the bridge - Required                                                |
 |           | `protocol` - Protocol used for the communication (Binary, Ascii) - Required - Default = Binary      |
-|           | `baudrate` - Baud rate of the bridge - Required - Default = 9600                                        |
+|           | `baudrate` - Baud rate of the bridge - Required - Default = 9600                                    |
 |           | `maxZoneNumber` - Maximum zone number to be added during discovery - Required - Default = 16        |
+|           | `ignoreZoneStatusTransitions` - Ignore Zone Status Transitions - Required - Default = false         |
 | partition | `partitionNumber` - Partition number (1-8) - Required                                               |
 | zone      | `zoneNumber` - Zone number (1-192) - Required                                                       |
 | keypad    | `keypadAddress` - Keypad address (192-255) - Required                                               |


### PR DESCRIPTION
Small correction to the binding's README file.

- Added missing ignoreZoneStatusTransitions parameter