### PR TITLE
[hue] Fix JUnit tests for revised ColorUtil

### DIFF
--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
@@ -265,13 +265,13 @@ public class HueLightHandlerTest {
 
     @Test
     public void assertXYCommandForColorChannelWhite() {
-        String expectedReply = "{\"xy\" : [ 0.3227 , 0.32900003 ], \"bri\" : 254, \"transitiontime\" : 4}";
+        String expectedReply = "{\"xy\" : [ 0.3227267 , 0.3290229 ], \"bri\" : 254, \"transitiontime\" : 4}";
         assertSendCommandForColor(HSBType.WHITE, new HueLightState().colormode(ColorMode.XY), expectedReply);
     }
 
     @Test
     public void assertXYCommandForColorChannelColorful() {
-        String expectedReply = "{\"xy\" : [ 0.14649999 , 0.115600005 ], \"bri\" : 127, \"transitiontime\" : 4}";
+        String expectedReply = "{\"xy\" : [ 0.14657576 , 0.115629844 ], \"bri\" : 127, \"transitiontime\" : 4}";
         assertSendCommandForColor(new HSBType("220,90,50"), new HueLightState().colormode(ColorMode.XY), expectedReply);
     }
 


### PR DESCRIPTION
Requires https://github.com/openhab/openhab-core/pull/4124

In https://github.com/openhab/openhab-core/pull/4124 we introduced some improvements in the precision of the HSB to XY color conversions. Which means that the conversions produce slightly different (more accurate) coordinates. The JUnit tests for the Hue binding depended on seeing the prior less precise coordinates. This PR modifies the JUnit tests to use the new expected XY coordinates.

**Nota Bene**: for this reason -- therefore -- this PR will FAIL the CI build until https://github.com/openhab/openhab-core/pull/4124 will have been merged!

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>