### PR TITLE
[shelly] Enable accumulated channels for Shelly Pro 3EM

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/provider/ShellyChannelDefinitions.java
@@ -328,7 +328,8 @@ public class ShellyChannelDefinitions {
         addChannel(thing, add, profile.settings.sleepTime != null, CHGR_SENSOR, CHANNEL_SENSOR_SLEEPTIME);
 
         // If device has more than 1 meter the channel accumulatedWatts receives the accumulated value
-        boolean accuChannel = profile.hasRelays && profile.numMeters > 1 && !profile.isRoller && !profile.isRGBW2;
+        boolean accuChannel = profile.is3EM
+                || (profile.hasRelays && profile.numMeters > 1 && !profile.isRoller && !profile.isRGBW2);
         addChannel(thing, add, accuChannel, CHGR_DEVST, CHANNEL_DEVST_ACCUWATTS);
         addChannel(thing, add, accuChannel, CHGR_DEVST, CHANNEL_DEVST_ACCUTOTAL);
         addChannel(thing, add, accuChannel && (status.emeters != null), CHGR_DEVST, CHANNEL_DEVST_ACCURETURNED);


### PR DESCRIPTION
# Description
The Shelly Pro 3EM does not show the accumulated channels on the device, although the values are transferred from the device.

The reason seems to be this [commit](https://github.com/openhab/openhab-addons/pull/15922/commits/3e120b7ecd4cfd0593a09c22fb2de0afebe9bdaf). The **Pro 3EM** has no internal relay (only available as an add-on), unlike the **3EM** and the **Pro EM**.

Fixes #16552 
openHAB Community: [Discussion](https://community.openhab.org/t/shelly-binding/56862/3742)




