### PR TITLE
[netatmo] Enhance bridge status reporting

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/config/ConfigurationLevel.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/config/ConfigurationLevel.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public enum ConfigurationLevel {
     EMPTY_CLIENT_ID("@text/conf-error-no-client-id"),
     EMPTY_CLIENT_SECRET("@text/conf-error-no-client-secret"),
-    REFRESH_TOKEN_NEEDED("@text/conf-error-grant-needed"),
+    REFRESH_TOKEN_NEEDED("@text/conf-error-grant-needed [ \"%s\" ]"),
     COMPLETED("");
 
     public String message;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/ApiBridgeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/ApiBridgeHandler.java
@@ -232,7 +232,7 @@ public class ApiBridgeHandler extends BaseBridgeHandler {
         servlet.startListening();
         grantServlet = Optional.of(servlet);
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                ConfigurationLevel.REFRESH_TOKEN_NEEDED.message);
+                ConfigurationLevel.REFRESH_TOKEN_NEEDED.message.formatted(servlet.getPath()));
     }
 
     public ApiHandlerConfiguration getConfiguration() {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/NetatmoServlet.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/NetatmoServlet.java
@@ -36,9 +36,9 @@ public abstract class NetatmoServlet extends HttpServlet {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final HttpService httpService;
+    private final String path;
 
     protected final ApiBridgeHandler handler;
-    protected final String path;
 
     public NetatmoServlet(ApiBridgeHandler handler, HttpService httpService, String localPath) {
         this.path = BASE_PATH + localPath + "/" + handler.getId();
@@ -59,5 +59,9 @@ public abstract class NetatmoServlet extends HttpServlet {
         logger.debug("Stopping Netatmo Servlet {}", path);
         httpService.unregister(path);
         this.destroy();
+    }
+
+    public String getPath() {
+        return path;
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/WebhookServlet.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/WebhookServlet.java
@@ -66,7 +66,7 @@ public class WebhookServlet extends NetatmoServlet {
     @Override
     public void startListening() {
         super.startListening();
-        URI uri = UriBuilder.fromUri(webHookUrl).path(path + webHookPostfix).build();
+        URI uri = UriBuilder.fromUri(webHookUrl).path(getPath() + webHookPostfix).build();
         try {
             logger.info("Setting up WebHook at Netatmo to {}", uri.toString());
             hookSet = securityApi.addwebhook(uri);

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/i18n/netatmo.properties
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/i18n/netatmo.properties
@@ -459,7 +459,7 @@ config.refreshInterval.description = The refresh interval to poll Netatmo API (i
 
 conf-error-no-client-id = Cannot connect to Netatmo bridge as no client id is available in the configuration
 conf-error-no-client-secret = Cannot connect to Netatmo bridge as no client secret is available in the configuration
-conf-error-grant-needed = Configuration incomplete, please grant the binding to Netatmo Connect.
+conf-error-grant-needed = Complete the configuration by granting the binding to Netatmo Connect : `{0}`.
 status-bridge-offline = Bridge is not connected to Netatmo API
 device-not-connected = Thing is not reachable
 data-over-limit = Data seems quite old

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/i18n/netatmo.properties
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/i18n/netatmo.properties
@@ -459,7 +459,7 @@ config.refreshInterval.description = The refresh interval to poll Netatmo API (i
 
 conf-error-no-client-id = Cannot connect to Netatmo bridge as no client id is available in the configuration
 conf-error-no-client-secret = Cannot connect to Netatmo bridge as no client secret is available in the configuration
-conf-error-grant-needed = Complete the configuration by granting the binding to Netatmo Connect : `{0}`.
+conf-error-grant-needed = Complete the configuration by granting the binding to Netatmo Connect: ''{0}''.
 status-bridge-offline = Bridge is not connected to Netatmo API
 device-not-connected = Thing is not reachable
 data-over-limit = Data seems quite old


### PR DESCRIPTION
This small PR just reports the granting path in the status of the bridge so the user does not have to search in the log to find the path to grant the binding against the API

![image](https://github.com/openhab/openhab-addons/assets/3328789/ff558aab-f1e5-4a5c-88d1-e896ba45743c)

Extracted from #16489 