### PR TITLE
[mqtt] Simplify homeassistant thing types, and use AbstractStorageBasedTypeProvider

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
@@ -14,22 +14,19 @@ package org.openhab.binding.mqtt.generic;
 
 import java.net.URI;
 import java.util.Collection;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.internal.MqttThingHandlerFactory;
+import org.openhab.core.storage.StorageService;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.AbstractStorageBasedTypeProvider;
 import org.openhab.core.thing.binding.ThingTypeProvider;
 import org.openhab.core.thing.type.ChannelGroupType;
 import org.openhab.core.thing.type.ChannelGroupTypeProvider;
 import org.openhab.core.thing.type.ChannelGroupTypeUID;
-import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeProvider;
-import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.ThingType;
 import org.openhab.core.thing.type.ThingTypeBuilder;
 import org.openhab.core.thing.type.ThingTypeRegistry;
@@ -45,89 +42,30 @@ import org.osgi.service.component.annotations.Reference;
  * This provider is started on-demand only, as soon as {@link MqttThingHandlerFactory} or an extension requires it.
  *
  * @author David Graeff - Initial contribution
+ * @author Cody Cutrer - Use AbstractStorageBasedTypeProvider
  *
  */
 @NonNullByDefault
 @Component(immediate = false, service = { ThingTypeProvider.class, ChannelTypeProvider.class,
         ChannelGroupTypeProvider.class, MqttChannelTypeProvider.class })
-public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupTypeProvider, ChannelTypeProvider {
-    private final ThingTypeRegistry typeRegistry;
-
-    private final Map<ChannelTypeUID, ChannelType> types = new ConcurrentHashMap<>();
-    private final Map<ChannelGroupTypeUID, ChannelGroupType> groups = new ConcurrentHashMap<>();
-    private final Map<ThingTypeUID, ThingType> things = new ConcurrentHashMap<>();
+public class MqttChannelTypeProvider extends AbstractStorageBasedTypeProvider {
+    private final ThingTypeRegistry thingTypeRegistry;
 
     @Activate
-    public MqttChannelTypeProvider(@Reference ThingTypeRegistry typeRegistry) {
-        super();
-        this.typeRegistry = typeRegistry;
+    public MqttChannelTypeProvider(@Reference ThingTypeRegistry thingTypeRegistry,
+            @Reference StorageService storageService) {
+        super(storageService);
+        this.thingTypeRegistry = thingTypeRegistry;
     }
 
-    @Override
-    public Collection<ChannelType> getChannelTypes(@Nullable Locale locale) {
-        return types.values();
-    }
-
-    @Override
-    public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
-        return types.get(channelTypeUID);
-    }
-
-    @Override
-    public @Nullable ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID,
-            @Nullable Locale locale) {
-        return groups.get(channelGroupTypeUID);
-    }
-
-    @Override
-    public Collection<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale) {
-        return groups.values();
-    }
-
-    @Override
-    public Collection<ThingType> getThingTypes(@Nullable Locale locale) {
-        return things.values();
-    }
-
-    public Set<ThingTypeUID> getThingTypeUIDs() {
-        return things.keySet();
-    }
-
-    @Override
-    public @Nullable ThingType getThingType(ThingTypeUID thingTypeUID, @Nullable Locale locale) {
-        return things.get(thingTypeUID);
-    }
-
-    public void removeChannelType(ChannelTypeUID uid) {
-        types.remove(uid);
-    }
-
-    public void removeChannelGroupType(ChannelGroupTypeUID uid) {
-        groups.remove(uid);
-    }
-
-    public void setChannelGroupType(ChannelGroupTypeUID uid, ChannelGroupType type) {
-        groups.put(uid, type);
-    }
-
-    public void setChannelType(ChannelTypeUID uid, ChannelType type) {
-        types.put(uid, type);
-    }
-
-    public void removeThingType(ThingTypeUID uid) {
-        things.remove(uid);
-    }
-
-    public void setThingType(ThingTypeUID uid, ThingType type) {
-        things.put(uid, type);
-    }
-
-    public void setThingTypeIfAbsent(ThingTypeUID uid, ThingType type) {
-        things.putIfAbsent(uid, type);
+    public void putThingTypeIfAbsent(ThingTypeUID uid, ThingType type) {
+        if (getThingType(uid, null) == null) {
+            putThingType(type);
+        }
     }
 
     public ThingTypeBuilder derive(ThingTypeUID newTypeId, ThingTypeUID baseTypeId) {
-        ThingType baseType = typeRegistry.getThingType(baseTypeId);
+        ThingType baseType = thingTypeRegistry.getThingType(baseTypeId);
 
         ThingTypeBuilder result = ThingTypeBuilder.instance(newTypeId, baseType.getLabel())
                 .withChannelGroupDefinitions(baseType.getChannelGroupDefinitions())
@@ -154,5 +92,26 @@ public class MqttChannelTypeProvider implements ThingTypeProvider, ChannelGroupT
         }
 
         return result;
+    }
+
+    public void updateChannelGroupTypesForPrefix(String prefix, Collection<ChannelGroupType> types) {
+        Collection<ChannelGroupType> oldCgts = channelGroupTypesForPrefix(prefix);
+
+        Set<ChannelGroupTypeUID> oldUids = oldCgts.stream().map(ChannelGroupType::getUID).collect(Collectors.toSet());
+        Collection<ChannelGroupTypeUID> uids = types.stream().map(ChannelGroupType::getUID).toList();
+
+        oldUids.removeAll(uids);
+        // oldUids now contains only UIDs that no longer exist. so remove them
+        oldUids.stream().forEach(uid -> removeChannelGroupType(uid));
+        types.stream().forEach(t -> putChannelGroupType(t));
+    }
+
+    public void removeChannelGroupTypesForPrefix(String prefix) {
+        channelGroupTypesForPrefix(prefix).stream().forEach(cgt -> removeChannelGroupType(cgt.getUID()));
+    }
+
+    private Collection<ChannelGroupType> channelGroupTypesForPrefix(String prefix) {
+        return getChannelGroupTypes(null).stream().filter(cgt -> cgt.getUID().getId().startsWith(prefix + "_"))
+                .toList();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/MqttChannelTypeProvider.java
@@ -58,12 +58,6 @@ public class MqttChannelTypeProvider extends AbstractStorageBasedTypeProvider {
         this.thingTypeRegistry = thingTypeRegistry;
     }
 
-    public void putThingTypeIfAbsent(ThingTypeUID uid, ThingType type) {
-        if (getThingType(uid, null) == null) {
-            putThingType(type);
-        }
-    }
-
     public ThingTypeBuilder derive(ThingTypeUID newTypeId, ThingTypeUID baseTypeId) {
         ThingType baseType = thingTypeRegistry.getThingType(baseTypeId);
 
@@ -102,12 +96,12 @@ public class MqttChannelTypeProvider extends AbstractStorageBasedTypeProvider {
 
         oldUids.removeAll(uids);
         // oldUids now contains only UIDs that no longer exist. so remove them
-        oldUids.stream().forEach(uid -> removeChannelGroupType(uid));
-        types.stream().forEach(t -> putChannelGroupType(t));
+        oldUids.forEach(this::removeChannelGroupType);
+        types.forEach(this::putChannelGroupType);
     }
 
     public void removeChannelGroupTypesForPrefix(String prefix) {
-        channelGroupTypesForPrefix(prefix).stream().forEach(cgt -> removeChannelGroupType(cgt.getUID()));
+        channelGroupTypesForPrefix(prefix).forEach(cgt -> removeChannelGroupType(cgt.getUID()));
     }
 
     private Collection<ChannelGroupType> channelGroupTypesForPrefix(String prefix) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/ChildMap.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/ChildMap.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.binding.mqtt.generic.tools;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -62,6 +65,24 @@ public class ChildMap<T> {
 
     public Stream<T> stream() {
         return map.values().stream();
+    }
+
+    /**
+     * Streams the objects in this map in the order of the given keys.
+     * 
+     * Extraneous keys are ignored, and missing keys are included at the end in unspecified order.
+     * 
+     * @param order The keys in the order they should be streamed
+     */
+    public Stream<T> stream(Collection<String> order) {
+        // need to make a copy to avoid editing `map` itself
+        Set<String> missingKeys = new HashSet<>(map.keySet());
+        missingKeys.removeAll(order);
+        Stream<T> result = order.stream().map(k -> map.get(k)).filter(Objects::nonNull).map(Objects::requireNonNull);
+        if (!missingKeys.isEmpty()) {
+            result = Stream.concat(result, missingKeys.stream().map(k -> map.get(k)).map(Objects::requireNonNull));
+        }
+        return result;
     }
 
     /**
@@ -133,5 +154,9 @@ public class ChildMap<T> {
      */
     public void put(String key, T value) {
         map.put(key, value);
+    }
+
+    public Set<String> keySet() {
+        return map.keySet();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/generic/internal/MqttBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/generic/internal/MqttBindingConstants.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.homeassistant.generic.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * The {@link MqttBindingConstants} class defines common constants, which are
@@ -29,5 +30,13 @@ public class MqttBindingConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID HOMEASSISTANT_MQTT_THING = new ThingTypeUID(BINDING_ID, "homeassistant");
 
-    public static final String CONFIG_HA_CHANNEL = "channel-type:mqtt:ha-channel";
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_COLOR = new ChannelTypeUID(BINDING_ID, "ha-color");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_DIMMER = new ChannelTypeUID(BINDING_ID, "ha-dimmer");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_IMAGE = new ChannelTypeUID(BINDING_ID, "ha-image");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_NUMBER = new ChannelTypeUID(BINDING_ID, "ha-number");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_ROLLERSHUTTER = new ChannelTypeUID(BINDING_ID,
+            "ha-rollershutter");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_STRING = new ChannelTypeUID(BINDING_ID, "ha-string");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_SWITCH = new ChannelTypeUID(BINDING_ID, "ha-switch");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_TRIGGER = new ChannelTypeUID(BINDING_ID, "ha-trigger");
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/generic/internal/MqttBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/generic/internal/MqttBindingConstants.java
@@ -14,7 +14,6 @@ package org.openhab.binding.mqtt.homeassistant.generic.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * The {@link MqttBindingConstants} class defines common constants, which are
@@ -29,14 +28,4 @@ public class MqttBindingConstants {
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID HOMEASSISTANT_MQTT_THING = new ThingTypeUID(BINDING_ID, "homeassistant");
-
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_COLOR = new ChannelTypeUID(BINDING_ID, "ha-color");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_DIMMER = new ChannelTypeUID(BINDING_ID, "ha-dimmer");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_IMAGE = new ChannelTypeUID(BINDING_ID, "ha-image");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_NUMBER = new ChannelTypeUID(BINDING_ID, "ha-number");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_ROLLERSHUTTER = new ChannelTypeUID(BINDING_ID,
-            "ha-rollershutter");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_STRING = new ChannelTypeUID(BINDING_ID, "ha-string");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_SWITCH = new ChannelTypeUID(BINDING_ID, "ha-switch");
-    public static final ChannelTypeUID CHANNEL_TYPE_UID_TRIGGER = new ChannelTypeUID(BINDING_ID, "ha-trigger");
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
@@ -23,10 +22,8 @@ import org.openhab.binding.mqtt.generic.ChannelConfigBuilder;
 import org.openhab.binding.mqtt.generic.ChannelState;
 import org.openhab.binding.mqtt.generic.ChannelStateTransformation;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
-import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.generic.values.Value;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.component.AbstractComponent;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -36,12 +33,12 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
 import org.openhab.core.thing.type.ChannelDefinition;
 import org.openhab.core.thing.type.ChannelDefinitionBuilder;
+import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
-import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.CommandDescription;
-import org.openhab.core.types.StateDescriptionFragment;
+import org.openhab.core.types.StateDescription;
 
 /**
  * An {@link AbstractComponent}s derived class consists of one or multiple channels.
@@ -65,18 +62,21 @@ public class ComponentChannel {
     private final ChannelUID channelUID;
     private final ChannelState channelState;
     private final Channel channel;
-    private final ChannelType type;
     private final ChannelTypeUID channelTypeUID;
+    private final @Nullable StateDescription stateDescription;
+    private final @Nullable CommandDescription commandDescription;
     private final ChannelStateUpdateListener channelStateUpdateListener;
 
-    private ComponentChannel(ChannelUID channelUID, ChannelState channelState, Channel channel, ChannelType type,
-            ChannelTypeUID channelTypeUID, ChannelStateUpdateListener channelStateUpdateListener) {
+    private ComponentChannel(ChannelUID channelUID, ChannelState channelState, Channel channel,
+            ChannelTypeUID channelTypeUID, @Nullable StateDescription stateDescription,
+            @Nullable CommandDescription commandDescription, ChannelStateUpdateListener channelStateUpdateListener) {
         super();
         this.channelUID = channelUID;
         this.channelState = channelState;
         this.channel = channel;
-        this.type = type;
         this.channelTypeUID = channelTypeUID;
+        this.stateDescription = stateDescription;
+        this.commandDescription = commandDescription;
         this.channelStateUpdateListener = channelStateUpdateListener;
     }
 
@@ -88,8 +88,20 @@ public class ComponentChannel {
         return channel;
     }
 
+    public ChannelTypeUID getChannelTypeUID() {
+        return channelTypeUID;
+    }
+
     public ChannelState getState() {
         return channelState;
+    }
+
+    public @Nullable StateDescription getStateDescription() {
+        return stateDescription;
+    }
+
+    public @Nullable CommandDescription getCommandDescription() {
+        return commandDescription;
     }
 
     public CompletableFuture<@Nullable Void> stop() {
@@ -104,15 +116,7 @@ public class ComponentChannel {
         return channelState.start(connection, scheduler, timeout);
     }
 
-    public void addChannelTypes(MqttChannelTypeProvider channelTypeProvider) {
-        channelTypeProvider.setChannelType(channelTypeUID, type);
-    }
-
-    public void removeChannelTypes(MqttChannelTypeProvider channelTypeProvider) {
-        channelTypeProvider.removeChannelType(channelTypeUID);
-    }
-
-    public ChannelDefinition type() {
+    public ChannelDefinition channelDefinition() {
         return new ChannelDefinitionBuilder(channelUID.getId(), channelTypeUID).build();
     }
 
@@ -123,6 +127,7 @@ public class ComponentChannel {
     public static class Builder {
         private final AbstractComponent<?> component;
         private final String channelID;
+        private ChannelTypeUID channelTypeUID;
         private final Value valueState;
         private final String label;
         private final ChannelStateUpdateListener channelStateUpdateListener;
@@ -141,10 +146,11 @@ public class ComponentChannel {
 
         private String format = "%s";
 
-        public Builder(AbstractComponent<?> component, String channelID, Value valueState, String label,
-                ChannelStateUpdateListener channelStateUpdateListener) {
+        public Builder(AbstractComponent<?> component, String channelID, ChannelTypeUID channelTypeUID,
+                Value valueState, String label, ChannelStateUpdateListener channelStateUpdateListener) {
             this.component = component;
             this.channelID = channelID;
+            this.channelTypeUID = channelTypeUID;
             this.valueState = valueState;
             this.label = label;
             this.isAdvanced = false;
@@ -230,11 +236,8 @@ public class ComponentChannel {
             ChannelState channelState;
             Channel channel;
             ChannelType type;
-            ChannelTypeUID channelTypeUID;
 
             channelUID = component.buildChannelUID(channelID);
-            channelTypeUID = new ChannelTypeUID(MqttBindingConstants.BINDING_ID,
-                    channelUID.getGroupId() + "_" + channelID);
             channelState = new HomeAssistantChannelState(
                     ChannelConfigBuilder.create().withRetain(retain).withQos(qos).withStateTopic(stateTopic)
                             .withCommandTopic(commandTopic).makeTrigger(trigger).withFormatter(format).build(),
@@ -244,30 +247,32 @@ public class ComponentChannel {
             if (!component.isEnabledByDefault()) {
                 isAdvanced = true;
             }
-
-            ChannelTypeBuilder typeBuilder;
-            if (this.trigger) {
-                typeBuilder = ChannelTypeBuilder.trigger(channelTypeUID, label);
-            } else {
-                StateDescriptionFragment stateDescription = valueState.createStateDescription(commandTopic == null)
-                        .build();
-                CommandDescription commandDescription = valueState.createCommandDescription().build();
-                typeBuilder = ChannelTypeBuilder.state(channelTypeUID, label, channelState.getItemType())
-                        .withStateDescriptionFragment(stateDescription).withCommandDescription(commandDescription);
+            if (isAdvanced) {
+                channelTypeUID = new ChannelTypeUID(channelTypeUID.getBindingId(),
+                        channelTypeUID.getId() + "-advanced");
             }
-            type = typeBuilder.withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL))
-                    .isAdvanced(isAdvanced).build();
+
+            ChannelKind kind;
+            StateDescription stateDescription = null;
+            CommandDescription commandDescription = null;
+            if (this.trigger) {
+                kind = ChannelKind.TRIGGER;
+            } else {
+                kind = ChannelKind.STATE;
+                stateDescription = valueState.createStateDescription(commandTopic == null).build().toStateDescription();
+                commandDescription = valueState.createCommandDescription().build();
+            }
 
             Configuration configuration = new Configuration();
             configuration.put("config", component.getChannelConfigurationJson());
             component.getHaID().toConfig(configuration);
 
             channel = ChannelBuilder.create(channelUID, channelState.getItemType()).withType(channelTypeUID)
-                    .withKind(type.getKind()).withLabel(label).withConfiguration(configuration)
+                    .withKind(kind).withLabel(label).withConfiguration(configuration)
                     .withAutoUpdatePolicy(autoUpdatePolicy).build();
 
-            ComponentChannel result = new ComponentChannel(channelUID, channelState, channel, type, channelTypeUID,
-                    channelStateUpdateListener);
+            ComponentChannel result = new ComponentChannel(channelUID, channelState, channel, channelTypeUID,
+                    stateDescription, commandDescription, channelStateUpdateListener);
 
             TransformationServiceProvider transformationProvider = component.getTransformationServiceProvider();
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
@@ -59,37 +60,24 @@ import org.openhab.core.types.StateDescription;
 public class ComponentChannel {
     private static final String JINJA = "JINJA";
 
-    private final ChannelUID channelUID;
     private final ChannelState channelState;
     private final Channel channel;
-    private final ChannelTypeUID channelTypeUID;
     private final @Nullable StateDescription stateDescription;
     private final @Nullable CommandDescription commandDescription;
     private final ChannelStateUpdateListener channelStateUpdateListener;
 
-    private ComponentChannel(ChannelUID channelUID, ChannelState channelState, Channel channel,
-            ChannelTypeUID channelTypeUID, @Nullable StateDescription stateDescription,
+    private ComponentChannel(ChannelState channelState, Channel channel, @Nullable StateDescription stateDescription,
             @Nullable CommandDescription commandDescription, ChannelStateUpdateListener channelStateUpdateListener) {
         super();
-        this.channelUID = channelUID;
         this.channelState = channelState;
         this.channel = channel;
-        this.channelTypeUID = channelTypeUID;
         this.stateDescription = stateDescription;
         this.commandDescription = commandDescription;
         this.channelStateUpdateListener = channelStateUpdateListener;
     }
 
-    public ChannelUID getChannelUID() {
-        return channelUID;
-    }
-
     public Channel getChannel() {
         return channel;
-    }
-
-    public ChannelTypeUID getChannelTypeUID() {
-        return channelTypeUID;
     }
 
     public ChannelState getState() {
@@ -117,7 +105,8 @@ public class ComponentChannel {
     }
 
     public ChannelDefinition channelDefinition() {
-        return new ChannelDefinitionBuilder(channelUID.getId(), channelTypeUID).build();
+        return new ChannelDefinitionBuilder(channel.getUID().getId(),
+                Objects.requireNonNull(channel.getChannelTypeUID())).withLabel(channel.getLabel()).build();
     }
 
     public void resetState() {
@@ -271,8 +260,8 @@ public class ComponentChannel {
                     .withKind(kind).withLabel(label).withConfiguration(configuration)
                     .withAutoUpdatePolicy(autoUpdatePolicy).build();
 
-            ComponentChannel result = new ComponentChannel(channelUID, channelState, channel, channelTypeUID,
-                    stateDescription, commandDescription, channelStateUpdateListener);
+            ComponentChannel result = new ComponentChannel(channelState, channel, stateDescription, commandDescription,
+                    channelStateUpdateListener);
 
             TransformationServiceProvider transformationProvider = component.getTransformationServiceProvider();
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -224,7 +224,6 @@ public class ComponentChannel {
             ChannelUID channelUID;
             ChannelState channelState;
             Channel channel;
-            ChannelType type;
 
             channelUID = component.buildChannelUID(channelID);
             channelState = new HomeAssistantChannelState(

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannelType.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannelType.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mqtt.homeassistant.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.core.thing.type.ChannelTypeUID;
+
+/**
+ * The types of HomeAssistant channels components.
+ *
+ * @author Cody Cutrer - Initial contribution
+ */
+@NonNullByDefault
+public enum ComponentChannelType {
+    COLOR("ha-color"),
+    DIMMER("ha-dimmer"),
+    IMAGE("ha-image"),
+    NUMBER("ha-number"),
+    ROLLERSHUTTER("ha-rollershutter"),
+    STRING("ha-string"),
+    SWITCH("ha-switch"),
+    TRIGGER("ha-trigger");
+
+    final ChannelTypeUID channelTypeUID;
+
+    ComponentChannelType(String id) {
+        channelTypeUID = new ChannelTypeUID(MqttBindingConstants.BINDING_ID, id);
+    }
+
+    public ChannelTypeUID getChannelTypeUID() {
+        return channelTypeUID;
+    }
+}

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
@@ -53,6 +53,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
     private final ChannelStateUpdateListener updateListener;
     private final AvailabilityTracker tracker;
     private final TransformationServiceProvider transformationServiceProvider;
+    private final boolean newStyleChannels;
 
     protected final CompletableFuture<@Nullable Void> discoverFinishedFuture = new CompletableFuture<>();
     private final Gson gson;
@@ -79,13 +80,14 @@ public class DiscoverComponents implements MqttMessageSubscriber {
      */
     public DiscoverComponents(ThingUID thingUID, ScheduledExecutorService scheduler,
             ChannelStateUpdateListener channelStateUpdateListener, AvailabilityTracker tracker, Gson gson,
-            TransformationServiceProvider transformationServiceProvider) {
+            TransformationServiceProvider transformationServiceProvider, boolean newStyleChannels) {
         this.thingUID = thingUID;
         this.scheduler = scheduler;
         this.updateListener = channelStateUpdateListener;
         this.gson = gson;
         this.tracker = tracker;
         this.transformationServiceProvider = transformationServiceProvider;
+        this.newStyleChannels = newStyleChannels;
     }
 
     @Override
@@ -101,7 +103,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         if (config.length() > 0) {
             try {
                 component = ComponentFactory.createComponent(thingUID, haID, config, updateListener, tracker, scheduler,
-                        gson, transformationServiceProvider);
+                        gson, transformationServiceProvider, newStyleChannels);
                 component.setConfigSeen();
 
                 logger.trace("Found HomeAssistant component {}", haID);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -187,8 +187,18 @@ public class HaID {
      *
      * @return group id
      */
-    public String getGroupId(@Nullable final String uniqueId) {
+    public String getGroupId(@Nullable final String uniqueId, boolean newStyleChannels) {
         String result = uniqueId;
+
+        // newStyleChannels are auto-discovered things with openHAB >= 4.2.0
+        // assuming the topic has both a node ID and an object ID, simply use
+        // the component type and object ID - without encoding(!)
+        // since the only character allowed in object IDs but not allowed in UID
+        // is `-`. It also doesn't need to be reversible, so it's okay to just
+        // collapse `-` to `_`.
+        if (!nodeID.isBlank() && newStyleChannels) {
+            return component + "_" + objectID.replace('-', '_');
+        }
 
         // the null test is only here so the compile knows, result is not null afterwards
         if (result == null || result.isBlank()) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -190,7 +190,7 @@ public class HaID {
     public String getGroupId(@Nullable final String uniqueId, boolean newStyleChannels) {
         String result = uniqueId;
 
-        // newStyleChannels are auto-discovered things with openHAB >= 4.2.0
+        // newStyleChannels are auto-discovered things with openHAB >= 4.3.0
         // assuming the topic has both a node ID and an object ID, simply use
         // the component type and object ID - without encoding(!)
         // since the only character allowed in object IDs but not allowed in UID

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -340,4 +340,8 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     public Gson getGson() {
         return componentConfiguration.getGson();
     }
+
+    public C getChannelConfiguration() {
+        return channelConfiguration;
+    }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -48,8 +48,6 @@ import org.openhab.core.thing.type.ChannelGroupTypeUID;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.StateDescription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
@@ -63,8 +61,6 @@ import com.google.gson.Gson;
 @NonNullByDefault
 public abstract class AbstractComponent<C extends AbstractChannelConfiguration> {
     private static final String JINJA_PREFIX = "JINJA:";
-
-    private final Logger logger = LoggerFactory.getLogger(AbstractComponent.class);
 
     // Component location fields
     protected final ComponentConfiguration componentConfiguration;
@@ -82,7 +78,6 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     protected final C channelConfiguration;
 
     protected boolean configSeen;
-    protected final boolean newStyleChannels;
     protected final boolean singleChannelComponent;
     protected final String groupId;
     protected final String uniqueId;
@@ -104,8 +99,7 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     public AbstractComponent(ComponentFactory.ComponentConfiguration componentConfiguration, Class<C> clazz,
             boolean newStyleChannels, boolean singleChannelComponent) {
         this.componentConfiguration = componentConfiguration;
-        this.newStyleChannels = newStyleChannels;
-        this.singleChannelComponent = newStyleChannels ? singleChannelComponent : false;
+        this.singleChannelComponent = newStyleChannels && singleChannelComponent;
 
         this.channelConfigurationJson = componentConfiguration.getConfigJSON();
         this.channelConfiguration = componentConfiguration.getConfig(clazz);
@@ -117,18 +111,11 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
         if (name != null && !name.isEmpty()) {
             groupId = this.haID.getGroupId(channelConfiguration.getUniqueId(), newStyleChannels);
 
-            if (this.singleChannelComponent) {
-                this.channelGroupUID = null;
-            } else {
-
-                this.channelGroupUID = new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);
-            }
+            this.channelGroupUID = this.singleChannelComponent
+                    ? new ChannelGroupUID(componentConfiguration.getThingUID(), groupId)
+                    : null;
         } else {
-            if (newStyleChannels && this.singleChannelComponent) {
-                groupId = haID.component;
-            } else {
-                groupId = "";
-            }
+            this.groupId = this.singleChannelComponent ? haID.component : "";
             this.channelGroupUID = null;
         }
         uniqueId = this.haID.getGroupId(channelConfiguration.getUniqueId(), false);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -111,9 +111,8 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
         if (name != null && !name.isEmpty()) {
             groupId = this.haID.getGroupId(channelConfiguration.getUniqueId(), newStyleChannels);
 
-            this.channelGroupUID = this.singleChannelComponent
-                    ? new ChannelGroupUID(componentConfiguration.getThingUID(), groupId)
-                    : null;
+            this.channelGroupUID = this.singleChannelComponent ? null
+                    : new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);
         } else {
             this.groupId = this.singleChannelComponent ? haID.component : "";
             this.channelGroupUID = null;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -30,6 +30,7 @@ import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.HaID;
 import org.openhab.binding.mqtt.homeassistant.internal.component.ComponentFactory.ComponentConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
@@ -45,7 +46,6 @@ import org.openhab.core.thing.type.ChannelGroupDefinition;
 import org.openhab.core.thing.type.ChannelGroupType;
 import org.openhab.core.thing.type.ChannelGroupTypeBuilder;
 import org.openhab.core.thing.type.ChannelGroupTypeUID;
-import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.StateDescription;
 
@@ -154,12 +154,12 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
         }
     }
 
-    protected ComponentChannel.Builder buildChannel(String channelID, ChannelTypeUID channelTypeUID, Value valueState,
-            String label, ChannelStateUpdateListener channelStateUpdateListener) {
+    protected ComponentChannel.Builder buildChannel(String channelID, ComponentChannelType channelType,
+            Value valueState, String label, ChannelStateUpdateListener channelStateUpdateListener) {
         if (singleChannelComponent) {
             channelID = groupId;
         }
-        return new ComponentChannel.Builder(this, channelID, channelTypeUID, valueState, label,
+        return new ComponentChannel.Builder(this, channelID, channelType.getChannelTypeUID(), valueState, label,
                 channelStateUpdateListener);
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractRawSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractRawSchemaLight.java
@@ -32,8 +32,8 @@ abstract class AbstractRawSchemaLight extends Light {
 
     protected ComponentChannel rawChannel;
 
-    public AbstractRawSchemaLight(ComponentFactory.ComponentConfiguration builder) {
-        super(builder);
+    public AbstractRawSchemaLight(ComponentFactory.ComponentConfiguration builder, boolean newStyleChannels) {
+        super(builder, newStyleChannels);
         hiddenChannels.add(rawChannel = buildChannel(RAW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
                 new TextValue(), "Raw state", this).stateTopic(channelConfiguration.stateTopic)
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractRawSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractRawSchemaLight.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
@@ -33,9 +34,10 @@ abstract class AbstractRawSchemaLight extends Light {
 
     public AbstractRawSchemaLight(ComponentFactory.ComponentConfiguration builder) {
         super(builder);
-        hiddenChannels.add(rawChannel = buildChannel(RAW_CHANNEL_ID, new TextValue(), "Raw state", this)
-                .stateTopic(channelConfiguration.stateTopic).commandTopic(channelConfiguration.commandTopic,
-                        channelConfiguration.isRetain(), channelConfiguration.getQos())
+        hiddenChannels.add(rawChannel = buildChannel(RAW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                new TextValue(), "Raw state", this).stateTopic(channelConfiguration.stateTopic)
+                .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
+                        channelConfiguration.getQos())
                 .build(false));
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractRawSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractRawSchemaLight.java
@@ -14,8 +14,8 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -34,8 +34,8 @@ abstract class AbstractRawSchemaLight extends Light {
 
     public AbstractRawSchemaLight(ComponentFactory.ComponentConfiguration builder, boolean newStyleChannels) {
         super(builder, newStyleChannels);
-        hiddenChannels.add(rawChannel = buildChannel(RAW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                new TextValue(), "Raw state", this).stateTopic(channelConfiguration.stateTopic)
+        hiddenChannels.add(rawChannel = buildChannel(RAW_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(),
+                "Raw state", this).stateTopic(channelConfiguration.stateTopic)
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
                 .build(false));

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 
 import com.google.gson.annotations.SerializedName;
@@ -74,22 +75,24 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
         final String[] stateEnum = { channelConfiguration.stateDisarmed, channelConfiguration.stateArmedHome,
                 channelConfiguration.stateArmedAway, channelConfiguration.statePending,
                 channelConfiguration.stateTriggered };
-        buildChannel(STATE_CHANNEL_ID, new TextValue(stateEnum), getName(), componentConfiguration.getUpdateListener())
+        buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(stateEnum),
+                getName(), componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
                 .build();
 
         String commandTopic = channelConfiguration.commandTopic;
         if (commandTopic != null) {
-            buildChannel(SWITCH_DISARM_CHANNEL_ID, new TextValue(new String[] { channelConfiguration.payloadDisarm }),
-                    getName(), componentConfiguration.getUpdateListener())
+            buildChannel(SWITCH_DISARM_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    new TextValue(new String[] { channelConfiguration.payloadDisarm }), getName(),
+                    componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
 
-            buildChannel(SWITCH_ARM_HOME_CHANNEL_ID,
+            buildChannel(SWITCH_ARM_HOME_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
                     new TextValue(new String[] { channelConfiguration.payloadArmHome }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
 
-            buildChannel(SWITCH_ARM_AWAY_CHANNEL_ID,
+            buildChannel(SWITCH_ARM_AWAY_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
                     new TextValue(new String[] { channelConfiguration.payloadArmAway }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -69,8 +69,8 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
         protected String payloadArmAway = "ARM_AWAY";
     }
 
-    public AlarmControlPanel(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public AlarmControlPanel(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         final String[] stateEnum = { channelConfiguration.stateDisarmed, channelConfiguration.stateArmedHome,
                 channelConfiguration.stateArmedAway, channelConfiguration.statePending,

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 
 import com.google.gson.annotations.SerializedName;
@@ -75,24 +75,24 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
         final String[] stateEnum = { channelConfiguration.stateDisarmed, channelConfiguration.stateArmedHome,
                 channelConfiguration.stateArmedAway, channelConfiguration.statePending,
                 channelConfiguration.stateTriggered };
-        buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(stateEnum),
-                getName(), componentConfiguration.getUpdateListener())
+        buildChannel(STATE_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(stateEnum), getName(),
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
                 .build();
 
         String commandTopic = channelConfiguration.commandTopic;
         if (commandTopic != null) {
-            buildChannel(SWITCH_DISARM_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+            buildChannel(SWITCH_DISARM_CHANNEL_ID, ComponentChannelType.STRING,
                     new TextValue(new String[] { channelConfiguration.payloadDisarm }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
 
-            buildChannel(SWITCH_ARM_HOME_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+            buildChannel(SWITCH_ARM_HOME_CHANNEL_ID, ComponentChannelType.STRING,
                     new TextValue(new String[] { channelConfiguration.payloadArmHome }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
 
-            buildChannel(SWITCH_ARM_AWAY_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+            buildChannel(SWITCH_ARM_AWAY_CHANNEL_ID, ComponentChannelType.STRING,
                     new TextValue(new String[] { channelConfiguration.payloadArmAway }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.Value;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.ExpireUpdateStateListener;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.OffDelayUpdateStateListener;
@@ -72,7 +73,8 @@ public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfigur
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
-        buildChannel(SENSOR_CHANNEL_ID, value, "value", getListener(componentConfiguration, value))
+        buildChannel(SENSOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, "value",
+                getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
@@ -68,12 +68,12 @@ public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfigur
         protected @Nullable List<String> jsonAttributes;
     }
 
-    public BinarySensor(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public BinarySensor(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
-        buildChannel(SENSOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, "value",
+        buildChannel(SENSOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),
                 getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.Value;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.ExpireUpdateStateListener;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.OffDelayUpdateStateListener;
@@ -73,7 +73,7 @@ public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfigur
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
-        buildChannel(SENSOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),
+        buildChannel(SENSOR_CHANNEL_ID, ComponentChannelType.SWITCH, value, getName(),
                 getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
@@ -47,8 +47,8 @@ public class Button extends AbstractComponent<Button.ChannelConfiguration> {
         protected String payloadPress = "PRESS";
     }
 
-    public Button(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Button(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadPress });
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
 
@@ -51,7 +52,8 @@ public class Button extends AbstractComponent<Button.ChannelConfiguration> {
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadPress });
 
-        buildChannel(BUTTON_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
+        buildChannel(BUTTON_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+                componentConfiguration.getUpdateListener())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
 
@@ -52,7 +52,7 @@ public class Button extends AbstractComponent<Button.ChannelConfiguration> {
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadPress });
 
-        buildChannel(BUTTON_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+        buildChannel(BUTTON_CHANNEL_ID, ComponentChannelType.STRING, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
@@ -39,8 +39,8 @@ public class Camera extends AbstractComponent<Camera.ChannelConfiguration> {
         protected String topic = "";
     }
 
-    public Camera(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Camera(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         ImageValue value = new ImageValue();
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.mqtt.generic.values.ImageValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 
 /**
@@ -43,7 +44,7 @@ public class Camera extends AbstractComponent<Camera.ChannelConfiguration> {
 
         ImageValue value = new ImageValue();
 
-        buildChannel(CAMERA_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
-                .stateTopic(channelConfiguration.topic).build();
+        buildChannel(CAMERA_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_IMAGE, value, getName(),
+                componentConfiguration.getUpdateListener()).stateTopic(channelConfiguration.topic).build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
@@ -14,7 +14,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.mqtt.generic.values.ImageValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 
 /**
@@ -44,7 +44,7 @@ public class Camera extends AbstractComponent<Camera.ChannelConfiguration> {
 
         ImageValue value = new ImageValue();
 
-        buildChannel(CAMERA_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_IMAGE, value, getName(),
+        buildChannel(CAMERA_CHANNEL_ID, ComponentChannelType.IMAGE, value, getName(),
                 componentConfiguration.getUpdateListener()).stateTopic(channelConfiguration.topic).build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -212,8 +212,8 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
         protected Boolean sendIfOff = true;
     }
 
-    public Climate(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Climate(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         BigDecimal precision = channelConfiguration.precision != null ? channelConfiguration.precision
                 : channelConfiguration.temperatureUnit.getDefaultPrecision();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -27,11 +27,13 @@ import org.openhab.binding.mqtt.generic.values.NumberValue;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -218,75 +220,81 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
         final ChannelStateUpdateListener updateListener = componentConfiguration.getUpdateListener();
 
         ComponentChannel actionChannel = buildOptionalChannel(ACTION_CH_ID,
-                new TextValue(ACTION_MODES.toArray(new String[0])), updateListener, null, null,
-                channelConfiguration.actionTemplate, channelConfiguration.actionTopic, null);
+                MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(ACTION_MODES.toArray(new String[0])),
+                updateListener, null, null, channelConfiguration.actionTemplate, channelConfiguration.actionTopic,
+                null);
 
         final Predicate<Command> commandFilter = channelConfiguration.sendIfOff ? null
                 : getCommandFilter(actionChannel);
 
-        buildOptionalChannel(AUX_CH_ID, new OnOffValue(), updateListener, null, channelConfiguration.auxCommandTopic,
-                channelConfiguration.auxStateTemplate, channelConfiguration.auxStateTopic, commandFilter);
+        buildOptionalChannel(AUX_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, new OnOffValue(), updateListener,
+                null, channelConfiguration.auxCommandTopic, channelConfiguration.auxStateTemplate,
+                channelConfiguration.auxStateTopic, commandFilter);
 
-        buildOptionalChannel(AWAY_MODE_CH_ID, new OnOffValue(), updateListener, null,
-                channelConfiguration.awayModeCommandTopic, channelConfiguration.awayModeStateTemplate,
-                channelConfiguration.awayModeStateTopic, commandFilter);
+        buildOptionalChannel(AWAY_MODE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, new OnOffValue(),
+                updateListener, null, channelConfiguration.awayModeCommandTopic,
+                channelConfiguration.awayModeStateTemplate, channelConfiguration.awayModeStateTopic, commandFilter);
 
-        buildOptionalChannel(CURRENT_TEMPERATURE_CH_ID,
+        buildOptionalChannel(CURRENT_TEMPERATURE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
                 new NumberValue(null, null, precision, channelConfiguration.temperatureUnit.getUnit()), updateListener,
                 null, null, channelConfiguration.currentTemperatureTemplate,
                 channelConfiguration.currentTemperatureTopic, commandFilter);
 
-        buildOptionalChannel(FAN_MODE_CH_ID, new TextValue(channelConfiguration.fanModes.toArray(new String[0])),
-                updateListener, channelConfiguration.fanModeCommandTemplate, channelConfiguration.fanModeCommandTopic,
+        buildOptionalChannel(FAN_MODE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                new TextValue(channelConfiguration.fanModes.toArray(new String[0])), updateListener,
+                channelConfiguration.fanModeCommandTemplate, channelConfiguration.fanModeCommandTopic,
                 channelConfiguration.fanModeStateTemplate, channelConfiguration.fanModeStateTopic, commandFilter);
 
         List<String> holdModes = channelConfiguration.holdModes;
         if (holdModes != null && !holdModes.isEmpty()) {
-            buildOptionalChannel(HOLD_CH_ID, new TextValue(holdModes.toArray(new String[0])), updateListener,
+            buildOptionalChannel(HOLD_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    new TextValue(holdModes.toArray(new String[0])), updateListener,
                     channelConfiguration.holdCommandTemplate, channelConfiguration.holdCommandTopic,
                     channelConfiguration.holdStateTemplate, channelConfiguration.holdStateTopic, commandFilter);
         }
 
-        buildOptionalChannel(MODE_CH_ID, new TextValue(channelConfiguration.modes.toArray(new String[0])),
-                updateListener, channelConfiguration.modeCommandTemplate, channelConfiguration.modeCommandTopic,
+        buildOptionalChannel(MODE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                new TextValue(channelConfiguration.modes.toArray(new String[0])), updateListener,
+                channelConfiguration.modeCommandTemplate, channelConfiguration.modeCommandTopic,
                 channelConfiguration.modeStateTemplate, channelConfiguration.modeStateTopic, commandFilter);
 
-        buildOptionalChannel(SWING_CH_ID, new TextValue(channelConfiguration.swingModes.toArray(new String[0])),
-                updateListener, channelConfiguration.swingCommandTemplate, channelConfiguration.swingCommandTopic,
+        buildOptionalChannel(SWING_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                new TextValue(channelConfiguration.swingModes.toArray(new String[0])), updateListener,
+                channelConfiguration.swingCommandTemplate, channelConfiguration.swingCommandTopic,
                 channelConfiguration.swingStateTemplate, channelConfiguration.swingStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_CH_ID,
+        buildOptionalChannel(TEMPERATURE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureCommandTemplate,
                 channelConfiguration.temperatureCommandTopic, channelConfiguration.temperatureStateTemplate,
                 channelConfiguration.temperatureStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_HIGH_CH_ID,
+        buildOptionalChannel(TEMPERATURE_HIGH_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureHighCommandTemplate,
                 channelConfiguration.temperatureHighCommandTopic, channelConfiguration.temperatureHighStateTemplate,
                 channelConfiguration.temperatureHighStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_LOW_CH_ID,
+        buildOptionalChannel(TEMPERATURE_LOW_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureLowCommandTemplate,
                 channelConfiguration.temperatureLowCommandTopic, channelConfiguration.temperatureLowStateTemplate,
                 channelConfiguration.temperatureLowStateTopic, commandFilter);
 
-        buildOptionalChannel(POWER_CH_ID, new OnOffValue(), updateListener, null,
-                channelConfiguration.powerCommandTopic, null, null, null);
+        buildOptionalChannel(POWER_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, new OnOffValue(),
+                updateListener, null, channelConfiguration.powerCommandTopic, null, null, null);
     }
 
     @Nullable
-    private ComponentChannel buildOptionalChannel(String channelId, Value valueState,
+    private ComponentChannel buildOptionalChannel(String channelId, ChannelTypeUID channelTypeUID, Value valueState,
             ChannelStateUpdateListener channelStateUpdateListener, @Nullable String commandTemplate,
             @Nullable String commandTopic, @Nullable String stateTemplate, @Nullable String stateTopic,
             @Nullable Predicate<Command> commandFilter) {
         if ((commandTopic != null && !commandTopic.isBlank()) || (stateTopic != null && !stateTopic.isBlank())) {
-            return buildChannel(channelId, valueState, getName(), channelStateUpdateListener)
+            return buildChannel(channelId, channelTypeUID, valueState, getName(), channelStateUpdateListener)
                     .stateTopic(stateTopic, stateTemplate, channelConfiguration.getValueTemplate())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos(),
                             commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -27,13 +27,12 @@ import org.openhab.binding.mqtt.generic.values.NumberValue;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
-import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -219,82 +218,81 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
                 : channelConfiguration.temperatureUnit.getDefaultPrecision();
         final ChannelStateUpdateListener updateListener = componentConfiguration.getUpdateListener();
 
-        ComponentChannel actionChannel = buildOptionalChannel(ACTION_CH_ID,
-                MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(ACTION_MODES.toArray(new String[0])),
-                updateListener, null, null, channelConfiguration.actionTemplate, channelConfiguration.actionTopic,
-                null);
+        ComponentChannel actionChannel = buildOptionalChannel(ACTION_CH_ID, ComponentChannelType.STRING,
+                new TextValue(ACTION_MODES.toArray(new String[0])), updateListener, null, null,
+                channelConfiguration.actionTemplate, channelConfiguration.actionTopic, null);
 
         final Predicate<Command> commandFilter = channelConfiguration.sendIfOff ? null
                 : getCommandFilter(actionChannel);
 
-        buildOptionalChannel(AUX_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, new OnOffValue(), updateListener,
-                null, channelConfiguration.auxCommandTopic, channelConfiguration.auxStateTemplate,
+        buildOptionalChannel(AUX_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(), updateListener, null,
+                channelConfiguration.auxCommandTopic, channelConfiguration.auxStateTemplate,
                 channelConfiguration.auxStateTopic, commandFilter);
 
-        buildOptionalChannel(AWAY_MODE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, new OnOffValue(),
-                updateListener, null, channelConfiguration.awayModeCommandTopic,
-                channelConfiguration.awayModeStateTemplate, channelConfiguration.awayModeStateTopic, commandFilter);
+        buildOptionalChannel(AWAY_MODE_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(), updateListener, null,
+                channelConfiguration.awayModeCommandTopic, channelConfiguration.awayModeStateTemplate,
+                channelConfiguration.awayModeStateTopic, commandFilter);
 
-        buildOptionalChannel(CURRENT_TEMPERATURE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
+        buildOptionalChannel(CURRENT_TEMPERATURE_CH_ID, ComponentChannelType.NUMBER,
                 new NumberValue(null, null, precision, channelConfiguration.temperatureUnit.getUnit()), updateListener,
                 null, null, channelConfiguration.currentTemperatureTemplate,
                 channelConfiguration.currentTemperatureTopic, commandFilter);
 
-        buildOptionalChannel(FAN_MODE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+        buildOptionalChannel(FAN_MODE_CH_ID, ComponentChannelType.STRING,
                 new TextValue(channelConfiguration.fanModes.toArray(new String[0])), updateListener,
                 channelConfiguration.fanModeCommandTemplate, channelConfiguration.fanModeCommandTopic,
                 channelConfiguration.fanModeStateTemplate, channelConfiguration.fanModeStateTopic, commandFilter);
 
         List<String> holdModes = channelConfiguration.holdModes;
         if (holdModes != null && !holdModes.isEmpty()) {
-            buildOptionalChannel(HOLD_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+            buildOptionalChannel(HOLD_CH_ID, ComponentChannelType.STRING,
                     new TextValue(holdModes.toArray(new String[0])), updateListener,
                     channelConfiguration.holdCommandTemplate, channelConfiguration.holdCommandTopic,
                     channelConfiguration.holdStateTemplate, channelConfiguration.holdStateTopic, commandFilter);
         }
 
-        buildOptionalChannel(MODE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+        buildOptionalChannel(MODE_CH_ID, ComponentChannelType.STRING,
                 new TextValue(channelConfiguration.modes.toArray(new String[0])), updateListener,
                 channelConfiguration.modeCommandTemplate, channelConfiguration.modeCommandTopic,
                 channelConfiguration.modeStateTemplate, channelConfiguration.modeStateTopic, commandFilter);
 
-        buildOptionalChannel(SWING_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+        buildOptionalChannel(SWING_CH_ID, ComponentChannelType.STRING,
                 new TextValue(channelConfiguration.swingModes.toArray(new String[0])), updateListener,
                 channelConfiguration.swingCommandTemplate, channelConfiguration.swingCommandTopic,
                 channelConfiguration.swingStateTemplate, channelConfiguration.swingStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
+        buildOptionalChannel(TEMPERATURE_CH_ID, ComponentChannelType.NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureCommandTemplate,
                 channelConfiguration.temperatureCommandTopic, channelConfiguration.temperatureStateTemplate,
                 channelConfiguration.temperatureStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_HIGH_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
+        buildOptionalChannel(TEMPERATURE_HIGH_CH_ID, ComponentChannelType.NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureHighCommandTemplate,
                 channelConfiguration.temperatureHighCommandTopic, channelConfiguration.temperatureHighStateTemplate,
                 channelConfiguration.temperatureHighStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_LOW_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER,
+        buildOptionalChannel(TEMPERATURE_LOW_CH_ID, ComponentChannelType.NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureLowCommandTemplate,
                 channelConfiguration.temperatureLowCommandTopic, channelConfiguration.temperatureLowStateTemplate,
                 channelConfiguration.temperatureLowStateTopic, commandFilter);
 
-        buildOptionalChannel(POWER_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, new OnOffValue(),
-                updateListener, null, channelConfiguration.powerCommandTopic, null, null, null);
+        buildOptionalChannel(POWER_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(), updateListener, null,
+                channelConfiguration.powerCommandTopic, null, null, null);
     }
 
     @Nullable
-    private ComponentChannel buildOptionalChannel(String channelId, ChannelTypeUID channelTypeUID, Value valueState,
+    private ComponentChannel buildOptionalChannel(String channelId, ComponentChannelType channelType, Value valueState,
             ChannelStateUpdateListener channelStateUpdateListener, @Nullable String commandTemplate,
             @Nullable String commandTopic, @Nullable String stateTemplate, @Nullable String stateTopic,
             @Nullable Predicate<Command> commandFilter) {
         if ((commandTopic != null && !commandTopic.isBlank()) || (stateTopic != null && !stateTopic.isBlank())) {
-            return buildChannel(channelId, channelTypeUID, valueState, getName(), channelStateUpdateListener)
+            return buildChannel(channelId, channelType, valueState, getName(), channelStateUpdateListener)
                     .stateTopic(stateTopic, stateTemplate, channelConfiguration.getValueTemplate())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos(),
                             commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/ComponentFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/ComponentFactory.java
@@ -48,45 +48,46 @@ public class ComponentFactory {
      */
     public static AbstractComponent<?> createComponent(ThingUID thingUID, HaID haID, String channelConfigurationJSON,
             ChannelStateUpdateListener updateListener, AvailabilityTracker tracker, ScheduledExecutorService scheduler,
-            Gson gson, TransformationServiceProvider transformationServiceProvider) throws ConfigurationException {
+            Gson gson, TransformationServiceProvider transformationServiceProvider, boolean newStyleChannels)
+            throws ConfigurationException {
         ComponentConfiguration componentConfiguration = new ComponentConfiguration(thingUID, haID,
                 channelConfigurationJSON, gson, updateListener, tracker, scheduler)
                 .transformationProvider(transformationServiceProvider);
         switch (haID.component) {
             case "alarm_control_panel":
-                return new AlarmControlPanel(componentConfiguration);
+                return new AlarmControlPanel(componentConfiguration, newStyleChannels);
             case "binary_sensor":
-                return new BinarySensor(componentConfiguration);
+                return new BinarySensor(componentConfiguration, newStyleChannels);
             case "button":
-                return new Button(componentConfiguration);
+                return new Button(componentConfiguration, newStyleChannels);
             case "camera":
-                return new Camera(componentConfiguration);
+                return new Camera(componentConfiguration, newStyleChannels);
             case "cover":
-                return new Cover(componentConfiguration);
+                return new Cover(componentConfiguration, newStyleChannels);
             case "fan":
-                return new Fan(componentConfiguration);
+                return new Fan(componentConfiguration, newStyleChannels);
             case "climate":
-                return new Climate(componentConfiguration);
+                return new Climate(componentConfiguration, newStyleChannels);
             case "device_automation":
-                return new DeviceTrigger(componentConfiguration);
+                return new DeviceTrigger(componentConfiguration, newStyleChannels);
             case "light":
-                return Light.create(componentConfiguration);
+                return Light.create(componentConfiguration, newStyleChannels);
             case "lock":
-                return new Lock(componentConfiguration);
+                return new Lock(componentConfiguration, newStyleChannels);
             case "number":
-                return new Number(componentConfiguration);
+                return new Number(componentConfiguration, newStyleChannels);
             case "scene":
-                return new Scene(componentConfiguration);
+                return new Scene(componentConfiguration, newStyleChannels);
             case "select":
-                return new Select(componentConfiguration);
+                return new Select(componentConfiguration, newStyleChannels);
             case "sensor":
-                return new Sensor(componentConfiguration);
+                return new Sensor(componentConfiguration, newStyleChannels);
             case "switch":
-                return new Switch(componentConfiguration);
+                return new Switch(componentConfiguration, newStyleChannels);
             case "update":
-                return new Update(componentConfiguration);
+                return new Update(componentConfiguration, newStyleChannels);
             case "vacuum":
-                return new Vacuum(componentConfiguration);
+                return new Vacuum(componentConfiguration, newStyleChannels);
             default:
                 throw new UnsupportedComponentException("Component '" + haID + "' is unsupported!");
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
@@ -85,8 +85,8 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
     @Nullable
     ComponentChannel stateChannel = null;
 
-    public Cover(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Cover(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         String stateTopic = channelConfiguration.stateTopic;
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.RollershutterValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.library.types.StopMoveType;
@@ -95,16 +96,17 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
             TextValue value = new TextValue(new String[] { channelConfiguration.stateClosed,
                     channelConfiguration.stateClosing, channelConfiguration.stateOpen,
                     channelConfiguration.stateOpening, channelConfiguration.stateStopped });
-            buildChannel(STATE_CHANNEL_ID, value, "State", componentConfiguration.getUpdateListener())
-                    .stateTopic(stateTopic).isAdvanced(true).build();
+            buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, "State",
+                    componentConfiguration.getUpdateListener()).stateTopic(stateTopic).isAdvanced(true).build();
         }
 
         if (channelConfiguration.commandTopic != null) {
-            hiddenChannels.add(stateChannel = buildChannel(STATE_CHANNEL_ID, new TextValue(), "State",
-                    componentConfiguration.getUpdateListener())
-                    .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
-                            channelConfiguration.getQos())
-                    .build(false));
+            hiddenChannels
+                    .add(stateChannel = buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                            new TextValue(), "State", componentConfiguration.getUpdateListener())
+                            .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
+                                    channelConfiguration.getQos())
+                            .build(false));
         } else {
             // no command topic. we need to make sure we send
             // integers for open and close
@@ -132,8 +134,8 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
                 channelConfiguration.payloadClose, channelConfiguration.payloadStop, channelConfiguration.stateOpen,
                 channelConfiguration.stateClosed, inverted, channelConfiguration.setPositionTopic == null);
 
-        buildChannel(COVER_CHANNEL_ID, value, "Cover", componentConfiguration.getUpdateListener())
-                .stateTopic(rollershutterStateTopic, stateTemplate)
+        buildChannel(COVER_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_ROLLERSHUTTER, value, "Cover",
+                componentConfiguration.getUpdateListener()).stateTopic(rollershutterStateTopic, stateTemplate)
                 .commandTopic(rollershutterCommandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos())
                 .commandFilter(command -> {
                     if (stateChannel == null) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
@@ -16,8 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.RollershutterValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.StringType;
@@ -96,17 +96,16 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
             TextValue value = new TextValue(new String[] { channelConfiguration.stateClosed,
                     channelConfiguration.stateClosing, channelConfiguration.stateOpen,
                     channelConfiguration.stateOpening, channelConfiguration.stateStopped });
-            buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, "State",
+            buildChannel(STATE_CHANNEL_ID, ComponentChannelType.STRING, value, "State",
                     componentConfiguration.getUpdateListener()).stateTopic(stateTopic).isAdvanced(true).build();
         }
 
         if (channelConfiguration.commandTopic != null) {
-            hiddenChannels
-                    .add(stateChannel = buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                            new TextValue(), "State", componentConfiguration.getUpdateListener())
-                            .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
-                                    channelConfiguration.getQos())
-                            .build(false));
+            hiddenChannels.add(stateChannel = buildChannel(STATE_CHANNEL_ID, ComponentChannelType.STRING,
+                    new TextValue(), "State", componentConfiguration.getUpdateListener())
+                    .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
+                            channelConfiguration.getQos())
+                    .build(false));
         } else {
             // no command topic. we need to make sure we send
             // integers for open and close
@@ -134,7 +133,7 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
                 channelConfiguration.payloadClose, channelConfiguration.payloadStop, channelConfiguration.stateOpen,
                 channelConfiguration.stateClosed, inverted, channelConfiguration.setPositionTopic == null);
 
-        buildChannel(COVER_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_ROLLERSHUTTER, value, "Cover",
+        buildChannel(COVER_CHANNEL_ID, ComponentChannelType.ROLLERSHUTTER, value, "Cover",
                 componentConfiguration.getUpdateListener()).stateTopic(rollershutterStateTopic, stateTemplate)
                 .commandTopic(rollershutterCommandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos())
                 .commandFilter(command -> {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -21,6 +21,7 @@ import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.mapping.ColorMode;
 import org.openhab.binding.mqtt.generic.values.ColorValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -60,7 +61,8 @@ public class DefaultSchemaLight extends Light {
     @Override
     protected void buildChannels() {
         ComponentChannel localOnOffChannel;
-        localOnOffChannel = onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, onOffValue, "On/Off State", this)
+        localOnOffChannel = onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
+                onOffValue, "On/Off State", this)
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.stateValueTemplate)
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
@@ -69,8 +71,8 @@ public class DefaultSchemaLight extends Light {
         @Nullable
         ComponentChannel localBrightnessChannel = null;
         if (channelConfiguration.brightnessStateTopic != null || channelConfiguration.brightnessCommandTopic != null) {
-            localBrightnessChannel = brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID, brightnessValue,
-                    "Brightness", this)
+            localBrightnessChannel = brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID,
+                    MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER, brightnessValue, "Brightness", this)
                     .stateTopic(channelConfiguration.brightnessStateTopic, channelConfiguration.brightnessValueTemplate)
                     .commandTopic(channelConfiguration.brightnessCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -78,20 +80,23 @@ public class DefaultSchemaLight extends Light {
         }
 
         if (channelConfiguration.whiteCommandTopic != null) {
-            buildChannel(WHITE_CHANNEL_ID, brightnessValue, "Go directly to white of a specific brightness", this)
+            buildChannel(WHITE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER, brightnessValue,
+                    "Go directly to white of a specific brightness", this)
                     .commandTopic(channelConfiguration.whiteCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
                     .isAdvanced(true).build();
         }
 
         if (channelConfiguration.colorModeStateTopic != null) {
-            buildChannel(COLOR_MODE_CHANNEL_ID, new TextValue(), "Current color mode", this)
+            buildChannel(COLOR_MODE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
+                    "Current color mode", this)
                     .stateTopic(channelConfiguration.colorModeStateTopic, channelConfiguration.colorModeValueTemplate)
                     .build();
         }
 
         if (channelConfiguration.colorTempStateTopic != null || channelConfiguration.colorTempCommandTopic != null) {
-            buildChannel(COLOR_TEMP_CHANNEL_ID, colorTempValue, "Color Temperature", this)
+            buildChannel(COLOR_TEMP_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER, colorTempValue,
+                    "Color Temperature", this)
                     .stateTopic(channelConfiguration.colorTempStateTopic, channelConfiguration.colorTempValueTemplate)
                     .commandTopic(channelConfiguration.colorTempCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -100,7 +105,8 @@ public class DefaultSchemaLight extends Light {
 
         if (effectValue != null
                 && (channelConfiguration.effectStateTopic != null || channelConfiguration.effectCommandTopic != null)) {
-            buildChannel(EFFECT_CHANNEL_ID, Objects.requireNonNull(effectValue), "Lighting Effect", this)
+            buildChannel(EFFECT_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    Objects.requireNonNull(effectValue), "Lighting Effect", this)
                     .stateTopic(channelConfiguration.effectStateTopic, channelConfiguration.effectValueTemplate)
                     .commandTopic(channelConfiguration.effectCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -109,8 +115,8 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.rgbStateTopic != null || channelConfiguration.rgbCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(rgbChannel = buildChannel(RGB_CHANNEL_ID, new ColorValue(ColorMode.RGB, null, null, 100),
-                    "RGB state", this)
+            hiddenChannels.add(rgbChannel = buildChannel(RGB_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR,
+                    new ColorValue(ColorMode.RGB, null, null, 100), "RGB state", this)
                     .stateTopic(channelConfiguration.rgbStateTopic, channelConfiguration.rgbValueTemplate)
                     .commandTopic(channelConfiguration.rgbCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -119,7 +125,8 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.rgbwStateTopic != null || channelConfiguration.rgbwCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(buildChannel(RGBW_CHANNEL_ID, new TextValue(), "RGBW state", this)
+            hiddenChannels.add(buildChannel(RGBW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    new TextValue(), "RGBW state", this)
                     .stateTopic(channelConfiguration.rgbwStateTopic, channelConfiguration.rgbwValueTemplate)
                     .commandTopic(channelConfiguration.rgbwCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -128,7 +135,8 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.rgbwwStateTopic != null || channelConfiguration.rgbwwCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(buildChannel(RGBWW_CHANNEL_ID, new TextValue(), "RGBWW state", this)
+            hiddenChannels.add(buildChannel(RGBWW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    new TextValue(), "RGBWW state", this)
                     .stateTopic(channelConfiguration.rgbwwStateTopic, channelConfiguration.rgbwwValueTemplate)
                     .commandTopic(channelConfiguration.rgbwwCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -137,17 +145,18 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.xyStateTopic != null || channelConfiguration.xyCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(
-                    xyChannel = buildChannel(XY_CHANNEL_ID, new ColorValue(ColorMode.XYY, null, null, 100), "XY State",
-                            this).stateTopic(channelConfiguration.xyStateTopic, channelConfiguration.xyValueTemplate)
-                            .commandTopic(channelConfiguration.xyCommandTopic, channelConfiguration.isRetain(),
-                                    channelConfiguration.getQos())
-                            .build(false));
+            hiddenChannels.add(xyChannel = buildChannel(XY_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR,
+                    new ColorValue(ColorMode.XYY, null, null, 100), "XY State", this)
+                    .stateTopic(channelConfiguration.xyStateTopic, channelConfiguration.xyValueTemplate)
+                    .commandTopic(channelConfiguration.xyCommandTopic, channelConfiguration.isRetain(),
+                            channelConfiguration.getQos())
+                    .build(false));
         }
 
         if (channelConfiguration.hsStateTopic != null || channelConfiguration.hsCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(this.hsChannel = buildChannel(HS_CHANNEL_ID, new TextValue(), "Hue and Saturation", this)
+            hiddenChannels.add(this.hsChannel = buildChannel(HS_CHANNEL_ID,
+                    MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(), "Hue and Saturation", this)
                     .stateTopic(channelConfiguration.hsStateTopic, channelConfiguration.hsValueTemplate)
                     .commandTopic(channelConfiguration.hsCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -159,7 +168,7 @@ public class DefaultSchemaLight extends Light {
             if (localBrightnessChannel != null) {
                 hiddenChannels.add(localBrightnessChannel);
             }
-            buildChannel(COLOR_CHANNEL_ID, colorValue, "Color", this)
+            buildChannel(COLOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR, colorValue, "Color", this)
                     .commandTopic(DUMMY_TOPIC, channelConfiguration.isRetain(), channelConfiguration.getQos())
                     .commandFilter(this::handleColorCommand).build();
         } else if (localBrightnessChannel != null) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -54,8 +54,8 @@ public class DefaultSchemaLight extends Light {
     protected @Nullable ComponentChannel rgbChannel;
     protected @Nullable ComponentChannel xyChannel;
 
-    public DefaultSchemaLight(ComponentFactory.ComponentConfiguration builder) {
-        super(builder);
+    public DefaultSchemaLight(ComponentFactory.ComponentConfiguration builder, boolean newStyleChannels) {
+        super(builder, newStyleChannels);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -21,8 +21,8 @@ import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.mapping.ColorMode;
 import org.openhab.binding.mqtt.generic.values.ColorValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
@@ -61,8 +61,8 @@ public class DefaultSchemaLight extends Light {
     @Override
     protected void buildChannels() {
         ComponentChannel localOnOffChannel;
-        localOnOffChannel = onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
-                onOffValue, "On/Off State", this)
+        localOnOffChannel = onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, ComponentChannelType.SWITCH, onOffValue,
+                "On/Off State", this)
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.stateValueTemplate)
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
@@ -72,7 +72,7 @@ public class DefaultSchemaLight extends Light {
         ComponentChannel localBrightnessChannel = null;
         if (channelConfiguration.brightnessStateTopic != null || channelConfiguration.brightnessCommandTopic != null) {
             localBrightnessChannel = brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID,
-                    MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER, brightnessValue, "Brightness", this)
+                    ComponentChannelType.DIMMER, brightnessValue, "Brightness", this)
                     .stateTopic(channelConfiguration.brightnessStateTopic, channelConfiguration.brightnessValueTemplate)
                     .commandTopic(channelConfiguration.brightnessCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -80,7 +80,7 @@ public class DefaultSchemaLight extends Light {
         }
 
         if (channelConfiguration.whiteCommandTopic != null) {
-            buildChannel(WHITE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER, brightnessValue,
+            buildChannel(WHITE_CHANNEL_ID, ComponentChannelType.DIMMER, brightnessValue,
                     "Go directly to white of a specific brightness", this)
                     .commandTopic(channelConfiguration.whiteCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -88,15 +88,14 @@ public class DefaultSchemaLight extends Light {
         }
 
         if (channelConfiguration.colorModeStateTopic != null) {
-            buildChannel(COLOR_MODE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
-                    "Current color mode", this)
+            buildChannel(COLOR_MODE_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(), "Current color mode",
+                    this)
                     .stateTopic(channelConfiguration.colorModeStateTopic, channelConfiguration.colorModeValueTemplate)
                     .build();
         }
 
         if (channelConfiguration.colorTempStateTopic != null || channelConfiguration.colorTempCommandTopic != null) {
-            buildChannel(COLOR_TEMP_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER, colorTempValue,
-                    "Color Temperature", this)
+            buildChannel(COLOR_TEMP_CHANNEL_ID, ComponentChannelType.NUMBER, colorTempValue, "Color Temperature", this)
                     .stateTopic(channelConfiguration.colorTempStateTopic, channelConfiguration.colorTempValueTemplate)
                     .commandTopic(channelConfiguration.colorTempCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -105,8 +104,8 @@ public class DefaultSchemaLight extends Light {
 
         if (effectValue != null
                 && (channelConfiguration.effectStateTopic != null || channelConfiguration.effectCommandTopic != null)) {
-            buildChannel(EFFECT_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                    Objects.requireNonNull(effectValue), "Lighting Effect", this)
+            buildChannel(EFFECT_CHANNEL_ID, ComponentChannelType.STRING, Objects.requireNonNull(effectValue),
+                    "Lighting Effect", this)
                     .stateTopic(channelConfiguration.effectStateTopic, channelConfiguration.effectValueTemplate)
                     .commandTopic(channelConfiguration.effectCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -115,7 +114,7 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.rgbStateTopic != null || channelConfiguration.rgbCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(rgbChannel = buildChannel(RGB_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR,
+            hiddenChannels.add(rgbChannel = buildChannel(RGB_CHANNEL_ID, ComponentChannelType.COLOR,
                     new ColorValue(ColorMode.RGB, null, null, 100), "RGB state", this)
                     .stateTopic(channelConfiguration.rgbStateTopic, channelConfiguration.rgbValueTemplate)
                     .commandTopic(channelConfiguration.rgbCommandTopic, channelConfiguration.isRetain(),
@@ -125,27 +124,27 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.rgbwStateTopic != null || channelConfiguration.rgbwCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(buildChannel(RGBW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                    new TextValue(), "RGBW state", this)
-                    .stateTopic(channelConfiguration.rgbwStateTopic, channelConfiguration.rgbwValueTemplate)
-                    .commandTopic(channelConfiguration.rgbwCommandTopic, channelConfiguration.isRetain(),
-                            channelConfiguration.getQos())
-                    .build(false));
+            hiddenChannels
+                    .add(buildChannel(RGBW_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(), "RGBW state", this)
+                            .stateTopic(channelConfiguration.rgbwStateTopic, channelConfiguration.rgbwValueTemplate)
+                            .commandTopic(channelConfiguration.rgbwCommandTopic, channelConfiguration.isRetain(),
+                                    channelConfiguration.getQos())
+                            .build(false));
         }
 
         if (channelConfiguration.rgbwwStateTopic != null || channelConfiguration.rgbwwCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(buildChannel(RGBWW_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                    new TextValue(), "RGBWW state", this)
-                    .stateTopic(channelConfiguration.rgbwwStateTopic, channelConfiguration.rgbwwValueTemplate)
-                    .commandTopic(channelConfiguration.rgbwwCommandTopic, channelConfiguration.isRetain(),
-                            channelConfiguration.getQos())
-                    .build(false));
+            hiddenChannels.add(
+                    buildChannel(RGBWW_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(), "RGBWW state", this)
+                            .stateTopic(channelConfiguration.rgbwwStateTopic, channelConfiguration.rgbwwValueTemplate)
+                            .commandTopic(channelConfiguration.rgbwwCommandTopic, channelConfiguration.isRetain(),
+                                    channelConfiguration.getQos())
+                            .build(false));
         }
 
         if (channelConfiguration.xyStateTopic != null || channelConfiguration.xyCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(xyChannel = buildChannel(XY_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR,
+            hiddenChannels.add(xyChannel = buildChannel(XY_CHANNEL_ID, ComponentChannelType.COLOR,
                     new ColorValue(ColorMode.XYY, null, null, 100), "XY State", this)
                     .stateTopic(channelConfiguration.xyStateTopic, channelConfiguration.xyValueTemplate)
                     .commandTopic(channelConfiguration.xyCommandTopic, channelConfiguration.isRetain(),
@@ -155,8 +154,8 @@ public class DefaultSchemaLight extends Light {
 
         if (channelConfiguration.hsStateTopic != null || channelConfiguration.hsCommandTopic != null) {
             hasColorChannel = true;
-            hiddenChannels.add(this.hsChannel = buildChannel(HS_CHANNEL_ID,
-                    MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(), "Hue and Saturation", this)
+            hiddenChannels.add(this.hsChannel = buildChannel(HS_CHANNEL_ID, ComponentChannelType.STRING,
+                    new TextValue(), "Hue and Saturation", this)
                     .stateTopic(channelConfiguration.hsStateTopic, channelConfiguration.hsValueTemplate)
                     .commandTopic(channelConfiguration.hsCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -168,7 +167,7 @@ public class DefaultSchemaLight extends Light {
             if (localBrightnessChannel != null) {
                 hiddenChannels.add(localBrightnessChannel);
             }
-            buildChannel(COLOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR, colorValue, "Color", this)
+            buildChannel(COLOR_CHANNEL_ID, ComponentChannelType.COLOR, colorValue, "Color", this)
                     .commandTopic(DUMMY_TOPIC, channelConfiguration.isRetain(), channelConfiguration.getQos())
                     .commandFilter(this::handleColorCommand).build();
         } else if (localBrightnessChannel != null) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
@@ -45,8 +45,8 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
         protected @Nullable String payload;
     }
 
-    public DeviceTrigger(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public DeviceTrigger(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         if (!"trigger".equals(channelConfiguration.automationType)) {
             throw new ConfigurationException("Component:DeviceTrigger must have automation_type 'trigger'");

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 
@@ -65,7 +66,8 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
             value = new TextValue();
         }
 
-        buildChannel(channelConfiguration.type, value, getName(), componentConfiguration.getUpdateListener())
+        buildChannel(channelConfiguration.type, MqttBindingConstants.CHANNEL_TYPE_UID_TRIGGER, value, getName(),
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.topic, channelConfiguration.getValueTemplate()).trigger(true).build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 
@@ -66,7 +66,7 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
             value = new TextValue();
         }
 
-        buildChannel(channelConfiguration.type, MqttBindingConstants.CHANNEL_TYPE_UID_TRIGGER, value, getName(),
+        buildChannel(channelConfiguration.type, ComponentChannelType.TRIGGER, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.topic, channelConfiguration.getValueTemplate()).trigger(true).build();
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 
 import com.google.gson.annotations.SerializedName;
@@ -54,7 +55,8 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> {
         super(componentConfiguration, ChannelConfiguration.class);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
-        buildChannel(SWITCH_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
+        buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -51,8 +51,8 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> {
         protected String payloadOff = "OFF";
     }
 
-    public Fan(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Fan(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
         buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 
 import com.google.gson.annotations.SerializedName;
@@ -55,7 +55,7 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> {
         super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
-        buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),
+        buildChannel(SWITCH_CHANNEL_ID, ComponentChannelType.SWITCH, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -74,8 +74,8 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
 
     TextValue colorModeValue;
 
-    public JSONSchemaLight(ComponentFactory.ComponentConfiguration builder) {
-        super(builder);
+    public JSONSchemaLight(ComponentFactory.ComponentConfiguration builder, boolean newStyleChannels) {
+        super(builder, newStyleChannels);
         colorModeValue = new TextValue();
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.UnsupportedComponentException;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -84,7 +85,8 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
         if (supportedColorModes != null && supportedColorModes.contains(LightColorMode.COLOR_MODE_COLOR_TEMP)) {
             colorModeValue = new TextValue(
                     supportedColorModes.stream().map(LightColorMode::serializedName).toArray(String[]::new));
-            buildChannel(COLOR_MODE_CHANNEL_ID, colorModeValue, "Color Mode", this).isAdvanced(true).build();
+            buildChannel(COLOR_MODE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, colorModeValue,
+                    "Color Mode", this).isAdvanced(true).build();
         }
 
         if (channelConfiguration.colorMode) {
@@ -98,26 +100,28 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
             }
 
             if (supportedColorModes.contains(LightColorMode.COLOR_MODE_COLOR_TEMP)) {
-                buildChannel(COLOR_TEMP_CHANNEL_ID, colorTempValue, "Color Temperature", this)
-                        .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(command -> handleColorTempCommand(command))
-                        .build();
+                buildChannel(COLOR_TEMP_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER, colorTempValue,
+                        "Color Temperature", this).commandTopic(DUMMY_TOPIC, true, 1)
+                        .commandFilter(command -> handleColorTempCommand(command)).build();
             }
         }
 
         if (hasColorChannel) {
-            buildChannel(COLOR_CHANNEL_ID, colorValue, "Color", this).commandTopic(DUMMY_TOPIC, true, 1)
-                    .commandFilter(this::handleCommand).build();
+            buildChannel(COLOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR, colorValue, "Color", this)
+                    .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
         } else if (channelConfiguration.brightness) {
-            brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID, brightnessValue, "Brightness", this)
-                    .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
+            brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER,
+                    brightnessValue, "Brightness", this).commandTopic(DUMMY_TOPIC, true, 1)
+                    .commandFilter(this::handleCommand).build();
         } else {
-            onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, onOffValue, "On/Off State", this)
-                    .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
+            onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, onOffValue,
+                    "On/Off State", this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
         }
 
         if (effectValue != null) {
-            buildChannel(EFFECT_CHANNEL_ID, Objects.requireNonNull(effectValue), "Lighting Effect", this)
-                    .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(command -> handleEffectCommand(command)).build();
+            buildChannel(EFFECT_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    Objects.requireNonNull(effectValue), "Lighting Effect", this).commandTopic(DUMMY_TOPIC, true, 1)
+                    .commandFilter(command -> handleEffectCommand(command)).build();
 
         }
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -21,7 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.UnsupportedComponentException;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -85,8 +85,8 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
         if (supportedColorModes != null && supportedColorModes.contains(LightColorMode.COLOR_MODE_COLOR_TEMP)) {
             colorModeValue = new TextValue(
                     supportedColorModes.stream().map(LightColorMode::serializedName).toArray(String[]::new));
-            buildChannel(COLOR_MODE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, colorModeValue,
-                    "Color Mode", this).isAdvanced(true).build();
+            buildChannel(COLOR_MODE_CHANNEL_ID, ComponentChannelType.STRING, colorModeValue, "Color Mode", this)
+                    .isAdvanced(true).build();
         }
 
         if (channelConfiguration.colorMode) {
@@ -100,27 +100,26 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
             }
 
             if (supportedColorModes.contains(LightColorMode.COLOR_MODE_COLOR_TEMP)) {
-                buildChannel(COLOR_TEMP_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER, colorTempValue,
-                        "Color Temperature", this).commandTopic(DUMMY_TOPIC, true, 1)
+                buildChannel(COLOR_TEMP_CHANNEL_ID, ComponentChannelType.NUMBER, colorTempValue, "Color Temperature",
+                        this).commandTopic(DUMMY_TOPIC, true, 1)
                         .commandFilter(command -> handleColorTempCommand(command)).build();
             }
         }
 
         if (hasColorChannel) {
-            buildChannel(COLOR_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_COLOR, colorValue, "Color", this)
+            buildChannel(COLOR_CHANNEL_ID, ComponentChannelType.COLOR, colorValue, "Color", this)
                     .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
         } else if (channelConfiguration.brightness) {
-            brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER,
-                    brightnessValue, "Brightness", this).commandTopic(DUMMY_TOPIC, true, 1)
-                    .commandFilter(this::handleCommand).build();
+            brightnessChannel = buildChannel(BRIGHTNESS_CHANNEL_ID, ComponentChannelType.DIMMER, brightnessValue,
+                    "Brightness", this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
         } else {
-            onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, onOffValue,
-                    "On/Off State", this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
+            onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, ComponentChannelType.SWITCH, onOffValue, "On/Off State",
+                    this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand).build();
         }
 
         if (effectValue != null) {
-            buildChannel(EFFECT_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                    Objects.requireNonNull(effectValue), "Lighting Effect", this).commandTopic(DUMMY_TOPIC, true, 1)
+            buildChannel(EFFECT_CHANNEL_ID, ComponentChannelType.STRING, Objects.requireNonNull(effectValue),
+                    "Lighting Effect", this).commandTopic(DUMMY_TOPIC, true, 1)
                     .commandFilter(command -> handleEffectCommand(command)).build();
 
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
@@ -245,21 +245,22 @@ public abstract class Light extends AbstractComponent<Light.ChannelConfiguration
 
     protected final ChannelStateUpdateListener channelStateUpdateListener;
 
-    public static Light create(ComponentFactory.ComponentConfiguration builder) throws UnsupportedComponentException {
+    public static Light create(ComponentFactory.ComponentConfiguration builder, boolean newStyleChannels)
+            throws UnsupportedComponentException {
         String schema = builder.getConfig(ChannelConfiguration.class).schema;
         switch (schema) {
             case DEFAULT_SCHEMA:
-                return new DefaultSchemaLight(builder);
+                return new DefaultSchemaLight(builder, newStyleChannels);
             case JSON_SCHEMA:
-                return new JSONSchemaLight(builder);
+                return new JSONSchemaLight(builder, newStyleChannels);
             default:
                 throw new UnsupportedComponentException(
                         "Component '" + builder.getHaID() + "' of schema '" + schema + "' is not supported!");
         }
     }
 
-    protected Light(ComponentFactory.ComponentConfiguration builder) {
-        super(builder, ChannelConfiguration.class);
+    protected Light(ComponentFactory.ComponentConfiguration builder, boolean newStyleChannels) {
+        super(builder, ChannelConfiguration.class, newStyleChannels);
         this.channelStateUpdateListener = builder.getUpdateListener();
 
         @Nullable

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -82,7 +83,8 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
                         channelConfiguration.stateUnlocking, channelConfiguration.stateJammed },
                 channelConfiguration.payloadLock, channelConfiguration.payloadUnlock);
 
-        buildChannel(LOCK_CHANNEL_ID, lockValue, "Lock", componentConfiguration.getUpdateListener())
+        buildChannel(LOCK_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, lockValue, "Lock",
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
@@ -103,7 +105,8 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
         stateValue = new TextValue(new String[] { channelConfiguration.stateJammed, channelConfiguration.stateLocked,
                 channelConfiguration.stateLocking, channelConfiguration.stateUnlocked,
                 channelConfiguration.stateUnlocking }, commands);
-        buildChannel(STATE_CHANNEL_ID, stateValue, "State", componentConfiguration.getUpdateListener())
+        buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, stateValue, "State",
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
@@ -73,8 +73,8 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
     private OnOffValue lockValue;
     private TextValue stateValue;
 
-    public Lock(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Lock(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         this.optimistic = channelConfiguration.optimistic || channelConfiguration.stateTopic.isBlank();
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
@@ -17,7 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -83,7 +83,7 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
                         channelConfiguration.stateUnlocking, channelConfiguration.stateJammed },
                 channelConfiguration.payloadLock, channelConfiguration.payloadUnlock);
 
-        buildChannel(LOCK_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, lockValue, "Lock",
+        buildChannel(LOCK_CHANNEL_ID, ComponentChannelType.SWITCH, lockValue, "Lock",
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
@@ -105,7 +105,7 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
         stateValue = new TextValue(new String[] { channelConfiguration.stateJammed, channelConfiguration.stateLocked,
                 channelConfiguration.stateLocking, channelConfiguration.stateUnlocked,
                 channelConfiguration.stateUnlocking }, commands);
-        buildChannel(STATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, stateValue, "State",
+        buildChannel(STATE_CHANNEL_ID, ComponentChannelType.STRING, stateValue, "State",
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.NumberValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 import org.openhab.core.types.util.UnitUtils;
@@ -82,7 +83,8 @@ public class Number extends AbstractComponent<Number.ChannelConfiguration> {
         NumberValue value = new NumberValue(channelConfiguration.min, channelConfiguration.max,
                 channelConfiguration.step, UnitUtils.parseUnit(channelConfiguration.unitOfMeasurement));
 
-        buildChannel(NUMBER_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
+        buildChannel(NUMBER_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER, value, getName(),
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
@@ -70,8 +70,8 @@ public class Number extends AbstractComponent<Number.ChannelConfiguration> {
         protected @Nullable String jsonAttributesTemplate;
     }
 
-    public Number(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Number(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
                 : channelConfiguration.stateTopic.isBlank();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.NumberValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 import org.openhab.core.types.util.UnitUtils;
@@ -83,7 +83,7 @@ public class Number extends AbstractComponent<Number.ChannelConfiguration> {
         NumberValue value = new NumberValue(channelConfiguration.min, channelConfiguration.max,
                 channelConfiguration.step, UnitUtils.parseUnit(channelConfiguration.unitOfMeasurement));
 
-        buildChannel(NUMBER_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER, value, getName(),
+        buildChannel(NUMBER_CHANNEL_ID, ComponentChannelType.NUMBER, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
@@ -45,8 +45,8 @@ public class Scene extends AbstractComponent<Scene.ChannelConfiguration> {
         protected String payloadOn = "ON";
     }
 
-    public Scene(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Scene(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadOn });
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
 
@@ -49,7 +50,8 @@ public class Scene extends AbstractComponent<Scene.ChannelConfiguration> {
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadOn });
 
-        buildChannel(SCENE_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
+        buildChannel(SCENE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+                componentConfiguration.getUpdateListener())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
 
@@ -50,7 +50,7 @@ public class Scene extends AbstractComponent<Scene.ChannelConfiguration> {
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadOn });
 
-        buildChannel(SCENE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+        buildChannel(SCENE_CHANNEL_ID, ComponentChannelType.STRING, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 
@@ -66,7 +67,8 @@ public class Select extends AbstractComponent<Select.ChannelConfiguration> {
 
         TextValue value = new TextValue(channelConfiguration.options);
 
-        buildChannel(SELECT_CHANNEL_ID, value, getName(), componentConfiguration.getUpdateListener())
+        buildChannel(SELECT_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
@@ -55,8 +55,8 @@ public class Select extends AbstractComponent<Select.ChannelConfiguration> {
         protected @Nullable String jsonAttributesTemplate;
     }
 
-    public Select(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Select(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
                 : channelConfiguration.stateTopic.isBlank();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 
@@ -67,7 +67,7 @@ public class Select extends AbstractComponent<Select.ChannelConfiguration> {
 
         TextValue value = new TextValue(channelConfiguration.options);
 
-        buildChannel(SELECT_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+        buildChannel(SELECT_CHANNEL_ID, ComponentChannelType.STRING, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
@@ -69,8 +69,8 @@ public class Sensor extends AbstractComponent<Sensor.ChannelConfiguration> {
         protected @Nullable List<String> jsonAttributes;
     }
 
-    public Sensor(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Sensor(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         Value value;
         String uom = channelConfiguration.unitOfMeasurement;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
@@ -21,8 +21,10 @@ import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.NumberValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.ExpireUpdateStateListener;
+import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.util.UnitUtils;
 
 import com.google.gson.annotations.SerializedName;
@@ -73,22 +75,26 @@ public class Sensor extends AbstractComponent<Sensor.ChannelConfiguration> {
         Value value;
         String uom = channelConfiguration.unitOfMeasurement;
         String sc = channelConfiguration.stateClass;
+        ChannelTypeUID type;
 
         if (uom != null && !uom.isBlank()) {
             value = new NumberValue(null, null, null, UnitUtils.parseUnit(uom));
+            type = MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER;
         } else if (sc != null && !sc.isBlank()) {
             // see state_class at https://developers.home-assistant.io/docs/core/entity/sensor#properties
             // > If not None, the sensor is assumed to be numerical
             value = new NumberValue(null, null, null, null);
+            type = MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER;
         } else {
             value = new TextValue();
+            type = MqttBindingConstants.CHANNEL_TYPE_UID_STRING;
         }
 
         String icon = channelConfiguration.getIcon();
 
         boolean trigger = TRIGGER_ICONS.matcher(icon).matches();
 
-        buildChannel(SENSOR_CHANNEL_ID, value, getName(), getListener(componentConfiguration, value))
+        buildChannel(SENSOR_CHANNEL_ID, type, value, getName(), getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
                 .trigger(trigger).build();
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
@@ -21,10 +21,9 @@ import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.NumberValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.listener.ExpireUpdateStateListener;
-import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.util.UnitUtils;
 
 import com.google.gson.annotations.SerializedName;
@@ -75,19 +74,19 @@ public class Sensor extends AbstractComponent<Sensor.ChannelConfiguration> {
         Value value;
         String uom = channelConfiguration.unitOfMeasurement;
         String sc = channelConfiguration.stateClass;
-        ChannelTypeUID type;
+        ComponentChannelType type;
 
         if (uom != null && !uom.isBlank()) {
             value = new NumberValue(null, null, null, UnitUtils.parseUnit(uom));
-            type = MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER;
+            type = ComponentChannelType.NUMBER;
         } else if (sc != null && !sc.isBlank()) {
             // see state_class at https://developers.home-assistant.io/docs/core/entity/sensor#properties
             // > If not None, the sensor is assumed to be numerical
             value = new NumberValue(null, null, null, null);
-            type = MqttBindingConstants.CHANNEL_TYPE_UID_NUMBER;
+            type = ComponentChannelType.NUMBER;
         } else {
             value = new TextValue();
-            type = MqttBindingConstants.CHANNEL_TYPE_UID_STRING;
+            type = ComponentChannelType.STRING;
         }
 
         String icon = channelConfiguration.getIcon();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 
@@ -72,7 +73,8 @@ public class Switch extends AbstractComponent<Switch.ChannelConfiguration> {
         OnOffValue value = new OnOffValue(channelConfiguration.stateOn, channelConfiguration.stateOff,
                 channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
-        buildChannel(SWITCH_CHANNEL_ID, value, "state", componentConfiguration.getUpdateListener())
+        buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, "state",
+                componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
@@ -60,8 +60,8 @@ public class Switch extends AbstractComponent<Switch.ChannelConfiguration> {
         protected @Nullable String jsonAttributesTemplate;
     }
 
-    public Switch(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Switch(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
 
         boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
                 : channelConfiguration.stateTopic.isBlank();
@@ -73,7 +73,7 @@ public class Switch extends AbstractComponent<Switch.ChannelConfiguration> {
         OnOffValue value = new OnOffValue(channelConfiguration.stateOn, channelConfiguration.stateOff,
                 channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
-        buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, "state",
+        buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
@@ -15,7 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
 
@@ -73,7 +73,7 @@ public class Switch extends AbstractComponent<Switch.ChannelConfiguration> {
         OnOffValue value = new OnOffValue(channelConfiguration.stateOn, channelConfiguration.stateOff,
                 channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
-        buildChannel(SWITCH_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH, value, getName(),
+        buildChannel(SWITCH_CHANNEL_ID, ComponentChannelType.SWITCH, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -149,7 +150,8 @@ public class Update extends AbstractComponent<Update.ChannelConfiguration> imple
         String commandTopic = channelConfiguration.commandTopic;
         String payloadInstall = channelConfiguration.payloadInstall;
 
-        var builder = buildChannel(UPDATE_CHANNEL_ID, value, getName(), this);
+        var builder = buildChannel(UPDATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
+                this);
         if (channelConfiguration.stateTopic != null) {
             builder.stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate());
         }
@@ -162,7 +164,8 @@ public class Update extends AbstractComponent<Update.ChannelConfiguration> imple
 
         if (channelConfiguration.latestVersionTopic != null) {
             value = new TextValue();
-            latestVersionChannel = buildChannel(LATEST_VERSION_CHANNEL_ID, value, getName(), this)
+            latestVersionChannel = buildChannel(LATEST_VERSION_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                    value, getName(), this)
                     .stateTopic(channelConfiguration.latestVersionTopic, channelConfiguration.latestVersionTemplate)
                     .build(false);
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
@@ -143,8 +143,8 @@ public class Update extends AbstractComponent<Update.ChannelConfiguration> imple
     private ReleaseState state = new ReleaseState();
     private @Nullable ReleaseStateListener listener = null;
 
-    public Update(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Update(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         TextValue value = new TextValue();
         String commandTopic = channelConfiguration.commandTopic;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
@@ -20,8 +20,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.library.types.StringType;
@@ -150,8 +150,7 @@ public class Update extends AbstractComponent<Update.ChannelConfiguration> imple
         String commandTopic = channelConfiguration.commandTopic;
         String payloadInstall = channelConfiguration.payloadInstall;
 
-        var builder = buildChannel(UPDATE_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, value, getName(),
-                this);
+        var builder = buildChannel(UPDATE_CHANNEL_ID, ComponentChannelType.STRING, value, getName(), this);
         if (channelConfiguration.stateTopic != null) {
             builder.stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate());
         }
@@ -164,8 +163,8 @@ public class Update extends AbstractComponent<Update.ChannelConfiguration> imple
 
         if (channelConfiguration.latestVersionTopic != null) {
             value = new TextValue();
-            latestVersionChannel = buildChannel(LATEST_VERSION_CHANNEL_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                    value, getName(), this)
+            latestVersionChannel = buildChannel(LATEST_VERSION_CHANNEL_ID, ComponentChannelType.STRING, value,
+                    getName(), this)
                     .stateTopic(channelConfiguration.latestVersionTopic, channelConfiguration.latestVersionTemplate)
                     .build(false);
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -26,8 +26,10 @@ import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.PercentageValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
+import org.openhab.core.thing.type.ChannelTypeUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,8 +228,9 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             addPayloadToList(deviceSupportedFeatures, FEATURE_START, channelConfiguration.payloadStart, commands);
         }
 
-        buildOptionalChannel(COMMAND_CH_ID, new TextValue(commands.toArray(new String[0])), updateListener, null,
-                channelConfiguration.commandTopic, null, null);
+        buildOptionalChannel(COMMAND_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                new TextValue(commands.toArray(new String[0])), updateListener, null, channelConfiguration.commandTopic,
+                null, null);
 
         final var fanSpeedList = channelConfiguration.fanSpeedList;
         if (deviceSupportedFeatures.contains(FEATURE_FAN_SPEED) && fanSpeedList != null && !fanSpeedList.isEmpty()) {
@@ -236,48 +239,51 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             }
             var fanSpeedValue = new TextValue(fanSpeedList.toArray(new String[0]));
             if (channelConfiguration.schema == Schema.LEGACY) {
-                buildOptionalChannel(FAN_SPEED_CH_ID, fanSpeedValue, updateListener, null,
-                        channelConfiguration.setFanSpeedTopic, channelConfiguration.fanSpeedTemplate,
-                        channelConfiguration.fanSpeedTopic);
+                buildOptionalChannel(FAN_SPEED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, fanSpeedValue,
+                        updateListener, null, channelConfiguration.setFanSpeedTopic,
+                        channelConfiguration.fanSpeedTemplate, channelConfiguration.fanSpeedTopic);
             } else if (deviceSupportedFeatures.contains(FEATURE_STATUS)) {
-                buildOptionalChannel(FAN_SPEED_CH_ID, fanSpeedValue, updateListener, null,
-                        channelConfiguration.setFanSpeedTopic, "{{ value_json.fan_speed }}",
+                buildOptionalChannel(FAN_SPEED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, fanSpeedValue,
+                        updateListener, null, channelConfiguration.setFanSpeedTopic, "{{ value_json.fan_speed }}",
                         channelConfiguration.stateTopic);
             } else {
                 LOGGER.info("Status feature is disabled, unable to get fan speed.");
-                buildOptionalChannel(FAN_SPEED_CH_ID, fanSpeedValue, updateListener, null,
-                        channelConfiguration.setFanSpeedTopic, null, null);
+                buildOptionalChannel(FAN_SPEED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, fanSpeedValue,
+                        updateListener, null, channelConfiguration.setFanSpeedTopic, null, null);
             }
         }
 
         if (deviceSupportedFeatures.contains(FEATURE_SEND_COMMAND)) {
-            buildOptionalChannel(CUSTOM_COMMAND_CH_ID, new TextValue(), updateListener, null,
-                    channelConfiguration.sendCommandTopic, null, null);
+            buildOptionalChannel(CUSTOM_COMMAND_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
+                    updateListener, null, channelConfiguration.sendCommandTopic, null, null);
         }
 
         if (channelConfiguration.schema == Schema.LEGACY) {
             // I assume, that if these topics defined in config, then we don't need to check features
-            buildOptionalChannel(BATTERY_LEVEL_CH_ID,
+            buildOptionalChannel(BATTERY_LEVEL_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER,
                     new PercentageValue(BigDecimal.ZERO, BigDecimal.valueOf(100), BigDecimal.ONE, null, null),
                     updateListener, null, null, channelConfiguration.batteryLevelTemplate,
                     channelConfiguration.batteryLevelTopic);
-            buildOptionalChannel(CHARGING_CH_ID, new OnOffValue(TRUE, FALSE), updateListener, null, null,
-                    channelConfiguration.chargingTemplate, channelConfiguration.chargingTopic);
-            buildOptionalChannel(CLEANING_CH_ID, new OnOffValue(TRUE, FALSE), updateListener, null, null,
-                    channelConfiguration.cleaningTemplate, channelConfiguration.cleaningTopic);
-            buildOptionalChannel(DOCKED_CH_ID, new OnOffValue(TRUE, FALSE), updateListener, null, null,
-                    channelConfiguration.dockedTemplate, channelConfiguration.dockedTopic);
-            buildOptionalChannel(ERROR_CH_ID, new TextValue(), updateListener, null, null,
-                    channelConfiguration.errorTemplate, channelConfiguration.errorTopic);
+            buildOptionalChannel(CHARGING_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
+                    new OnOffValue(TRUE, FALSE), updateListener, null, null, channelConfiguration.chargingTemplate,
+                    channelConfiguration.chargingTopic);
+            buildOptionalChannel(CLEANING_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
+                    new OnOffValue(TRUE, FALSE), updateListener, null, null, channelConfiguration.cleaningTemplate,
+                    channelConfiguration.cleaningTopic);
+            buildOptionalChannel(DOCKED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
+                    new OnOffValue(TRUE, FALSE), updateListener, null, null, channelConfiguration.dockedTemplate,
+                    channelConfiguration.dockedTopic);
+            buildOptionalChannel(ERROR_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
+                    updateListener, null, null, channelConfiguration.errorTemplate, channelConfiguration.errorTopic);
         } else {
             if (deviceSupportedFeatures.contains(FEATURE_STATUS)) {
                 // state key is mandatory
-                buildOptionalChannel(STATE_CH_ID,
+                buildOptionalChannel(STATE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
                         new TextValue(new String[] { STATE_CLEANING, STATE_DOCKED, STATE_PAUSED, STATE_IDLE,
                                 STATE_RETURNING, STATE_ERROR }),
                         updateListener, null, null, "{{ value_json.state }}", channelConfiguration.stateTopic);
                 if (deviceSupportedFeatures.contains(FEATURE_BATTERY)) {
-                    buildOptionalChannel(BATTERY_LEVEL_CH_ID,
+                    buildOptionalChannel(BATTERY_LEVEL_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER,
                             new PercentageValue(BigDecimal.ZERO, BigDecimal.valueOf(100), BigDecimal.ONE, null, null),
                             updateListener, null, null, "{{ value_json.battery_level }}",
                             channelConfiguration.stateTopic);
@@ -285,16 +291,17 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             }
         }
 
-        buildOptionalChannel(JSON_ATTRIBUTES_CH_ID, new TextValue(), updateListener, null, null,
-                channelConfiguration.jsonAttributesTemplate, channelConfiguration.jsonAttributesTopic);
+        buildOptionalChannel(JSON_ATTRIBUTES_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
+                updateListener, null, null, channelConfiguration.jsonAttributesTemplate,
+                channelConfiguration.jsonAttributesTopic);
     }
 
     @Nullable
-    private ComponentChannel buildOptionalChannel(String channelId, Value valueState,
+    private ComponentChannel buildOptionalChannel(String channelId, ChannelTypeUID channelTypeUID, Value valueState,
             ChannelStateUpdateListener channelStateUpdateListener, @Nullable String commandTemplate,
             @Nullable String commandTopic, @Nullable String stateTemplate, @Nullable String stateTopic) {
         if ((commandTopic != null && !commandTopic.isBlank()) || (stateTopic != null && !stateTopic.isBlank())) {
-            return buildChannel(channelId, valueState, getName(), channelStateUpdateListener)
+            return buildChannel(channelId, channelTypeUID, valueState, getName(), channelStateUpdateListener)
                     .stateTopic(stateTopic, stateTemplate, channelConfiguration.getValueTemplate())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos(),
                             commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -190,8 +190,8 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
      *
      * @param componentConfiguration generic componentConfiguration with not parsed JSON config
      */
-    public Vacuum(ComponentFactory.ComponentConfiguration componentConfiguration) {
-        super(componentConfiguration, ChannelConfiguration.class);
+    public Vacuum(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
         final ChannelStateUpdateListener updateListener = componentConfiguration.getUpdateListener();
 
         final var allowedSupportedFeatures = channelConfiguration.schema == Schema.LEGACY ? LEGACY_SUPPORTED_FEATURES

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -26,10 +26,9 @@ import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.PercentageValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
-import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
-import org.openhab.core.thing.type.ChannelTypeUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -228,9 +227,8 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             addPayloadToList(deviceSupportedFeatures, FEATURE_START, channelConfiguration.payloadStart, commands);
         }
 
-        buildOptionalChannel(COMMAND_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
-                new TextValue(commands.toArray(new String[0])), updateListener, null, channelConfiguration.commandTopic,
-                null, null);
+        buildOptionalChannel(COMMAND_CH_ID, ComponentChannelType.STRING, new TextValue(commands.toArray(new String[0])),
+                updateListener, null, channelConfiguration.commandTopic, null, null);
 
         final var fanSpeedList = channelConfiguration.fanSpeedList;
         if (deviceSupportedFeatures.contains(FEATURE_FAN_SPEED) && fanSpeedList != null && !fanSpeedList.isEmpty()) {
@@ -239,51 +237,50 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             }
             var fanSpeedValue = new TextValue(fanSpeedList.toArray(new String[0]));
             if (channelConfiguration.schema == Schema.LEGACY) {
-                buildOptionalChannel(FAN_SPEED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, fanSpeedValue,
-                        updateListener, null, channelConfiguration.setFanSpeedTopic,
-                        channelConfiguration.fanSpeedTemplate, channelConfiguration.fanSpeedTopic);
+                buildOptionalChannel(FAN_SPEED_CH_ID, ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
+                        channelConfiguration.setFanSpeedTopic, channelConfiguration.fanSpeedTemplate,
+                        channelConfiguration.fanSpeedTopic);
             } else if (deviceSupportedFeatures.contains(FEATURE_STATUS)) {
-                buildOptionalChannel(FAN_SPEED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, fanSpeedValue,
-                        updateListener, null, channelConfiguration.setFanSpeedTopic, "{{ value_json.fan_speed }}",
+                buildOptionalChannel(FAN_SPEED_CH_ID, ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
+                        channelConfiguration.setFanSpeedTopic, "{{ value_json.fan_speed }}",
                         channelConfiguration.stateTopic);
             } else {
                 LOGGER.info("Status feature is disabled, unable to get fan speed.");
-                buildOptionalChannel(FAN_SPEED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, fanSpeedValue,
-                        updateListener, null, channelConfiguration.setFanSpeedTopic, null, null);
+                buildOptionalChannel(FAN_SPEED_CH_ID, ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
+                        channelConfiguration.setFanSpeedTopic, null, null);
             }
         }
 
         if (deviceSupportedFeatures.contains(FEATURE_SEND_COMMAND)) {
-            buildOptionalChannel(CUSTOM_COMMAND_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
-                    updateListener, null, channelConfiguration.sendCommandTopic, null, null);
+            buildOptionalChannel(CUSTOM_COMMAND_CH_ID, ComponentChannelType.STRING, new TextValue(), updateListener,
+                    null, channelConfiguration.sendCommandTopic, null, null);
         }
 
         if (channelConfiguration.schema == Schema.LEGACY) {
             // I assume, that if these topics defined in config, then we don't need to check features
-            buildOptionalChannel(BATTERY_LEVEL_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER,
+            buildOptionalChannel(BATTERY_LEVEL_CH_ID, ComponentChannelType.DIMMER,
                     new PercentageValue(BigDecimal.ZERO, BigDecimal.valueOf(100), BigDecimal.ONE, null, null),
                     updateListener, null, null, channelConfiguration.batteryLevelTemplate,
                     channelConfiguration.batteryLevelTopic);
-            buildOptionalChannel(CHARGING_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
-                    new OnOffValue(TRUE, FALSE), updateListener, null, null, channelConfiguration.chargingTemplate,
+            buildOptionalChannel(CHARGING_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(TRUE, FALSE),
+                    updateListener, null, null, channelConfiguration.chargingTemplate,
                     channelConfiguration.chargingTopic);
-            buildOptionalChannel(CLEANING_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
-                    new OnOffValue(TRUE, FALSE), updateListener, null, null, channelConfiguration.cleaningTemplate,
+            buildOptionalChannel(CLEANING_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(TRUE, FALSE),
+                    updateListener, null, null, channelConfiguration.cleaningTemplate,
                     channelConfiguration.cleaningTopic);
-            buildOptionalChannel(DOCKED_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_SWITCH,
-                    new OnOffValue(TRUE, FALSE), updateListener, null, null, channelConfiguration.dockedTemplate,
-                    channelConfiguration.dockedTopic);
-            buildOptionalChannel(ERROR_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
-                    updateListener, null, null, channelConfiguration.errorTemplate, channelConfiguration.errorTopic);
+            buildOptionalChannel(DOCKED_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(TRUE, FALSE), updateListener,
+                    null, null, channelConfiguration.dockedTemplate, channelConfiguration.dockedTopic);
+            buildOptionalChannel(ERROR_CH_ID, ComponentChannelType.STRING, new TextValue(), updateListener, null, null,
+                    channelConfiguration.errorTemplate, channelConfiguration.errorTopic);
         } else {
             if (deviceSupportedFeatures.contains(FEATURE_STATUS)) {
                 // state key is mandatory
-                buildOptionalChannel(STATE_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING,
+                buildOptionalChannel(STATE_CH_ID, ComponentChannelType.STRING,
                         new TextValue(new String[] { STATE_CLEANING, STATE_DOCKED, STATE_PAUSED, STATE_IDLE,
                                 STATE_RETURNING, STATE_ERROR }),
                         updateListener, null, null, "{{ value_json.state }}", channelConfiguration.stateTopic);
                 if (deviceSupportedFeatures.contains(FEATURE_BATTERY)) {
-                    buildOptionalChannel(BATTERY_LEVEL_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_DIMMER,
+                    buildOptionalChannel(BATTERY_LEVEL_CH_ID, ComponentChannelType.DIMMER,
                             new PercentageValue(BigDecimal.ZERO, BigDecimal.valueOf(100), BigDecimal.ONE, null, null),
                             updateListener, null, null, "{{ value_json.battery_level }}",
                             channelConfiguration.stateTopic);
@@ -291,17 +288,16 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             }
         }
 
-        buildOptionalChannel(JSON_ATTRIBUTES_CH_ID, MqttBindingConstants.CHANNEL_TYPE_UID_STRING, new TextValue(),
-                updateListener, null, null, channelConfiguration.jsonAttributesTemplate,
-                channelConfiguration.jsonAttributesTopic);
+        buildOptionalChannel(JSON_ATTRIBUTES_CH_ID, ComponentChannelType.STRING, new TextValue(), updateListener, null,
+                null, channelConfiguration.jsonAttributesTemplate, channelConfiguration.jsonAttributesTopic);
     }
 
     @Nullable
-    private ComponentChannel buildOptionalChannel(String channelId, ChannelTypeUID channelTypeUID, Value valueState,
+    private ComponentChannel buildOptionalChannel(String channelId, ComponentChannelType channelType, Value valueState,
             ChannelStateUpdateListener channelStateUpdateListener, @Nullable String commandTemplate,
             @Nullable String commandTopic, @Nullable String stateTemplate, @Nullable String stateTopic) {
         if ((commandTopic != null && !commandTopic.isBlank()) || (stateTopic != null && !stateTopic.isBlank())) {
-            return buildChannel(channelId, channelTypeUID, valueState, getName(), channelStateUpdateListener)
+            return buildChannel(channelId, channelType, valueState, getName(), channelStateUpdateListener)
                     .stateTopic(stateTopic, stateTemplate, channelConfiguration.getValueTemplate())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos(),
                             commandTemplate)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -51,6 +51,7 @@ import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.type.ThingType;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -144,7 +145,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypes() {
-        return typeProvider.getThingTypeUIDs();
+        return typeProvider.getThingTypes(null).stream().map(ThingType::getUID).collect(Collectors.toSet());
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -51,7 +51,6 @@ import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.type.ThingType;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -206,11 +205,8 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
                     .fromString(new String(payload, StandardCharsets.UTF_8), gson);
 
             final String thingID = config.getThingId(haID.objectID);
-
-            final ThingTypeUID typeID = new ThingTypeUID(MqttBindingConstants.BINDING_ID,
-                    MqttBindingConstants.HOMEASSISTANT_MQTT_THING.getId() + "_" + thingID);
-
-            final ThingUID thingUID = new ThingUID(typeID, connectionBridge, thingID);
+            final ThingUID thingUID = new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, connectionBridge,
+                    thingID);
 
             thingIDPerTopic.put(topic, thingUID);
 
@@ -282,10 +278,6 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         results.clear();
         componentsPerThingID.clear();
         for (DiscoveryResult result : localResults) {
-            final ThingTypeUID typeID = result.getThingTypeUID();
-            ThingType type = typeProvider.derive(typeID, MqttBindingConstants.HOMEASSISTANT_MQTT_THING).build();
-            typeProvider.setThingTypeIfAbsent(typeID, type);
-
             thingDiscovered(result);
         }
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -237,6 +237,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
             properties = handlerConfig.appendToProperties(properties);
             properties = config.appendToProperties(properties);
             properties.put("deviceId", thingID);
+            properties.put("newStyleChannels", "true");
 
             // Because we need the new properties map with the updated "components" list
             results.put(thingUID.getAsString(),

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -109,6 +109,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
     protected final TransformationServiceProvider transformationServiceProvider;
 
     private boolean started;
+    private boolean newStyleChannels;
     private @Nullable Update updateComponent;
 
     /**
@@ -132,8 +133,12 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
         this.transformationServiceProvider = transformationServiceProvider;
         this.attributeReceiveTimeout = attributeReceiveTimeout;
         this.delayedProcessing = new DelayedBatchProcessing<>(attributeReceiveTimeout, this, scheduler);
+
+        Map<String, String> properties = getThing().getProperties();
+        newStyleChannels = "true".equals(thing.getProperties().get("newStyleChannels"));
+
         this.discoverComponents = new DiscoverComponents(thing.getUID(), scheduler, this, this, gson,
-                this.transformationServiceProvider);
+                this.transformationServiceProvider, newStyleChannels);
     }
 
     @Override
@@ -168,7 +173,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
             } else {
                 try {
                     component = ComponentFactory.createComponent(thingUID, haID, channelConfigurationJSON, this, this,
-                            scheduler, gson, transformationServiceProvider);
+                            scheduler, gson, transformationServiceProvider, newStyleChannels);
                     if (typeID.equals(MqttBindingConstants.HOMEASSISTANT_MQTT_THING)) {
                         typeID = calculateThingTypeUID(component);
                     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -129,7 +129,6 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
         this.attributeReceiveTimeout = attributeReceiveTimeout;
         this.delayedProcessing = new DelayedBatchProcessing<>(attributeReceiveTimeout, this, scheduler);
 
-        Map<String, String> properties = getThing().getProperties();
         newStyleChannels = "true".equals(thing.getProperties().get("newStyleChannels"));
 
         this.discoverComponents = new DiscoverComponents(thing.getUID(), scheduler, this, this, gson,

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/config/homeassistant-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/config/homeassistant-channel-config.xml
@@ -7,7 +7,7 @@
 	<config-description uri="channel-type:mqtt:ha-channel">
 		<parameter name="component" type="text" readOnly="true" required="true">
 			<label>Component</label>
-			<description>HomeAssistant component type (e.g. binary_sensor, switch, light)</description>
+			<description>Home Assistant component type (e.g. binary_sensor, switch, light)</description>
 			<default></default>
 		</parameter>
 		<parameter name="nodeid" type="text" readOnly="true">
@@ -17,12 +17,12 @@
 		</parameter>
 		<parameter name="objectid" type="text" readOnly="true" required="true">
 			<label>Object ID</label>
-			<description>Object id of the component</description>
+			<description>Object ID of the component</description>
 			<default></default>
 		</parameter>
 		<parameter name="config" type="text" readOnly="true" required="true">
-			<label>Json Configuration</label>
-			<description>The json configuration string received by the component via MQTT.</description>
+			<label>JSON Configuration</label>
+			<description>The JSON configuration string received by the component via MQTT.</description>
 			<default></default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/i18n/mqtt.properties
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/i18n/mqtt.properties
@@ -9,6 +9,39 @@ thing-type.config.mqtt.homeassistant.basetopic.label = MQTT Base Prefix
 thing-type.config.mqtt.homeassistant.basetopic.description = MQTT base prefix
 thing-type.config.mqtt.homeassistant.topics.label = MQTT Config Topic
 thing-type.config.mqtt.homeassistant.topics.description = List of Home Assistant configuration topics (e.g. button/my-device/restart)
+
+# channel types
+
+channel-type.mqtt.ha-color-advanced.label = Color
+channel-type.mqtt.ha-color.label = Color
+channel-type.mqtt.ha-dimmer-advanced.label = Dimmer
+channel-type.mqtt.ha-dimmer.label = Dimmer
+channel-type.mqtt.ha-image-advanced.label = Image
+channel-type.mqtt.ha-image.label = Image
+channel-type.mqtt.ha-number-advanced.label = Number
+channel-type.mqtt.ha-number.label = Number
+channel-type.mqtt.ha-rollershutter-advanced.label = Rollershutter
+channel-type.mqtt.ha-rollershutter.label = Rollershutter
+channel-type.mqtt.ha-string-advanced.label = String
+channel-type.mqtt.ha-string.label = String
+channel-type.mqtt.ha-switch-advanced.label = Switch
+channel-type.mqtt.ha-switch.label = Switch
+channel-type.mqtt.ha-trigger-advanced.label = Trigger
+channel-type.mqtt.ha-trigger.label = Trigger
+
+# channel types config
+
+channel-type.config.mqtt.ha-channel.component.label = Component
+channel-type.config.mqtt.ha-channel.component.description = Home Assistant component type (e.g. binary_sensor, switch, light)
+channel-type.config.mqtt.ha-channel.config.label = JSON Configuration
+channel-type.config.mqtt.ha-channel.config.description = The JSON configuration string received by the component via MQTT.
+channel-type.config.mqtt.ha-channel.nodeid.label = Node ID
+channel-type.config.mqtt.ha-channel.nodeid.description = Optional node name of the component
+channel-type.config.mqtt.ha-channel.objectid.label = Object ID
+channel-type.config.mqtt.ha-channel.objectid.description = Object ID of the component
+
+# thing types config
+
 thing-type.config.mqtt.homeassistant-updatable.basetopic.label = MQTT Base Prefix
 thing-type.config.mqtt.homeassistant-updatable.basetopic.description = MQTT base prefix
 thing-type.config.mqtt.homeassistant-updatable.topics.label = MQTT Config Topic

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/thing/homeassistant-channels.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/thing/homeassistant-channels.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="mqtt"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="ha-color">
+		<item-type>Color</item-type>
+		<label>Color</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-dimmer">
+		<item-type>Dimmer</item-type>
+		<label>Dimmer</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-image">
+		<item-type>Image</item-type>
+		<label>Image</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-number">
+		<item-type>Number</item-type>
+		<label>Number</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-rollershutter">
+		<item-type>Rollershutter</item-type>
+		<label>Rollershutter</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-string">
+		<item-type>String</item-type>
+		<label>String</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-switch">
+		<item-type>Switch</item-type>
+		<label>Switch</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-trigger">
+		<kind>trigger</kind>
+		<label>Trigger</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-color-advanced" advanced="true">
+		<item-type>Color</item-type>
+		<label>Color</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-dimmer-advanced" advanced="true">
+		<item-type>Dimmer</item-type>
+		<label>Dimmer</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-image-advanced" advanced="true">
+		<item-type>Image</item-type>
+		<label>Image</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-number-advanced" advanced="true">
+		<item-type>Number</item-type>
+		<label>Number</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-rollershutter-advanced" advanced="true">
+		<item-type>Rollershutter</item-type>
+		<label>Rollershutter</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-string-advanced" advanced="true">
+		<item-type>String</item-type>
+		<label>String</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-switch-advanced" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Switch</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-trigger-advanced" advanced="true">
+		<kind>trigger</kind>
+		<label>Trigger</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractHomeAssistantTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractHomeAssistantTests.java
@@ -39,9 +39,11 @@ import org.openhab.binding.mqtt.generic.MqttChannelStateDescriptionProvider;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.handler.BrokerHandler;
+import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttMessageSubscriber;
 import org.openhab.core.test.java.JavaTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -52,6 +54,7 @@ import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
+import org.openhab.core.thing.type.ThingType;
 import org.openhab.core.thing.type.ThingTypeBuilder;
 import org.openhab.core.thing.type.ThingTypeRegistry;
 import org.openhab.transform.jinja.internal.JinjaTransformationService;
@@ -74,11 +77,12 @@ public abstract class AbstractHomeAssistantTests extends JavaTest {
     public static final String BRIDGE_ID = UUID.randomUUID().toString();
     public static final ThingUID BRIDGE_UID = new ThingUID(BRIDGE_TYPE_UID, BRIDGE_ID);
 
-    public static final String HA_TYPE_ID = "homeassistant";
-    public static final String HA_TYPE_LABEL = "Homeassistant";
-    public static final ThingTypeUID HA_TYPE_UID = new ThingTypeUID(BINDING_ID, HA_TYPE_ID);
+    public static final String HA_TYPE_LABEL = "Home Assistant Thing";
+    public static final ThingTypeUID HA_TYPE_UID = new ThingTypeUID(BINDING_ID, "homeassistant_dynamic_type");
     public static final String HA_ID = UUID.randomUUID().toString();
-    public static final ThingUID HA_UID = new ThingUID(HA_TYPE_UID, HA_ID);
+    public static final ThingUID HA_UID = new ThingUID(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, HA_ID);
+    public static final ThingType HA_THING_TYPE = ThingTypeBuilder
+            .instance(MqttBindingConstants.HOMEASSISTANT_MQTT_THING, HA_TYPE_LABEL).build();
 
     protected @Mock @NonNullByDefault({}) MqttBrokerConnection bridgeConnection;
     protected @Mock @NonNullByDefault({}) ThingTypeRegistry thingTypeRegistry;
@@ -99,13 +103,12 @@ public abstract class AbstractHomeAssistantTests extends JavaTest {
     public void beforeEachAbstractHomeAssistantTests() {
         when(thingTypeRegistry.getThingType(BRIDGE_TYPE_UID))
                 .thenReturn(ThingTypeBuilder.instance(BRIDGE_TYPE_UID, BRIDGE_TYPE_LABEL).build());
-        when(thingTypeRegistry.getThingType(HA_TYPE_UID))
-                .thenReturn(ThingTypeBuilder.instance(HA_TYPE_UID, HA_TYPE_LABEL).build());
+        when(thingTypeRegistry.getThingType(MqttBindingConstants.HOMEASSISTANT_MQTT_THING)).thenReturn(HA_THING_TYPE);
         when(transformationServiceProvider
                 .getTransformationService(JinjaTransformationProfile.PROFILE_TYPE_UID.getId()))
                 .thenReturn(jinjaTransformationService);
 
-        channelTypeProvider = spy(new MqttChannelTypeProvider(thingTypeRegistry));
+        channelTypeProvider = spy(new MqttChannelTypeProvider(thingTypeRegistry, new VolatileStorageService()));
         stateDescriptionProvider = spy(new MqttChannelStateDescriptionProvider());
         channelTypeRegistry = spy(new ChannelTypeRegistry());
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractHomeAssistantTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractHomeAssistantTests.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.binding.mqtt.generic.MqttChannelStateDescriptionProvider;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.handler.BrokerHandler;
@@ -50,6 +51,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ThingTypeBuilder;
 import org.openhab.core.thing.type.ThingTypeRegistry;
 import org.openhab.transform.jinja.internal.JinjaTransformationService;
@@ -83,6 +85,8 @@ public abstract class AbstractHomeAssistantTests extends JavaTest {
     protected @Mock @NonNullByDefault({}) TransformationServiceProvider transformationServiceProvider;
 
     protected @NonNullByDefault({}) MqttChannelTypeProvider channelTypeProvider;
+    protected @NonNullByDefault({}) MqttChannelStateDescriptionProvider stateDescriptionProvider;
+    protected @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
 
     protected final Bridge bridgeThing = BridgeBuilder.create(BRIDGE_TYPE_UID, BRIDGE_UID).build();
     protected final BrokerHandler bridgeHandler = spy(new BrokerHandler(bridgeThing));
@@ -102,6 +106,8 @@ public abstract class AbstractHomeAssistantTests extends JavaTest {
                 .thenReturn(jinjaTransformationService);
 
         channelTypeProvider = spy(new MqttChannelTypeProvider(thingTypeRegistry));
+        stateDescriptionProvider = spy(new MqttChannelStateDescriptionProvider());
+        channelTypeRegistry = spy(new ChannelTypeRegistry());
 
         setupConnection();
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.openhab.binding.mqtt.generic.MqttChannelStateDescriptionProvider;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.generic.values.Value;
@@ -45,6 +46,7 @@ import org.openhab.core.library.types.HSBType;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -76,8 +78,8 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
 
         when(callbackMock.getBridge(eq(BRIDGE_UID))).thenReturn(bridgeThing);
 
-        thingHandler = new LatchThingHandler(haThing, channelTypeProvider, transformationServiceProvider,
-                SUBSCRIBE_TIMEOUT, ATTRIBUTE_RECEIVE_TIMEOUT);
+        thingHandler = new LatchThingHandler(haThing, channelTypeProvider, stateDescriptionProvider,
+                channelTypeRegistry, transformationServiceProvider, SUBSCRIBE_TIMEOUT, ATTRIBUTE_RECEIVE_TIMEOUT);
         thingHandler.setConnection(bridgeConnection);
         thingHandler.setCallback(callbackMock);
         thingHandler = spy(thingHandler);
@@ -285,9 +287,11 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
         private @Nullable AbstractComponent<@NonNull ? extends AbstractChannelConfiguration> discoveredComponent;
 
         public LatchThingHandler(Thing thing, MqttChannelTypeProvider channelTypeProvider,
+                MqttChannelStateDescriptionProvider stateDescriptionProvider, ChannelTypeRegistry channelTypeRegistry,
                 TransformationServiceProvider transformationServiceProvider, int subscribeTimeout,
                 int attributeReceiveTimeout) {
-            super(thing, channelTypeProvider, transformationServiceProvider, subscribeTimeout, attributeReceiveTimeout);
+            super(thing, channelTypeProvider, stateDescriptionProvider, channelTypeRegistry,
+                    transformationServiceProvider, subscribeTimeout, attributeReceiveTimeout);
         }
 
         @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
@@ -195,7 +195,7 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
      */
     protected void assertTriggered(AbstractComponent<@NonNull ? extends AbstractChannelConfiguration> component,
             String channelId, String trigger) {
-        verify(thingHandler).triggerChannel(eq(component.getChannel(channelId).getChannelUID()), eq(trigger));
+        verify(thingHandler).triggerChannel(eq(component.getChannel(channelId).getChannel().getUID()), eq(trigger));
     }
 
     /**
@@ -279,7 +279,7 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
     protected void sendCommand(AbstractComponent<@NonNull ? extends AbstractChannelConfiguration> component,
             String channelId, Command command) {
         var channel = Objects.requireNonNull(component.getChannel(channelId));
-        thingHandler.handleCommand(channel.getChannelUID(), command);
+        thingHandler.handleCommand(channel.getChannel().getUID(), command);
     }
 
     protected static class LatchThingHandler extends HomeAssistantThingHandler {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensorTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensorTests.java
@@ -67,7 +67,7 @@ public class BinarySensorTests extends AbstractComponentTests {
         assertThat(component.getName(), is("onoffsensor"));
         assertThat(component.getGroupUID().getId(), is("sn1"));
 
-        assertChannel(component, BinarySensor.SENSOR_CHANNEL_ID, "zigbee2mqtt/sensor/state", "", "value",
+        assertChannel(component, BinarySensor.SENSOR_CHANNEL_ID, "zigbee2mqtt/sensor/state", "", "onoffsensor",
                 OnOffValue.class);
 
         publishMessage("zigbee2mqtt/sensor/state", "{ \"state\": \"ON_\" }");

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensorTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensorTests.java
@@ -65,7 +65,7 @@ public class BinarySensorTests extends AbstractComponentTests {
 
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("onoffsensor"));
-        assertThat(component.getGroupUID().getId(), is("sn1"));
+        assertThat(component.getGroupId(), is("sn1"));
 
         assertChannel(component, BinarySensor.SENSOR_CHANNEL_ID, "zigbee2mqtt/sensor/state", "", "onoffsensor",
                 OnOffValue.class);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SensorTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SensorTests.java
@@ -65,7 +65,7 @@ public class SensorTests extends AbstractComponentTests {
 
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("sensor1"));
-        assertThat(component.getGroupUID().getId(), is("sn1"));
+        assertThat(component.getGroupId(), is("sn1"));
 
         assertChannel(component, Sensor.SENSOR_CHANNEL_ID, "zigbee2mqtt/sensor/state", "", "sensor1",
                 NumberValue.class);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SwitchTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SwitchTests.java
@@ -66,8 +66,8 @@ public class SwitchTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("th1 auto lock"));
 
-        assertChannel(component, Switch.SWITCH_CHANNEL_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/auto_lock", "state",
-                OnOffValue.class);
+        assertChannel(component, Switch.SWITCH_CHANNEL_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/auto_lock",
+                "th1 auto lock", OnOffValue.class);
 
         publishMessage("zigbee2mqtt/th1", "{\"auto_lock\": \"MANUAL\"}");
         assertState(component, Switch.SWITCH_CHANNEL_ID, OnOffType.OFF);
@@ -111,7 +111,7 @@ public class SwitchTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("th1 auto lock"));
 
-        assertChannel(component, Switch.SWITCH_CHANNEL_ID, "zigbee2mqtt/th1", "", "state", OnOffValue.class);
+        assertChannel(component, Switch.SWITCH_CHANNEL_ID, "zigbee2mqtt/th1", "", "th1 auto lock", OnOffValue.class);
 
         publishMessage("zigbee2mqtt/th1", "{\"auto_lock\": \"MANUAL\"}");
         assertState(component, Switch.SWITCH_CHANNEL_ID, OnOffType.OFF);
@@ -151,7 +151,7 @@ public class SwitchTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("th1 auto lock"));
 
-        assertChannel(component, Switch.SWITCH_CHANNEL_ID, "", "zigbee2mqtt/th1/set/auto_lock", "state",
+        assertChannel(component, Switch.SWITCH_CHANNEL_ID, "", "zigbee2mqtt/th1/set/auto_lock", "th1 auto lock",
                 OnOffValue.class);
 
         component.getChannel(Switch.SWITCH_CHANNEL_ID).getState().publishValue(OnOffType.OFF);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandlerTests.java
@@ -37,6 +37,7 @@ import org.openhab.binding.mqtt.homeassistant.internal.component.Sensor;
 import org.openhab.binding.mqtt.homeassistant.internal.component.Switch;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.types.StateDescription;
 
 /**
  * Tests for {@link HomeAssistantThingHandler}
@@ -73,8 +74,8 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
 
         when(callbackMock.getBridge(eq(BRIDGE_UID))).thenReturn(bridgeThing);
 
-        thingHandler = new HomeAssistantThingHandler(haThing, channelTypeProvider, transformationServiceProvider,
-                SUBSCRIBE_TIMEOUT, ATTRIBUTE_RECEIVE_TIMEOUT);
+        thingHandler = new HomeAssistantThingHandler(haThing, channelTypeProvider, stateDescriptionProvider,
+                channelTypeRegistry, transformationServiceProvider, SUBSCRIBE_TIMEOUT, ATTRIBUTE_RECEIVE_TIMEOUT);
         thingHandler.setConnection(bridgeConnection);
         thingHandler.setCallback(callbackMock);
         nonSpyThingHandler = thingHandler;
@@ -106,7 +107,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
 
         thingHandler.delayedProcessing.forceProcessNow();
         assertThat(haThing.getChannels().size(), CoreMatchers.is(6));
-        verify(channelTypeProvider, times(6)).setChannelType(any(), any());
+        verify(stateDescriptionProvider, times(6)).setDescription(any(), any(StateDescription.class));
         verify(channelTypeProvider, times(1)).setChannelGroupType(any(), any());
 
         configTopic = "homeassistant/switch/0x847127fffe11dd6a_auto_lock_zigbee2mqtt/config";
@@ -117,7 +118,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
 
         thingHandler.delayedProcessing.forceProcessNow();
         assertThat(haThing.getChannels().size(), CoreMatchers.is(7));
-        verify(channelTypeProvider, times(7)).setChannelType(any(), any());
+        verify(stateDescriptionProvider, times(7)).setDescription(any(), any(StateDescription.class));
         verify(channelTypeProvider, times(2)).setChannelGroupType(any(), any());
     }
 
@@ -240,7 +241,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
                 getResourceAsByteArray("component/configTS0601AutoLock.json"));
         thingHandler.delayedProcessing.forceProcessNow();
         assertThat(haThing.getChannels().size(), CoreMatchers.is(7));
-        verify(channelTypeProvider, times(7)).setChannelType(any(), any());
+        verify(stateDescriptionProvider, times(7)).setDescription(any(), any(StateDescription.class));
 
         // When dispose
         thingHandler.dispose();
@@ -250,8 +251,8 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
             verify(bridgeConnection, timeout(SUBSCRIBE_TIMEOUT)).unsubscribe(eq(t), any());
         });
 
-        // Expect channel types removed, 6 for climate and 1 for switch
-        verify(channelTypeProvider, times(7)).removeChannelType(any());
+        // Expect channel descriptions removed, 6 for climate and 1 for switch
+        verify(stateDescriptionProvider, times(7)).remove(any());
         // Expect channel group types removed, 1 for each component
         verify(channelTypeProvider, times(2)).removeChannelGroupType(any());
     }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandlerTests.java
@@ -106,9 +106,9 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         verify(thingHandler, times(1)).componentDiscovered(eq(new HaID(configTopic)), any(Climate.class));
 
         thingHandler.delayedProcessing.forceProcessNow();
-        assertThat(haThing.getChannels().size(), CoreMatchers.is(6));
+        assertThat(nonSpyThingHandler.getThing().getChannels().size(), CoreMatchers.is(6));
         verify(stateDescriptionProvider, times(6)).setDescription(any(), any(StateDescription.class));
-        verify(channelTypeProvider, times(1)).setChannelGroupType(any(), any());
+        verify(channelTypeProvider, times(1)).putChannelGroupType(any());
 
         configTopic = "homeassistant/switch/0x847127fffe11dd6a_auto_lock_zigbee2mqtt/config";
         thingHandler.discoverComponents.processMessage(configTopic,
@@ -117,9 +117,9 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         verify(thingHandler, times(1)).componentDiscovered(eq(new HaID(configTopic)), any(Switch.class));
 
         thingHandler.delayedProcessing.forceProcessNow();
-        assertThat(haThing.getChannels().size(), CoreMatchers.is(7));
-        verify(stateDescriptionProvider, times(7)).setDescription(any(), any(StateDescription.class));
-        verify(channelTypeProvider, times(2)).setChannelGroupType(any(), any());
+        assertThat(nonSpyThingHandler.getThing().getChannels().size(), CoreMatchers.is(7));
+        verify(stateDescriptionProvider, atLeast(7)).setDescription(any(), any(StateDescription.class));
+        verify(channelTypeProvider, times(3)).putChannelGroupType(any());
     }
 
     /**
@@ -171,7 +171,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         verify(thingHandler, times(1)).componentDiscovered(eq(new HaID(configTopicTempCorridor)), any(Sensor.class));
         thingHandler.delayedProcessing.forceProcessNow();
         waitForAssert(() -> {
-            assertThat("1 channel created", thingHandler.getThing().getChannels().size() == 1);
+            assertThat("1 channel created", nonSpyThingHandler.getThing().getChannels().size() == 1);
         });
 
         //
@@ -187,7 +187,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         thingHandler.delayedProcessing.forceProcessNow();
         verify(thingHandler, times(1)).componentDiscovered(eq(new HaID(configTopicTempOutside)), any(Sensor.class));
         waitForAssert(() -> {
-            assertThat("2 channel created", thingHandler.getThing().getChannels().size() == 2);
+            assertThat("2 channel created", nonSpyThingHandler.getThing().getChannels().size() == 2);
         });
 
         //
@@ -202,7 +202,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         thingHandler.delayedProcessing.forceProcessNow();
 
         waitForAssert(() -> {
-            assertThat("2 channel created", thingHandler.getThing().getChannels().size() == 2);
+            assertThat("2 channel created", nonSpyThingHandler.getThing().getChannels().size() == 2);
         });
 
         //
@@ -220,7 +220,7 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         verify(thingHandler, times(2)).componentDiscovered(eq(new HaID(configTopicTempCorridor)), any(Sensor.class));
 
         waitForAssert(() -> {
-            assertThat("2 channel created", thingHandler.getThing().getChannels().size() == 2);
+            assertThat("2 channel created", nonSpyThingHandler.getThing().getChannels().size() == 2);
         });
     }
 
@@ -240,8 +240,8 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
                 "homeassistant/switch/0x847127fffe11dd6a_auto_lock_zigbee2mqtt/config",
                 getResourceAsByteArray("component/configTS0601AutoLock.json"));
         thingHandler.delayedProcessing.forceProcessNow();
-        assertThat(haThing.getChannels().size(), CoreMatchers.is(7));
-        verify(stateDescriptionProvider, times(7)).setDescription(any(), any(StateDescription.class));
+        assertThat(nonSpyThingHandler.getThing().getChannels().size(), CoreMatchers.is(7));
+        verify(stateDescriptionProvider, atLeast(7)).setDescription(any(), any(StateDescription.class));
 
         // When dispose
         thingHandler.dispose();
@@ -250,6 +250,28 @@ public class HomeAssistantThingHandlerTests extends AbstractHomeAssistantTests {
         MQTT_TOPICS.forEach(t -> {
             verify(bridgeConnection, timeout(SUBSCRIBE_TIMEOUT)).unsubscribe(eq(t), any());
         });
+    }
+
+    @Test
+    public void testRemoveThing() {
+        thingHandler.initialize();
+
+        // Expect subscription on each topic from config
+        CONFIG_TOPICS.forEach(t -> {
+            var fullTopic = HandlerConfiguration.DEFAULT_BASETOPIC + "/" + t + "/config";
+            verify(bridgeConnection, timeout(SUBSCRIBE_TIMEOUT)).subscribe(eq(fullTopic), any());
+        });
+        thingHandler.discoverComponents.processMessage(
+                "homeassistant/climate/0x847127fffe11dd6a_climate_zigbee2mqtt/config",
+                getResourceAsByteArray("component/configTS0601ClimateThermostat.json"));
+        thingHandler.discoverComponents.processMessage(
+                "homeassistant/switch/0x847127fffe11dd6a_auto_lock_zigbee2mqtt/config",
+                getResourceAsByteArray("component/configTS0601AutoLock.json"));
+        thingHandler.delayedProcessing.forceProcessNow();
+        assertThat(nonSpyThingHandler.getThing().getChannels().size(), CoreMatchers.is(7));
+
+        // When dispose
+        nonSpyThingHandler.handleRemoval();
 
         // Expect channel descriptions removed, 6 for climate and 1 for switch
         verify(stateDescriptionProvider, times(7)).remove(any());

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -60,8 +60,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class HomieThingHandler extends AbstractMQTTThingHandler implements DeviceCallback, Consumer<List<Object>> {
-    private static final String[] EMPTY_ARRAY = new String[] {};
-
     private final Logger logger = LoggerFactory.getLogger(HomieThingHandler.class);
     protected Device device;
     protected final MqttChannelTypeProvider channelTypeProvider;

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.mqtt.homie.internal.handler;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -58,6 +60,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class HomieThingHandler extends AbstractMQTTThingHandler implements DeviceCallback, Consumer<List<Object>> {
+    private static final String[] EMPTY_ARRAY = new String[] {};
+
     private final Logger logger = LoggerFactory.getLogger(HomieThingHandler.class);
     protected Device device;
     protected final MqttChannelTypeProvider channelTypeProvider;
@@ -140,6 +144,8 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
         if (config.removetopics) {
             this.removeRetainedTopics();
         }
+        channelTypeProvider.removeThingType(thing.getThingTypeUID());
+        channelTypeProvider.removeChannelGroupTypesForPrefix(thing.getThingTypeUID().getId());
         super.handleRemoval();
     }
 
@@ -169,7 +175,6 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
         }
         delayedProcessing.join();
         device.stop();
-        channelTypeProvider.removeThingType(device.thingTypeUID);
         super.stop();
     }
 
@@ -216,7 +221,6 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
 
     @Override
     public void nodeRemoved(Node node) {
-        channelTypeProvider.removeChannelGroupType(node.channelGroupTypeUID);
         delayedProcessing.accept(node);
     }
 
@@ -228,7 +232,6 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
 
     @Override
     public void nodeAddedOrChanged(Node node) {
-        channelTypeProvider.setChannelGroupType(node.channelGroupTypeUID, node.type());
         delayedProcessing.accept(node);
     }
 
@@ -288,27 +291,42 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
     private void updateThingType() {
         // Make sure any dynamic channel types exist (i.e. ones created for a number channel with a specific dimension)
         device.nodes.stream().flatMap(n -> n.properties.stream()).map(Property::getChannelType).filter(Objects::nonNull)
-                .forEach(ct -> channelTypeProvider.setChannelType(ct.getUID(), ct));
+                .forEach(ct -> channelTypeProvider.putChannelType(Objects.requireNonNull(ct)));
 
         // if this is a dynamic type, then we update the type
         ThingTypeUID typeID = device.thingTypeUID;
         if (!MqttBindingConstants.HOMIE300_MQTT_THING.equals(typeID)) {
-            device.nodes.stream()
-                    .forEach(n -> channelTypeProvider.setChannelGroupType(n.channelGroupTypeUID, n.type()));
+            channelTypeProvider.updateChannelGroupTypesForPrefix(thing.getThingTypeUID().getId(), device.nodes.stream()
+                    .map(n -> n.type(thing.getThingTypeUID().getId(), channelTypeProvider)).toList());
 
-            List<ChannelGroupDefinition> groupDefs = device.nodes().stream().map(Node::getChannelGroupDefinition)
-                    .collect(Collectors.toList());
+            List<ChannelGroupDefinition> groupDefs = device.nodes.stream(nodeOrder())
+                    .map(n -> n.getChannelGroupDefinition(thing.getThingTypeUID().getId())).toList();
             var builder = channelTypeProvider.derive(typeID, MqttBindingConstants.HOMIE300_MQTT_THING)
                     .withChannelGroupDefinitions(groupDefs);
-            ThingType thingType = builder.build();
 
-            channelTypeProvider.setThingType(typeID, thingType);
+            channelTypeProvider.putThingType(builder.build());
         }
     }
 
     private void updateChannels() {
-        List<Channel> channels = device.nodes().stream().flatMap(n -> n.properties.stream())
-                .map(p -> p.getChannel(channelTypeRegistry)).collect(Collectors.toList());
+        List<Channel> channels = device.nodes.stream(nodeOrder())
+                .flatMap(node -> node.properties
+                        .stream(node.propertyOrder(thing.getThingTypeUID().getId(), channelTypeProvider))
+                        .map(p -> p.getChannel(channelTypeRegistry)))
+                .toList();
         updateThing(editThing().withChannels(channels).build());
+    }
+
+    private Collection<String> nodeOrder() {
+        String[] nodes = device.attributes.nodes;
+        if (nodes != null) {
+            return Stream.of(nodes).toList();
+        }
+        ThingType thingType = channelTypeProvider.getThingType(thing.getThingTypeUID(), null);
+        if (thingType != null) {
+            return thingType.getChannelGroupDefinitions().stream().map(ChannelGroupDefinition::getId).toList();
+        }
+
+        return device.nodes.keySet();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.mqtt.homie.internal.homie300;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +23,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass;
 import org.openhab.binding.mqtt.generic.tools.ChildMap;
 import org.openhab.binding.mqtt.homie.generic.internal.MqttBindingConstants;
@@ -47,6 +49,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class Node implements AbstractMqttAttributeClass.AttributeChanged {
+    private static final String[] EMPTY_ARRAY = new String[] {};
+
     private final Logger logger = LoggerFactory.getLogger(Node.class);
     // Homie
     public final String nodeID;
@@ -55,7 +59,6 @@ public class Node implements AbstractMqttAttributeClass.AttributeChanged {
     // Runtime
     public final DeviceCallback callback;
     protected final ChannelGroupUID channelGroupUID;
-    public final ChannelGroupTypeUID channelGroupTypeUID;
     private final String topic;
     private boolean initialized = false;
 
@@ -72,7 +75,6 @@ public class Node implements AbstractMqttAttributeClass.AttributeChanged {
         this.topic = topic + "/" + nodeID;
         this.nodeID = nodeID;
         this.callback = callback;
-        channelGroupTypeUID = new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID, UIDUtils.encode(this.topic));
         channelGroupUID = new ChannelGroupUID(thingUID, UIDUtils.encode(nodeID));
         properties = new ChildMap<>();
     }
@@ -117,15 +119,16 @@ public class Node implements AbstractMqttAttributeClass.AttributeChanged {
     /**
      * Return the channel group type for this Node.
      */
-    public ChannelGroupType type() {
-        final List<ChannelDefinition> channelDefinitions = properties.stream()
-                .map(p -> Objects.requireNonNull(p.getChannelDefinition())).collect(Collectors.toList());
-        return ChannelGroupTypeBuilder.instance(channelGroupTypeUID, attributes.name)
+    public ChannelGroupType type(String prefix, MqttChannelTypeProvider channelTypeProvider) {
+        final List<ChannelDefinition> channelDefinitions = properties.stream(propertyOrder(prefix, channelTypeProvider))
+                .map(p -> Objects.requireNonNull(p.getChannelDefinition())).toList();
+        return ChannelGroupTypeBuilder.instance(getChannelGroupTypeUID(prefix), attributes.name)
                 .withChannelDefinitions(channelDefinitions).build();
     }
 
-    public ChannelGroupDefinition getChannelGroupDefinition() {
-        return new ChannelGroupDefinition(channelGroupUID.getId(), channelGroupTypeUID, attributes.name, null);
+    public ChannelGroupDefinition getChannelGroupDefinition(String prefix) {
+        return new ChannelGroupDefinition(channelGroupUID.getId(), getChannelGroupTypeUID(prefix), attributes.name,
+                null);
     }
 
     /**
@@ -219,5 +222,22 @@ public class Node implements AbstractMqttAttributeClass.AttributeChanged {
                 .collect(Collectors.toList()).forEach(topics::addAll);
 
         return topics;
+    }
+
+    public Collection<String> propertyOrder(String prefix, MqttChannelTypeProvider channelTypeProvider) {
+        String[] properties = attributes.properties;
+        if (properties != null) {
+            return Stream.of(properties).toList();
+        }
+        ChannelGroupType channelGroupType = channelTypeProvider.getChannelGroupType(getChannelGroupTypeUID(prefix),
+                null);
+        if (channelGroupType != null) {
+            return channelGroupType.getChannelDefinitions().stream().map(ChannelDefinition::getId).toList();
+        }
+        return this.properties.keySet();
+    }
+
+    private ChannelGroupTypeUID getChannelGroupTypeUID(String prefix) {
+        return new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID, prefix + "_" + UIDUtils.encode(this.topic));
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
@@ -49,8 +49,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class Node implements AbstractMqttAttributeClass.AttributeChanged {
-    private static final String[] EMPTY_ARRAY = new String[] {};
-
     private final Logger logger = LoggerFactory.getLogger(Node.class);
     // Homie
     public final String nodeID;

--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
@@ -62,6 +62,7 @@ import org.openhab.binding.mqtt.homie.internal.homie300.PropertyAttributes.DataT
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -99,7 +100,8 @@ public class HomieThingHandlerTests {
     private @NonNullByDefault({}) Thing thing;
     private @NonNullByDefault({}) HomieThingHandler thingHandler;
 
-    private final MqttChannelTypeProvider channelTypeProvider = spy(new MqttChannelTypeProvider(thingTypeRegistryMock));
+    private final MqttChannelTypeProvider channelTypeProvider = spy(
+            new MqttChannelTypeProvider(thingTypeRegistryMock, new VolatileStorageService()));
     private final MqttChannelStateDescriptionProvider stateDescriptionProvider = new MqttChannelStateDescriptionProvider();
 
     private final String deviceID = ThingChannelConstants.TEST_HOMIE_THING.getId();

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/DiscoverComponentsTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/DiscoverComponentsTest.java
@@ -84,7 +84,7 @@ public class DiscoverComponentsTest extends JavaOSGiTest {
         Gson gson = new GsonBuilder().registerTypeAdapterFactory(new ChannelConfigurationTypeAdapterFactory()).create();
 
         DiscoverComponents discover = spy(new DiscoverComponents(ThingChannelConstants.TEST_HOME_ASSISTANT_THING,
-                scheduler, channelStateUpdateListener, availabilityTracker, gson, transformationServiceProvider));
+                scheduler, channelStateUpdateListener, availabilityTracker, gson, transformationServiceProvider, true));
 
         HandlerConfiguration config = new HandlerConfiguration("homeassistant", List.of("switch/object"));
 

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
@@ -161,7 +161,8 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         ComponentDiscovered cd = (haID, c) -> {
             haComponents.put(c.getGroupUID().getId(), c);
             c.addChannelTypes(channelTypeProvider);
-            channelTypeProvider.putChannelGroupType(Objects.requireNonNull(c.getGroupTypeUID()), Objects.requireNonNull(c.getType()));
+            channelTypeProvider.putChannelGroupType(Objects.requireNonNull(c.getGroupTypeUID()),
+                    Objects.requireNonNull(c.getType()));
             latch.countDown();
         };
 

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
@@ -161,8 +161,7 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         ComponentDiscovered cd = (haID, c) -> {
             haComponents.put(c.getGroupUID().getId(), c);
             c.addChannelTypes(channelTypeProvider);
-            channelTypeProvider.setChannelGroupType(Objects.requireNonNull(c.getGroupTypeUID()),
-                    Objects.requireNonNull(c.getType()));
+            channelTypeProvider.putChannelGroupType(Objects.requireNonNull(c.getGroupTypeUID()), Objects.requireNonNull(c.getType()));
             latch.countDown();
         };
 
@@ -182,9 +181,9 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         assertThat(haComponents.size(), is(1));
 
         // For the switch component we should have one channel group type and one channel type
-        // setChannelGroupType is called once above
-        verify(channelTypeProvider, times(2)).setChannelGroupType(any(), any());
-        verify(channelTypeProvider, times(1)).setChannelType(any(), any());
+        // putChannelGroupType is called once above
+        verify(channelTypeProvider, times(2)).putChannelGroupType(any(), any());
+        verify(channelTypeProvider, times(1)).putChannelType(any(), any());
 
         String channelGroupId = UIDUtils
                 .encode("node_" + ThingChannelConstants.TEST_HOME_ASSISTANT_THING.getId() + "_switch");

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
@@ -55,7 +55,6 @@ import org.openhab.core.io.transport.mqtt.MqttConnectionState;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
-import org.openhab.core.util.UIDUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -177,10 +176,10 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         assertNull(failure);
         assertThat(haComponents.size(), is(1));
 
-        String channelGroupId = UIDUtils
-                .encode("node_" + ThingChannelConstants.TEST_HOME_ASSISTANT_THING.getId() + "_switch");
+        String channelGroupId = "switch_" + ThingChannelConstants.TEST_HOME_ASSISTANT_THING.getId();
+        String channelId = Switch.SWITCH_CHANNEL_ID;
 
-        State value = haComponents.get(channelGroupId).getChannel(Switch.SWITCH_CHANNEL_ID).getState().getCache()
+        State value = haComponents.get(channelGroupId).getChannel(channelGroupId).getState().getCache()
                 .getChannelState();
         assertThat(value, is(UnDefType.UNDEF));
 
@@ -194,8 +193,7 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         verify(channelStateUpdateListener, timeout(4000).times(1)).updateChannelState(any(), any());
 
         // Value should be ON now.
-        value = haComponents.get(channelGroupId).getChannel(Switch.SWITCH_CHANNEL_ID).getState().getCache()
-                .getChannelState();
+        value = haComponents.get(channelGroupId).getChannel(channelGroupId).getState().getCache().getChannelState();
         assertThat(value, is(OnOffType.ON));
     }
 }


### PR DESCRIPTION
This is a rather large PR, but is built of a few commits with essentially two distinct goals. I have not tested them individually, and there are lots of interactions between the two goals, which is why I did not disentangle them.

This first goal is to simplify and optimize thing and channel types for mqtt.homeassistant. This fixes #14295. This in itself has two user visible changes:
 * Thing types have not actually changed, but thing *UIDs* have. Auto Discovery will no longer use the per-thing thing type in the thing ID, but will use the "base" thing type (available in the binding's XML) of `mqtt:homeassistant` in its ID. In practice, newly discovered things will get UIDs such as `mqtt:homeassistant:mosquitto:awair-element-63611` instead of `mqtt:homeassistant_awair_2Delement_2D63611:mosquitto:awair_2Delement_2D63611` (unnecessary escaping has also been removed). Existing things will not change their UID. I'm not sure if this is considered a breaking change, since existing things will not change at all. But if you were to delete the thing, and re-add it from discovery, it would end up with a different ID. This new behavior matches how mqtt.homie works.
 * Channel IDs have been simplified. First, if a component has no name (in the Home Assistant configuration), it will not generate a channel group at all. Second, the channel group name is now only the component's name, instead of including the entire thing ID in the channel group, it is now only the component name (which already has to be unique within a Home Assistant device, so not a problem there). The channel group *type* (which is unseen by the user) remains the fully unique id, which includes the thing id. Third, if a component only has a single channel, it also doesn't create a channel group, just a single channel for that component without a group.
   For this change, I did a bit of hoop-jumping to pass a property through from auto-discovery, so that existing things will not have their channels change, only newly discovered and created things will use this new channel type. Again, I'm not sure if this counts as a breaking change. If it does, I'm possibly inclined to _not_ use this hinky property, and simply apply the new channel IDs to all things. An example change is from `mqtt:homeassistant_zigbee2mqtt_5F0x8cf681fffe32e58e:mosquitto:zigbee2mqtt_5F0x8cf681fffe32e58e:0x8cf681fffe32e58e_5Fbattery_5Fzigbee2mqtt#sensor` to `mqtt:homeassistant:mosquitto:zigbee2mqtt_5F0x8cf681fffe32e58e:sensor_battery`

The second goal is relatively simple - use AbstractStorageBasedTypeProvider. Because the thing and channel group types are dynamic, they don't exist in the binding's XML. But since openHAB 4.0, if a thing type isn't available at startup, it will leave the thing in an unknown state for two minutes before it initializes it. By using AbstractStorageBasedTypeProvider, the dynamic types will be persisted to JSON storage, and thus available immediately at startup, avoiding the two minute delay. This fixes #15577
