### PR TITLE
[awattar] Declare countries

### DIFF
--- a/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/addon/addon.xml
@@ -7,5 +7,6 @@
 	<name>aWATTar Binding</name>
 	<description>Hourly Electricity Prices for Germany and Austria.</description>
 	<connection>cloud</connection>
+	<countries>at,de</countries>
 
 </addon:addon>


### PR DESCRIPTION
According to the [documentation](https://www.openhab.org/addons/bindings/awattar/) this binding is for the German and Austrian provider aWATTar, and Thing configuration parameter `country` should be either AT or DE.