### PR TITLE
[jdbc] Provide better MySQL datatype for `DateTimeType`

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMysqlDAO.java
@@ -90,7 +90,7 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
         this.dbMeta = dbMeta;
         // Initialize sqlTypes, depending on DB version for example
         if (dbMeta.isDbVersionGreater(5, 5)) {
-            sqlTypes.put("DATETIMEITEM", "TIMESTAMP(3)");
+            sqlTypes.put("DATETIMEITEM", "DATETIME(3)");
             sqlTypes.put("tablePrimaryKey", "TIMESTAMP(3)");
             sqlTypes.put("tablePrimaryValue", "NOW(3)");
         }


### PR DESCRIPTION
See analysis here: https://github.com/openhab/openhab-addons/issues/15697#issuecomment-2032937666
And test results here: https://github.com/openhab/openhab-addons/issues/15697#issuecomment-2032983898

I can currently only test MySQL, so I have scoped the fix accordingly, although other implementations may suffer from something similar.

Resolves #15697
Regression of openhab/openhab1-addons#4605 (in MySQL, both `DATETIME` and `TIMESTAMP` support microsecond precision)