### PR TITLE
Provide unit hints for humidity/noise/volume channels

### DIFF
--- a/bundles/org.openhab.binding.airq/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.airq/src/main/resources/OH-INF/thing/thing-types.xml
@@ -223,7 +223,7 @@
 	</channel-type>
 
 	<channel-type id="humidity" advanced="false">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<state readOnly="true" pattern="%.2f %%"></state>
 	</channel-type>
@@ -380,13 +380,13 @@
 	</channel-type>
 
 	<channel-type id="humidity_maxerr" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Max. Error Humidity</label>
 		<state readOnly="true" pattern="± %.2f %%"></state>
 	</channel-type>
 
 	<channel-type id="humidity_abs_maxerr" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Max. Error Abs. Humidity</label>
 		<state readOnly="true" pattern="± %.2f %%"></state>
 	</channel-type>

--- a/bundles/org.openhab.binding.airq/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.airq/src/main/resources/OH-INF/thing/thing-types.xml
@@ -295,7 +295,7 @@
 	</channel-type>
 
 	<channel-type id="sound" advanced="false">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Noise</label>
 		<state readOnly="true" pattern="%.1f %unit%"></state>
 	</channel-type>

--- a/bundles/org.openhab.binding.airvisualnode/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/resources/OH-INF/thing/thing-types.xml
@@ -71,7 +71,7 @@
 	</channel-type>
 
 	<channel-type id="Humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Humidity, %</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -636,7 +636,7 @@
 	</channel-type>
 	<!-- Alexa.HumiditySensor -->
 	<channel-type id="relativeHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Relative humidity measured by the thermostat.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.ambientweather/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.ambientweather/src/main/resources/OH-INF/thing/channels.xml
@@ -50,7 +50,7 @@
 	</channel-type>
 
 	<channel-type id="relativeHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Relative Humidity</label>
 		<description>Forecast relative humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/thing/channel-types.xml
@@ -122,7 +122,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Current Humidity</label>
 		<description>Current measured humidity.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.bluetooth.airthings/src/main/resources/OH-INF/thing/airthings.xml
+++ b/bundles/org.openhab.binding.bluetooth.airthings/src/main/resources/OH-INF/thing/airthings.xml
@@ -102,7 +102,7 @@
 	</thing-type>
 
 	<channel-type id="airthings_humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Humidity level</description>
 		<state readOnly="true" pattern="%.1f %%"/>

--- a/bundles/org.openhab.binding.bluetooth.blukii/src/main/resources/OH-INF/thing/blukii.xml
+++ b/bundles/org.openhab.binding.bluetooth.blukii/src/main/resources/OH-INF/thing/blukii.xml
@@ -44,7 +44,7 @@
 	</channel-type>
 
 	<channel-type id="blukii_humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.bluetooth.ruuvitag/src/main/resources/OH-INF/thing/ruuvitag.xml
+++ b/bundles/org.openhab.binding.bluetooth.ruuvitag/src/main/resources/OH-INF/thing/ruuvitag.xml
@@ -64,7 +64,7 @@
 		<state readOnly="true" pattern="%.0f"/>
 	</channel-type>
 	<channel-type id="ruuvitag_humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.boschshc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -549,7 +549,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current measured humidity.</description>
 		<state readOnly="true"/>

--- a/bundles/org.openhab.binding.bticinosmarther/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.bticinosmarther/src/main/resources/OH-INF/thing/thing-types.xml
@@ -87,7 +87,7 @@
 	</channel-type>
 
 	<channel-type id="measures-humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Indoor humidity as measured by the sensor</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.daikin/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.daikin/src/main/resources/OH-INF/thing/thing-types.xml
@@ -115,7 +115,7 @@
 	</channel-type>
 
 	<channel-type id="acunit-humidity" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Indoor Humidity</label>
 		<description>The indoor humidity as measured by the A/C unit</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/sensor-channel-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/sensor-channel-types.xml
@@ -126,7 +126,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
@@ -243,7 +243,7 @@
 	</channel-type>
 
 	<channel-type id="atmospheric-humidity-channel">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current relative humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecobee/src/main/resources/OH-INF/thing/thing-types.xml
@@ -260,7 +260,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="actualHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Actual Humidity</label>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
@@ -285,12 +285,12 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="desiredHumidity" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Desired Humidity</label>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="desiredDehumidity" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Desired Dehumidity</label>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
@@ -1389,7 +1389,7 @@
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="weatherRelativeHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Relative Humidity</label>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
@@ -1739,7 +1739,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="sensorHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Sensor Humidity</label>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.electroluxair/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.electroluxair/src/main/resources/OH-INF/thing/thing-types.xml
@@ -89,7 +89,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
@@ -53,7 +53,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<category>Humidity</category>
 		<tags>

--- a/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/thing/thing-types.xml
@@ -318,7 +318,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="humidity-channel">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<category>Humidity</category>
 		<state readOnly="true" pattern="%.1f %unit%"/>

--- a/bundles/org.openhab.binding.foobot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.foobot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -82,7 +82,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Humidity Level</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/thing/channel-types.xml
@@ -449,7 +449,7 @@
 	</channel-type>
 
 	<channel-type id="alarm-volume">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Alarm Volume</label>
 		<category>oh:freeboxos:sirene</category>
 		<state min="0" max="100" step="1" pattern="%d %unit%"/>

--- a/bundles/org.openhab.binding.gardena/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gardena/src/main/resources/OH-INF/thing/thing-types.xml
@@ -597,7 +597,7 @@
 	</channel-type>
 
 	<channel-type id="soilHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Soil Humidity</label>
 		<description>Soil humidity</description>
 		<state readOnly="true" pattern="%d %%"/>

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/thing/thing-types.xml
@@ -123,7 +123,7 @@
 		<description>Valve switch</description>
 	</channel-type>
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>The humidity reported by the device</description>
 		<state readOnly="true" pattern="%.1f %unit%"/>

--- a/bundles/org.openhab.binding.ipobserver/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipobserver/src/main/resources/OH-INF/thing/thing-types.xml
@@ -97,7 +97,7 @@
 		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="humidityIndoor">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Indoor Humidity</label>
 		<description>Current Humidity Indoors</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/OH-INF/thing/thing-types.xml
@@ -485,7 +485,7 @@
 
 	<!-- Humidity Channel Type -->
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>@text/channel-type.humidity.label</label>
 		<description>@text/channel-type.humidity.description</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
@@ -84,7 +84,7 @@
 		</config-description>
 	</channel-type>
 	<channel-type id="humidity-wifi">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>This zone measures humidity</description>
 		<state readOnly="true"/>
@@ -265,7 +265,7 @@
 		</config-description>
 	</channel-type>
 	<channel-type id="humidity-pro">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>This zone measures humidity</description>
 		<state readOnly="true"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/channels.xml
@@ -96,7 +96,7 @@
 
 	<!-- HumiditySensor -->
 	<channel-type id="humiditySensorHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Actual Humidity</label>
 		<description>Actual measured room humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.mihome/src/main/resources/OH-INF/thing/channel.xml
+++ b/bundles/org.openhab.binding.mihome/src/main/resources/OH-INF/thing/channel.xml
@@ -124,7 +124,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<category>Humidity</category>
 		<state pattern="%.1f %unit%" readOnly="true">

--- a/bundles/org.openhab.binding.modbus.helioseasycontrols/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.helioseasycontrols/src/main/resources/OH-INF/thing/thing-types.xml
@@ -338,7 +338,7 @@
 	</channel-type>
 
 	<channel-type id="humidityControlSetValue" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity Control Set Value</label>
 		<description>Humidity control set value (in percent)</description>
 		<category>Humidity</category>
@@ -346,7 +346,7 @@
 	</channel-type>
 
 	<channel-type id="humidityControlSteps" advanced="true">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity Control Steps</label>
 		<description>Humidity control steps (in percent)</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.modbus.stiebeleltron/src/main/resources/OH-INF/thing/heatpump-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.stiebeleltron/src/main/resources/OH-INF/thing/heatpump-channel-types.xml
@@ -16,7 +16,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="fek-humidity-type">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>FEK Humidity</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/resources/OH-INF/thing/thing-types.xml
@@ -93,7 +93,7 @@
 		<state readOnly="true" pattern="%.0f"/>
 	</channel-type>
 	<channel-type id="ruuvitag_humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.nest/src/main/resources/OH-INF/thing/sdm-channels.xml
+++ b/bundles/org.openhab.binding.nest/src/main/resources/OH-INF/thing/sdm-channels.xml
@@ -121,7 +121,7 @@
 
 	<!-- Thermostat -->
 	<channel-type id="SDMAmbientHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Ambient Humidity</label>
 		<description>Lists the current ambient humidity percentage from the thermostat</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/thing/channels.xml
@@ -285,7 +285,7 @@
 	</channel-type>
 
 	<channel-type id="noise">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Noise</label>
 		<description>Current Noise Level.</description>
 		<category>SoundVolume</category>

--- a/bundles/org.openhab.binding.omnilink/src/main/resources/OH-INF/thing/humidity-sensor.xml
+++ b/bundles/org.openhab.binding.omnilink/src/main/resources/OH-INF/thing/humidity-sensor.xml
@@ -27,7 +27,7 @@
 
 	<!-- Humidity Channels -->
 	<channel-type id="sensor_humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>The current relative humidity at this humidity sensor.</description>
 		<category>Humidity</category>
@@ -39,7 +39,7 @@
 	</channel-type>
 
 	<channel-type id="sensor_humidity_low_setpoint">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Low SetPoint</label>
 		<description>The current low setpoint for this humidity sensor.</description>
 		<category>Humidity</category>
@@ -47,7 +47,7 @@
 	</channel-type>
 
 	<channel-type id="sensor_humidity_high_setpoint">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>High SetPoint</label>
 		<description>The current high setpoint for this humidity sensor.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.onewire/src/main/resources/OH-INF/thing/common.xml
+++ b/bundles/org.openhab.binding.onewire/src/main/resources/OH-INF/thing/common.xml
@@ -63,13 +63,13 @@
 	</channel-type>
 	<!-- Relative Humidity Channel -->
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Relative humidity (0-100%)</description>
 		<state readOnly="true" pattern="%.0f %%"/>
 	</channel-type>
 	<channel-type id="humidityconf">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Relative humidity (0-100%)</description>
 		<state readOnly="true" pattern="%.0f %%"/>

--- a/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
@@ -593,7 +593,7 @@
 	</channel-type>
 
 	<channel-type id="vh_relativehumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Relative Humidity</label>
 		<description>Relative humidity exhaust air</description>
 		<state readOnly="true" pattern="%d %%"/>

--- a/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/resources/OH-INF/thing/channel-types.xml
@@ -603,7 +603,7 @@
 	</channel-type>
 
 	<channel-type id="forecasted-atmospheric-humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Forecasted Humidity</label>
 		<description>Forecasted atmospheric relative humidity.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/thing/channel.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/OH-INF/thing/channel.xml
@@ -13,7 +13,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current relative humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -50,7 +50,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>The Current Humidity Reading of the Thermostat</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.robonect/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.robonect/src/main/resources/OH-INF/thing/thing-types.xml
@@ -149,7 +149,7 @@
 	</channel-type>
 
 	<channel-type id="humidityType">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>The relative humidity in the mower in percent</description>
 		<state readOnly="true" pattern="%d %%"/>

--- a/bundles/org.openhab.binding.sensibo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.sensibo/src/main/resources/OH-INF/thing/channels.xml
@@ -15,7 +15,7 @@
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="currentHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Current Humidity</label>
 		<category>Humidity</category>
 		<tags>

--- a/bundles/org.openhab.binding.sensorcommunity/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sensorcommunity/src/main/resources/OH-INF/thing/thing-types.xml
@@ -108,19 +108,19 @@
 		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="noise-eq-channel">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Average Noise</label>
 		<description>Average noise level from the selected Sensor ID</description>
 		<state pattern="%.1f dB" readOnly="true"/>
 	</channel-type>
 	<channel-type id="noise-min-channel">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Minimum Noise</label>
 		<description>Minimum noise level (last 2.5 minutes) from the selected Sensor ID</description>
 		<state pattern="%.1f dB" readOnly="true"/>
 	</channel-type>
 	<channel-type id="noise-max-channel">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Maximum Noise</label>
 		<description>Maximum noise level (last 2.5 minutes) from the selected Sensor ID</description>
 		<state pattern="%.1f dB" readOnly="true"/>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_sensor.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_sensor.xml
@@ -310,7 +310,7 @@
 	</channel-type>
 
 	<channel-type id="sensorHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>@text/channel-type.shelly.sensorHumidity.label</label>
 		<description>@text/channel-type.shelly.sensorHumidity.description</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
@@ -149,7 +149,7 @@
 	</channel-type>
 
 	<channel-type id="roomHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Measured humidity value</description>
 		<category>humidity</category>

--- a/bundles/org.openhab.binding.somfytahoma/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/resources/OH-INF/thing/channels.xml
@@ -156,7 +156,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Relative Humidity</label>
 		<description>The current relative humidity</description>
 		<state readOnly="true" min="0" max="100" pattern="%f.1 %unit%"/>

--- a/bundles/org.openhab.binding.somneo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.somneo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -439,7 +439,7 @@
 	</channel-type>
 
 	<channel-type id="noise">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Noise</label>
 		<description>The current noise in dB.</description>
 		<category>Noise</category>

--- a/bundles/org.openhab.binding.somneo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.somneo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -404,7 +404,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>The current humidity in %.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.tellstick/src/main/resources/OH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/resources/OH-INF/thing/sensor.xml
@@ -80,7 +80,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Actual measured room Humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.valloxmv/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.valloxmv/src/main/resources/OH-INF/thing/thing-types.xml
@@ -145,7 +145,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current humidity of the air flow exhausting the building.</description>
 		<state readOnly="true" min="0" max="100" pattern="%d %unit%"/>

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -337,7 +337,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Indoor Humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.ventaair/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.ventaair/src/main/resources/OH-INF/thing/channels.xml
@@ -96,7 +96,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current Humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.verisure/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.verisure/src/main/resources/OH-INF/thing/thing-types.xml
@@ -665,7 +665,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Current humidity in %.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.vesync/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.vesync/src/main/resources/OH-INF/thing/thing-types.xml
@@ -285,14 +285,14 @@
 	</channel-type>
 
 	<channel-type id="deviceHumidityType">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity Level</label>
 		<description>System representation of humidity</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 
 	<channel-type id="deviceConfigTargetHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity Set Point</label>
 		<description>Humidity Set Point</description>
 		<state readOnly="false" pattern="%.0f %unit%"/>

--- a/bundles/org.openhab.binding.weathercompany/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.weathercompany/src/main/resources/OH-INF/thing/thing-types.xml
@@ -390,7 +390,7 @@
 	</channel-type>
 
 	<channel-type id="relativeHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Relative Humidity</label>
 		<description>Forecasted relative humidity</description>
 		<state readOnly="true" pattern="%.0f %unit%"/>

--- a/bundles/org.openhab.binding.weatherunderground/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/resources/OH-INF/thing/thing-types.xml
@@ -301,7 +301,7 @@
 	</channel-type>
 
 	<channel-type id="relativeHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Relative Humidity</label>
 		<description>Forecast relative humidity</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-types.xml
@@ -126,7 +126,7 @@
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Outdoor Humidity</label>
 		<description>Outdoor humidity in %.</description>
 		<category>Humidity</category>
@@ -138,7 +138,7 @@
 	</channel-type>
 
 	<channel-type id="indoor-humidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Indoor Humidity</label>
 		<description>Indoor humidity in %.</description>
 		<category>Humidity</category>

--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/thing/thing-types.xml
@@ -96,7 +96,7 @@
 		<category>SoundVolume</category>
 	</channel-type>
 	<channel-type id="volumeDB">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Volume in dB</label>
 		<description>Volume level - decibel (dB)</description>
 		<category>SoundVolume</category>


### PR DESCRIPTION
Depends on openhab/openhab-core#4079

Based on these searches:
```shell
grep -R "<item-type>Number:Dimensionless</item-type>" -B 1 | grep -i humidity | sort
grep -R "<item-type>Number:Dimensionless</item-type>" -B 1 | grep -i noise | sort
grep -R "<item-type>Number:Dimensionless</item-type>" -B 1 | grep -i sound | sort
grep -R "<item-type>Number:Dimensionless</item-type>" -B 1 | grep -i volume | sort
```