### PR TITLE
[siemensrds] Remove r.H. from humidity state description pattern

### DIFF
--- a/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
@@ -149,11 +149,11 @@
 	</channel-type>
 
 	<channel-type id="roomHumidity">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type unitHint="%">Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Measured humidity value</description>
 		<category>humidity</category>
-		<state readOnly="true" pattern="%.0f %%r.H."/>
+		<state readOnly="true" pattern="%.0f %%"/>
 	</channel-type>
 
 	<channel-type id="roomAirQuality">

--- a/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
@@ -149,7 +149,7 @@
 	</channel-type>
 
 	<channel-type id="roomHumidity">
-		<item-type unitHint="%">Number:Dimensionless</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Measured humidity value</description>
 		<category>humidity</category>


### PR DESCRIPTION
Remove "r.H." from state description pattern.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>