### PR TITLE
[tibber] Add two channels: consumption and production for current hour

### DIFF
--- a/bundles/org.openhab.binding.tibber/README.md
+++ b/bundles/org.openhab.binding.tibber/README.md
@@ -37,29 +37,31 @@ Tibber Default:
 
 Tibber Pulse (optional):
 
-| Channel ID                  | Description                              | Read-only |
-|-----------------------------|------------------------------------------|-----------|
-| live_timestamp              | Timestamp for live measurements          | True      |
-| live_power                  | Live Power Consumption                   | True      |
-| live_lastMeterConsumption   | Last Recorded Meter Consumption          | True      |
-| live_accumulatedConsumption | Accumulated Consumption since Midnight   | True      |
-| live_accumulatedCost        | Accumulated Cost since Midnight          | True      |
-| live_accumulatedReward      | Accumulated Reward since Midnight        | True      |
-| live_currency               | Currency of Cost                         | True      |
-| live_minPower               | Min Power Consumption since Midnight     | True      |
-| live_averagePower           | Average Power Consumption since Midnight | True      |
-| live_maxPower               | Max Power Consumption since Midnight     | True      |
-| live_voltage1               | Voltage Phase 1                          | True      |
-| live_voltage2               | Voltage Phase  2                         | True      |
-| live_voltage3               | Voltage Phase 3                          | True      |
-| live_current1               | Current Phase 1                          | True      |
-| live_current2               | Current Phase 2                          | True      |
-| live_current3               | Current Phase 3                          | True      |
-| live_powerProduction        | Live Power Production                    | True      |
-| live_accumulatedProduction  | Accumulated Production since Midnight    | True      |
-| live_lastMeterProduction    | Last Recorded Meter Production           | True      |
-| live_minPowerproduction     | Min Power Production since Midnight      | True      |
-| live_maxPowerproduction     | Max Power Production since Midnight      | True      |
+| Channel ID                          | Description                                   | Read-only |
+|-------------------------------------|-----------------------------------------------|-----------|
+| live_timestamp                      | Timestamp for live measurements               | True      |
+| live_power                          | Live Power Consumption                        | True      |
+| live_lastMeterConsumption           | Last Recorded Meter Consumption               | True      |
+| live_accumulatedConsumption         | Accumulated Consumption since Midnight        | True      |
+| live_accumulatedConsumptionThisHour | Accumulated Consumption since last hour shift | True      |
+| live_accumulatedCost                | Accumulated Cost since Midnight               | True      |
+| live_accumulatedReward              | Accumulated Reward since Midnight             | True      |
+| live_currency                       | Currency of Cost                              | True      |
+| live_minPower                       | Min Power Consumption since Midnight          | True      |
+| live_averagePower                   | Average Power Consumption since Midnight      | True      |
+| live_maxPower                       | Max Power Consumption since Midnight          | True      |
+| live_voltage1                       | Voltage Phase 1                               | True      |
+| live_voltage2                       | Voltage Phase  2                              | True      |
+| live_voltage3                       | Voltage Phase 3                               | True      |
+| live_current1                       | Current Phase 1                               | True      |
+| live_current2                       | Current Phase 2                               | True      |
+| live_current3                       | Current Phase 3                               | True      |
+| live_powerProduction                | Live Power Production                         | True      |
+| live_accumulatedProduction          | Accumulated Production since Midnight         | True      |
+| live_accumulatedProductionThisHour  | Accumulated Production since last hour shift  | True      |
+| live_lastMeterProduction            | Last Recorded Meter Production                | True      |
+| live_minPowerproduction             | Min Power Production since Midnight           | True      |
+| live_maxPowerproduction             | Max Power Production since Midnight           | True      |
 
 ## Binding Configuration
 
@@ -238,6 +240,7 @@ DateTime                   TibberAPILiveTimestamp                "Timestamp - Li
 Number:Power               TibberAPILivePower                    "Live Power Consumption [%.0f W]"           {channel="tibber:tibberapi:7cfae492:live_power"}
 Number:Energy              TibberAPILiveLastMeterConsumption     "Last Meter Consumption [%.2f kWh]"         {channel="tibber:tibberapi:7cfae492:live_lastMeterConsumption"}
 Number:Energy              TibberAPILiveAccumulatedConsumption   "Accumulated Consumption [%.2f kWh]"        {channel="tibber:tibberapi:7cfae492:live_accumulatedConsumption"}
+Number:Energy              TibberAPILiveAccumulatedConsumptionThisHour   "kWh consumed since since last hour shift [%.2f kWh]"        {channel="tibber:tibberapi:7cfae492:live_accumulatedConsumptionLastHour"}
 Number:Dimensionless       TibberAPILiveAccumulatedCost          "Accumulated Cost [%.2f NOK]"               {channel="tibber:tibberapi:7cfae492:live_accumulatedCost"}
 Number:Dimensionless       TibberAPILiveAccumulatedReward        "Accumulated Reward [%.2f NOK]"             {channel="tibber:tibberapi:7cfae492:live_accumulatedReward"}
 String                     TibberAPILiveCurrency                 "Currency"                                  {channel="tibber:tibberapi:7cfae492:live_currency"}
@@ -252,6 +255,7 @@ Number:ElectricCurrent     TibberAPILiveCurrent2                 "Live Current P
 Number:ElectricCurrent     TibberAPILiveCurrent3                 "Live Current Phase 3 [%.1 A]"              {channel="tibber:tibberapi:7cfae492:live_current3"}
 Number:Power               TibberAPILivePowerProduction          "Live Power Production [%.0f W]"            {channel="tibber:tibberapi:7cfae492:live_powerProduction"}
 Number:Energy              TibberAPILiveAccumulatedProduction    "Accumulated Production [%.2f kWh]"         {channel="tibber:tibberapi:7cfae492:live_accumulatedProduction"}
+Number:Energy              TibberAPILiveAccumulatedProductionThisHour   "Net kWh produced since last hour shift [%.2f kWh]"        {channel="tibber:tibberapi:7cfae492:live_accumulatedProductionThisHour"}
 Number:Energy              TibberAPILiveLastMeterProduction      "Min Power Production [%.0f W]"             {channel="tibber:tibberapi:7cfae492:live_lastMeterProduction"}
 Number:Power               TibberAPILiveMinPowerproduction       "Min Power Production [%.0f W]"             {channel="tibber:tibberapi:7cfae492:live_minPowerproduction"}
 Number:Power               TibberAPILiveMaxPowerproduction       "Max Power Production [%.0f W]"             {channel="tibber:tibberapi:7cfae492:live_maxPowerproduction"}

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/TibberBindingConstants.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/TibberBindingConstants.java
@@ -60,6 +60,7 @@ public class TibberBindingConstants {
     public static final String LIVE_LASTMETERCONSUMPTION = "live_lastMeterConsumption";
     public static final String LIVE_LASTMETERPRODUCTION = "live_lastMeterProduction";
     public static final String LIVE_ACCUMULATEDCONSUMPTION = "live_accumulatedConsumption";
+    public static final String LIVE_ACCUMULATEDCONSUMPTION_THIS_HOUR = "live_accumulatedConsumptionThisHour";
     public static final String LIVE_ACCUMULATEDCOST = "live_accumulatedCost";
     public static final String LIVE_ACCUMULATEREWARD = "live_accumulatedReward";
     public static final String LIVE_CURRENCY = "live_currency";
@@ -74,6 +75,7 @@ public class TibberBindingConstants {
     public static final String LIVE_CURRENT3 = "live_current3";
     public static final String LIVE_POWERPRODUCTION = "live_powerProduction";
     public static final String LIVE_ACCUMULATEDPRODUCTION = "live_accumulatedProduction";
+    public static final String LIVE_ACCUMULATEDPRODUCTION_THIS_HOUR = "live_accumulatedProductionThisHour";
     public static final String LIVE_MINPOWERPRODUCTION = "live_minPowerproduction";
     public static final String LIVE_MAXPOWERPRODUCTION = "live_maxPowerproduction";
 

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -566,6 +566,10 @@ public class TibberHandler extends BaseThingHandler {
                 if (myObject.has("accumulatedConsumption")) {
                     updateChannel(LIVE_ACCUMULATEDCONSUMPTION, myObject.get("accumulatedConsumption").toString());
                 }
+                if (myObject.has("accumulatedConsumptionLastHour")) {
+                    updateChannel(LIVE_ACCUMULATEDCONSUMPTION_THIS_HOUR,
+                            myObject.get("accumulatedConsumptionLastHour").toString());
+                }
                 if (myObject.has("accumulatedCost")) {
                     updateChannel(LIVE_ACCUMULATEDCOST, myObject.get("accumulatedCost").toString());
                 }
@@ -608,6 +612,10 @@ public class TibberHandler extends BaseThingHandler {
                 if (myObject.has("accumulatedProduction")) {
                     updateChannel(LIVE_ACCUMULATEDPRODUCTION, myObject.get("accumulatedProduction").toString());
                 }
+                if (myObject.has("accumulatedProductionLastHour")) {
+                    updateChannel(LIVE_ACCUMULATEDPRODUCTION_THIS_HOUR,
+                            myObject.get("accumulatedProductionLastHour").toString());
+                }
                 if (myObject.has("minPowerProduction")) {
                     updateChannel(LIVE_MINPOWERPRODUCTION, myObject.get("minPowerProduction").toString());
                 }
@@ -630,8 +638,8 @@ public class TibberHandler extends BaseThingHandler {
         public void startSubscription() {
             String query = "{\"id\":\"1\",\"type\":\"subscribe\",\"payload\":{\"variables\":{},\"extensions\":{},\"operationName\":null,\"query\":\"subscription {\\n liveMeasurement(homeId:\\\""
                     + tibberConfig.getHomeid()
-                    + "\\\") {\\n timestamp\\n power\\n lastMeterConsumption\\n lastMeterProduction\\n accumulatedConsumption\\n accumulatedCost\\n accumulatedReward\\n currency\\n minPower\\n averagePower\\n maxPower\\n"
-                    + "voltagePhase1\\n voltagePhase2\\n voltagePhase3\\n currentL1\\n currentL2\\n currentL3\\n powerProduction\\n accumulatedProduction\\n minPowerProduction\\n maxPowerProduction\\n }\\n }\\n\"}}";
+                    + "\\\") {\\n timestamp\\n power\\n lastMeterConsumption\\n lastMeterProduction\\n accumulatedConsumption\\n accumulatedConsumptionLastHour\\n accumulatedCost\\n accumulatedReward\\n currency\\n minPower\\n averagePower\\n maxPower\\n"
+                    + "voltagePhase1\\n voltagePhase2\\n voltagePhase3\\n currentL1\\n currentL2\\n currentL3\\n powerProduction\\n accumulatedProduction\\n accumulatedProductionLastHour\\n minPowerProduction\\n maxPowerProduction\\n }\\n }\\n\"}}";
             try {
                 TibberWebSocketListener socket = TibberHandler.this.socket;
                 if (socket != null) {

--- a/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/thing/thing-types.xml
@@ -47,7 +47,7 @@
 		</channels>
 		<properties>
 			<property name="vendor">Tibber</property>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 		<config-description>
 			<parameter name="token" type="text" required="true">

--- a/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/thing/thing-types.xml
@@ -26,6 +26,7 @@
 			<channel id="live_lastMeterConsumption" typeId="consumption"/>
 			<channel id="live_lastMeterProduction" typeId="production"/>
 			<channel id="live_accumulatedConsumption" typeId="consumption"/>
+			<channel id="live_accumulatedConsumptionThisHour" typeId="consumption"/>
 			<channel id="live_accumulatedCost" typeId="cost"/>
 			<channel id="live_accumulatedReward" typeId="reward"/>
 			<channel id="live_currency" typeId="currency"/>
@@ -42,6 +43,7 @@
 			<channel id="live_minPowerproduction" typeId="power"/>
 			<channel id="live_maxPowerproduction" typeId="power"/>
 			<channel id="live_accumulatedProduction" typeId="production"/>
+			<channel id="live_accumulatedProductionThisHour" typeId="production"/>
 		</channels>
 		<properties>
 			<property name="vendor">Tibber</property>

--- a/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/update/instructions.xml
@@ -9,6 +9,16 @@
 				<type>tibber:production</type>
 			</add-channel>
 		</instruction-set>
+		<instruction-set targetVersion="2">
+			<add-channel id="live_accumulatedConsumptionThisHour">
+				<type>tibber:consumption</type>
+			</add-channel>
+		</instruction-set>
+		<instruction-set targetVersion="2">
+			<add-channel id="live_accumulatedProductionThisHour">
+				<type>tibber:production</type>
+			</add-channel>
+		</instruction-set>
 	</thing-type>
 
 </update:update-descriptions>

--- a/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.tibber/src/main/resources/OH-INF/update/instructions.xml
@@ -13,8 +13,6 @@
 			<add-channel id="live_accumulatedConsumptionThisHour">
 				<type>tibber:consumption</type>
 			</add-channel>
-		</instruction-set>
-		<instruction-set targetVersion="2">
 			<add-channel id="live_accumulatedProductionThisHour">
 				<type>tibber:production</type>
 			</add-channel>


### PR DESCRIPTION
Makes net consumption/production since last hour shift available