### PR TITLE
[orbitbhyve] Fix handling of multiple sprinkler controllers

### DIFF
--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveBridgeHandler.java
@@ -321,11 +321,11 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
         List<OrbitBhyveDevice> devices = getDevices();
         for (Thing th : getThing().getThings()) {
             if (th.isEnabled()) {
-                String deviceId = th.getUID().getId();
                 ThingHandler handler = th.getHandler();
                 if (handler instanceof OrbitBhyveSprinklerHandler sprinklerHandler) {
+                    String deviceId = sprinklerHandler.getSprinklerId();
                     for (OrbitBhyveDevice device : devices) {
-                        if (deviceId.equals(th.getUID().getId())) {
+                        if (deviceId.equals(device.getId())) {
                             updateDeviceStatus(device, sprinklerHandler);
                         }
                     }
@@ -345,9 +345,9 @@ public class OrbitBhyveBridgeHandler extends ConfigStatusBridgeHandler {
 
     private void updateDeviceStatus(String deviceId) {
         for (Thing th : getThing().getThings()) {
-            if (deviceId.equals(th.getUID().getId())) {
-                ThingHandler handler = th.getHandler();
-                if (handler instanceof OrbitBhyveSprinklerHandler sprinklerHandler) {
+            ThingHandler handler = th.getHandler();
+            if (handler instanceof OrbitBhyveSprinklerHandler sprinklerHandler) {
+                if (deviceId.equals(sprinklerHandler.getSprinklerId())) {
                     OrbitBhyveDevice device = getDevice(deviceId);
                     updateDeviceStatus(device, sprinklerHandler);
                 }

--- a/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveSprinklerHandler.java
+++ b/bundles/org.openhab.binding.orbitbhyve/src/main/java/org/openhab/binding/orbitbhyve/internal/handler/OrbitBhyveSprinklerHandler.java
@@ -120,7 +120,7 @@ public class OrbitBhyveSprinklerHandler extends BaseThingHandler {
         }
     }
 
-    private String getSprinklerId() {
+    public String getSprinklerId() {
         return getThing().getConfiguration().get("id") != null ? getThing().getConfiguration().get("id").toString()
                 : "";
     }


### PR DESCRIPTION
Need to compare the device id from the thing config with the device id's in the devices array. It was comparing the id of the thing with the id of the thing.
