### PR TITLE
[mqtt] fix UnDefType comparison in PercentageValue

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -73,7 +73,7 @@ public class PercentageValue extends Value {
 
     @Override
     public PercentType parseCommand(Command command) throws IllegalArgumentException {
-        PercentType oldvalue = (state == UnDefType.UNDEF) ? new PercentType() : (PercentType) state;
+        PercentType oldvalue = (state instanceof UnDefType) ? new PercentType() : (PercentType) state;
         // Nothing do to -> We have received a percentage
         if (command instanceof PercentType percent) {
             return percent;


### PR DESCRIPTION
Since #16307, the state could get set to NULL, not just UNDEF, and once it got in that state PercentageValue would throw an error every time it received any other message or command, effectively rendering the channel broken until openHAB restarted.
