### PR TITLE
[netatmo] IllegalArgumentException for DoorTags

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/DoorTagChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/DoorTagChannelHelper.java
@@ -42,8 +42,14 @@ public class DoorTagChannelHelper extends ChannelHelper {
     protected @Nullable State internalGetProperty(String channelId, NAThing naThing, Configuration config) {
         if (naThing instanceof HomeStatusModule doorTag) {
             if (CHANNEL_STATUS.equalsIgnoreCase(channelId)) {
-                return doorTag.getStatus().map(status -> (State) OpenClosedType.valueOf(status.toUpperCase()))
-                        .orElse(UnDefType.UNDEF);
+                return doorTag.getStatus().map(status -> {
+                    try {
+                        return (State) OpenClosedType.valueOf(status.toUpperCase());
+                    } catch (IllegalArgumentException e) {
+                        // Issue #16629 tag can also return 'no_news'
+                        return UnDefType.UNDEF;
+                    }
+                }).orElse(UnDefType.UNDEF);
             }
         }
         return null;


### PR DESCRIPTION
Apparently door tags may report other values than open / closed.

Resolves #16629

From the event feed, the no_news answer corresponds to a signal lost event in the Netatmo UI, so setting state to UNDEF seems appropriate.
