### PR TITLE
[mqtt] Treat incoming empty string as NULL for enum

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
@@ -106,7 +106,11 @@ public class TextValue extends Value {
         final Set<String> states = this.states;
         String valueStr = command.toString();
         if (states != null && !states.contains(valueStr)) {
-            throw new IllegalArgumentException("Value " + valueStr + " not within range");
+            if (valueStr.isEmpty()) {
+                return UnDefType.NULL;
+            } else {
+                throw new IllegalArgumentException("Value " + valueStr + " not within range");
+            }
         }
         return new StringType(valueStr);
     }


### PR DESCRIPTION
Since #16307, everything except TextValue would treat an empty string as NULL. TextValue was excluded because empty string could be a valid value. Instead it had a config option added to match for a NULL value if you wanted. BUT, if a TextValue has specific valid states configured (such as from Homie or Home Assistant bindings), then empty string is no longer a valid value, and should receive the same treatment of setting the state to NULL when encountered.
