### PR TITLE
[ipcamera] Fix Reolink Siren

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -337,11 +337,11 @@ public class ReolinkHandler extends ChannelDuplexHandler {
             case CHANNEL_ACTIVATE_ALARM_OUTPUT: // cameras built in siren
                 if (OnOffType.ON.equals(command)) {
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=AudioAlarmPlay" + ipCameraHandler.reolinkAuth,
-                            "[{\"cmd\": \"AudioAlarmPlay\", \"param\": {\"alarm_mode\": \"manul\", \"manual_switch\": 1, \"channel\": "
+                            "[{\"cmd\": \"AudioAlarmPlay\", \"param\": {\"alarm_mode\": \"manul\", \"times\": 1, \"manual_switch\": 1, \"channel\": "
                                     + ipCameraHandler.cameraConfig.getNvrChannel() + " }}]");
                 } else {
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=AudioAlarmPlay" + ipCameraHandler.reolinkAuth,
-                            "[{\"cmd\": \"AudioAlarmPlay\", \"param\": {\"alarm_mode\": \"manul\", \"manual_switch\": 0, \"channel\": "
+                            "[{\"cmd\": \"AudioAlarmPlay\", \"param\": {\"alarm_mode\": \"manul\", \"times\": 1, \"manual_switch\": 0, \"channel\": "
                                     + ipCameraHandler.cameraConfig.getNvrChannel() + " }}]");
                 }
                 break;


### PR DESCRIPTION
Updated AudioAlarmPlay http post request to include times parameter to fix the siren for reolink cameras.

This was tested and confirmed to work on both a Reolink E1 Zoom camera as well as a Reolink Doorbell WiFi camera.

Signed-off-by: Simmon Yau <simmonyau@gmail.com>
