### PR TITLE
[energidataservice] Log warning when spot prices are unavailable

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -239,6 +239,7 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
 
             if (isLinked(CHANNEL_SPOT_PRICE)) {
                 if (cacheManager.getNumberOfFutureSpotPrices() < 13) {
+                    logger.warn("Spot prices are not yet available, retry scheduled (see details in Thing properties)");
                     retryPolicy = RetryPolicyFactory.whenExpectedSpotPriceDataMissing(DAILY_REFRESH_TIME_CET,
                             NORD_POOL_TIMEZONE);
                 } else {


### PR DESCRIPTION
Today I noticed that my [dishwasher price calculation automation](https://community.openhab.org/t/dishwasher-price-calculation-automation/139207) did not work as expected, and investigated why.

I found that is what caused by a simple lack of spot price data from the service: https://www.energidataservice.dk/news
> 2024-04-12
>Currently we experience technical problems updating a number of datasets. We are working on solving the error.

Even though the spot price channel may be `UNDEF` (when prices are very behind) and the `nextCall` property is before ~13:00 next day, the binding is probably a bit too silent in this case. Thus a warning would help. Since retries use an exponential backoff strategy, they should not occur too often or spam the log in any way.