### PR TITLE
[energidataservice] Restrict CO₂ emission datasets to price area DK1/DK2

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/README.md
+++ b/bundles/org.openhab.binding.energidataservice/README.md
@@ -154,6 +154,9 @@ Channel `co2-emission-prognosis` provides estimated prognosis for future emissio
 Depending on the time of the day, an update of the prognosis may include estimates for more than 9 hours, but every update will have at least 9 hours into the future.
 A persistence configuration is required for this channel.
 
+Please note that the CO₂ emission channels only apply to Denmark.
+These channels will not be updated when the configured price area is not DK1 or DK2.
+
 ## Thing Actions
 
 Thing actions can be used to perform calculations as well as import prices directly into rules without relying on persistence.

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/ApiController.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/ApiController.java
@@ -263,6 +263,9 @@ public class ApiController {
         if (dataset != Dataset.CO2Emission && dataset != Dataset.CO2EmissionPrognosis) {
             throw new IllegalArgumentException("Invalid dataset " + dataset + " for getting CO2 emissions");
         }
+        if (!"DK1".equals(priceArea) && !"DK2".equals(priceArea)) {
+            throw new IllegalArgumentException("Invalid price area " + priceArea + " for getting CO2 emissions");
+        }
         Request request = httpClient.newRequest(ENDPOINT + DATASET_PATH + dataset)
                 .timeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS) //
                 .param("start", start.toString()) //

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -197,6 +197,18 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
     }
 
     @Override
+    public void channelLinked(ChannelUID channelUID) {
+        super.channelLinked(channelUID);
+
+        if (!"DK1".equals(config.priceArea) && !"DK2".equals(config.priceArea)
+                && (CHANNEL_CO2_EMISSION_PROGNOSIS.equals(channelUID.getId())
+                        || CHANNEL_CO2_EMISSION_REALTIME.contains(channelUID.getId()))) {
+            logger.warn("Item linked to channel '{}', but price area {} is not supported for this channel",
+                    channelUID.getId(), config.priceArea);
+        }
+    }
+
+    @Override
     public void channelUnlinked(ChannelUID channelUID) {
         super.channelUnlinked(channelUID);
 
@@ -404,6 +416,10 @@ public class EnergiDataServiceHandler extends BaseThingHandler {
 
     private void updateCo2Emissions(Dataset dataset, String channelId, DateQueryParameter dateQueryParameter)
             throws InterruptedException, DataServiceException {
+        if (!"DK1".equals(config.priceArea) && !"DK2".equals(config.priceArea)) {
+            // Dataset is only for Denmark.
+            return;
+        }
         Map<String, String> properties = editProperties();
         CO2EmissionRecord[] emissionRecords = apiController.getCo2Emissions(dataset, config.priceArea,
                 dateQueryParameter, properties);


### PR DESCRIPTION
Avoid trying to request CO₂ emission data for price areas outside Denmark.

No data would be found, which would result in the Thing showing as **OFFLINE** with description "No records" (without impact on updates for other channels though).

When linking a CO₂ emission channel while configured price area is not DK*, a warning will be logged.

Regression of #16330