### PR TITLE
[tr064] Enable fourth WiFi channel and improvements

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -130,17 +130,23 @@ The call-types are the same as provided by the FritzBox, i.e. `1` (inbound), `2`
 
 | channel              | item-type                 | advanced | description                                                                                                  |
 |----------------------|---------------------------|:--------:|--------------------------------------------------------------------------------------------------------------|
-| `wifi24GHzEnable`    | `Switch`                  |          | Enable/Disable the 2.4 GHz WiFi device.                                                                      |
-| `wifi5GHzEnable`     | `Switch`                  |          | Enable/Disable the 5.0 GHz WiFi device.                                                                      |
-| `wifiGuestEnable`    | `Switch`                  |          | Enable/Disable the guest WiFi.                                                                               |
+| `wifi24GHzEnable`    | `Switch`                  |          | Enable/Disable the 2.4 GHz WiFi device. Deprecated for removal. Use `wifi1Enable`.                           |
+| `wifi5GHzEnable`     | `Switch`                  |          | Enable/Disable the 5.0 GHz WiFi device. Deprecated for removal. Use `wifi2Enable`.                           |
+| `wifiGuestEnable`    | `Switch`                  |          | Enable/Disable the guest WiFi. Deprecated for removal. Use `wifi3Enable`.                                    |
+| `wifiXEnable`        | `Switch`                  |          | Enable/Disable the WiFi X. See below for details.                                                            |
 | `macOnline`          | `Switch`                  |    x     | Online status of the device with the given MAC                                                               |
 | `macOnlineIpAddress` | `String`                  |    x     | IP of the MAC (uses same parameter as `macOnline`)                                                           |
 | `macSignalStrength1` | `Number`                  |    x     | Wifi Signal Strength of the device with the given MAC. This is set in case the Device is connected to 2.4Ghz |
 | `macSpeed1`          | `Number:DataTransferRate` |    x     | Wifi Speed of the device with the given MAC. This is set in case the Device is connected to 2.4Ghz           |
 | `macSignalStrength2` | `Number`                  |    x     | Wifi Signal Strength of the device with the given MAC. This is set in case the Device is connected to 5Ghz   |
 | `macSpeed2`          | `Number:DataTransferRate` |    x     | Wifi Speed of the device with the given MAC. This is set in case the Device is connected to 5Ghz             |
-Older FritzBox devices may not support 5 GHz WiFi.
-In this case you have to use the `wifi5GHzEnable` channel for switching the guest WiFi.
+
+***Note:*** The `wifi24GHzEnable`, `wifi5GHzEnable` and `wifiGuestEnable`channels have been deprecated and will be removed in future versions.
+They are replaced by `wifiXEnable` (with `X` being a number between `1` and `4`).
+
+- FritzBoxes which do not support 5 GHz use `wifi1Enable` for the standard WiFi and `wifi2Enable`for the guest WiFi.
+- FritzBoxes which support 5 GHz use `wifi1Enable` for the 2.5 GHz WiFi, `wifi2Enable` for the 5 GHz WiFi and `wifi3Enable` for the guest WiFi.
+- FritzBoxes which support two 5 GHz networks use `wifi1Enable` for the 2.5 GHz WiFi, `wifi2Enable` and `wifi3Enable` for the 5 GHz WiFis and `wifi4Enable` for the guest WiFi.
 
 ### WANConnection `subdevice` channels
 

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -117,24 +117,55 @@
 	</channel>
 
 	<!-- LAN Device -->
-	<channel name="wifi24GHzEnable" label="WiFi 2.4 GHz" description="Enable/Disable the 2.4 GHz WiFi device.">
+	<channel name="wifi24GHzEnable" label="WiFi 2.4 GHz (DEPRECATED)"
+		description="Enable/Disable the 2.4 GHz WiFi device. Please re-link to wifi1Enable.">
 		<item type="Switch"/>
 		<service deviceType="urn:dslforum-org:device:LANDevice:1"
 			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration1"/>
 		<getAction name="GetInfo" argument="NewEnable"/>
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>
-	<channel name="wifi5GHzEnable" label="WiFi 5 GHz" description="Enable/Disable the 5.0 GHz WiFi device.">
+	<channel name="wifi5GHzEnable" label="WiFi 5 GHz (DEPRECATED)"
+		description="Enable/Disable the 5.0 GHz WiFi device.  Please re-link to wifi2Enable.">
 		<item type="Switch"/>
 		<service deviceType="urn:dslforum-org:device:LANDevice:1"
 			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration2"/>
 		<getAction name="GetInfo" argument="NewEnable"/>
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>
-	<channel name="wifiGuestEnable" label="WiFi Guest" description="Enable/Disable the guest WiFi.">
+	<channel name="wifiGuestEnable" label="WiFi Guest (DEPRECATED)"
+		description="Enable/Disable the guest WiFi. Please re-link to wifi3Enable.">
 		<item type="Switch"/>
 		<service deviceType="urn:dslforum-org:device:LANDevice:1"
 			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration3"/>
+		<getAction name="GetInfo" argument="NewEnable"/>
+		<setAction name="SetEnable" argument="NewEnable"/>
+	</channel>
+	<channel name="wifi1Enable" label="WiFi #1" description="Enable/Disable WiFi #1.">
+		<item type="Switch"/>
+		<service deviceType="urn:dslforum-org:device:LANDevice:1"
+			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration1"/>
+		<getAction name="GetInfo" argument="NewEnable"/>
+		<setAction name="SetEnable" argument="NewEnable"/>
+	</channel>
+	<channel name="wifi2Enable" label="WiFi #2" description="Enable/Disable WiFi #2.">
+		<item type="Switch"/>
+		<service deviceType="urn:dslforum-org:device:LANDevice:1"
+			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration2"/>
+		<getAction name="GetInfo" argument="NewEnable"/>
+		<setAction name="SetEnable" argument="NewEnable"/>
+	</channel>
+	<channel name="wifi3Enable" label="WiFi #3" description="Enable/Disable WiFi #3.">
+		<item type="Switch"/>
+		<service deviceType="urn:dslforum-org:device:LANDevice:1"
+			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration3"/>
+		<getAction name="GetInfo" argument="NewEnable"/>
+		<setAction name="SetEnable" argument="NewEnable"/>
+	</channel>
+	<channel name="wifi4Enable" label="WiFi #4" description="Enable/Disable WiFi #4.">
+		<item type="Switch"/>
+		<service deviceType="urn:dslforum-org:device:LANDevice:1"
+			serviceId="urn:WLANConfiguration-com:serviceId:WLANConfiguration4"/>
 		<getAction name="GetInfo" argument="NewEnable"/>
 		<setAction name="SetEnable" argument="NewEnable"/>
 	</channel>


### PR DESCRIPTION
Supersedes #16454

See discussion in other PR. This makes the channel naming more consistent, but requires re-linking of the channel (we can rename channels, but not re-link them with update instructions). Therefore the old channels are still supported and will be removed in a future version. 