### PR TITLE
[energidataservice] Adjust retry policy for extended spot price unavailability

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/ApiController.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/ApiController.java
@@ -122,12 +122,8 @@ public class ApiController {
         try {
             String responseContent = sendRequest(request, properties);
             ElspotpriceRecords records = gson.fromJson(responseContent, ElspotpriceRecords.class);
-            if (records == null) {
+            if (records == null || Objects.isNull(records.records())) {
                 throw new DataServiceException("Error parsing response");
-            }
-
-            if (records.total() == 0 || Objects.isNull(records.records()) || records.records().length == 0) {
-                throw new DataServiceException("No records");
             }
 
             return Arrays.stream(records.records()).filter(Objects::nonNull).toArray(ElspotpriceRecord[]::new);

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/retry/RetryPolicyFactory.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/retry/RetryPolicyFactory.java
@@ -76,15 +76,10 @@ public class RetryPolicyFactory {
     /**
      * Determine {@link RetryStrategy} when expected spot price data is missing.
      *
-     * @param localTime the time of daily data request
-     * @param zoneId time-zone
      * @return retry strategy
      */
-    public static RetryStrategy whenExpectedSpotPriceDataMissing(LocalTime localTime, ZoneId zoneId) {
-        LocalTime now = LocalTime.now(zoneId);
-        if (now.isAfter(localTime)) {
-            return new ExponentialBackoff().withMinimum(Duration.ofMinutes(10)).withJitter(0.2);
-        }
-        return atFixedTime(localTime, zoneId);
+    public static RetryStrategy whenExpectedSpotPriceDataMissing() {
+        return new ExponentialBackoff().withMinimum(Duration.ofMinutes(10)).withMaximum(Duration.ofHours(1))
+                .withJitter(0.2);
     }
 }


### PR DESCRIPTION
The number of **future** spot prices changes throughout a day:
- 00:00 (midnight): 24 prices should be available, i.e. all hours of the day.
- 01:00: 23 prices available.
- (...)
- 11:00: 13 prices available.
- 12:00: 12 prices available.
- 13:00: 35 prices available (11 for this day and 24 for tomorrow)
- 14:00: 34 prices available
- (...)

We always receive 24 prices per day, so the logic for determining if we have everything is quite simple:
- We should always have at least 13 future prices.
- Except between 12:00 and 13:00, we have only 12.

If everything is working, we'll fetch new prices once per day - around 13:00. However, if we are missing spot prices for a longer period, we'll have to retry.

The logic here had a flaw. It said:
- Less than 13 prices from 13:00? Let's apply exponential backoff strategy. This is fine.
- Less than 13 prices before 13:00? Let's apply fixed time (13:00) strategy. This is fine between 12:00 and 13:00 if we have exactly 12 prices.
- Before 12:00, if we have less than 13 prices available, we are already missing prices. In this case we should apply exponential backoff strategy, not wait until 13:00.

The following is fixed:
- If we have less than 13 prices before 12:00 - apply exponential backoff strategy.
- When spot prices are missing, don't wait longer than one hour between retries.
- Properties are updated also when exceptions are thrown from `ApiController`.
- Don't throw exception when there are no spot price records returned by the API. Having 0 or 1 records should be handled by the same logic and the Thing should stay **ONLINE**.