### PR TITLE
[ipcamera] Fix Reolink Duo Floodlight whiteLED Channel

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -496,16 +496,16 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 if (OnOffType.OFF.equals(command) || PercentType.ZERO.equals(command)) {
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetWhiteLed" + ipCameraHandler.reolinkAuth,
                             "[{\"cmd\": \"SetWhiteLed\",\"param\": {\"WhiteLed\": {\"state\": 0,\"channel\": "
-                                    + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"mode\": 1}}}]");
+                                    + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"mode\": 0}}}]");
                 } else if (OnOffType.ON.equals(command)) {
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetWhiteLed" + ipCameraHandler.reolinkAuth,
                             "[{\"cmd\": \"SetWhiteLed\",\"param\": {\"WhiteLed\": {\"state\": 1,\"channel\": "
-                                    + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"mode\": 0}}}]");
+                                    + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"mode\": 2}}}]");
                 } else if (command instanceof PercentType percentCommand) {
                     int value = percentCommand.toBigDecimal().intValue();
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetWhiteLed" + ipCameraHandler.reolinkAuth,
                             "[{\"cmd\": \"SetWhiteLed\",\"param\": {\"WhiteLed\": {\"state\": 1,\"channel\": "
-                                    + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"mode\": 1,\"bright\": " + value
+                                    + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"mode\": 2,\"bright\": " + value
                                     + "}}}]");
                 }
         }


### PR DESCRIPTION
Updated whiteLED channel for reolink ipcamera so that when the light is turned on, it will stay on forever and if the light is turned off, it will stay off forever. This is achieved by setting the floodlight mode to "Always On at Night" when the floodlight is turned on and to Off when the floodlight is turned off. Prior to this change, the mode would be set to Auto when turning the floodlight off and to Off when setting the floodlight ON and then back to Auto if you change the brightness via the dimmer.

This was tested and confirmed on a Reolink Duo Floodlight POE camera and is working well for me. I believe this setting would be more ideal for most users but I could be wrong. I just thought it was odd that the floodlight wouldn't stay on longer than 3 minutes after the brightness was set to 100. The same thing probably could have been achieved if mode is set to 0 for all 3 settings.

Signed-off-by: Simmon Yau [simmonyau@gmail.com](mailto:simmonyau@gmail.com)