### PR TITLE
[Renault] Fix retrieval of cockpit/odometer information

### DIFF
--- a/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/MyRenaultHttpSession.java
+++ b/bundles/org.openhab.binding.renault/src/main/java/org/openhab/binding/renault/internal/api/MyRenaultHttpSession.java
@@ -235,7 +235,7 @@ public class MyRenaultHttpSession {
     public void getCockpit(Car car) throws RenaultForbiddenException, RenaultUpdateException,
             RenaultNotImplementedException, RenaultAPIGatewayException {
         JsonObject responseJson = getKamereonResponse("/commerce/v1/accounts/" + kamereonaccountId
-                + "/kamereon/kca/car-adapter/v2/cars/" + config.vin + "/cockpit?country=" + getCountry(config));
+                + "/kamereon/kca/car-adapter/v1/cars/" + config.vin + "/cockpit?country=" + getCountry(config));
         if (responseJson != null) {
             car.setCockpit(responseJson);
         }


### PR DESCRIPTION
# [Renault] Cockpit/odometer information no longer retrieved #16669

As per the excellent Bug report this apply the suggested fix.  

# Description

The odometer information no longer works in version 2 of the API so switching to V1 restores this channel.  This is a problem on the Renault API but the suggested fix repairs the binding.

# Testing

This was built and tested on my installation and the odometer value is updated again.  Also the Bug report suggest this fix worked on their test installation.