### PR TITLE
[radiothermostat] Skip shutdown actions if thing offline

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/handler/RadioThermostatHandler.java
@@ -288,12 +288,14 @@ public class RadioThermostatHandler extends BaseThingHandler implements RadioThe
         connector.removeEventListener(this);
 
         // Disable Remote Temp and Message Area on shutdown
-        if (isLinked(REMOTE_TEMP)) {
-            connector.sendCommand("rem_mode", "0", REMOTE_TEMP_RESOURCE);
-        }
+        if (ThingStatus.ONLINE.equals(this.getThing().getStatus())) {
+            if (isLinked(REMOTE_TEMP)) {
+                connector.sendCommand("rem_mode", "0", REMOTE_TEMP_RESOURCE);
+            }
 
-        if (isLinked(MESSAGE)) {
-            connector.sendCommand("mode", "0", PMA_RESOURCE);
+            if (isLinked(MESSAGE)) {
+                connector.sendCommand("mode", "0", PMA_RESOURCE);
+            }
         }
 
         ScheduledFuture<?> refreshJob = this.refreshJob;


### PR DESCRIPTION
Improvement to #15492. Skip shutdown actions if thing is offline to prevent slowness when the binding is disposed.