### PR TITLE
[netatmo] Fix Live Picture not always available

### DIFF
--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -528,7 +528,7 @@ Warnings:
 | status         | monitoring           | Switch       | Read-write | State of the camera (video surveillance on/off)                                                                                             |
 | status         | sd-card              | String       | Read-only  | State of the SD card                                                                                                                        |
 | status         | alim                 | String       | Read-only  | State of the power connector                                                                                                                |
-| live           | picture              | Image        | Read-only  | Camera Live Snapshot                                                                                                                        |
+| live           | picture (**)         | Image        | Read-only  | Camera Live Snapshot                                                                                                                        |
 | live           | local-picture-url    | String       | Read-only  | Local Url of the live snapshot for this camera                                                                                              |
 | live           | vpn-picture-url      | String       | Read-only  | Url of the live snapshot for this camera through Netatmo VPN.                                                                               |
 | live           | local-stream-url (*) | String       | Read-only  | Local Url of the live stream for this camera (accessible if openhab server and camera are located on the same lan.                          |
@@ -547,6 +547,7 @@ Warnings:
 | last-event     | person-id            | String       | Read-only  | Id of the person the event is about (if any)                                                                                                |
 
 (*) This channel is configurable : low, poor, high.
+(**) This channel handles the REFRESH command for on demand update.
 
 **Supported channels for the Presence Camera thing:**
 

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/HomeStatusModule.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/HomeStatusModule.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.netatmo.internal.api.dto;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -96,8 +95,8 @@ public class HomeStatusModule extends NAThing {
         return sirenStatus;
     }
 
-    public String getVpnUrl() {
-        return Objects.requireNonNull(vpnUrl);
+    public @Nullable String getVpnUrl() {
+        return vpnUrl;
     }
 
     public boolean isLocal() {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/HomeStatusModule.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/HomeStatusModule.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.netatmo.internal.api.dto;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -95,8 +96,8 @@ public class HomeStatusModule extends NAThing {
         return sirenStatus;
     }
 
-    public @Nullable String getVpnUrl() {
-        return vpnUrl;
+    public String getVpnUrl() {
+        return Objects.requireNonNull(vpnUrl);
     }
 
     public boolean isLocal() {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/WebhookEvent.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/WebhookEvent.java
@@ -63,7 +63,7 @@ public class WebhookEvent extends Event {
 
     @Override
     public @Nullable String getPersonId() {
-        return persons.size() > 0 ? persons.keySet().iterator().next() : null;
+        return persons.isEmpty() ? null : persons.keySet().iterator().next();
     }
 
     @Override

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
@@ -40,6 +40,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
@@ -141,6 +142,9 @@ public class CameraCapability extends HomeSecurityThingCapability {
     public void handleCommand(String channelName, Command command) {
         if (command instanceof OnOffType && CHANNEL_MONITORING.equals(channelName)) {
             getSecurityCapability().ifPresent(cap -> cap.changeStatus(localUrl, OnOffType.ON.equals(command)));
+        } else if (command instanceof RefreshType && CHANNEL_LIVEPICTURE.equals(channelName)) {
+            handler.updateState(GROUP_CAM_LIVE, CHANNEL_LIVEPICTURE,
+                    toRawType(cameraHelper.getLivePictureURL(localUrl != null, true)));
         } else {
             super.handleCommand(channelName, command);
         }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
@@ -87,7 +87,7 @@ public class CameraCapability extends HomeSecurityThingCapability {
         super.updateHomeStatusModule(newData);
         // Per documentation vpn_url expires every 3 hours and on camera reboot. So useless to reping it if not changed
         String newVpnUrl = newData.getVpnUrl();
-        if (newVpnUrl != null && !newVpnUrl.equals(vpnUrl)) {
+        if (!newVpnUrl.equals(vpnUrl)) {
             // This will also decrease the number of requests emitted toward Netatmo API.
             localUrl = newData.isLocal() ? ping(newVpnUrl) : null;
             logger.debug("localUrl set to {} for camera {}", localUrl, thingUID);

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
@@ -87,7 +87,7 @@ public class CameraCapability extends HomeSecurityThingCapability {
         super.updateHomeStatusModule(newData);
         // Per documentation vpn_url expires every 3 hours and on camera reboot. So useless to reping it if not changed
         String newVpnUrl = newData.getVpnUrl();
-        if (!newVpnUrl.equals(vpnUrl)) {
+        if (newVpnUrl != null && !newVpnUrl.equals(vpnUrl)) {
             // This will also decrease the number of requests emitted toward Netatmo API.
             localUrl = newData.isLocal() ? ping(newVpnUrl) : null;
             logger.debug("localUrl set to {} for camera {}", localUrl, thingUID);

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
@@ -15,6 +15,7 @@ package org.openhab.binding.netatmo.internal.handler.channelhelper;
 import static org.openhab.binding.netatmo.internal.NetatmoBindingConstants.*;
 import static org.openhab.binding.netatmo.internal.utils.ChannelTypeUtils.*;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -36,8 +37,8 @@ import org.openhab.core.types.UnDefType;
 public class CameraChannelHelper extends ChannelHelper {
     private static final String QUALITY_CONF_ENTRY = "quality";
     private static final String LIVE_PICTURE = "/live/snapshot_720.jpg";
-    private boolean isLocal;
-    private @Nullable String vpnUrl;
+
+    private @NonNullByDefault({}) String vpnUrl;
     private @Nullable String localUrl;
 
     public CameraChannelHelper(Set<String> providedGroups) {
@@ -45,55 +46,66 @@ public class CameraChannelHelper extends ChannelHelper {
     }
 
     public void setUrls(String vpnUrl, @Nullable String localUrl) {
-        this.localUrl = localUrl;
         this.vpnUrl = vpnUrl;
-        this.isLocal = localUrl != null;
-    }
-
-    public @Nullable String getLocalURL() {
-        return localUrl;
+        this.localUrl = localUrl;
     }
 
     @Override
     protected @Nullable State internalGetProperty(String channelId, NAThing naThing, Configuration config) {
         if (naThing instanceof HomeStatusModule camera) {
-            boolean isMonitoring = OnOffType.ON.equals(camera.getMonitoring());
-            switch (channelId) {
-                case CHANNEL_MONITORING:
-                    return camera.getMonitoring();
-                case CHANNEL_SD_CARD:
-                    return toStringType(camera.getSdStatus());
-                case CHANNEL_ALIM_STATUS:
-                    return toStringType(camera.getAlimStatus());
-                case CHANNEL_LIVEPICTURE_VPN_URL:
-                    return toStringType(getLivePictureURL(false, isMonitoring));
-                case CHANNEL_LIVEPICTURE_LOCAL_URL:
-                    return toStringType(getLivePictureURL(true, isMonitoring));
-                case CHANNEL_LIVEPICTURE:
-                    return toRawType(getLivePictureURL(isLocal, isMonitoring));
-                case CHANNEL_LIVESTREAM_VPN_URL:
-                    return getLiveStreamURL(false, (String) config.get(QUALITY_CONF_ENTRY), isMonitoring);
-                case CHANNEL_LIVESTREAM_LOCAL_URL:
-                    return getLiveStreamURL(true, (String) config.get(QUALITY_CONF_ENTRY), isMonitoring);
-            }
+            return switch (channelId) {
+                case CHANNEL_MONITORING -> camera.getMonitoring();
+                case CHANNEL_SD_CARD -> toStringType(camera.getSdStatus());
+                case CHANNEL_ALIM_STATUS -> toStringType(camera.getAlimStatus());
+                default -> liveChannels(channelId, config, camera, OnOffType.ON.equals(camera.getMonitoring()),
+                        localUrl != null);
+            };
         }
         return null;
     }
 
-    private @Nullable String getLivePictureURL(boolean local, boolean isMonitoring) {
-        String url = local ? localUrl : vpnUrl;
-        if (!isMonitoring || (local && !isLocal) || url == null) {
+    private @Nullable State liveChannels(String channelId, Configuration config, HomeStatusModule camera,
+            boolean isMonitoring, boolean isLocal) {
+        if (vpnUrl == null) {
+            setUrls(Objects.requireNonNull(camera.getVpnUrl()), localUrl);
+        }
+        return switch (channelId) {
+            case CHANNEL_LIVEPICTURE_VPN_URL -> toStringType(getLivePictureURL(false, isMonitoring));
+            case CHANNEL_LIVEPICTURE_LOCAL_URL ->
+                isLocal ? toStringType(getLivePictureURL(true, isMonitoring)) : UnDefType.NULL;
+            case CHANNEL_LIVEPICTURE -> {
+                State result = toRawType(getLivePictureURL(isLocal, isMonitoring));
+                if (UnDefType.NULL.equals(result) && isLocal) {
+                    // If local read of the picture is unsuccessfull, try the VPN version
+                    result = toRawType(getLivePictureURL(false, isMonitoring));
+                }
+                yield result;
+            }
+            case CHANNEL_LIVESTREAM_VPN_URL ->
+                getLiveStreamURL(false, (String) config.get(QUALITY_CONF_ENTRY), isMonitoring);
+            case CHANNEL_LIVESTREAM_LOCAL_URL ->
+                isLocal ? getLiveStreamURL(true, (String) config.get(QUALITY_CONF_ENTRY), isMonitoring)
+                        : UnDefType.NULL;
+            default -> null;
+        };
+    }
+
+    private String getUrl(boolean local) {
+        return Objects.requireNonNull(local ? localUrl : vpnUrl);
+    }
+
+    public @Nullable String getLivePictureURL(boolean local, boolean isMonitoring) {
+        if (!isMonitoring || (local && (localUrl != null))) {
             return null;
         }
-        return "%s%s".formatted(url, LIVE_PICTURE);
+        return "%s%s".formatted(getUrl(local), LIVE_PICTURE);
     }
 
     private State getLiveStreamURL(boolean local, @Nullable String configQual, boolean isMonitoring) {
-        String url = local ? localUrl : vpnUrl;
-        if (!isMonitoring || (local && !isLocal) || url == null) {
+        if (!isMonitoring || (local && (localUrl != null))) {
             return UnDefType.NULL;
         }
         String finalQual = configQual != null ? configQual : "poor";
-        return toStringType("%s/live/%s", url, local ? "files/%s/index.m3u8".formatted(finalQual) : "index.m3u8");
+        return toStringType("%s/live/%sindex.m3u8", getUrl(local), local ? "files/%s/".formatted(finalQual) : "");
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
@@ -15,7 +15,6 @@ package org.openhab.binding.netatmo.internal.handler.channelhelper;
 import static org.openhab.binding.netatmo.internal.NetatmoBindingConstants.*;
 import static org.openhab.binding.netatmo.internal.utils.ChannelTypeUtils.*;
 
-import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -38,14 +37,14 @@ public class CameraChannelHelper extends ChannelHelper {
     private static final String QUALITY_CONF_ENTRY = "quality";
     private static final String LIVE_PICTURE = "/live/snapshot_720.jpg";
 
-    private @NonNullByDefault({}) String vpnUrl;
+    private @Nullable String vpnUrl;
     private @Nullable String localUrl;
 
     public CameraChannelHelper(Set<String> providedGroups) {
         super(providedGroups);
     }
 
-    public void setUrls(String vpnUrl, @Nullable String localUrl) {
+    public void setUrls(@Nullable String vpnUrl, @Nullable String localUrl) {
         this.localUrl = localUrl;
         this.vpnUrl = vpnUrl;
     }
@@ -65,16 +64,17 @@ public class CameraChannelHelper extends ChannelHelper {
     }
 
     public @Nullable String getLivePictureURL(boolean local, boolean isMonitoring) {
-        if (!isMonitoring || (local && (localUrl == null))) {
+        String url = getUrl(local);
+        if (!isMonitoring || url == null) {
             return null;
         }
-        return "%s%s".formatted(getUrl(local), LIVE_PICTURE);
+        return "%s%s".formatted(url, LIVE_PICTURE);
     }
 
     private @Nullable State liveChannels(String channelId, String qualityConf, HomeStatusModule camera,
             boolean isMonitoring, boolean isLocal) {
         if (vpnUrl == null) {
-            setUrls(Objects.requireNonNull(camera.getVpnUrl()), localUrl);
+            setUrls(camera.getVpnUrl(), localUrl);
         }
         return switch (channelId) {
             case CHANNEL_LIVESTREAM_LOCAL_URL ->
@@ -99,10 +99,11 @@ public class CameraChannelHelper extends ChannelHelper {
     }
 
     private State getLiveStreamURL(boolean local, @Nullable String configQual, boolean isMonitoring) {
-        if (!isMonitoring || (local && (localUrl == null))) {
+        String url = getUrl(local);
+        if (!isMonitoring || url == null) {
             return UnDefType.NULL;
         }
         String finalQual = configQual != null ? configQual : "poor";
-        return toStringType("%s/live/%sindex.m3u8", getUrl(local), local ? "files/%s/".formatted(finalQual) : "");
+        return toStringType("%s/live/%sindex.m3u8", url, local ? "files/%s/".formatted(finalQual) : "");
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
@@ -99,7 +99,7 @@ public class CameraChannelHelper extends ChannelHelper {
     }
 
     private State getLiveStreamURL(boolean local, @Nullable String configQual, boolean isMonitoring) {
-        if (!isMonitoring || (local && (localUrl != null))) {
+        if (!isMonitoring || (local && (localUrl == null))) {
             return UnDefType.NULL;
         }
         String finalQual = configQual != null ? configQual : "poor";

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
@@ -46,8 +46,8 @@ public class CameraChannelHelper extends ChannelHelper {
     }
 
     public void setUrls(String vpnUrl, @Nullable String localUrl) {
-        this.vpnUrl = vpnUrl;
         this.localUrl = localUrl;
+        this.vpnUrl = vpnUrl;
     }
 
     @Override
@@ -65,7 +65,7 @@ public class CameraChannelHelper extends ChannelHelper {
     }
 
     public @Nullable String getLivePictureURL(boolean local, boolean isMonitoring) {
-        if (!isMonitoring || (local && (localUrl != null))) {
+        if (!isMonitoring || (local && (localUrl == null))) {
             return null;
         }
         return "%s%s".formatted(getUrl(local), LIVE_PICTURE);
@@ -94,8 +94,8 @@ public class CameraChannelHelper extends ChannelHelper {
         };
     }
 
-    private String getUrl(boolean local) {
-        return Objects.requireNonNull(local ? localUrl : vpnUrl);
+    private @Nullable String getUrl(boolean local) {
+        return local ? localUrl : vpnUrl;
     }
 
     private State getLiveStreamURL(boolean local, @Nullable String configQual, boolean isMonitoring) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/utils/ChannelTypeUtils.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/utils/ChannelTypeUtils.java
@@ -40,6 +40,7 @@ import org.openhab.core.types.UnDefType;
  */
 @NonNullByDefault
 public class ChannelTypeUtils {
+    private static final int DEFAULT_TIMEOUT_MS = 30000;
 
     public static @Nullable QuantityType<?> commandToQuantity(Command command, MeasureClass measureClass) {
         Measure measureDef = measureClass.measureDefinition;
@@ -90,7 +91,8 @@ public class ChannelTypeUtils {
 
     public static State toRawType(@Nullable String pictureUrl) {
         if (pictureUrl != null) {
-            RawType picture = HttpUtil.downloadImage(pictureUrl);
+            // Retrieving local picture can be quite long then extend the timeout.
+            RawType picture = HttpUtil.downloadImage(pictureUrl, DEFAULT_TIMEOUT_MS);
             if (picture != null) {
                 return picture;
             }


### PR DESCRIPTION
Partially resolves issue #15883 .

Making tests, I identified that:
 
- When camera is on local network, the default timeout (5s) can be too short (maybe long SD card reading ?) and leads to a null value => time out extended (30s)
- A fallback on VPN camera live picture as been added.

- Identified a race condition that lead to display live picture before localUrl or vpnUrl are set leading to UndefType.NULL in the item.

Enhanced:

- live#picture now handles REFRESH command requests.
- vpnUrl that should never be null.