### PR TITLE
[jdbc] Reduce the default character limit for `VARCHAR` columns in MySQL

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMariadbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMariadbDAO.java
@@ -56,8 +56,10 @@ public class JdbcMariadbDAO extends JdbcBaseDAO {
      */
     private void initSqlTypes() {
         logger.debug("JDBC::initSqlTypes: Initialize the type array");
+
+        // MariaDB using utf-8 max = 16383, using 16383-128 = 16255
         sqlTypes.put("IMAGEITEM", "VARCHAR(16255)");
-        sqlTypes.put("STRINGITEM", "VARCHAR(16255)"); // MariaDB using utf-8 max = 16383, using 16383-128 = 16255
+        sqlTypes.put("STRINGITEM", "VARCHAR(16255)");
     }
 
     /**

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMysqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMysqlDAO.java
@@ -60,7 +60,10 @@ public class JdbcMysqlDAO extends JdbcBaseDAO {
      */
     private void initSqlTypes() {
         logger.debug("JDBC::initSqlTypes: Initialize the type array");
-        sqlTypes.put("STRINGITEM", "VARCHAR(21717)");// mysql using utf-8 max 65535/3 = 21845, using 21845-128 = 21717
+
+        // MySQL using utf8mb4 max 65535/4 = 16383, using 16383-128 = 16255
+        sqlTypes.put("IMAGEITEM", "VARCHAR(16255)");
+        sqlTypes.put("STRINGITEM", "VARCHAR(16255)");
     }
 
     /**


### PR DESCRIPTION
See https://dev.mysql.com/doc/refman/8.3/en/storage-requirements.html and namely:
> The effective maximum number of bytes that can be stored in a [VARCHAR](https://dev.mysql.com/doc/refman/8.3/en/char.html) or [VARBINARY](https://dev.mysql.com/doc/refman/8.3/en/binary-varbinary.html) column is subject to the maximum row size of 65,535 bytes, which is shared among all columns. For a [VARCHAR](https://dev.mysql.com/doc/refman/8.3/en/char.html) column that stores multibyte characters, the effective maximum number of characters is less. For example, utf8mb4 characters can require up to four bytes per character, so a [VARCHAR](https://dev.mysql.com/doc/refman/8.3/en/char.html) column that uses the utf8mb4 character set can be declared to be a maximum of 16,383 characters. See [Section 10.4.7, “Limits on Table Column Count and Row Size”](https://dev.mysql.com/doc/refman/8.3/en/column-count-limit.html).

The old size was based on up to three bytes per character, but **utf8mb4** can require up to four bytes per character. On top of that we need space for the `time` column as well. This is now aligned with MariaDB:

https://github.com/openhab/openhab-addons/blob/6ebf0f974e204aacde9d62c1d37c6bf10c475e8f/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcMariadbDAO.java#L59-L60

Resolves #13920
Resolves #16678