### PR TITLE
[netatmo] Fix error introduced in #16681

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeSecurityThingCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeSecurityThingCapability.java
@@ -43,8 +43,8 @@ public class HomeSecurityThingCapability extends Capability {
             List<ChannelHelper> channelHelpers) {
         super(handler);
         this.descriptionProvider = descriptionProvider;
-        this.eventHelper = (EventChannelHelper) channelHelpers.stream().filter(c -> c instanceof EventChannelHelper)
-                .findFirst().orElseThrow(() -> new IllegalArgumentException(
+        this.eventHelper = channelHelpers.stream().filter(EventChannelHelper.class::isInstance)
+                .map(EventChannelHelper.class::cast).findFirst().orElseThrow(() -> new IllegalArgumentException(
                         "HomeSecurityThingCapability must find an EventChannelHelper, please file a bug report."));
         eventHelper.setModuleType(moduleType);
     }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/EventCameraChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/EventCameraChannelHelper.java
@@ -30,7 +30,7 @@ import org.openhab.core.types.State;
  *
  */
 @NonNullByDefault
-public class EventCameraChannelHelper extends ChannelHelper {
+public class EventCameraChannelHelper extends EventChannelHelper {
 
     public EventCameraChannelHelper(Set<String> providedGroups) {
         super(providedGroups);


### PR DESCRIPTION
An IAE appeared for Doorbell modules : 

```
2024-04-29 17:05:59.269 [ERROR] [core.thing.internal.ThingManagerImpl] - Exception occurred while calling thing handler factory 'org.openhab.binding.netatmo.internal.NetatmoHandlerFactory@7160fe3a': HomeSecurityThingCapability must find an EventChannelHelper, please file a bug report.
java.lang.IllegalArgumentException: HomeSecurityThingCapability must find an EventChannelHelper, please file a bug report.
	at org.openhab.binding.netatmo.internal.handler.capability.HomeSecurityThingCapability.lambda$1(HomeSecurityThingCapability.java:47) ~[?:?]
	at java.util.Optional.orElseThrow(Optional.java:403) ~[?:?]
	at org.openhab.binding.netatmo.internal.handler.capability.HomeSecurityThingCapability.<init>(HomeSecurityThingCapability.java:47) ~[?:?]
	at org.openhab.binding.netatmo.internal.handler.capability.CameraCapability.<init>(CameraCapability.java:71) ~[?:?]
	at org.openhab.binding.netatmo.internal.handler.capability.DoorbellCapability.<init>(DoorbellCapability.java:33) ~[?:?]
	at org.openhab.binding.netatmo.internal.NetatmoHandlerFactory.lambda$4(NetatmoHandlerFactory.java:141) ~[?:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at org.openhab.binding.netatmo.internal.NetatmoHandlerFactory.buildHandler(NetatmoHandlerFactory.java:128) ~[?:?]
	at org.openhab.binding.netatmo.internal.NetatmoHandlerFactory.lambda$2(NetatmoHandlerFactory.java:114) ~[?:?]
	at java.util.Optional.map(Optional.java:260) ~[?:?]
	at org.openhab.binding.netatmo.internal.NetatmoHandlerFactory.createHandler(NetatmoHandlerFactory.java:114) ~[?:?]
	at org.openhab.core.thing.binding.BaseThingHandlerFactory.registerHandler(BaseThingHandlerFactory.java:136) ~[?:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.doRegisterHandler(ThingManagerImpl.java:531) ~[?:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.registerHandler(ThingManagerImpl.java:519) ~[?:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.registerAndInitializeHandler(ThingManagerImpl.java:927) ~[?:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.lambda$2(ThingManagerImpl.java:551) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:842) [?:?]
```

The test I made while working on it was on Presence, so this one has gone unnoticed until deployed on my production.