### PR TITLE
[energidataservice] Introduce a trigger channel to announce the availability of day-ahead prices

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/README.md
+++ b/bundles/org.openhab.binding.energidataservice/README.md
@@ -170,6 +170,14 @@ A persistence configuration is required for this channel.
 Please note that the CO₂ emission channels only apply to Denmark.
 These channels will not be updated when the configured price area is not DK1 or DK2.
 
+#### Trigger Channels
+
+Advanced channel `event` can trigger the following events:
+
+| Event                | Description                    |
+|----------------------|--------------------------------|
+| DAY_AHEAD_AVAILABLE  | Day-ahead prices are available |
+
 ## Thing Actions
 
 Thing actions can be used to perform calculations as well as import prices directly into rules without relying on persistence.
@@ -556,6 +564,39 @@ logInfo("Spot price two hours from now", price.toString)
 var hourStart = time.toZDT().plusHours(2).truncatedTo(time.ChronoUnit.HOURS);
 var price = items.SpotPrice.history.historicState(hourStart).quantityState;
 console.log("Spot price two hours from now: " + price);
+```
+
+:::
+
+::::
+
+### Trigger Channel Example
+
+:::: tabs
+
+::: tab DSL
+
+```javascript
+rule "Day-ahead event"
+when
+    Channel 'energidataservice:service:energidataservice:electricity#event' triggered 'DAY_AHEAD_AVAILABLE'
+then
+    logInfo("Day-ahead", "Day-ahead prices for the next day are now available")
+end
+```
+
+:::
+
+::: tab JavaScript
+
+```javascript
+rules.when()
+    .channel('energidataservice:service:energidataservice:electricity#event').triggered('DAY_AHEAD_AVAILABLE')
+    .then(event =>
+    {
+        console.log('Day-ahead prices for the next day are now available');
+    })
+    .build("Day-ahead event");
 ```
 
 :::

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/EnergiDataServiceBindingConstants.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/EnergiDataServiceBindingConstants.java
@@ -56,6 +56,7 @@ public class EnergiDataServiceBindingConstants {
             + ChannelUID.CHANNEL_GROUP_SEPARATOR + "co2-emission-prognosis";
     public static final String CHANNEL_CO2_EMISSION_REALTIME = CHANNEL_GROUP_ELECTRICITY
             + ChannelUID.CHANNEL_GROUP_SEPARATOR + "co2-emission-realtime";
+    public static final String CHANNEL_EVENT = CHANNEL_GROUP_ELECTRICITY + ChannelUID.CHANNEL_GROUP_SEPARATOR + "event";
 
     public static final Set<String> ELECTRICITY_CHANNELS = Set.of(CHANNEL_SPOT_PRICE, CHANNEL_GRID_TARIFF,
             CHANNEL_SYSTEM_TARIFF, CHANNEL_TRANSMISSION_GRID_TARIFF, CHANNEL_ELECTRICITY_TAX,
@@ -66,6 +67,9 @@ public class EnergiDataServiceBindingConstants {
     public static final String PROPERTY_TOTAL_CALLS = "totalCalls";
     public static final String PROPERTY_LAST_CALL = "lastCall";
     public static final String PROPERTY_NEXT_CALL = "nextCall";
+
+    // List of all events
+    public static final String EVENT_DAY_AHEAD_AVAILABLE = "DAY_AHEAD_AVAILABLE";
 
     // List of supported currencies
     public static final Currency CURRENCY_DKK = Currency.getInstance("DKK");

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
@@ -81,6 +81,8 @@ channel-type.energidataservice.co2-emission.label = CO₂ Emission
 channel-type.energidataservice.co2-emission.description = CO₂ emission in g/kWh.
 channel-type.energidataservice.datahub-price.label = Datahub Price
 channel-type.energidataservice.datahub-price.description = Datahub price.
+channel-type.energidataservice.event.label = Event
+channel-type.energidataservice.event.description = Event triggered
 channel-type.energidataservice.spot-price.label = Spot Price
 channel-type.energidataservice.spot-price.description = Spot price.
 

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-groups.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-groups.xml
@@ -40,6 +40,7 @@
 				<label>CO₂ Emission Realtime</label>
 				<description>Near up-to-date history for CO₂ emission from electricity consumed in Denmark in g/kWh.</description>
 			</channel>
+			<channel id="event" typeId="event"/>
 		</channels>
 	</channel-group-type>
 

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/channel-types.xml
@@ -29,4 +29,15 @@
 		<state readOnly="true" pattern="%.1f %unit%"></state>
 	</channel-type>
 
+	<channel-type id="event" advanced="true">
+		<kind>trigger</kind>
+		<label>Event</label>
+		<description>Event triggered</description>
+		<event>
+			<options>
+				<option value="DAY_AHEAD_AVAILABLE">Day-ahead prices are available</option>
+			</options>
+		</event>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/thing-service.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/thing/thing-service.xml
@@ -14,7 +14,7 @@
 		</channel-groups>
 
 		<properties>
-			<property name="thingTypeVersion">5</property>
+			<property name="thingTypeVersion">6</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:energidataservice:service"/>

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/update/instructions.xml
@@ -78,6 +78,12 @@
 			</add-channel>
 		</instruction-set>
 
+		<instruction-set targetVersion="6">
+			<add-channel id="event" groupIds="electricity">
+				<type>energidataservice:event</type>
+			</add-channel>
+		</instruction-set>
+
 	</thing-type>
 
 </update:update-descriptions>


### PR DESCRIPTION
This introduces a new trigger channel allowing rules to know when day-ahead prices are available.

See https://community.openhab.org/t/bringing-electricity-information-from-eloverblik-dk-and-energidataservice-dk-into-openhab/143470/100