### PR TITLE
[hue] Fix migration of API v1 legacy data to new v2 things

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -64,6 +64,10 @@ public class HueBindingConstants {
             THING_TYPE_TAP_SWITCH, THING_TYPE_PRESENCE_SENSOR, THING_TYPE_TEMPERATURE_SENSOR,
             THING_TYPE_LIGHT_LEVEL_SENSOR, THING_TYPE_GROUP);
 
+    public static final Set<ThingTypeUID> V1_LIGHT_THING_TYPE_UIDS = Set.of(THING_TYPE_COLOR_LIGHT,
+            THING_TYPE_COLOR_TEMPERATURE_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_EXTENDED_COLOR_LIGHT,
+            THING_TYPE_ON_OFF_LIGHT, THING_TYPE_ON_OFF_PLUG, THING_TYPE_DIMMABLE_PLUG);
+
     // List all channels
     public static final String CHANNEL_COLORTEMPERATURE = "color_temperature";
     public static final String CHANNEL_COLORTEMPERATURE_ABS = "color_temperature_abs";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -64,10 +64,6 @@ public class HueBindingConstants {
             THING_TYPE_TAP_SWITCH, THING_TYPE_PRESENCE_SENSOR, THING_TYPE_TEMPERATURE_SENSOR,
             THING_TYPE_LIGHT_LEVEL_SENSOR, THING_TYPE_GROUP);
 
-    public static final Set<ThingTypeUID> V1_LIGHT_THING_TYPE_UIDS = Set.of(THING_TYPE_COLOR_LIGHT,
-            THING_TYPE_COLOR_TEMPERATURE_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_EXTENDED_COLOR_LIGHT,
-            THING_TYPE_ON_OFF_LIGHT, THING_TYPE_ON_OFF_PLUG, THING_TYPE_DIMMABLE_PLUG);
-
     // List all channels
     public static final String CHANNEL_COLORTEMPERATURE = "color_temperature";
     public static final String CHANNEL_COLORTEMPERATURE_ABS = "color_temperature_abs";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/console/HueCommandExtension.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/console/HueCommandExtension.java
@@ -203,7 +203,6 @@ public class HueCommandExtension extends AbstractConsoleCommandExtension impleme
                                         Optional<Thing> legacyThingOptional = clip2BridgeHandler.getLegacyThing(idv1);
                                         if (legacyThingOptional.isPresent()) {
                                             Thing legacyThing = legacyThingOptional.get();
-                                            thingId = legacyThing.getUID().getId();
                                             String legacyLabel = legacyThing.getLabel();
                                             thingLabel = Objects.nonNull(legacyLabel) ? legacyLabel : thingLabel;
                                         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/Clip2ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/Clip2ThingDiscoveryService.java
@@ -121,7 +121,6 @@ public class Clip2ThingDiscoveryService extends AbstractThingHandlerDiscoverySer
                         if (legacyThingOptional.isPresent()) {
                             Thing legacyThing = legacyThingOptional.get();
                             legacyThingUID = legacyThing.getUID().getAsString();
-                            thingId = legacyThing.getUID().getId();
                             String legacyLabel = legacyThing.getLabel();
                             thingLabel = Objects.nonNull(legacyLabel) ? legacyLabel : thingLabel;
                         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -344,6 +344,10 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
     /**
      * Get the v1 legacy Hue thing (if any) which has a Bridge having the same IP address as this, and an ID that
      * matches the given parameter.
+     * <p>
+     * Note: API v1 'hue:bridge:[light]:123' and 'hue:bridge:[sensor]:123' things are both candidates to migrate to an
+     * API v2 'hue:bridge-api2:device:123' thing. So to prevent ambiguity, this returns an empty result if a legacy
+     * sensor is found having the same OH thing Id as an existing legacy light.
      *
      * @param targetIdV1 the idV1 attribute to match.
      * @return Optional result containing the legacy thing (if found).
@@ -366,13 +370,21 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
         }
 
         ThingUID legacyBridgeUID = legacyBridge.get().getUID();
-        return thingRegistry.getAll().stream() //
+        List<Thing> legacyThings = thingRegistry.getAll().stream()
                 .filter(thing -> legacyBridgeUID.equals(thing.getBridgeUID())
-                        && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID())) //
-                .filter(thing -> {
-                    Object id = thing.getConfiguration().get(config);
-                    return (id instanceof String) && targetIdV1.endsWith("/" + (String) id);
-                }).findFirst();
+                        && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID()))
+                .toList();
+
+        Optional<Thing> foundThing = legacyThings.stream().filter(
+                thing -> thing.getConfiguration().get(config) instanceof String id && targetIdV1.endsWith("/" + id))
+                .findFirst();
+
+        if (SENSOR_ID.equals(config) && foundThing.isPresent()) {
+            String foundThingId = foundThing.get().getUID().getId();
+            return legacyThings.stream().filter(thing -> V1_LIGHT_THING_TYPE_UIDS.contains(thing.getThingTypeUID()))
+                    .anyMatch(thing -> foundThingId.equals(thing.getUID().getId())) ? Optional.empty() : foundThing;
+        }
+        return foundThing;
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -344,10 +344,6 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
     /**
      * Get the v1 legacy Hue thing (if any) which has a Bridge having the same IP address as this, and an ID that
      * matches the given parameter.
-     * <p>
-     * Note: API v1 'hue:bridge:[light]:123' and 'hue:bridge:[sensor]:123' things are both candidates to migrate to an
-     * API v2 'hue:bridge-api2:device:123' thing. So to prevent ambiguity, this returns an empty result if a legacy
-     * sensor is found having the same OH thing Id as an existing legacy light.
      *
      * @param targetIdV1 the idV1 attribute to match.
      * @return Optional result containing the legacy thing (if found).
@@ -370,21 +366,12 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
         }
 
         ThingUID legacyBridgeUID = legacyBridge.get().getUID();
-        List<Thing> legacyThings = thingRegistry.getAll().stream()
+        return thingRegistry.getAll().stream()
                 .filter(thing -> legacyBridgeUID.equals(thing.getBridgeUID())
                         && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID()))
-                .toList();
-
-        Optional<Thing> foundThing = legacyThings.stream().filter(
-                thing -> thing.getConfiguration().get(config) instanceof String id && targetIdV1.endsWith("/" + id))
+                .filter(thing -> thing.getConfiguration().get(config) instanceof String id
+                        && targetIdV1.endsWith("/" + id))
                 .findFirst();
-
-        if (SENSOR_ID.equals(config) && foundThing.isPresent()) {
-            String foundThingId = foundThing.get().getUID().getId();
-            return legacyThings.stream().filter(thing -> V1_LIGHT_THING_TYPE_UIDS.contains(thing.getThingTypeUID()))
-                    .anyMatch(thing -> foundThingId.equals(thing.getUID().getId())) ? Optional.empty() : foundThing;
-        }
-        return foundThing;
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -366,9 +366,9 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
         }
 
         ThingUID legacyBridgeUID = legacyBridge.get().getUID();
-        return thingRegistry.getAll().stream()
+        return thingRegistry.getAll().stream() //
                 .filter(thing -> legacyBridgeUID.equals(thing.getBridgeUID())
-                        && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID()))
+                        && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID())) //
                 .filter(thing -> thing.getConfiguration().get(config) instanceof String id
                         && targetIdV1.endsWith("/" + id))
                 .findFirst();

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/Clip2BridgeHandler.java
@@ -366,11 +366,10 @@ public class Clip2BridgeHandler extends BaseBridgeHandler {
         }
 
         ThingUID legacyBridgeUID = legacyBridge.get().getUID();
-        return thingRegistry.getAll().stream() //
+        return thingRegistry.getAll().stream()
                 .filter(thing -> legacyBridgeUID.equals(thing.getBridgeUID())
-                        && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID())) //
-                .filter(thing -> thing.getConfiguration().get(config) instanceof String id
-                        && targetIdV1.endsWith("/" + id))
+                        && V1_THING_TYPE_UIDS.contains(thing.getThingTypeUID())
+                        && thing.getConfiguration().get(config) instanceof String id && targetIdV1.endsWith("/" + id))
                 .findFirst();
     }
 


### PR DESCRIPTION
Resolves #16711 

When migrating a system from API v1 to v2, there could under some circumstances, be conflicts preventing a) the creation of new v2 things, and b) the migration thing attributes and linked items from the legacy v1 thing to the respective new v2 thing. This was due to ambiguous thing ids if there happened to be multiple v1 legacy things having identical thing ids and different thing type ids.

This PR resolves that issue by ensuring that:
1. all new v2 things are created with a unique thing id, and 
2. thing attributes, and item channel linkages are copied from the correct v1 legacy thing

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>