### PR TITLE
Fix maven-javadoc-plugin upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.12.0</version>
+          <version>3.6.3</version>
           <configuration>
             <failOnError>!${quality.skip}</failOnError>
             <tags>


### PR DESCRIPTION
#16683 mentioned:
> maven-javadoc-plugin, 3.2.0 to 3.6.3, see https://github.com/apache/maven-javadoc-plugin/releases

but actually changed version to 3.12.0, causing this build warning:
```
[WARNING] The POM for org.apache.maven.plugins:maven-javadoc-plugin:jar:3.12.0 is missing, no dependency information available
[WARNING] Failed to retrieve plugin descriptor for org.apache.maven.plugins:maven-javadoc-plugin:3.12.0: Plugin org.apache.maven.plugins:maven-javadoc-plugin:3.12.0 or one of its dependencies could not be resolved: org.apache.maven.plugins:maven-javadoc-plugin:jar:3.12.0 was not found in https://openhab.jfrog.io/openhab/libs-snapshot during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of openhab-snapshot has elapsed or updates are forced
```

I verified with openhab/openhab-core#4197 that 3.6.3 is correct:
https://github.com/openhab/openhab-core/blob/4dfbfb4995820089fbb92aaa64db09437d7e55ac/pom.xml#L324-L326