### PR TITLE
[jablotron] Migrate to v2.2 API

### DIFF
--- a/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/JablotronBindingConstants.java
+++ b/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/JablotronBindingConstants.java
@@ -54,11 +54,13 @@ public class JablotronBindingConstants {
     public static final String CHANNEL_STATUS_PGY = "statusPGY";
 
     // Constants
-    public static final String JABLOTRON_API_URL = "https://api.jablonet.net/api/1.6/";
-    public static final String AGENT = "Swagger-Codegen/1.0.0/android";
+    public static final String JABLOTRON_API_URL = "https://api.jablonet.net/api/2.2/";
+    public static final String AGENT = "net.jablonet/8.3.5.3331 (iPhone 14 Pro Max; iOS 17.4; )";
     public static final int TIMEOUT_SEC = 10;
     public static final String SYSTEM = "openHAB";
     public static final String VENDOR = "JABLOTRON:Jablotron";
+    public static final String CLIENT_VERSION = "MYJ-PUB-IOS-8.3.5.3331";
+    public static final String CLIENT_DEVICE = "Apple|iPhone 14 Pro Max|17.4";
     public static final String APPLICATION_JSON = "application/json";
     public static final String WWW_FORM_URLENCODED = "application/x-www-form-urlencoded; charset=UTF-8";
     public static final String AUTHENTICATION_CHALLENGE = "Authentication challenge without WWW-Authenticate header";

--- a/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/internal/handler/JablotronBridgeHandler.java
+++ b/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/internal/handler/JablotronBridgeHandler.java
@@ -399,7 +399,8 @@ public class JablotronBridgeHandler extends BaseBridgeHandler {
     private Request createRequest(String url) {
         return httpClient.newRequest(url).method(HttpMethod.POST).header(HttpHeader.ACCEPT, APPLICATION_JSON)
                 .header(HttpHeader.ACCEPT_LANGUAGE, bridgeConfig.getLang()).header(HttpHeader.ACCEPT_ENCODING, "*")
-                .header("x-vendor-id", VENDOR).agent(AGENT).timeout(TIMEOUT_SEC, TimeUnit.SECONDS);
+                .header("x-vendor-id", VENDOR).header("x-client-version", CLIENT_VERSION)
+                .header("x-client-device", CLIENT_DEVICE).agent(AGENT).timeout(TIMEOUT_SEC, TimeUnit.SECONDS);
     }
 
     private void relogin() {


### PR DESCRIPTION
The current Jablotron API v1.6 is no longer working. I updated the binding to the currrent API v2.2
I am not sure if you are planning a bugfix release for the 4.1.x branch, but this is definitely a hot candidate.

here is the issue:
https://github.com/openhab/openhab-addons/issues/16740

here is the discussion:
https://community.openhab.org/t/jablotron-alarm-binding-for-openhab/41930/209