### PR TITLE
[shelly] Enable use of analog input with Shelly Plus Add-on

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiClient.java
@@ -620,7 +620,11 @@ public class Shelly2ApiClient extends ShellyHttpClient {
             status.extVoltage = new ShellyExtVoltage(ds.voltmeter100.voltage);
         }
         if (ds.input100 != null) {
-            status.extDigitalInput = new ShellyExtDigitalInput(getBool(ds.input100.state));
+            if (ds.input100.state != null) {
+                status.extDigitalInput = new ShellyExtDigitalInput(getBool(ds.input100.state));
+            } else if (ds.input100.percent != null) {
+                status.extAnalogInput = new ShellyExtAnalogInput(getDouble(ds.input100.percent));
+            }
         }
     }
 


### PR DESCRIPTION
Improvement: This patch enables reading the analog input of a Shelly Plus Add-on as a percentage value when it's attached to a host Shelly device. The analogue input will show up as an external sensor channel on the Shelly Thing.

Signed-off-by: Fabian Fagerholm <fabbe@paniq.net>