### PR TITLE
[somfytahoma] force the gateway discovery if the LAN mode is not working

### DIFF
--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
@@ -307,8 +307,15 @@ public class SomfyTahomaBridgeHandler extends BaseBridgeHandler {
                             isDevModeReady() ? "LAN mode" : cloudFallback ? "Cloud mode fallback" : "Cloud mode");
                 } else {
                     logger.debug("Events id error: {}", id);
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                            "unable to register events");
+                    if (!thingConfig.isDevMode()) {
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                "unable to register events");
+                    } else {
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                "LAN mode is not properly configured");
+                        logger.debug("Forcing the gateway discovery");
+                        discoverGateway();
+                    }
                 }
             }
         } catch (JsonSyntaxException e) {


### PR DESCRIPTION
This PR improves the functionality of the LAN mode.
When the first direct call over the lan fails, it forces the gateway discovery. This comes useful in several scenarios
- either the user misconfigured the IP address or the IP address of the gateway changes.

thanks.