### PR TITLE
Sunsynk poms & codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -347,6 +347,7 @@
 /bundles/org.openhab.binding.speedtest/ @MikeTheTux
 /bundles/org.openhab.binding.spotify/ @Hilbrand
 /bundles/org.openhab.binding.squeezebox/ @digitaldan @mhilbush
+/bundles/org.openhab.binding.sunsynk/ @leec77
 /bundles/org.openhab.binding.surepetcare/ @renescherer @HerzScheisse
 /bundles/org.openhab.binding.synopanalyzer/ @clinique
 /bundles/org.openhab.binding.systeminfo/ @mherwege

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1728,6 +1728,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.sunsynk</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.surepetcare</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -380,6 +380,7 @@
     <module>org.openhab.binding.speedtest</module>
     <module>org.openhab.binding.spotify</module>
     <module>org.openhab.binding.squeezebox</module>
+    <module>org.openhab.binding.sunsynk</module>
     <module>org.openhab.binding.surepetcare</module>
     <module>org.openhab.binding.synopanalyzer</module>
     <module>org.openhab.binding.systeminfo</module>


### PR DESCRIPTION
# Build Integration requirements for new binding sunsynk
Initial contribution
This is the first time I have contributed and am a novice at using git and developing bindings, your understanding and patients would be appreciated.

# Description
Adding binding.sunsynk to binding POM to integrate it in the Maven build.
Binding  in separate  pull request.

Adds  a new binding that  communicated with the Sun Synk Web services in order  to automate Electrical Power Inverter control


# Testing
Built against 4.2.0-SNAPSHOT - Build #3989
Built JAR can be found [here] (https://github.com/LeeC77/sunsynk)

See Community [thread] (https://community.openhab.org/t/new-sun-synk-connect-account-and-inverter-binding/155680)