### PR TITLE
[denonmarantz] Add UoM support for volume dB channels

### DIFF
--- a/bundles/org.openhab.binding.denonmarantz/README.md
+++ b/bundles/org.openhab.binding.denonmarantz/README.md
@@ -52,25 +52,25 @@ The DenonMarantz AVR supports the following channels (some channels are model sp
 | _Main zone_             |              |
 |  mainZone#power    | Switch (RW) | Main zone power on/off
 |  mainZone#volume       | Dimmer (RW) | Main zone volume
-|  mainZone#volumeDB     | Number (RW) | Main zone volume in dB (-80 offset)
+|  mainZone#volumeDB     | Number:Dimensionless (RW) | Main zone volume in dB (-80 offset)
 |  mainZone#mute             | Switch (RW) | Main zone mute
 |  mainZone#input            | String (RW) | Main zone input (e.g. TV, TUNER, ..)
 |  _Zone 2_               |              |
 |  zone2#power | Switch (RW) | Zone 2 power on/off
 |  zone2#volume | Dimmer (RW) | Zone 2 volume
-|  zone2#volumeDB | Number (RW) | Zone 2 volume in dB (-80 offset)
+|  zone2#volumeDB | Number:Dimensionless (RW) | Zone 2 volume in dB (-80 offset)
 |  zone2#mute | Switch (RW) | Zone 2 mute
 |  zone2#input | String (RW) | Zone 2 input
 |  _Zone 3_               |              |
 |  zone3#power | Switch (RW) | Zone 3 power on/off
 |  zone3#volume | Dimmer (RW) | Zone 3 volume
-|  zone3#volumeDB | Number (RW) | Zone 3 volume in dB (-80 offset)
+|  zone3#volumeDB | Number:Dimensionless (RW) | Zone 3 volume in dB (-80 offset)
 |  zone3#mute | Switch (RW) | Zone 3 mute
 |  zone3#input | String (RW) | Zone 3 input
 |  _Zone 4_               |              |
 |  zone4#power | Switch (RW) | Zone 4 power on/off
 |  zone4#volume | Dimmer (RW) | Zone 4 volume
-|  zone4#volumeDB | Number (RW) | Zone 4 volume in dB (-80 offset)
+|  zone4#volumeDB | Number:Dimensionless (RW) | Zone 4 volume in dB (-80 offset)
 |  zone4#mute | Switch (RW) | Zone 4 mute
 |  zone4#input | String (RW) | Zone 4 input
 
@@ -89,14 +89,14 @@ Thing denonmarantz:avr:1 "Receiver" @ "Living room" [host="192.168.1.100"]
 `.items` file:
 
 ```java
-Switch marantz_power    "Receiver" <switch>         {channel="denonmarantz:avr:1:general#power"}
-Dimmer marantz_volume   "Volume"   <soundvolume>    {channel="denonmarantz:avr:1:mainZone#volume"}
-Number marantz_volumeDB "Volume [%.1f dB]"          {channel="denonmarantz:avr:1:mainzone#volume"}
-Switch marantz_mute     "Mute"     <mute>           {channel="denonmarantz:avr:1:mainZone#mute"}
-Switch marantz_z2power  "Zone 2"                    {channel="denonmarantz:avr:1:zone2#power"}
-String marantz_input    "Input [%s]"                {channel="denonmarantz:avr:1:mainZone#input" }
-String marantz_surround "Surround: [%s]"            {channel="denonmarantz:avr:1:general#surroundProgram"}
-String marantz_command                              {channel="denonmarantz:avr:1:general#command"}
+Switch               marantz_power    "Receiver" <switch>         {channel="denonmarantz:avr:1:general#power"}
+Dimmer               marantz_volume   "Volume"   <soundvolume>    {channel="denonmarantz:avr:1:mainZone#volume"}
+Number:Dimensionless marantz_volumeDB "Volume [%.1f dB]"          {channel="denonmarantz:avr:1:mainzone#volume", unit="dB"}
+Switch               marantz_mute     "Mute"     <mute>           {channel="denonmarantz:avr:1:mainZone#mute"}
+Switch               marantz_z2power  "Zone 2"                    {channel="denonmarantz:avr:1:zone2#power"}
+String               marantz_input    "Input [%s]"                {channel="denonmarantz:avr:1:mainZone#input" }
+String               marantz_surround "Surround: [%s]"            {channel="denonmarantz:avr:1:general#surroundProgram"}
+String               marantz_command                              {channel="denonmarantz:avr:1:general#command"}
 ```
 
 `.sitemap` file:

--- a/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/DenonMarantzState.java
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/DenonMarantzState.java
@@ -16,10 +16,11 @@ import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
 
 /**
@@ -164,8 +165,8 @@ public class DenonMarantzState {
             this.mainVolume = newVal;
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_MAIN_VOLUME, newVal);
             // update the main volume in dB too
-            State mainVolumeDB = this.mainVolumeDB = DecimalType
-                    .valueOf(volume.subtract(DenonMarantzBindingConstants.DB_OFFSET).toString());
+            State mainVolumeDB = this.mainVolumeDB = new QuantityType<>(
+                    volume.subtract(DenonMarantzBindingConstants.DB_OFFSET), Units.DECIBEL);
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_MAIN_VOLUME_DB, mainVolumeDB);
         }
     }
@@ -224,8 +225,8 @@ public class DenonMarantzState {
             this.zone2Volume = newVal;
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_ZONE2_VOLUME, newVal);
             // update the volume in dB too
-            State zone2VolumeDB = this.zone2VolumeDB = DecimalType
-                    .valueOf(volume.subtract(DenonMarantzBindingConstants.DB_OFFSET).toString());
+            State zone2VolumeDB = this.zone2VolumeDB = new QuantityType<>(
+                    volume.subtract(DenonMarantzBindingConstants.DB_OFFSET), Units.DECIBEL);
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_ZONE2_VOLUME_DB, zone2VolumeDB);
         }
     }
@@ -260,8 +261,8 @@ public class DenonMarantzState {
             this.zone3Volume = newVal;
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_ZONE3_VOLUME, newVal);
             // update the volume in dB too
-            State zone3VolumeDB = this.zone3VolumeDB = DecimalType
-                    .valueOf(volume.subtract(DenonMarantzBindingConstants.DB_OFFSET).toString());
+            State zone3VolumeDB = this.zone3VolumeDB = new QuantityType<>(
+                    volume.subtract(DenonMarantzBindingConstants.DB_OFFSET), Units.DECIBEL);
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_ZONE3_VOLUME_DB, zone3VolumeDB);
         }
     }
@@ -296,8 +297,8 @@ public class DenonMarantzState {
             this.zone4Volume = newVal;
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_ZONE4_VOLUME, newVal);
             // update the volume in dB too
-            State zone4VolumeDB = this.zone4VolumeDB = DecimalType
-                    .valueOf(volume.subtract(DenonMarantzBindingConstants.DB_OFFSET).toString());
+            State zone4VolumeDB = this.zone4VolumeDB = new QuantityType<>(
+                    volume.subtract(DenonMarantzBindingConstants.DB_OFFSET), Units.DECIBEL);
             handler.stateChanged(DenonMarantzBindingConstants.CHANNEL_ZONE4_VOLUME_DB, zone4VolumeDB);
         }
     }

--- a/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/connector/DenonMarantzConnector.java
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/connector/DenonMarantzConnector.java
@@ -26,7 +26,9 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 
@@ -188,9 +190,16 @@ public abstract class DenonMarantzConnector {
         Command dbCommand = command;
         if (dbCommand instanceof PercentType) {
             throw new UnsupportedCommandTypeException();
-        } else if (dbCommand instanceof DecimalType) {
+        } else if (dbCommand instanceof DecimalType decimalCommand) {
             // convert dB to 'normal' volume by adding the offset of 80
-            dbCommand = new DecimalType(((DecimalType) command).toBigDecimal().add(DB_OFFSET));
+            dbCommand = new DecimalType(decimalCommand.toBigDecimal().add(DB_OFFSET));
+        } else if (dbCommand instanceof QuantityType<?> quantityCommand) {
+            QuantityType<?> decibelCommand = quantityCommand.toUnit(Units.DECIBEL);
+            if (decibelCommand != null) {
+                dbCommand = new DecimalType(new BigDecimal(decibelCommand.doubleValue()).add(DB_OFFSET));
+            } else {
+                throw new UnsupportedCommandTypeException();
+            }
         }
         sendVolumeCommand(dbCommand, zone);
     }

--- a/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/xml/adapters/VolumeAdapter.java
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/xml/adapters/VolumeAdapter.java
@@ -22,7 +22,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Maps Denon volume values in db to percentage
+ * Maps Denon volume values in dB to percentage
  *
  * @author Jeroen Idserda - Initial contribution
  */

--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -29,6 +29,10 @@
 			</channel-group>
 		</channel-groups>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
 		<representation-property>serialNumber</representation-property>
 
 		<config-description>
@@ -138,11 +142,11 @@
 	</channel-type>
 
 	<channel-type id="volumeDB" advanced="true">
-		<item-type>Number</item-type>
+		<item-type unitHint="dB">Number:Dimensionless</item-type>
 		<label>Volume (dB)</label>
 		<description>Set the volume level (dB). Same as [mainVolume - 80].</description>
 		<category>SoundVolume</category>
-		<state min="-80" max="18" step="0.5" pattern="%.1f dB"/>
+		<state min="-80" max="18" step="0.5" pattern="%.1f %unit%"/>
 	</channel-type>
 
 	<channel-type id="mute">

--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="denonmarantz:avr">
+
+		<instruction-set targetVersion="1">
+			<update-channel id="volumeDB" groupIds="mainZone,zone2,zone3,zone4">
+				<type>denonmarantz:volumeDB</type>
+			</update-channel>
+		</instruction-set>
+
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
`VolumeDB` channels for all zones are now `Number:Dimensionless` with unit hint **dB**.