### PR TITLE
[icalendar] Ending maintenance

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -155,7 +155,7 @@
 /bundles/org.openhab.binding.hyperion/ @tavalin
 /bundles/org.openhab.binding.iammeter/ @lewei50
 /bundles/org.openhab.binding.iaqualink/ @digitaldan
-/bundles/org.openhab.binding.icalendar/ @daMihe
+/bundles/org.openhab.binding.icalendar/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.icloud/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.ihc/ @paulianttila
 /bundles/org.openhab.binding.insteon/ @robnielsen


### PR DESCRIPTION
Gracefully ending maintenace of icalendar. See the linked issue #16764 for details.