### PR TITLE
[MQTT] Fix tests after core change

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -28,6 +28,8 @@ import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttMessageSubscriber;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.Command;
@@ -378,7 +380,13 @@ public class ChannelState implements MqttMessageSubscriber {
 
         // Outgoing transformations
         for (ChannelStateTransformation t : transformationsOut) {
-            String commandString = mqttFormatter.getMQTTpublishValue(mqttCommandValue, "%s");
+            Command cValue = mqttCommandValue;
+            // Only pass numeric value for QuantityType.
+            if (mqttCommandValue instanceof QuantityType<?> qtCommandValue) {
+                cValue = new DecimalType(qtCommandValue.toBigDecimal());
+
+            }
+            String commandString = mqttFormatter.getMQTTpublishValue(cValue, "%s");
             String transformedValue = t.processValue(commandString);
             if (transformedValue != null) {
                 mqttFormatter = new TextValue();
@@ -395,7 +403,13 @@ public class ChannelState implements MqttMessageSubscriber {
         // Formatter: Applied before the channel state value is published to the MQTT broker.
         if (config.formatBeforePublish.length() > 0) {
             try {
-                commandString = mqttFormatter.getMQTTpublishValue(mqttCommandValue, config.formatBeforePublish);
+                Command cValue = mqttCommandValue;
+                // Only pass numeric value for QuantityType of format pattern is %s.
+                if ((mqttCommandValue instanceof QuantityType<?> qtCommandValue)
+                        && ("%s".equals(config.formatBeforePublish) || "%S".equals(config.formatBeforePublish))) {
+                    cValue = new DecimalType(qtCommandValue.toBigDecimal());
+                }
+                commandString = mqttFormatter.getMQTTpublishValue(cValue, config.formatBeforePublish);
             } catch (IllegalFormatException e) {
                 logger.debug("Format pattern incorrect for {}", channelUID, e);
                 commandString = mqttFormatter.getMQTTpublishValue(mqttCommandValue, null);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -378,7 +378,7 @@ public class ChannelState implements MqttMessageSubscriber {
 
         // Outgoing transformations
         for (ChannelStateTransformation t : transformationsOut) {
-            String commandString = mqttFormatter.getMQTTpublishValue(mqttCommandValue, null);
+            String commandString = mqttFormatter.getMQTTpublishValue(mqttCommandValue, "%s");
             String transformedValue = t.processValue(commandString);
             if (transformedValue != null) {
                 mqttFormatter = new TextValue();

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -84,7 +84,11 @@ public class NumberValue extends Value {
     public String getMQTTpublishValue(Command command, @Nullable String pattern) {
         String formatPattern = pattern;
         if (formatPattern == null) {
-            formatPattern = "%s";
+            if (command instanceof DecimalType || command instanceof QuantityType<?>) {
+                formatPattern = "%.0f";
+            } else {
+                formatPattern = "%s";
+            }
         }
 
         return command.format(formatPattern);


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/4169#issuecomment-2118869442

Some MQTT tests with QuantityTypes fail after https://github.com/openhab/openhab-core/pull/4169 because the MQTT binding assumes a format pattern of %s to drop the unit of the Number with Dimension. As this was changed in core, this PR introduces some logic in the MQTT binding to account for this.
All failing tests have run again and pass.

Also, default formatting for Number types was not in line with the documentation. It used %s, while the documentation states it should be %f, dropping all decimals (and the unit). It now is for Number types.