### PR TITLE
[ipcamera] Add new AI object detection alarms for Foscam cameras

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/FoscamHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/FoscamHandler.java
@@ -105,6 +105,30 @@ public class FoscamHandler extends ChannelDuplexHandler {
                 ipCameraHandler.setChannelState(CHANNEL_ENABLE_LED, OnOffType.ON);
             }
 
+            if (content.contains("<humanDetectAlarmState>2</humanDetectAlarmState>")) {
+                ipCameraHandler.motionDetected(CHANNEL_HUMAN_ALARM);
+            } else if (content.contains("<humanDetectAlarmState>1</humanDetectAlarmState>")) {
+                ipCameraHandler.noMotionDetected(CHANNEL_HUMAN_ALARM);
+            }
+
+            if (content.contains("<crossLineDetectAlarmState>2</crossLineDetectAlarmState>")) {
+                ipCameraHandler.motionDetected(CHANNEL_LINE_CROSSING_ALARM);
+            } else if (content.contains("<crossLineDetectAlarmState>1</crossLineDetectAlarmState>")) {
+                ipCameraHandler.noMotionDetected(CHANNEL_LINE_CROSSING_ALARM);
+            }
+
+            if (content.contains("<carDetectAlarmState>2</carDetectAlarmState>")) {
+                ipCameraHandler.motionDetected(CHANNEL_CAR_ALARM);
+            } else if (content.contains("<carDetectAlarmState>1</carDetectAlarmState>")) {
+                ipCameraHandler.noMotionDetected(CHANNEL_CAR_ALARM);
+            }
+
+            if (content.contains("<petDetectAlarmState>2</petDetectAlarmState>")) {
+                ipCameraHandler.motionDetected(CHANNEL_ANIMAL_ALARM);
+            } else if (content.contains("<petDetectAlarmState>1</petDetectAlarmState>")) {
+                ipCameraHandler.noMotionDetected(CHANNEL_ANIMAL_ALARM);
+            }
+
             if (content.contains("</CGI_Result>")) {
                 ctx.close();
             }

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1444,6 +1444,7 @@
 			<channel id="mp4History" typeId="mp4History"/>
 			<channel id="mp4HistoryLength" typeId="mp4HistoryLength"/>
 			<channel id="lastMotionType" typeId="lastMotionType"/>
+			<channel id="lineCrossingAlarm" typeId="lineCrossingAlarm"/>
 			<channel id="ffmpegMotionControl" typeId="ffmpegMotionControl"/>
 			<channel id="ffmpegMotionAlarm" typeId="ffmpegMotionAlarm"/>
 			<channel id="enableMotionAlarm" typeId="enableMotionAlarm"/>
@@ -1462,7 +1463,13 @@
 			<channel id="rtspUrl" typeId="rtspUrl"/>
 			<channel id="imageUrl" typeId="imageUrl"/>
 			<channel id="hlsUrl" typeId="hlsUrl"/>
+			<channel id="carAlarm" typeId="carAlarm"/>
+			<channel id="humanAlarm" typeId="humanAlarm"/>
+			<channel id="animalAlarm" typeId="animalAlarm"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description>
 
 			<parameter-group name="Settings">

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/update/instructions.xml
@@ -31,4 +31,20 @@
 		</instruction-set>
 	</thing-type>
 
+	<thing-type uid="ipcamera:foscam">
+		<instruction-set targetVersion="1">
+			<add-channel id="carAlarm">
+				<type>ipcamera:carAlarm</type>
+			</add-channel>
+			<add-channel id="humanAlarm">
+				<type>ipcamera:humanAlarm</type>
+			</add-channel>
+			<add-channel id="animalAlarm">
+				<type>ipcamera:animalAlarm</type>
+			</add-channel>
+			<add-channel id="lineCrossingAlarm">
+				<type>ipcamera:lineCrossingAlarm</type>
+			</add-channel>
+		</instruction-set>
+	</thing-type>
 </update:update-descriptions>


### PR DESCRIPTION
Adds support for some new object detection features on Foscam cameras that have these abilities supported. A a user reported and has already tested (what can be tested) on their camera here on the forum:

https://community.openhab.org/t/ipcamera-binding-and-motion-detect-does-not-work-as-expected/155697/11 