### PR TITLE
[ipcamera] Fix ONVIF alarms streams may stop and not restart on some cameras.

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -178,11 +178,11 @@ public class HikvisionHandler extends ChannelDuplexHandler {
                             removeChannels.add(channel);
                         }
                         // start checking the input IO status
-                        ipCameraHandler.lowPriorityRequests.set(0,
+                        ipCameraHandler.lowPriorityRequests.add(0,
                                 "/ISAPI/System/IO/inputs/" + ipCameraHandler.cameraConfig.getNvrChannel() + "/status");
                     } else {
                         // start checking the input IO status
-                        ipCameraHandler.lowPriorityRequests.set(0,
+                        ipCameraHandler.lowPriorityRequests.add(0,
                                 "/ISAPI/System/IO/inputs/" + ipCameraHandler.cameraConfig.getNvrChannel() + "/status");
                     }
                     ipCameraHandler.removeChannels(removeChannels);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1588,11 +1588,9 @@ public class IpCameraHandler extends BaseThingHandler {
                 sendHttpGET("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=AudioMutation");
                 break;
             case REOLINK_THING:
-                if (cameraConfig.getNvrChannel() > 0) {
-                    sendHttpGET("/api.cgi?cmd=GetAiState&channel=" + cameraConfig.getNvrChannel() + "&user="
-                            + cameraConfig.getUser() + "&password=" + cameraConfig.getPassword());
-                    sendHttpGET("/api.cgi?cmd=GetMdState&channel=" + cameraConfig.getNvrChannel() + "&user="
-                            + cameraConfig.getUser() + "&password=" + cameraConfig.getPassword());
+                if (cameraConfig.getOnvifPort() == 0) {
+                    sendHttpGET("/api.cgi?cmd=GetAiState&channel=" + cameraConfig.getNvrChannel() + reolinkAuth);
+                    sendHttpGET("/api.cgi?cmd=GetMdState&channel=" + cameraConfig.getNvrChannel() + reolinkAuth);
                 } else if (!snapshotPolling) {
                     checkCameraConnection();
                 }
@@ -1777,7 +1775,7 @@ public class IpCameraHandler extends BaseThingHandler {
             case ONVIF_THING:
                 return true;
             case REOLINK_THING:
-                if (cameraConfig.getNvrChannel() < 1) {
+                if (cameraConfig.getOnvifPort() > 0) {
                     return true;
                 }
         }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -61,6 +61,7 @@ import org.openhab.binding.ipcamera.internal.IpCameraDynamicStateDescriptionProv
 import org.openhab.binding.ipcamera.internal.MyNettyAuthHandler;
 import org.openhab.binding.ipcamera.internal.ReolinkHandler;
 import org.openhab.binding.ipcamera.internal.onvif.OnvifConnection;
+import org.openhab.binding.ipcamera.internal.onvif.OnvifConnection.RequestType;
 import org.openhab.binding.ipcamera.internal.servlet.CameraServlet;
 import org.openhab.core.OpenHAB;
 import org.openhab.core.library.types.DecimalType;
@@ -1556,19 +1557,13 @@ public class IpCameraHandler extends BaseThingHandler {
         // what needs to be done every poll//
         switch (thing.getThingTypeUID().getId()) {
             case GENERIC_THING:
-                if (!snapshotPolling) {
-                    checkCameraConnection();
-                }
+                checkCameraConnection();
                 break;
             case ONVIF_THING:
-                if (!snapshotPolling) {
-                    checkCameraConnection();
-                }
+                onvifCamera.sendOnvifRequest(RequestType.Renew, onvifCamera.subscriptionXAddr);
                 break;
             case INSTAR_THING:
-                if (!snapshotPolling) {
-                    checkCameraConnection();
-                }
+                checkCameraConnection();
                 noMotionDetected(CHANNEL_MOTION_ALARM);
                 noMotionDetected(CHANNEL_PIR_ALARM);
                 noMotionDetected(CHANNEL_HUMAN_ALARM);
@@ -1591,14 +1586,11 @@ public class IpCameraHandler extends BaseThingHandler {
                 if (cameraConfig.getOnvifPort() == 0) {
                     sendHttpGET("/api.cgi?cmd=GetAiState&channel=" + cameraConfig.getNvrChannel() + reolinkAuth);
                     sendHttpGET("/api.cgi?cmd=GetMdState&channel=" + cameraConfig.getNvrChannel() + reolinkAuth);
-                } else if (!snapshotPolling) {
-                    checkCameraConnection();
+                } else {
+                    onvifCamera.sendOnvifRequest(RequestType.Renew, onvifCamera.subscriptionXAddr);
                 }
                 break;
             case DAHUA_THING:
-                if (!snapshotPolling) {
-                    checkCameraConnection();
-                }
                 // Check for alarms, channel for NVRs appears not to work at filtering.
                 if (streamIsStopped("/cgi-bin/eventManager.cgi?action=attach&codes=[All]")) {
                     logger.info("The alarm stream was not running for camera {}, re-starting it now",
@@ -1607,9 +1599,6 @@ public class IpCameraHandler extends BaseThingHandler {
                 }
                 break;
             case DOORBIRD_THING:
-                if (!snapshotPolling) {
-                    checkCameraConnection();
-                }
                 // Check for alarms, channel for NVRs appears not to work at filtering.
                 if (streamIsStopped("/bha-api/monitor.cgi?ring=doorbell,motionsensor")) {
                     logger.info("The alarm stream was not running for camera {}, re-starting it now",

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -1731,20 +1731,14 @@ public class IpCameraHandler extends BaseThingHandler {
                             "[{ \"cmd\":\"GetAbility\", \"param\":{ \"User\":{ \"userName\":\"admin\" }}}]");
                 }
                 if (snapshotUri.isEmpty()) {
-                    if (cameraConfig.getNvrChannel() < 1) {
-                        snapshotUri = "/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=openHAB" + reolinkAuth;
-                    } else {
-                        snapshotUri = "/cgi-bin/api.cgi?cmd=Snap&channel=" + (cameraConfig.getNvrChannel() - 1)
-                                + "&rs=openHAB" + reolinkAuth;
-                    }
+                    // ReolinkHandler will change the snapshotUri in the response to /api.cgi?cmd=Login
+                    snapshotUri = "/cgi-bin/api.cgi?cmd=Snap&channel=" + cameraConfig.getNvrChannel() + "&rs=openHAB"
+                            + reolinkAuth;
                 }
+                // channel numbers for snapshots start at 0, while the rtsp start at 1
                 if (rtspUri.isEmpty()) {
-                    if (cameraConfig.getNvrChannel() < 1) {
-                        rtspUri = "rtsp://" + cameraConfig.getIp() + ":554/h264Preview_01_main";
-                    } else {
-                        rtspUri = "rtsp://" + cameraConfig.getIp() + ":554/h264Preview_0" + cameraConfig.getNvrChannel()
-                                + "_main";
-                    }
+                    rtspUri = "rtsp://" + cameraConfig.getIp() + ":554/h264Preview_0"
+                            + (cameraConfig.getNvrChannel() + 1) + "_main";
                 }
                 break;
         }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
@@ -65,11 +65,11 @@ public class OnvifCodec extends ChannelDuplexHandler {
         }
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
-            logger.info("IdleStateEvent received: {}", e.state());
+            logger.debug("IdleStateEvent received: {}", e.state());
             onvifConnection.setIsConnected(false);
             ctx.close();
         } else {
-            logger.info("Other ONVIF netty channel event occurred: {}", evt);
+            logger.debug("Other ONVIF netty channel event occurred: {}", evt);
         }
     }
 
@@ -78,7 +78,7 @@ public class OnvifCodec extends ChannelDuplexHandler {
         if (ctx == null || cause == null) {
             return;
         }
-        logger.info("Exception on ONVIF connection: {}", cause.getMessage());
+        logger.debug("Exception on ONVIF connection: {}", cause.getMessage());
         ctx.close();
     }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.CharsetUtil;
@@ -46,6 +47,11 @@ public class OnvifCodec extends ChannelDuplexHandler {
             return;
         }
         try {
+            if (msg instanceof HttpResponse response) {
+                if (response.status().code() != 200) {
+                    logger.trace("ONVIF replied with code {} message is {}", response.status().code(), msg);
+                }
+            }
             if (msg instanceof HttpContent content) {
                 incomingMessage += content.content().toString(CharsetUtil.UTF_8);
             }
@@ -65,11 +71,11 @@ public class OnvifCodec extends ChannelDuplexHandler {
         }
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
-            logger.info("IdleStateEvent received: {}", e.state());
+            logger.debug("IdleStateEvent received: {}", e.state());
             onvifConnection.setIsConnected(false);
             ctx.close();
         } else {
-            logger.info("Other ONVIF netty channel event occurred: {}", evt);
+            logger.debug("ONVIF netty channel event occurred: {}", evt);
         }
     }
 
@@ -78,7 +84,7 @@ public class OnvifCodec extends ChannelDuplexHandler {
         if (ctx == null || cause == null) {
             return;
         }
-        logger.info("Exception on ONVIF connection: {}", cause.getMessage());
+        logger.debug("Exception on ONVIF connection: {}", cause.getMessage());
         ctx.close();
     }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
@@ -65,11 +65,11 @@ public class OnvifCodec extends ChannelDuplexHandler {
         }
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
-            logger.debug("IdleStateEvent received: {}", e.state());
+            logger.info("IdleStateEvent received: {}", e.state());
             onvifConnection.setIsConnected(false);
             ctx.close();
         } else {
-            logger.debug("Other ONVIF netty channel event occurred: {}", evt);
+            logger.info("Other ONVIF netty channel event occurred: {}", evt);
         }
     }
 
@@ -78,7 +78,7 @@ public class OnvifCodec extends ChannelDuplexHandler {
         if (ctx == null || cause == null) {
             return;
         }
-        logger.debug("Exception on ONVIF connection: {}", cause.getMessage());
+        logger.info("Exception on ONVIF connection: {}", cause.getMessage());
         ctx.close();
     }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
@@ -65,11 +65,11 @@ public class OnvifCodec extends ChannelDuplexHandler {
         }
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
-            logger.trace("IdleStateEvent received: {}", e.state());
+            logger.info("IdleStateEvent received: {}", e.state());
             onvifConnection.setIsConnected(false);
             ctx.close();
         } else {
-            logger.trace("Other ONVIF netty channel event occurred: {}", evt);
+            logger.info("Other ONVIF netty channel event occurred: {}", evt);
         }
     }
 
@@ -78,7 +78,7 @@ public class OnvifCodec extends ChannelDuplexHandler {
         if (ctx == null || cause == null) {
             return;
         }
-        logger.debug("Exception on ONVIF connection: {}", cause.getMessage());
+        logger.info("Exception on ONVIF connection: {}", cause.getMessage());
         ctx.close();
     }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -583,27 +583,26 @@ public class OnvifConnection {
                     if (future == null) {
                         return;
                     }
-                    if (future.isSuccess()) {
+                    if (future.isDone() && future.isSuccess()) {
                         Channel ch = future.channel();
                         ch.writeAndFlush(request);
                     } else { // an error occurred
                         if (future.isDone() && !future.isCancelled()) {
                             Throwable cause = future.cause();
                             String msg = cause.getMessage();
-                            logger.debug("connect failed - cause {}", cause.getMessage());
+                            logger.debug("Connect failed - cause is: {}", cause.getMessage());
                             if (cause instanceof ConnectTimeoutException) {
                                 usingEvents = false;// Prevent Unsubscribe from being sent
                                 ipCameraHandler.cameraCommunicationError(
                                         "Camera timed out when trying to connect to the ONVIF port:" + port);
                             } else if ((cause instanceof ConnectException) && msg != null
-                                    && msg.contains("Connection refused")) {
+                                    && msg.contains("Connection refused ConnectException")) {
                                 usingEvents = false;// Prevent Unsubscribe from being sent
                                 ipCameraHandler.cameraCommunicationError(
                                         "Camera refused to connect when using ONVIF to port:" + port);
                             }
-                        }
-                        if (isConnected) {
-                            disconnect();
+                        } else {
+                            ipCameraHandler.cameraCommunicationError("Camera failed to connect due to being cancelled");
                         }
                     }
                 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -596,7 +596,7 @@ public class OnvifConnection {
                                 ipCameraHandler.cameraCommunicationError(
                                         "Camera timed out when trying to connect to the ONVIF port:" + port);
                             } else if ((cause instanceof ConnectException) && msg != null
-                                    && msg.contains("Connection refused ConnectException")) {
+                                    && msg.contains("Connection refused")) {
                                 usingEvents = false;// Prevent Unsubscribe from being sent
                                 ipCameraHandler.cameraCommunicationError(
                                         "Camera refused to connect when using ONVIF to port:" + port);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -380,6 +380,8 @@ public class OnvifConnection {
                     ipCameraHandler.rtspUri = rtspUri;
                 }
             }
+        } else {
+            logger.info("Unhandled ONVIF reply is: {}", message);
         }
     }
 

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -269,7 +269,7 @@ public class OnvifConnection {
                             + mediaProfileTokens.get(mediaProfileIndex)
                             + "</ProfileToken><Translation><Zoom x=\"-0.0240506344\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
                 case Renew:
-                    return "<Renew xmlns=\"http://docs.oasis-open.org/wsn/b-2\"><TerminationTime>PT1M</TerminationTime></Renew>";
+                    return "<Renew xmlns=\"http://docs.oasis-open.org/wsn/b-2\"><TerminationTime>PT16S</TerminationTime></Renew>";
                 case GetConfigurations:
                     return "<GetConfigurations xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"></GetConfigurations>";
                 case GetConfigurationOptions:
@@ -568,7 +568,7 @@ public class OnvifConnection {
 
                 @Override
                 public void initChannel(SocketChannel socketChannel) throws Exception {
-                    socketChannel.pipeline().addLast("idleStateHandler", new IdleStateHandler(20, 20, 20));
+                    socketChannel.pipeline().addLast("idleStateHandler", new IdleStateHandler(0, 0, 20));
                     socketChannel.pipeline().addLast("HttpClientCodec", new HttpClientCodec());
                     socketChannel.pipeline().addLast("OnvifCodec", new OnvifCodec(getHandle()));
                 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -381,7 +381,7 @@ public class OnvifConnection {
                 }
             }
         } else {
-            logger.info("Unhandled ONVIF reply is: {}", message);
+            logger.trace("Unhandled ONVIF reply is: {}", message);
         }
     }
 


### PR DESCRIPTION
Fixes a bug where some cameras reply with a different ONVIF reply content then expected and the ONVIF alarm stream halts and will not restart when this occurs. Did not effect any of the cameras that have their own API, this was only for ONVIF and also REOLINK thing types.