### PR TITLE
[androidtv] Upgrade Bouncy Castle to 1.78

### DIFF
--- a/bundles/org.openhab.binding.androidtv/pom.xml
+++ b/bundles/org.openhab.binding.androidtv/pom.xml
@@ -22,19 +22,19 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.75</version>
+      <version>1.78</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.75</version>
+      <version>1.78</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>1.75</version>
+      <version>1.78</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Supercedes #16712
Supercedes #16766

Should fix all of these:
https://github.com/openhab/openhab-addons/security/dependabot

Related to:
- openhab/openhab-core#4181
- openhab/openhab-core#4230

Core is currently on bcpkix-jdk18on 1.77 and was on 1.76 before openhab/openhab-core#4181, so it seems the binding doesn't have to be aligned.