### PR TITLE
[hdpowerview] Support SDDP addon suggestion finder

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/addon/addon.xml
@@ -27,6 +27,15 @@
 				</discovery-parameter>
 			</discovery-parameters>
 		</discovery-method>
+		<discovery-method>
+			<service-type>sddp</service-type>
+			<match-properties>
+				<match-property>
+					<name>type</name>
+					<regex>hunterdouglas:hub:powerview.*</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
 	</discovery-methods>
 
 </addon:addon>


### PR DESCRIPTION
The HDPowerview Hub can be discovered via SDDP. This PR adds support for that.

Depends on https://github.com/openhab/openhab-core/pull/4237

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>