### PR TITLE
[denonmarantz] Provide channels icons and semantic tags

### DIFF
--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/i18n/denonmarantz.properties
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/i18n/denonmarantz.properties
@@ -41,8 +41,12 @@ thing-type.config.denonmarantz.avr.zoneCount.description = Number of zones (incl
 
 channel-group-type.denonmarantz.general.label = General Control
 channel-group-type.denonmarantz.general.description = General channels for this AVR.
+channel-group-type.denonmarantz.general.channel.power.description = Power ON/OFF the AVR
 channel-group-type.denonmarantz.zone.label = Zone Control
 channel-group-type.denonmarantz.zone.description = Channels for a zone of this AVR.
+channel-group-type.denonmarantz.zone.channel.mute.description = Mute audio on this zone of the AVR
+channel-group-type.denonmarantz.zone.channel.power.description = Power ON/OFF this zone of the AVR
+channel-group-type.denonmarantz.zone.channel.volume.description = Set the volume level of this zone
 
 # channel types
 
@@ -94,23 +98,15 @@ channel-type.denonmarantz.input.state.option.IPD = IPD
 channel-type.denonmarantz.input.state.option.IRP = IRP
 channel-type.denonmarantz.input.state.option.FVP = FVP
 channel-type.denonmarantz.input.state.option.OTP = OTP
+channel-type.denonmarantz.input.state.option.BLUETOOTH = BLUETOOTH
+channel-type.denonmarantz.input.state.option.COAXIAL = COAXIAL
 channel-type.denonmarantz.input.state.option.DIGITALIN1 = DIGITALIN1
 channel-type.denonmarantz.input.state.option.DIGITALIN2 = DIGITALIN2
 channel-type.denonmarantz.input.state.option.ANALOGIN = ANALOGIN
 channel-type.denonmarantz.input.state.option.ANALOGIN2 = ANALOGIN2
-channel-type.denonmarantz.input.state.option.BLUETOOTH = BLUETOOTH
-channel-type.denonmarantz.input.state.option.COAXIAL = COAXIAL
-channel-type.denonmarantz.mainPower.label = Power
-channel-type.denonmarantz.mainPower.description = Power ON/OFF the AVR
-channel-type.denonmarantz.mute.label = Mute
-channel-type.denonmarantz.mute.description = Enable/Disable Mute on this zone of the AVR
 channel-type.denonmarantz.surroundProgram.label = Surround Program
 channel-type.denonmarantz.surroundProgram.description = Select the surround program of the AVR
 channel-type.denonmarantz.track.label = Now Playing (track)
 channel-type.denonmarantz.track.description = Displays the title of the now playing track.
-channel-type.denonmarantz.volume.label = Volume
-channel-type.denonmarantz.volume.description = Set the volume level of this zone
 channel-type.denonmarantz.volumeDB.label = Volume (dB)
 channel-type.denonmarantz.volumeDB.description = Set the volume level (dB). Same as [mainVolume - 80].
-channel-type.denonmarantz.zonePower.label = Power (zone)
-channel-type.denonmarantz.zonePower.description = Power ON/OFF this zone of the AVR

--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -30,7 +30,7 @@
 		</channel-groups>
 
 		<properties>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 
 		<representation-property>serialNumber</representation-property>
@@ -101,7 +101,9 @@
 		<label>General Control</label>
 		<description>General channels for this AVR.</description>
 		<channels>
-			<channel id="power" typeId="mainPower"/>
+			<channel id="power" typeId="system.power">
+				<description>Power ON/OFF the AVR</description>
+			</channel>
 			<channel id="surroundProgram" typeId="surroundProgram"/>
 			<channel id="artist" typeId="artist"/>
 			<channel id="album" typeId="album"/>
@@ -114,32 +116,19 @@
 		<label>Zone Control</label>
 		<description>Channels for a zone of this AVR.</description>
 		<channels>
-			<channel id="power" typeId="zonePower"/>
-			<channel id="volume" typeId="volume"/>
+			<channel id="power" typeId="system.power">
+				<description>Power ON/OFF this zone of the AVR</description>
+			</channel>
+			<channel id="volume" typeId="system.volume">
+				<description>Set the volume level of this zone</description>
+			</channel>
 			<channel id="volumeDB" typeId="volumeDB"/>
-			<channel id="mute" typeId="mute"/>
+			<channel id="mute" typeId="system.mute">
+				<description>Mute audio on this zone of the AVR</description>
+			</channel>
 			<channel id="input" typeId="input"/>
 		</channels>
 	</channel-group-type>
-
-	<channel-type id="mainPower">
-		<item-type>Switch</item-type>
-		<label>Power</label>
-		<description>Power ON/OFF the AVR</description>
-	</channel-type>
-
-	<channel-type id="zonePower">
-		<item-type>Switch</item-type>
-		<label>Power (zone)</label>
-		<description>Power ON/OFF this zone of the AVR</description>
-	</channel-type>
-
-	<channel-type id="volume">
-		<item-type>Dimmer</item-type>
-		<label>Volume</label>
-		<description>Set the volume level of this zone</description>
-		<category>SoundVolume</category>
-	</channel-type>
 
 	<channel-type id="volumeDB" advanced="true">
 		<item-type unitHint="dB">Number:Dimensionless</item-type>
@@ -147,12 +136,6 @@
 		<description>Set the volume level (dB). Same as [mainVolume - 80].</description>
 		<category>SoundVolume</category>
 		<state min="-80" max="18" step="0.5" pattern="%.1f %unit%"/>
-	</channel-type>
-
-	<channel-type id="mute">
-		<item-type>Switch</item-type>
-		<label>Mute</label>
-		<description>Enable/Disable Mute on this zone of the AVR</description>
 	</channel-type>
 
 	<channel-type id="input">

--- a/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/resources/OH-INF/update/instructions.xml
@@ -11,6 +11,25 @@
 			</update-channel>
 		</instruction-set>
 
+		<instruction-set targetVersion="2">
+			<update-channel id="power" groupIds="general">
+				<type>system:power</type>
+				<description>Power ON/OFF the AVR</description>
+			</update-channel>
+			<update-channel id="power" groupIds="mainZone,zone2,zone3,zone4">
+				<type>system:power</type>
+				<description>Power ON/OFF this zone of the AVR</description>
+			</update-channel>
+			<update-channel id="volume" groupIds="mainZone,zone2,zone3,zone4">
+				<type>system:volume</type>
+				<description>Set the volume level of this zone</description>
+			</update-channel>
+			<update-channel id="mute" groupIds="mainZone,zone2,zone3,zone4">
+				<type>system:mute</type>
+				<description>Mute audio on this zone of the AVR</description>
+			</update-channel>
+		</instruction-set>
+
 	</thing-type>
 
 </update:update-descriptions>


### PR DESCRIPTION
Refactored to use system channel types in order to provide icons and semantic tags (and in some cases also localized labels).