### PR TITLE
[solarforecast] adding codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -332,6 +332,7 @@
 /bundles/org.openhab.binding.sncf/ @clinique
 /bundles/org.openhab.binding.snmp/ @J-N-K
 /bundles/org.openhab.binding.solaredge/ @alexf2015
+/bundles/org.openhab.binding.solarforecast/ @weymann
 /bundles/org.openhab.binding.solarlog/ @johannrichard
 /bundles/org.openhab.binding.solarmax/ @jamietownsend
 /bundles/org.openhab.binding.solarwatt/ @sven-carstens


### PR DESCRIPTION
Add codeowner contact as requested by @jlaur in https://github.com/openhab/openhab-addons/pull/16814#issuecomment-2134072301
Needed for https://github.com/openhab/openhab-addons/pull/13308