### PR TITLE
[solarforecast] damp factor default 

### DIFF
--- a/bundles/org.openhab.binding.solarforecast/README.md
+++ b/bundles/org.openhab.binding.solarforecast/README.md
@@ -113,8 +113,8 @@ In case of empty the location configured in openHAB is obtained.
 | declination     | integer | Plane Declination: 0 for horizontal till 90 for vertical declination         | N/A     | yes      | false    |
 | azimuth         | integer | Plane Azimuth: -180 = north, -90 = east, 0 = south, 90 = west, 180 = north   | N/A     | yes      | false    |
 | kwp             | decimal | Installed Kilowatt Peak                                                      | N/A     | yes      | false    |
-| dampAM          | decimal | Damping factor of morning hours                                              | 0.25    | no       | true     |
-| dampPM          | decimal | Damping factor of evening hours                                              | 0.25    | no       | true     |
+| dampAM          | decimal | Damping factor of morning hours                                              | 0       | no       | true     |
+| dampPM          | decimal | Damping factor of evening hours                                              | 0       | no       | true     |
 | horizon         | text    | Horizon definition as comma separated integer values                         | N/A     | no       | true     |
 
 `refreshInterval` of forecast data needs to respect the throttling of the ForecastSolar service. 

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/config/ForecastSolarPlaneConfiguration.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/config/ForecastSolarPlaneConfiguration.java
@@ -26,7 +26,7 @@ public class ForecastSolarPlaneConfiguration {
     public int azimuth = -1;
     public double kwp = 0;
     public long refreshInterval = 30;
-    public double dampAM = 0.25;
-    public double dampPM = 0.25;
+    public double dampAM = 0;
+    public double dampPM = 0;
     public String horizon = SolarForecastBindingConstants.EMPTY;
 }

--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/config/fs-plane-config.xml
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/config/fs-plane-config.xml
@@ -25,13 +25,13 @@
 		<parameter name="dampAM" type="decimal" step="0.01" min="0" max="1">
 			<label>Morning Damping Factor</label>
 			<description>Damping factor of morning hours</description>
-			<default>0.25</default>
+			<default>0</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="dampPM" type="decimal" step="0.01" min="0" max="1">
 			<label>Evening Damping Factor</label>
 			<description>Damping factor of evening hours</description>
-			<default>0.25</default>
+			<default>0</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="horizon" type="text">


### PR DESCRIPTION
From discussion #16814 about wrong documented default value of damp factor I doubt 0.25 as I implemented is the right value.

Standard from [forecast.solar API](https://doc.forecast.solar/damping )  is 0 and this shall be applied in code & configuration.
