### PR TITLE
[solarforecast] wait 1 hour after http 429 error

### DIFF
--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/SolarForecastHandlerFactory.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/SolarForecastHandlerFactory.java
@@ -14,6 +14,7 @@ package org.openhab.binding.solarforecast.internal;
 
 import static org.openhab.binding.solarforecast.internal.SolarForecastBindingConstants.*;
 
+import java.time.Clock;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -23,6 +24,7 @@ import org.openhab.binding.solarforecast.internal.forecastsolar.handler.Forecast
 import org.openhab.binding.solarforecast.internal.forecastsolar.handler.ForecastSolarPlaneHandler;
 import org.openhab.binding.solarforecast.internal.solcast.handler.SolcastBridgeHandler;
 import org.openhab.binding.solarforecast.internal.solcast.handler.SolcastPlaneHandler;
+import org.openhab.binding.solarforecast.internal.utils.Utils;
 import org.openhab.core.i18n.LocationProvider;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.net.http.HttpClientFactory;
@@ -55,6 +57,7 @@ public class SolarForecastHandlerFactory extends BaseThingHandlerFactory {
             final @Reference TimeZoneProvider tzp) {
         timeZoneProvider = tzp;
         httpClient = hcf.getCommonHttpClient();
+        Utils.setClock(Clock.system(tzp.getTimeZone()));
         PointType pt = lp.getLocation();
         if (pt != null) {
             location = Optional.of(pt);

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/SolarForecastHandlerFactory.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/SolarForecastHandlerFactory.java
@@ -14,7 +14,6 @@ package org.openhab.binding.solarforecast.internal;
 
 import static org.openhab.binding.solarforecast.internal.SolarForecastBindingConstants.*;
 
-import java.time.Clock;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -57,7 +56,7 @@ public class SolarForecastHandlerFactory extends BaseThingHandlerFactory {
             final @Reference TimeZoneProvider tzp) {
         timeZoneProvider = tzp;
         httpClient = hcf.getCommonHttpClient();
-        Utils.setClock(Clock.system(tzp.getTimeZone()));
+        Utils.setTimeZoneProvider(tzp);
         PointType pt = lp.getLocation();
         if (pt != null) {
             location = Optional.of(pt);

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/handler/ForecastSolarBridgeHandler.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/handler/ForecastSolarBridgeHandler.java
@@ -14,6 +14,7 @@ package org.openhab.binding.solarforecast.internal.forecastsolar.handler;
 
 import static org.openhab.binding.solarforecast.internal.SolarForecastBindingConstants.*;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -136,7 +137,7 @@ public class ForecastSolarBridgeHandler extends BaseBridgeHandler implements Sol
         }
         if (calmDownEnd.isAfter(Instant.now(Utils.getClock()))) {
             // wait until calm down time is expired
-            long minutes = java.time.Duration.between(Instant.now(Utils.getClock()), calmDownEnd).toMinutes();
+            long minutes = Duration.between(Instant.now(Utils.getClock()), calmDownEnd).toMinutes();
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "@text/solarforecast.site.status.calmdown [\"" + minutes + "\"]");
             return;

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/handler/ForecastSolarBridgeHandler.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/handler/ForecastSolarBridgeHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.solarforecast.internal.SolarForecastBindingCon
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -55,10 +56,13 @@ import org.openhab.core.types.TimeSeries.Policy;
  */
 @NonNullByDefault
 public class ForecastSolarBridgeHandler extends BaseBridgeHandler implements SolarForecastProvider {
+    private static final int CALM_DOWN_TIME_MINUTES = 61;
+
     private List<ForecastSolarPlaneHandler> planes = new ArrayList<>();
     private Optional<PointType> homeLocation;
     private Optional<ForecastSolarBridgeConfiguration> configuration = Optional.empty();
     private Optional<ScheduledFuture<?>> refreshJob = Optional.empty();
+    private Instant calmDownEnd = Instant.MIN;
 
     public ForecastSolarBridgeHandler(Bridge bridge, Optional<PointType> location) {
         super(bridge);
@@ -130,6 +134,13 @@ public class ForecastSolarBridgeHandler extends BaseBridgeHandler implements Sol
         if (planes.isEmpty()) {
             return;
         }
+        if (calmDownEnd.isAfter(Instant.now(Utils.getClock()))) {
+            // wait until calm down time is expired
+            long minutes = java.time.Duration.between(Instant.now(Utils.getClock()), calmDownEnd).toMinutes();
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/solarforecast.site.status.calmdown [\"" + minutes + "\"]");
+            return;
+        }
         boolean update = true;
         double energySum = 0;
         double powerSum = 0;
@@ -138,7 +149,7 @@ public class ForecastSolarBridgeHandler extends BaseBridgeHandler implements Sol
             try {
                 ForecastSolarPlaneHandler sfph = iterator.next();
                 ForecastSolarObject fo = sfph.fetchData();
-                ZonedDateTime now = ZonedDateTime.now(fo.getZone());
+                ZonedDateTime now = ZonedDateTime.now(Utils.getClock());
                 energySum += fo.getActualEnergyValue(now);
                 powerSum += fo.getActualPowerValue(now);
                 daySum += fo.getDayTotal(now.toLocalDate());
@@ -231,5 +242,9 @@ public class ForecastSolarBridgeHandler extends BaseBridgeHandler implements Sol
             l.addAll(entry.getSolarForecasts());
         });
         return l;
+    }
+
+    public void calmDown() {
+        calmDownEnd = Instant.now(Utils.getClock()).plus(CALM_DOWN_TIME_MINUTES, ChronoUnit.MINUTES);
     }
 }

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/handler/ForecastSolarPlaneHandler.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/forecastsolar/handler/ForecastSolarPlaneHandler.java
@@ -144,11 +144,12 @@ public class ForecastSolarPlaneHandler extends BaseThingHandler implements Solar
                 }
                 try {
                     ContentResponse cr = httpClient.GET(url);
-                    if (cr.getStatus() == 200) {
+                    int responseStatus = cr.getStatus();
+                    if (responseStatus == 200) {
                         try {
                             ForecastSolarObject localForecast = new ForecastSolarObject(thing.getUID().getAsString(),
-                                    cr.getContentAsString(),
-                                    Instant.now().plus(configuration.get().refreshInterval, ChronoUnit.MINUTES));
+                                    cr.getContentAsString(), Instant.now(Utils.getClock())
+                                            .plus(configuration.get().refreshInterval, ChronoUnit.MINUTES));
                             updateStatus(ThingStatus.ONLINE);
                             updateState(CHANNEL_JSON, StringType.valueOf(cr.getContentAsString()));
                             setForecast(localForecast);
@@ -156,6 +157,14 @@ public class ForecastSolarPlaneHandler extends BaseThingHandler implements Solar
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                                     "@text/solarforecast.plane.status.json-status [\"" + fse.getMessage() + "\"]");
                         }
+                    } else if (responseStatus == 429) {
+                        // special handling for 429 response: https://doc.forecast.solar/facing429
+                        // bridge shall "calm down" until at least one hour is expired
+                        if (bridgeHandler.isPresent()) {
+                            bridgeHandler.get().calmDown();
+                        }
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                "@text/solarforecast.plane.status.http-status [\"" + cr.getStatus() + "\"]");
                     } else {
                         logger.trace("Call {} failed with status {}. Response: {}", url, cr.getStatus(),
                                 cr.getContentAsString());
@@ -179,7 +188,7 @@ public class ForecastSolarPlaneHandler extends BaseThingHandler implements Solar
     }
 
     private void updateChannels(ForecastSolarObject f) {
-        ZonedDateTime now = ZonedDateTime.now(f.getZone());
+        ZonedDateTime now = ZonedDateTime.now(Utils.getClock());
         double energyDay = f.getDayTotal(now.toLocalDate());
         double energyProduced = f.getActualEnergyValue(now);
         updateState(CHANNEL_ENERGY_ACTUAL, Utils.getEnergyState(energyProduced));

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/utils/Utils.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/utils/Utils.java
@@ -14,6 +14,7 @@ package org.openhab.binding.solarforecast.internal.utils;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
@@ -24,6 +25,7 @@ import javax.measure.quantity.Power;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.solarforecast.internal.actions.SolarForecast;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.TimeSeries.Entry;
@@ -35,14 +37,30 @@ import org.openhab.core.types.TimeSeries.Entry;
  */
 @NonNullByDefault
 public class Utils {
+    private static TimeZoneProvider timeZoneProvider = new TimeZoneProvider() {
+        @Override
+        public ZoneId getTimeZone() {
+            return ZoneId.systemDefault();
+        }
+    };
+
     private static Clock clock = Clock.systemDefaultZone();
 
+    /**
+     * Only for unit testing setting a fixed clock with desired date-time
+     *
+     * @param c
+     */
     public static void setClock(Clock c) {
         clock = c;
     }
 
+    public static void setTimeZoneProvider(TimeZoneProvider tzp) {
+        timeZoneProvider = tzp;
+    }
+
     public static Clock getClock() {
-        return clock;
+        return clock.withZone(timeZoneProvider.getTimeZone());
     }
 
     public static QuantityType<Energy> getEnergyState(double d) {

--- a/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/utils/Utils.java
+++ b/bundles/org.openhab.binding.solarforecast/src/main/java/org/openhab/binding/solarforecast/internal/utils/Utils.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.solarforecast.internal.utils;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
@@ -34,6 +35,16 @@ import org.openhab.core.types.TimeSeries.Entry;
  */
 @NonNullByDefault
 public class Utils {
+    private static Clock clock = Clock.systemDefaultZone();
+
+    public static void setClock(Clock c) {
+        clock = c;
+    }
+
+    public static Clock getClock() {
+        return clock;
+    }
+
     public static QuantityType<Energy> getEnergyState(double d) {
         if (d < 0) {
             return QuantityType.valueOf(-1, Units.KILOWATT_HOUR);

--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/i18n/solarforecast.properties
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/i18n/solarforecast.properties
@@ -79,6 +79,7 @@ solarforecast.site.status.api-key-missing = API key is mandatory
 solarforecast.site.status.timezone = Time zone {0} not found
 solarforecast.site.status.location-missing = Location neither configured in openHAB nor configuration
 solarforecast.site.status.exception = Exception during update: {0}
+solarforecast.site.status.calmdown = Too many requests, continue in {0} minutes
 solarforecast.plane.status.bridge-missing = Bridge not set
 solarforecast.plane.status.bridge-handler-not-found = Bridge handler not found
 solarforecast.plane.status.wrong-handler = Wrong handler {0}

--- a/bundles/org.openhab.binding.solarforecast/src/test/java/org/openhab/binding/solarforecast/CallbackMock.java
+++ b/bundles/org.openhab.binding.solarforecast/src/test/java/org/openhab/binding/solarforecast/CallbackMock.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.solarforecast;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,8 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -45,10 +48,27 @@ import org.openhab.core.types.TimeSeries.Policy;
 @NonNullByDefault
 public class CallbackMock implements ThingHandlerCallback {
 
-    Map<String, TimeSeries> seriesMap = new HashMap<String, TimeSeries>();
+    Map<String, TimeSeries> seriesMap = new HashMap<>();
+    Map<String, List<State>> stateMap = new HashMap<>();
+    ThingStatusInfo currentInfo = new ThingStatusInfo(ThingStatus.UNKNOWN, ThingStatusDetail.NONE, null);
 
     @Override
     public void stateUpdated(ChannelUID channelUID, State state) {
+        String key = channelUID.getAsString();
+        List<State> stateList = stateMap.get(key);
+        if (stateList == null) {
+            stateList = new ArrayList<>();
+        }
+        stateList.add(state);
+        stateMap.put(key, stateList);
+    }
+
+    public List<State> getStateList(String cuid) {
+        List<State> stateList = stateMap.get(cuid);
+        if (stateList == null) {
+            stateList = new ArrayList<State>();
+        }
+        return stateList;
     }
 
     @Override
@@ -70,6 +90,11 @@ public class CallbackMock implements ThingHandlerCallback {
 
     @Override
     public void statusUpdated(Thing thing, ThingStatusInfo thingStatus) {
+        currentInfo = thingStatus;
+    }
+
+    public ThingStatusInfo getStatus() {
+        return currentInfo;
     }
 
     @Override


### PR DESCRIPTION
Fixes #16811

After receiving [http status 429 for forecast.solar API](https://doc.forecast.solar/facing429) special treatment is necessary. All API calls for `sf-site` needs to stop for at least 1 hour to recover the `OFFLINE` situation.

Treatment for Clock added in order to perform valid unit tests.

