### PR TITLE
[systeminfo] Bump OSHI to 6.5.0

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/org.openhab.binding.systeminfo/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>6.4.12</version>
+      <version>6.5.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-systeminfo" description="System Info Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.github.oshi/oshi-core/6.4.8</bundle>
+		<bundle dependency="true">mvn:com.github.oshi/oshi-core/6.5.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.systeminfo/${project.version}</bundle>
 	</feature>
 </features>

--- a/itests/org.openhab.binding.systeminfo.tests/pom.xml
+++ b/itests/org.openhab.binding.systeminfo.tests/pom.xml
@@ -23,17 +23,17 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
-      <version>5.12.1</version>
+      <version>${jna.version}</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.12.1</version>
+      <version>${jna.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>6.4.8</version>
+      <version>6.5.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bump OSHI dependency version to 6.5.0

Release notes: https://github.com/oshi/oshi/blob/master/CHANGELOG.md
Especially https://github.com/oshi/oshi/pull/2538

Signed-off-by: Alexander Falkenstern [alexander.falkenstern@gmail.com](mailto:alexander.falkenstern@gmail.com)