### PR TITLE
[tapocontrol] bugfix cloud connection error

### DIFF
--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoCloudConnector.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/TapoCloudConnector.java
@@ -19,7 +19,6 @@ import static org.openhab.binding.tapocontrol.internal.helpers.utils.JsonUtils.*
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.Request;
 import org.openhab.binding.tapocontrol.internal.api.protocol.passthrough.PassthroughProtocol;
 import org.openhab.binding.tapocontrol.internal.devices.bridge.TapoBridgeHandler;
 import org.openhab.binding.tapocontrol.internal.devices.bridge.dto.TapoCloudLoginData;
@@ -184,14 +183,5 @@ public class TapoCloudConnector implements TapoConnectorInterface {
             url = url + "?token=" + token;
         }
         return url;
-    }
-
-    /**
-     * Set http-headers
-     */
-    public Request setHeaders(Request httpRequest) {
-        httpRequest.header("content-type", CONTENT_TYPE_JSON);
-        httpRequest.header("Accept", CONTENT_TYPE_JSON);
-        return httpRequest;
     }
 }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/aes/SecurePassthrough.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/aes/SecurePassthrough.java
@@ -112,7 +112,7 @@ public class SecurePassthrough implements TapoProtocolInterface {
             logger.trace("({}) encrypted request: '{}' with cookie '{}'", uid, tapoRequest, session.getCookie());
         }
 
-        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST.toString());
+        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST);
 
         /* set header */
         httpRequest = setHeaders(httpRequest);
@@ -141,7 +141,7 @@ public class SecurePassthrough implements TapoProtocolInterface {
         TapoRequest encryptedRequest = session.encryptRequest(tapoRequest);
         logger.trace("({}) sending encrypted request to '{}' with cookie '{}'", uid, url, session.getCookie());
 
-        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST.toString());
+        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST);
 
         /* set header */
         httpRequest = setHeaders(httpRequest);
@@ -192,7 +192,7 @@ public class SecurePassthrough implements TapoProtocolInterface {
      */
     @Override
     public void responseReceived(ContentResponse response, String command) throws TapoErrorHandler {
-        logger.trace("({}) recived response: {}", uid, response.getContentAsString());
+        logger.trace("({}) received response: {}", uid, response.getContentAsString());
         TapoResponse tapoResponse = getTapoResponse(response);
         httpDelegator.handleResponse(tapoResponse, command);
         httpDelegator.responsePasstrough(response.getContentAsString(), command);
@@ -266,7 +266,6 @@ public class SecurePassthrough implements TapoProtocolInterface {
      * Set HTTP-Headers
      */
     protected Request setHeaders(Request httpRequest) {
-        httpRequest.header("content-type", CONTENT_TYPE_JSON);
         httpRequest.header("Accept", CONTENT_TYPE_JSON);
         if (session.isHandshakeComplete()) {
             httpRequest.header(HTTP_AUTH_TYPE_COOKIE, session.getCookie());

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapProtocol.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/klap/KlapProtocol.java
@@ -94,7 +94,7 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
         String command = tapoRequest.method();
         logger.trace("({}) sending unencrypted request: '{}' to '{}' ", uid, tapoRequest, url);
 
-        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST.toString());
+        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST);
 
         /* set header */
         httpRequest = setHeaders(httpRequest);
@@ -126,7 +126,7 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
         Integer ivSequence = session.getIvSequence();
         logger.trace("({}) encrypted request is '{}' with sequence '{}'", uid, encrypteString, ivSequence);
 
-        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST.toString());
+        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST);
 
         /* set header and params */
         httpRequest = setHeaders(httpRequest);
@@ -263,7 +263,6 @@ public class KlapProtocol implements org.openhab.binding.tapocontrol.internal.ap
      */
     protected Request setHeaders(Request httpRequest) {
         if (!session.isHandshakeComplete()) {
-            httpRequest.header("content-type", CONTENT_TYPE_JSON);
             httpRequest.header("Accept", CONTENT_TYPE_JSON);
         }
         if (!session.getCookie().isBlank()) {

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/passthrough/PassthroughProtocol.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/api/protocol/passthrough/PassthroughProtocol.java
@@ -95,7 +95,7 @@ public class PassthroughProtocol implements TapoProtocolInterface {
         logger.trace("({}) sending encrypted request to '{}' ", uid, url);
         logger.trace("({}) unencrypted request: '{}'", uid, tapoRequest);
 
-        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST.toString());
+        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST);
 
         /* set header */
         httpRequest = setHeaders(httpRequest);
@@ -131,7 +131,7 @@ public class PassthroughProtocol implements TapoProtocolInterface {
         logger.trace("({}) sendAsncRequest to '{}'", uid, url);
         logger.trace("({}) command/payload: '{}''{}'", uid, command, tapoRequest.params());
 
-        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST.toString());
+        Request httpRequest = httpDelegator.getHttpClient().newRequest(url).method(HttpMethod.POST);
 
         /* set header */
         httpRequest = setHeaders(httpRequest);
@@ -180,7 +180,7 @@ public class PassthroughProtocol implements TapoProtocolInterface {
      */
     @Override
     public void responseReceived(ContentResponse response, String command) throws TapoErrorHandler {
-        logger.trace("({}) recived response: {}", uid, response.getContentAsString());
+        logger.trace("({}) received response: {}", uid, response.getContentAsString());
         TapoResponse tapoResponse = getTapoResponse(response);
         if (!tapoResponse.hasError()) {
             switch (command) {
@@ -222,8 +222,9 @@ public class PassthroughProtocol implements TapoProtocolInterface {
         if (response.getStatus() == 200) {
             return getTapoResponse(response.getContentAsString());
         } else {
-            logger.debug("({}) invalid response received", uid);
-            throw new TapoErrorHandler(ERR_BINDING_HTTP_RESPONSE, "invalid response receicved");
+            String reason = response.getStatus() + " " + response.getReason();
+            logger.debug("({}) invalid response received - {}", uid, reason);
+            throw new TapoErrorHandler(ERR_BINDING_HTTP_RESPONSE, reason);
         }
     }
 
@@ -250,7 +251,6 @@ public class PassthroughProtocol implements TapoProtocolInterface {
      * Set HTTP-Headers
      */
     public Request setHeaders(Request httpRequest) {
-        httpRequest.header("content-type", CONTENT_TYPE_JSON);
         httpRequest.header("Accept", CONTENT_TYPE_JSON);
         return httpRequest;
     }

--- a/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/dto/TapoRequest.java
+++ b/bundles/org.openhab.binding.tapocontrol/src/main/java/org/openhab/binding/tapocontrol/internal/dto/TapoRequest.java
@@ -13,11 +13,10 @@
 package org.openhab.binding.tapocontrol.internal.dto;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
-
-import io.reactivex.annotations.Nullable;
 
 /**
  * Holds data sent to device
@@ -31,7 +30,7 @@ public record TapoRequest(@Expose String method, @Expose @Nullable Object params
     /**
      * Create request with command (method) and data (params) sent to device
      */
-    public TapoRequest(String method, Object params) {
+    public TapoRequest(String method, @Nullable Object params) {
         this(method, params, System.currentTimeMillis());
     }
 
@@ -39,7 +38,7 @@ public record TapoRequest(@Expose String method, @Expose @Nullable Object params
      * Create request with command (method) sent to device
      */
     public TapoRequest(String method) {
-        this(method, "", System.currentTimeMillis());
+        this(method, null, System.currentTimeMillis());
     }
 
     /***********************************************


### PR DESCRIPTION
Bugfix: 
Fixed cloud connection error.
- Http-Header: Content-Type was sent twice and this caused a 405 error on cloud response
- Request did sent empty "params" object wich will cause an error in cloud. So "params" must be null that gson will not serialize it.