### PR TITLE
[systeminfo] Rename Systeminfo* to SystemInfo*

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/org.openhab.binding.systeminfo/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.binding.systeminfo</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: Systeminfo Binding</name>
+  <name>openHAB Add-ons :: Bundles :: SystemInfo Binding</name>
 
   <dependencies>
     <dependency>

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SystemInfoBindingConstants.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SystemInfoBindingConstants.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
 
 /**
- * The {@link SysteminfoBindingConstants} class defines common constants, which are
+ * The {@link SystemInfoBindingConstants} class defines common constants, which are
  * used across the whole binding.
  *
  * @author Svilen Valkanov - Initial contribution
@@ -24,7 +24,7 @@ import org.openhab.core.thing.ThingTypeUID;
  * @author Mark Herwege - Processor frequency channels
  */
 @NonNullByDefault
-public class SysteminfoBindingConstants {
+public class SystemInfoBindingConstants {
 
     public static final String BINDING_ID = "systeminfo";
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SystemInfoHandlerFactory.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SystemInfoHandlerFactory.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.systeminfo.internal;
 
-import static org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants.*;
+import static org.openhab.binding.systeminfo.internal.SystemInfoBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.systeminfo.internal.handler.SysteminfoHandler;
-import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
+import org.openhab.binding.systeminfo.internal.handler.SystemInfoHandler;
+import org.openhab.binding.systeminfo.internal.model.SystemInfoInterface;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -27,19 +27,19 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * The {@link SysteminfoHandlerFactory} is responsible for creating things and thing
+ * The {@link SystemInfoHandlerFactory} is responsible for creating things and thing
  * handlers.
  *
  * @author Svilen Valkanov - Initial contribution
- * @author Lyubomir Papazov - Pass systeminfo service to the SysteminfoHandler constructor
+ * @author Lyubomir Papazov - Pass systeminfo service to the SystemInfoHandler constructor
  * @author Wouter Born - Add null annotations
  * @author Mark Herwege - Add dynamic creation of extra channels
  */
 @NonNullByDefault
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.systeminfo")
-public class SysteminfoHandlerFactory extends BaseThingHandlerFactory {
-    private @NonNullByDefault({}) SysteminfoInterface systeminfo;
-    private @NonNullByDefault({}) SysteminfoThingTypeProvider thingTypeProvider;
+public class SystemInfoHandlerFactory extends BaseThingHandlerFactory {
+    private @NonNullByDefault({}) SystemInfoInterface systeminfo;
+    private @NonNullByDefault({}) SystemInfoThingTypeProvider thingTypeProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -58,26 +58,26 @@ public class SysteminfoHandlerFactory extends BaseThingHandlerFactory {
                 thingTypeProvider.storeChannelsConfig(thing); // Save the current channels configs, will be restored
                                                               // after thing type change.
             }
-            return new SysteminfoHandler(thing, thingTypeProvider, systeminfo);
+            return new SystemInfoHandler(thing, thingTypeProvider, systeminfo);
         }
         return null;
     }
 
     @Reference
-    public void bindSystemInfo(SysteminfoInterface systeminfo) {
+    public void bindSystemInfo(SystemInfoInterface systeminfo) {
         this.systeminfo = systeminfo;
     }
 
-    public void unbindSystemInfo(SysteminfoInterface systeminfo) {
+    public void unbindSystemInfo(SystemInfoInterface systeminfo) {
         this.systeminfo = null;
     }
 
     @Reference
-    public void setSysteminfoThingTypeProvider(SysteminfoThingTypeProvider thingTypeProvider) {
+    public void setSystemInfoThingTypeProvider(SystemInfoThingTypeProvider thingTypeProvider) {
         this.thingTypeProvider = thingTypeProvider;
     }
 
-    public void unsetSysteminfoThingTypeProvider(SysteminfoThingTypeProvider thingTypeProvider) {
+    public void unsetSystemInfoThingTypeProvider(SystemInfoThingTypeProvider thingTypeProvider) {
         this.thingTypeProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SystemInfoThingTypeProvider.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SystemInfoThingTypeProvider.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.systeminfo.internal;
 
-import static org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants.*;
+import static org.openhab.binding.systeminfo.internal.SystemInfoBindingConstants.*;
 
 import java.net.URI;
 import java.util.Collections;
@@ -51,17 +51,17 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Extended channels can be auto discovered and added to newly created groups in the
- * {@link org.openhab.binding.systeminfo.internal.handler.SysteminfoHandler}. The
- * thing needs to be updated to add the groups. The `SysteminfoThingTypeProvider` OSGi service gives access to the
+ * {@link org.openhab.binding.systeminfo.internal.handler.SystemInfoHandler}. The
+ * thing needs to be updated to add the groups. The `SystemInfoThingTypeProvider` OSGi service gives access to the
  * `ThingTypeRegistry` and serves the updated `ThingType`.
  *
  * @author Mark Herwege - Initial contribution
  *
  */
 @NonNullByDefault
-@Component(service = { SysteminfoThingTypeProvider.class, ThingTypeProvider.class })
-public class SysteminfoThingTypeProvider extends AbstractStorageBasedTypeProvider {
-    private final Logger logger = LoggerFactory.getLogger(SysteminfoThingTypeProvider.class);
+@Component(service = { SystemInfoThingTypeProvider.class, ThingTypeProvider.class })
+public class SystemInfoThingTypeProvider extends AbstractStorageBasedTypeProvider {
+    private final Logger logger = LoggerFactory.getLogger(SystemInfoThingTypeProvider.class);
 
     private final ThingTypeRegistry thingTypeRegistry;
     private final ChannelGroupTypeRegistry channelGroupTypeRegistry;
@@ -70,7 +70,7 @@ public class SysteminfoThingTypeProvider extends AbstractStorageBasedTypeProvide
     private final Map<ThingUID, Map<String, Configuration>> thingChannelsConfig = new HashMap<>();
 
     @Activate
-    public SysteminfoThingTypeProvider(@Reference ThingTypeRegistry thingTypeRegistry,
+    public SystemInfoThingTypeProvider(@Reference ThingTypeRegistry thingTypeRegistry,
             @Reference ChannelGroupTypeRegistry channelGroupTypeRegistry,
             @Reference ChannelTypeRegistry channelTypeRegistry, @Reference StorageService storageService) {
         super(storageService);

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SystemInfoDiscoveryService.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/discovery/SystemInfoDiscoveryService.java
@@ -12,14 +12,13 @@
  */
 package org.openhab.binding.systeminfo.internal.discovery;
 
-import static org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants.THING_TYPE_COMPUTER;
+import static org.openhab.binding.systeminfo.internal.SystemInfoBindingConstants.THING_TYPE_COMPUTER;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -31,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Discovery service implementation for the Systeminfo binding. It creates {@link DiscoveryResult} with
+ * Discovery service implementation for the SystemInfo binding. It creates {@link DiscoveryResult} with
  * {@link #DEFAULT_THING_LABEL}. The discovered Thing will have id - the hostname or {@link #DEFAULT_THING_ID}'
  *
  * @author Svilen Valkanov - Initial contribution
@@ -39,11 +38,11 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 @Component(service = DiscoveryService.class, configurationPid = "discovery.systeminfo")
-public class SysteminfoDiscoveryService extends AbstractDiscoveryService {
+public class SystemInfoDiscoveryService extends AbstractDiscoveryService {
     public static final String DEFAULT_THING_ID = "unknown";
     public static final String DEFAULT_THING_LABEL = "Local computer";
 
-    private final Logger logger = LoggerFactory.getLogger(SysteminfoDiscoveryService.class);
+    private final Logger logger = LoggerFactory.getLogger(SystemInfoDiscoveryService.class);
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_COMPUTER);
 
@@ -51,7 +50,7 @@ public class SysteminfoDiscoveryService extends AbstractDiscoveryService {
     private static final String THING_UID_VALID_CHARS = "A-Za-z0-9_-";
     private static final String HOST_NAME_SEPERATOR = "_";
 
-    public SysteminfoDiscoveryService() {
+    public SystemInfoDiscoveryService() {
         super(SUPPORTED_THING_TYPES_UIDS, DISCOVERY_TIME_SECONDS);
     }
 
@@ -74,8 +73,7 @@ public class SysteminfoDiscoveryService extends AbstractDiscoveryService {
                     DEFAULT_THING_ID);
         }
 
-        ThingTypeUID computerType = SysteminfoBindingConstants.THING_TYPE_COMPUTER;
-        ThingUID computer = new ThingUID(computerType, hostname);
+        ThingUID computer = new ThingUID(THING_TYPE_COMPUTER, hostname);
         thingDiscovered(DiscoveryResultBuilder.create(computer).withLabel(DEFAULT_THING_LABEL).build());
     }
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SystemInfoHandler.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SystemInfoHandler.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.systeminfo.internal.handler;
 
-import static org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants.*;
+import static org.openhab.binding.systeminfo.internal.SystemInfoBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -27,9 +27,9 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.systeminfo.internal.SysteminfoThingTypeProvider;
+import org.openhab.binding.systeminfo.internal.SystemInfoThingTypeProvider;
 import org.openhab.binding.systeminfo.internal.model.DeviceNotFoundException;
-import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
+import org.openhab.binding.systeminfo.internal.model.SystemInfoInterface;
 import org.openhab.core.cache.ExpiringCache;
 import org.openhab.core.cache.ExpiringCacheMap;
 import org.openhab.core.config.core.Configuration;
@@ -55,7 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link SysteminfoHandler} is responsible for providing real time information about the system
+ * The {@link SystemInfoHandler} is responsible for providing real time information about the system
  * (CPU, Memory, Storage, Display and others).
  *
  * @author Svilen Valkanov - Initial contribution
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Herwege - Processor frequency channels
  */
 @NonNullByDefault
-public class SysteminfoHandler extends BaseThingHandler {
+public class SystemInfoHandler extends BaseThingHandler {
     /**
      * Refresh interval for {@link #highPriorityChannels} in seconds.
      */
@@ -109,9 +109,9 @@ public class SysteminfoHandler extends BaseThingHandler {
      */
     public final String idExtString;
 
-    public final SysteminfoThingTypeProvider thingTypeProvider;
+    public final SystemInfoThingTypeProvider thingTypeProvider;
 
-    private SysteminfoInterface systeminfo;
+    private SystemInfoInterface systeminfo;
 
     private @Nullable ScheduledFuture<?> highPriorityTasks;
     private @Nullable ScheduledFuture<?> mediumPriorityTasks;
@@ -128,10 +128,10 @@ public class SysteminfoHandler extends BaseThingHandler {
     private ExpiringCacheMap<Integer, @Nullable DecimalType> processLoadCache = new ExpiringCacheMap<>(
             MIN_PROCESS_LOAD_REFRESH_INTERVAL_MS);
 
-    private final Logger logger = LoggerFactory.getLogger(SysteminfoHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(SystemInfoHandler.class);
 
-    public SysteminfoHandler(Thing thing, SysteminfoThingTypeProvider thingTypeProvider,
-            SysteminfoInterface systeminfo) {
+    public SystemInfoHandler(Thing thing, SystemInfoThingTypeProvider thingTypeProvider,
+            SystemInfoInterface systeminfo) {
         super(thing);
         this.thingTypeProvider = thingTypeProvider;
         this.systeminfo = systeminfo;
@@ -145,7 +145,7 @@ public class SysteminfoHandler extends BaseThingHandler {
                 thing.getThingTypeUID().getId());
         restoreChannelsConfig(); // After a thing type change, previous channel configs will have been stored, and will
                                  // be restored here.
-        if (instantiateSysteminfoLibrary() && isConfigurationValid() && updateProperties()) {
+        if (instantiateSystemInfoLibrary() && isConfigurationValid() && updateProperties()) {
             if (!addDynamicChannels()) { // If there are new channel groups, the thing will get recreated with a new
                                          // thing type and this handler will be disposed. Therefore do not do anything
                                          // further here.
@@ -165,13 +165,13 @@ public class SysteminfoHandler extends BaseThingHandler {
         super.handleRemoval();
     }
 
-    private boolean instantiateSysteminfoLibrary() {
+    private boolean instantiateSystemInfoLibrary() {
         try {
-            systeminfo.initializeSysteminfo();
-            logger.debug("Systeminfo implementation is instantiated!");
+            systeminfo.initializeSystemInfo();
+            logger.debug("SystemInfo implementation is instantiated!");
             return true;
         } catch (Exception e) {
-            logger.warn("Cannot instantiate Systeminfo object!", e);
+            logger.warn("Cannot instantiate SystemInfo object!", e);
             return false;
         }
     }
@@ -428,9 +428,9 @@ public class SysteminfoHandler extends BaseThingHandler {
     }
 
     /**
-     * This method gets the information for specific channel through the {@link SysteminfoInterface}. It uses the
-     * channel ID to call the correct method from the {@link SysteminfoInterface} with deviceIndex parameter (in case of
-     * multiple devices, for reference see {@link #getDeviceIndex(String)}})
+     * This method gets the information for specific channel through the {@link SystemInfoInterface}. It uses the
+     * channel ID to call the correct method from the {@link SystemInfoInterface} with deviceIndex parameter (in case of
+     * multiple devices, for reference see {@link SystemInfoHandler#getDeviceIndex(ChannelUID)}})
      *
      * @param channelUID the UID of the channel
      * @return State object or null, if there is no information for the device with this index
@@ -662,7 +662,7 @@ public class SysteminfoHandler extends BaseThingHandler {
      * first will have deviceIndex=0, the second deviceIndex=1 ant etc).
      * When no device index is specified, default value of 0 (first device in the list) is returned.
      *
-     * @param channelID the ID of the channel
+     * @param channelUID the ID of the channel
      * @return natural number (number >=0)
      */
     private int getDeviceIndex(ChannelUID channelUID) {

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISystemInfo.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISystemInfo.java
@@ -52,12 +52,12 @@ import oshi.software.os.OperatingSystem;
 import oshi.util.EdidUtil;
 
 /**
- * This implementation of {@link SysteminfoInterface} is using the open source library OSHI to provide system
+ * This implementation of {@link SystemInfoInterface} is using the open source library OSHI to provide system
  * information. OSHI is a free JNA-based (native) Operating System and Hardware Information library for Java.
  *
  * @author Svilen Valkanov - Initial contribution
  * @author Lyubomir Papazov - Move the initialization logic that could potentially take long time to the
- *         initializeSysteminfo method
+ *         initializeSystemInfo method
  * @author Christoph Weitkamp - Update to OSHI 3.13.0 - Replaced deprecated method
  *         CentralProcessor#getSystemSerialNumber()
  * @author Wouter Born - Update to OSHI 4.0.0 and add null annotations
@@ -68,10 +68,10 @@ import oshi.util.EdidUtil;
  * @see <a href="https://github.com/oshi/oshi">OSHI GitHub repository</a>
  */
 @NonNullByDefault
-@Component(service = SysteminfoInterface.class)
-public class OSHISysteminfo implements SysteminfoInterface {
+@Component(service = SystemInfoInterface.class)
+public class OSHISystemInfo implements SystemInfoInterface {
 
-    private final Logger logger = LoggerFactory.getLogger(OSHISysteminfo.class);
+    private final Logger logger = LoggerFactory.getLogger(OSHISystemInfo.class);
 
     private @NonNullByDefault({}) HardwareAbstractionLayer hal;
 
@@ -101,13 +101,13 @@ public class OSHISysteminfo implements SysteminfoInterface {
      * Some of the methods used in this constructor execute native code and require execute permissions
      *
      */
-    public OSHISysteminfo() {
-        logger.debug("OSHISysteminfo service is created");
+    public OSHISystemInfo() {
+        logger.debug("OSHISystemInfo service is created");
     }
 
     @Override
-    public void initializeSysteminfo() {
-        logger.debug("OSHISysteminfo service starts initializing");
+    public void initializeSystemInfo() {
+        logger.debug("OSHISystemInfo service starts initializing");
 
         SystemInfo systemInfo = new SystemInfo();
         hal = systemInfo.getHardware();

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/SystemInfoInterface.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/SystemInfoInterface.java
@@ -26,7 +26,7 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 
 /**
- * {@link SysteminfoInterface} defines the methods needed to provide this binding with the required system information.
+ * {@link SystemInfoInterface} defines the methods needed to provide this binding with the required system information.
  *
  * @author Svilen Valkanov - Initial contribution
  * @author Wouter Born - Add null annotations
@@ -35,12 +35,12 @@ import org.openhab.core.library.types.StringType;
  * @author Mark Herwege - Processor frequency channels
  */
 @NonNullByDefault
-public interface SysteminfoInterface {
+public interface SystemInfoInterface {
 
     /**
-     * Initialize logic for the Systeminfo implementation
+     * Initialize logic for the SystemInfo implementation
      */
-    void initializeSysteminfo();
+    void initializeSystemInfo();
 
     // Operating system info
     /**

--- a/itests/org.openhab.binding.systeminfo.tests/pom.xml
+++ b/itests/org.openhab.binding.systeminfo.tests/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.binding.systeminfo.tests</artifactId>
 
-  <name>openHAB Add-ons :: Integration Tests :: Systeminfo Binding Tests</name>
+  <name>openHAB Add-ons :: Integration Tests :: SystemInfo Binding Tests</name>
 
   <dependencies>
     <dependency>

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SystemInfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SystemInfoOSGiTest.java
@@ -39,13 +39,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants;
-import org.openhab.binding.systeminfo.internal.SysteminfoHandlerFactory;
-import org.openhab.binding.systeminfo.internal.discovery.SysteminfoDiscoveryService;
-import org.openhab.binding.systeminfo.internal.handler.SysteminfoHandler;
+import org.openhab.binding.systeminfo.internal.SystemInfoBindingConstants;
+import org.openhab.binding.systeminfo.internal.SystemInfoHandlerFactory;
+import org.openhab.binding.systeminfo.internal.discovery.SystemInfoDiscoveryService;
+import org.openhab.binding.systeminfo.internal.handler.SystemInfoHandler;
 import org.openhab.binding.systeminfo.internal.model.DeviceNotFoundException;
-import org.openhab.binding.systeminfo.internal.model.OSHISysteminfo;
-import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
+import org.openhab.binding.systeminfo.internal.model.OSHISystemInfo;
+import org.openhab.binding.systeminfo.internal.model.SystemInfoInterface;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -88,7 +88,7 @@ import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
 /**
- * OSGi tests for the {@link SysteminfoHandler}
+ * OSGi tests for the {@link SystemInfoHandler}
  *
  * @author Svilen Valkanov - Initial contribution
  * @author Lyubomir Papazov - Created a mock systeminfo object. This way, access to the user's OS will not be required,
@@ -99,13 +99,13 @@ import org.openhab.core.types.UnDefType;
 @NonNullByDefault
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class SysteminfoOSGiTest extends JavaOSGiTest {
+public class SystemInfoOSGiTest extends JavaOSGiTest {
 
     private static final String DEFAULT_TEST_THING_NAME = "work";
     private static final String DEFAULT_TEST_ITEM_NAME = "test";
     private static final String DEFAULT_CHANNEL_TEST_PRIORITY = "High";
     private static final int DEFAULT_CHANNEL_PID = -1;
-    private static final String DEFAULT_TEST_CHANNEL_ID = SysteminfoBindingConstants.CHANNEL_CPU_LOAD;
+    private static final String DEFAULT_TEST_CHANNEL_ID = SystemInfoBindingConstants.CHANNEL_CPU_LOAD;
     private static final int DEFAULT_DEVICE_INDEX = 0;
 
     /**
@@ -122,8 +122,8 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
     private @Nullable Thing systeminfoThing;
     private @Nullable GenericItem testItem;
 
-    private @Mock @NonNullByDefault({}) OSHISysteminfo mockedSystemInfo;
-    private @NonNullByDefault({}) SysteminfoHandlerFactory systeminfoHandlerFactory;
+    private @Mock @NonNullByDefault({}) OSHISystemInfo mockedSystemInfo;
+    private @NonNullByDefault({}) SystemInfoHandlerFactory systeminfoHandlerFactory;
     private @NonNullByDefault({}) ThingRegistry thingRegistry;
     private @NonNullByDefault({}) ItemRegistry itemRegistry;
     private @NonNullByDefault({}) ManagedThingProvider managedThingProvider;
@@ -136,7 +136,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         volatileStorageService = new VolatileStorageService();
         registerService(volatileStorageService);
 
-        // Preparing the mock with OS properties, that are used in the initialize method of SysteminfoHandler
+        // Preparing the mock with OS properties, that are used in the initialize method of SystemInfoHandler
         // Make this lenient because the assertInvalidThingConfigurationValuesAreHandled test does not require them
         lenient().when(mockedSystemInfo.getCpuLogicalCores()).thenReturn(new DecimalType(1));
         lenient().when(mockedSystemInfo.getCpuPhysicalCores()).thenReturn(new DecimalType(1));
@@ -154,14 +154,14 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         registerService(mockedSystemInfo);
 
         waitForAssert(() -> {
-            systeminfoHandlerFactory = getService(ThingHandlerFactory.class, SysteminfoHandlerFactory.class);
+            systeminfoHandlerFactory = getService(ThingHandlerFactory.class, SystemInfoHandlerFactory.class);
             assertThat(systeminfoHandlerFactory, is(notNullValue()));
         });
 
         if (systeminfoHandlerFactory != null) {
             // Unbind oshiSystemInfo service and bind the mock service to make the systeminfo binding tests independent
             // of the external OSHI library
-            SysteminfoInterface oshiSystemInfo = getService(SysteminfoInterface.class);
+            SystemInfoInterface oshiSystemInfo = getService(SystemInfoInterface.class);
             if (oshiSystemInfo != null) {
                 systeminfoHandlerFactory.unbindSystemInfo(oshiSystemInfo);
             }
@@ -218,9 +218,9 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     private void initializeThingWithChannelAndPID(String channelID, String acceptedItemType, int pid) {
         Configuration thingConfig = new Configuration();
-        thingConfig.put(SysteminfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME,
+        thingConfig.put(SystemInfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME,
                 new BigDecimal(DEFAULT_TEST_INTERVAL_HIGH));
-        thingConfig.put(SysteminfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
+        thingConfig.put(SystemInfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
                 new BigDecimal(DEFAULT_TEST_INTERVAL_MEDIUM));
         String priority = DEFAULT_CHANNEL_TEST_PRIORITY;
 
@@ -229,9 +229,9 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     private void initializeThingWithChannelAndPriority(String channelID, String acceptedItemType, String priority) {
         Configuration thingConfig = new Configuration();
-        thingConfig.put(SysteminfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME,
+        thingConfig.put(SystemInfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME,
                 new BigDecimal(DEFAULT_TEST_INTERVAL_HIGH));
-        thingConfig.put(SysteminfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
+        thingConfig.put(SystemInfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
                 new BigDecimal(DEFAULT_TEST_INTERVAL_MEDIUM));
         int pid = DEFAULT_CHANNEL_PID;
 
@@ -249,9 +249,9 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     private void initializeThingWithChannel(String channelID, String acceptedItemType) {
         Configuration thingConfig = new Configuration();
-        thingConfig.put(SysteminfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME,
+        thingConfig.put(SystemInfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME,
                 new BigDecimal(DEFAULT_TEST_INTERVAL_HIGH));
-        thingConfig.put(SysteminfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
+        thingConfig.put(SystemInfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
                 new BigDecimal(DEFAULT_TEST_INTERVAL_MEDIUM));
 
         String priority = DEFAULT_CHANNEL_TEST_PRIORITY;
@@ -261,7 +261,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     private void initializeThing(Configuration thingConfiguration, String channelID, String acceptedItemType,
             String priority, int pid) {
-        ThingTypeUID thingTypeUID = SysteminfoBindingConstants.THING_TYPE_COMPUTER;
+        ThingTypeUID thingTypeUID = SystemInfoBindingConstants.THING_TYPE_COMPUTER;
         ThingUID thingUID = new ThingUID(thingTypeUID, DEFAULT_TEST_THING_NAME);
 
         ChannelUID channelUID = new ChannelUID(thingUID, channelID);
@@ -269,7 +269,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         if ("load1".equals(channelTypeId) || "load5".equals(channelTypeId) || "load15".equals(channelTypeId)) {
             channelTypeId = "loadAverage";
         }
-        ChannelTypeUID channelTypeUID = new ChannelTypeUID(SysteminfoBindingConstants.BINDING_ID, channelTypeId);
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID(SystemInfoBindingConstants.BINDING_ID, channelTypeId);
         Configuration channelConfig = new Configuration();
         channelConfig.put("priority", priority);
         channelConfig.put("pid", new BigDecimal(pid));
@@ -287,7 +287,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         managedThingProvider.add(thing);
 
         waitForAssert(() -> {
-            SysteminfoHandler handler = (SysteminfoHandler) thing.getHandler();
+            SystemInfoHandler handler = (SystemInfoHandler) thing.getHandler();
             assertThat(handler, is(notNullValue()));
         });
 
@@ -310,9 +310,9 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
             assertThat("Thing status detail is " + thingStatusDetail + " with description " + description,
                     thing.getStatus(), is(equalTo(ThingStatus.ONLINE)));
         });
-        // The binding starts all refresh tasks in SysteminfoHandler.scheduleUpdates() after this delay !
+        // The binding starts all refresh tasks in SystemInfoHandler.scheduleUpdates() after this delay !
         try {
-            sleep(SysteminfoHandler.WAIT_TIME_CHANNEL_ITEM_LINK_INIT * 1000);
+            sleep(SystemInfoHandler.WAIT_TIME_CHANNEL_ITEM_LINK_INIT * 1000);
         } catch (InterruptedException e) {
             throw new AssertionError("Interrupted while sleeping");
         }
@@ -361,10 +361,10 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
         // invalid value - must be positive
         int refreshIntervalHigh = -5;
-        configuration.put(SysteminfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME, new BigDecimal(refreshIntervalHigh));
+        configuration.put(SystemInfoBindingConstants.HIGH_PRIORITY_REFRESH_TIME, new BigDecimal(refreshIntervalHigh));
 
         int refreshIntervalMedium = 3;
-        configuration.put(SysteminfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
+        configuration.put(SystemInfoBindingConstants.MEDIUM_PRIORITY_REFRESH_TIME,
                 new BigDecimal(refreshIntervalMedium));
         initializeThingWithConfiguration(configuration);
 
@@ -406,7 +406,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuMaxFreq() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_MAXFREQ;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_MAXFREQ;
         String acceptedItemType = "Number:Frequency";
 
         QuantityType<Frequency> mockedCpuMaxFreqValue = new QuantityType<>(2500, Units.HERTZ);
@@ -418,7 +418,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuFreq() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_FREQ;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_FREQ;
         String acceptedItemType = "Number:Frequency";
 
         QuantityType<Frequency> mockedCpuFreqValue = new QuantityType<>(2500, Units.HERTZ);
@@ -430,7 +430,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuLoadIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_LOAD;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_LOAD;
         String acceptedItemType = "Number";
 
         PercentType mockedCpuLoadValue = new PercentType(9);
@@ -442,7 +442,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuLoad1IsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_LOAD_1;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_LOAD_1;
         String acceptedItemType = "Number";
 
         DecimalType mockedCpuLoad1Value = new DecimalType(1.1);
@@ -454,7 +454,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuLoad5IsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_LOAD_5;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_LOAD_5;
         String acceptedItemType = "Number";
 
         DecimalType mockedCpuLoad5Value = new DecimalType(5.5);
@@ -466,7 +466,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuLoad15IsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_LOAD_15;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_LOAD_15;
         String acceptedItemType = "Number";
 
         DecimalType mockedCpuLoad15Value = new DecimalType(15.15);
@@ -478,7 +478,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuThreadsIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_THREADS;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_THREADS;
         String acceptedItemType = "Number";
 
         DecimalType mockedCpuThreadsValue = new DecimalType(16);
@@ -490,7 +490,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuUptimeIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_UPTIME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_UPTIME;
         String acceptedItemType = "Number:Time";
 
         QuantityType<Time> mockedCpuUptimeValue = new QuantityType<>(100, Units.MINUTE);
@@ -502,7 +502,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuDescriptionIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_DESCRIPTION;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_DESCRIPTION;
         String acceptedItemType = "String";
 
         StringType mockedCpuDescriptionValue = new StringType("Mocked Cpu Descr");
@@ -515,7 +515,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelCpuNameIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_CPU_NAME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_CPU_NAME;
         String acceptedItemType = "String";
 
         StringType mockedCpuNameValue = new StringType("Mocked Cpu Name");
@@ -527,7 +527,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelMemoryAvailableIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_MEMORY_AVAILABLE;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_MEMORY_AVAILABLE;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedMemoryAvailableValue = new QuantityType<>(1000, Units.MEBIBYTE);
@@ -540,7 +540,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelMemoryUsedIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_MEMORY_USED;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_MEMORY_USED;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedMemoryUsedValue = new QuantityType<>(24, Units.MEBIBYTE);
@@ -552,7 +552,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelMemoryTotalIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_MEMORY_TOTAL;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_MEMORY_TOTAL;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedMemoryTotalValue = new QuantityType<>(1024, Units.MEBIBYTE);
@@ -565,7 +565,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelMemoryAvailablePercentIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_MEMORY_AVAILABLE_PERCENT;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_MEMORY_AVAILABLE_PERCENT;
         String acceptedItemType = "Number";
 
         PercentType mockedMemoryAvailablePercentValue = new PercentType(97);
@@ -578,7 +578,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelSwapAvailableIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SWAP_AVAILABLE;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SWAP_AVAILABLE;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedSwapAvailableValue = new QuantityType<>(482, Units.MEBIBYTE);
@@ -591,7 +591,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelSwapUsedIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SWAP_USED;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SWAP_USED;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedSwapUsedValue = new QuantityType<>(30, Units.MEBIBYTE);
@@ -603,7 +603,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelSwapTotalIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SWAP_TOTAL;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SWAP_TOTAL;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedSwapTotalValue = new QuantityType<>(512, Units.MEBIBYTE);
@@ -615,7 +615,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelSwapAvailablePercentIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SWAP_AVAILABLE_PERCENT;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SWAP_AVAILABLE_PERCENT;
         String acceptedItemType = "Number";
 
         PercentType mockedSwapAvailablePercentValue = new PercentType(94);
@@ -628,7 +628,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageNameIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_NAME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_NAME;
         String acceptedItemType = "String";
 
         StringType mockedStorageName = new StringType("Mocked Storage Name");
@@ -640,7 +640,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageTypeIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_TYPE;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_TYPE;
         String acceptedItemType = "String";
 
         StringType mockedStorageType = new StringType("Mocked Storage Type");
@@ -652,7 +652,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageDescriptionIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_DESCRIPTION;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_DESCRIPTION;
         String acceptedItemType = "String";
 
         StringType mockedStorageDescription = new StringType("Mocked Storage Description");
@@ -665,7 +665,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageAvailableIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_AVAILABLE;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_AVAILABLE;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedStorageAvailableValue = new QuantityType<>(2000, Units.MEBIBYTE);
@@ -678,7 +678,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageUsedIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_USED;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_USED;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedStorageUsedValue = new QuantityType<>(500, Units.MEBIBYTE);
@@ -691,7 +691,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageTotalIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_TOTAL;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_TOTAL;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedStorageTotalValue = new QuantityType<>(2500, Units.MEBIBYTE);
@@ -704,7 +704,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelStorageAvailablePercentIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_STORAGE_AVAILABLE_PERCENT;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_STORAGE_AVAILABLE_PERCENT;
         String acceptedItemType = "Number";
 
         PercentType mockedStorageAvailablePercent = new PercentType(20);
@@ -718,7 +718,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelDriveNameIsUpdated() throws DeviceNotFoundException {
-        String channelID = SysteminfoBindingConstants.CHANNEL_DRIVE_NAME;
+        String channelID = SystemInfoBindingConstants.CHANNEL_DRIVE_NAME;
         String acceptedItemType = "String";
 
         StringType mockedDriveNameValue = new StringType("Mocked Drive Name");
@@ -730,7 +730,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelDriveModelIsUpdated() throws DeviceNotFoundException {
-        String channelID = SysteminfoBindingConstants.CHANNEL_DRIVE_MODEL;
+        String channelID = SystemInfoBindingConstants.CHANNEL_DRIVE_MODEL;
         String acceptedItemType = "String";
 
         StringType mockedDriveModelValue = new StringType("Mocked Drive Model");
@@ -742,7 +742,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelDriveSerialIsUpdated() throws DeviceNotFoundException {
-        String channelID = SysteminfoBindingConstants.CHANNEL_DRIVE_SERIAL;
+        String channelID = SystemInfoBindingConstants.CHANNEL_DRIVE_SERIAL;
         String acceptedItemType = "String";
 
         StringType mockedDriveSerialNumber = new StringType("Mocked Drive Serial Number");
@@ -757,7 +757,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
     // There is a bug opened for this issue - https://github.com/dblock/oshi/issues/185
     @Test
     public void assertChannelSensorsCpuTempIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SENSORS_CPU_TEMPERATURE;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SENSORS_CPU_TEMPERATURE;
         String acceptedItemType = "Number:Temperature";
 
         QuantityType<Temperature> mockedSensorsCpuTemperatureValue = new QuantityType<>(60, SIUnits.CELSIUS);
@@ -770,7 +770,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelSensorsCpuVoltageIsUpdated() {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SENOSRS_CPU_VOLTAGE;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SENOSRS_CPU_VOLTAGE;
         String acceptedItemType = "Number:ElectricPotential";
 
         QuantityType<ElectricPotential> mockedSensorsCpuVoltageValue = new QuantityType<>(1000, Units.VOLT);
@@ -783,7 +783,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelSensorsFanSpeedIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_SENSORS_FAN_SPEED;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_SENSORS_FAN_SPEED;
         String acceptedItemType = "Number";
 
         DecimalType mockedSensorsCpuFanSpeedValue = new DecimalType(180);
@@ -796,7 +796,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelBatteryNameIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_BATTERY_NAME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_BATTERY_NAME;
         String acceptedItemType = "String";
 
         StringType mockedBatteryName = new StringType("Mocked Battery Name");
@@ -808,7 +808,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelBatteryRemainingCapacityIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_BATTERY_REMAINING_CAPACITY;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_BATTERY_REMAINING_CAPACITY;
         String acceptedItemType = "Number";
 
         PercentType mockedBatteryRemainingCapacity = new PercentType(20);
@@ -822,7 +822,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelBatteryRemainingTimeIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_BATTERY_REMAINING_TIME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_BATTERY_REMAINING_TIME;
         String acceptedItemType = "Number:Time";
 
         QuantityType<Time> mockedBatteryRemainingTime = new QuantityType<>(3600, Units.MINUTE);
@@ -835,7 +835,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelDisplayInformationIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_DISPLAY_INFORMATION;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_DISPLAY_INFORMATION;
         String acceptedItemType = "String";
 
         StringType mockedDisplayInfo = new StringType("Mocked Display Information");
@@ -847,7 +847,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkIpIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_IP;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_IP;
         String acceptedItemType = "String";
 
         StringType mockedNetworkIp = new StringType("192.168.1.0");
@@ -859,7 +859,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkMacIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_MAC;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_MAC;
         String acceptedItemType = "String";
 
         StringType mockedNetworkMacValue = new StringType("AB-10-11-12-13-14");
@@ -871,7 +871,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkDataSentIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_DATA_SENT;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_DATA_SENT;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedNetworkDataSent = new QuantityType<>(1000, Units.MEBIBYTE);
@@ -883,7 +883,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkDataReceivedIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_DATA_RECEIVED;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_DATA_RECEIVED;
         String acceptedItemType = "Number:DataAmount";
 
         QuantityType<DataAmount> mockedNetworkDataReceiveed = new QuantityType<>(800, Units.MEBIBYTE);
@@ -896,7 +896,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkPacketsSentIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_PACKETS_SENT;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_PACKETS_SENT;
         String acceptedItemType = "Number";
 
         DecimalType mockedNetworkPacketsSent = new DecimalType(50);
@@ -909,7 +909,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkPacketsReceivedIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_PACKETS_RECEIVED;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_PACKETS_RECEIVED;
         String acceptedItemType = "Number";
 
         DecimalType mockedNetworkPacketsReceived = new DecimalType(48);
@@ -922,7 +922,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkNetworkNameIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_NAME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_NAME;
         String acceptedItemType = "String";
 
         StringType mockedNetworkName = new StringType("MockN-AQ34");
@@ -934,7 +934,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelNetworkNetworkDisplayNameIsUpdated() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_NETWORK_ADAPTER_NAME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_NETWORK_ADAPTER_NAME;
         String acceptedItemType = "String";
 
         StringType mockedNetworkAdapterName = new StringType("Mocked Network Adapter Name");
@@ -945,10 +945,10 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
                 mockedNetworkAdapterName);
     }
 
-    class SysteminfoDiscoveryServiceMock extends SysteminfoDiscoveryService {
+    class SystemInfoDiscoveryServiceMock extends SystemInfoDiscoveryService {
         String hostname;
 
-        SysteminfoDiscoveryServiceMock(String hostname) {
+        SystemInfoDiscoveryServiceMock(String hostname) {
             super();
             this.hostname = hostname;
         }
@@ -986,7 +986,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
     @Test
     public void testDiscoveryWithUnresolvedHostname() {
         String hostname = "unresolved";
-        String expectedHostname = SysteminfoDiscoveryService.DEFAULT_THING_ID;
+        String expectedHostname = SystemInfoDiscoveryService.DEFAULT_THING_ID;
 
         testDiscoveryService(expectedHostname, hostname);
     }
@@ -994,24 +994,24 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
     @Test
     public void testDiscoveryWithEmptyHostnameString() {
         String hostname = "";
-        String expectedHostname = SysteminfoDiscoveryService.DEFAULT_THING_ID;
+        String expectedHostname = SystemInfoDiscoveryService.DEFAULT_THING_ID;
 
         testDiscoveryService(expectedHostname, hostname);
     }
 
     private void testDiscoveryService(String expectedHostname, String hostname) {
-        SysteminfoDiscoveryService discoveryService = getService(DiscoveryService.class,
-                SysteminfoDiscoveryService.class);
+        SystemInfoDiscoveryService discoveryService = getService(DiscoveryService.class,
+                SystemInfoDiscoveryService.class);
         waitForAssert(() -> {
             assertThat(discoveryService, is(notNullValue()));
         });
-        SysteminfoDiscoveryServiceMock discoveryServiceMock = new SysteminfoDiscoveryServiceMock(hostname);
+        SystemInfoDiscoveryServiceMock discoveryServiceMock = new SystemInfoDiscoveryServiceMock(hostname);
         if (discoveryService != null) {
             unregisterService(DiscoveryService.class);
         }
         registerService(discoveryServiceMock, DiscoveryService.class.getName(), new Hashtable<>());
 
-        ThingTypeUID computerType = SysteminfoBindingConstants.THING_TYPE_COMPUTER;
+        ThingTypeUID computerType = SystemInfoBindingConstants.THING_TYPE_COMPUTER;
         ThingUID computerUID = new ThingUID(computerType, expectedHostname);
 
         discoveryServiceMock.startScan();
@@ -1030,7 +1030,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
             assertFalse(results.isEmpty(), "No Thing with UID " + computerUID.getAsString() + " in inbox");
         });
 
-        inbox.approve(computerUID, SysteminfoDiscoveryService.DEFAULT_THING_LABEL, null);
+        inbox.approve(computerUID, SystemInfoDiscoveryService.DEFAULT_THING_LABEL, null);
 
         waitForAssert(() -> {
             systeminfoThing = thingRegistry.get(computerUID);
@@ -1049,7 +1049,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelProcessThreadsIsUpdatedWithPIDse() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_PROCESS_THREADS;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_PROCESS_THREADS;
         String acceptedItemType = "Number";
         // The pid of the System idle process in Windows
         int pid = 0;
@@ -1064,7 +1064,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelProcessPathIsUpdatedWithPIDset() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_PROCESS_PATH;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_PROCESS_PATH;
         String acceptedItemType = "String";
         // The pid of the System idle process in Windows
         int pid = 0;
@@ -1078,7 +1078,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelProcessNameIsUpdatedWithPIDset() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_PROCESS_NAME;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_PROCESS_NAME;
         String acceptedItemType = "String";
         // The pid of the System idle process in Windows
         int pid = 0;
@@ -1092,7 +1092,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelProcessMemoryIsUpdatedWithPIDset() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_PROCESS_MEMORY;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_PROCESS_MEMORY;
         String acceptedItemType = "Number:DataAmount";
         // The pid of the System idle process in Windows
         int pid = 0;
@@ -1106,7 +1106,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertChannelProcessLoadIsUpdatedWithPIDset() throws DeviceNotFoundException {
-        String channnelID = SysteminfoBindingConstants.CHANNEL_PROCESS_LOAD;
+        String channnelID = SystemInfoBindingConstants.CHANNEL_PROCESS_LOAD;
         String acceptedItemType = "Number";
         // The pid of the System idle process in Windows
         int pid = 0;
@@ -1141,10 +1141,10 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         if (thingHandler == null) {
             throw new AssertionError("Thing handler is null");
         }
-        if (!(thingHandler.getClass().equals(SysteminfoHandler.class))) {
-            throw new AssertionError("Thing handler not of class SysteminfoHandler");
+        if (!(thingHandler.getClass().equals(SystemInfoHandler.class))) {
+            throw new AssertionError("Thing handler not of class SystemInfoHandler");
         }
-        SysteminfoHandler handler = (SysteminfoHandler) thingHandler;
+        SystemInfoHandler handler = (SystemInfoHandler) thingHandler;
         waitForAssert(() -> {
             assertThat("The initial priority of channel " + channel.getUID() + " is not as expected.",
                     channel.getConfiguration().get(priorityKey), is(equalTo(initialPriority)));


### PR DESCRIPTION
Just reflect naming conventions as described in https://www.openhab.org/docs/developer/guidelines.html

Signed-off-by: Alexander Falkenstern [alexander.falkenstern@gmail.com](mailto:alexander.falkenstern@gmail.com)