### PR TITLE
[volumio] Fixed volumio don't play playlist (#16826)

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -120,6 +120,9 @@ Hayward OmniLogic Connection Parameters:
 | colorLogicLightEnable      | Switch    | Colorlogic Light enable       |     R/W    |
 | colorLogicLightState       | String    | Colorlogic Light state        |      R     |
 | colorLogicLightCurrentShow | String    | Colorlogic Light current show |     R/W    |
+| colorLogicLightBrightness  | String    | Colorlogic Light brightness   |     R/W    |
+| colorLogicLightSpeed       | String    | Colorlogic Light speed        |     R/W    |
+**Brightness and speed channels only available on Hayward V2 lights
 
 ### Filter Channels
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -61,6 +61,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                     // Enable
                     data = bridgehandler.evaluateXPath("//Chlorinator/@enable", xmlResponse);
                     updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, data.get(i));
+                    channelStates.putAll(updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, data.get(i)));
 
                     // Operating Mode
                     data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);

--- a/bundles/org.openhab.binding.volumio/src/main/java/org/openhab/binding/volumio/internal/mapping/VolumioCommands.java
+++ b/bundles/org.openhab.binding.volumio/src/main/java/org/openhab/binding/volumio/internal/mapping/VolumioCommands.java
@@ -30,7 +30,7 @@ public class VolumioCommands {
 
     /* Player Status */
 
-    public static final String GET_STATE = "get-state";
+    public static final String GET_STATE = "getState";
 
     /* Player Controls */
 
@@ -46,9 +46,9 @@ public class VolumioCommands {
 
     public static final String SEEK = "seek";
 
-    public static final String RANDOM = "set-random";
+    public static final String RANDOM = "setRandom";
 
-    public static final String REPEAT = "set-repeat";
+    public static final String REPEAT = "setRepeat";
 
     /* Search */
 
@@ -64,27 +64,27 @@ public class VolumioCommands {
 
     /* MultiRoom */
 
-    public static final String GET_MULTIROOM_DEVICES = "get-multi-room-devices";
+    public static final String GET_MULTIROOM_DEVICES = "getMultiRoomDevices";
 
     /* Queue */
 
     /**
      * Replace the complete queue and play add/play the delivered entry.
      */
-    public static final String REPLACE_AND_PLAY = "replace-and-play";
+    public static final String REPLACE_AND_PLAY = "replaceAndPlay";
 
     public static final String ADD_PLAY = "addPlay";
 
-    public static final String CLEAR_QUEUE = "clear-queue";
+    public static final String CLEAR_QUEUE = "clearQueue";
 
     /* ... */
     public static final String SHUTDOWN = "shutdown";
 
     public static final String REBOOT = "reboot";
 
-    public static final String PLAY_PLAYLIST = "play-playlist";
+    public static final String PLAY_PLAYLIST = "playPlaylist";
 
-    public static final String PLAY_FAVOURITES = "play-favourites";
+    public static final String PLAY_FAVOURITES = "playFavourites";
 
-    public static final String PLAY_RADIO_FAVOURITES = "play-radio-favourites";
+    public static final String PLAY_RADIO_FAVOURITES = "playRadioFavourites";
 }

--- a/bundles/org.openhab.binding.volumio/src/main/java/org/openhab/binding/volumio/internal/mapping/VolumioCommands.java
+++ b/bundles/org.openhab.binding.volumio/src/main/java/org/openhab/binding/volumio/internal/mapping/VolumioCommands.java
@@ -66,8 +66,6 @@ public class VolumioCommands {
 
     public static final String GET_MULTIROOM_DEVICES = "getMultiRoomDevices";
 
-    /* Queue */
-
     /**
      * Replace the complete queue and play add/play the delivered entry.
      */


### PR DESCRIPTION
# Description

Fixed (#16826)

Playing a playlist from openhab is not possible. The problem was, that the commands, sent to the socket API of volumio, needs to be in camel case. This will be fixed with this PR.