### PR TITLE
[jdbc] Fix state and timestamp being discarded on `store` with alias

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -154,7 +154,7 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
     @Override
     public void store(Item item, ZonedDateTime date, State state, @Nullable String alias) {
         // alias is not supported
-        scheduler.execute(() -> internalStore(item, null, item.getState()));
+        scheduler.execute(() -> internalStore(item, date, state));
     }
 
     private synchronized void internalStore(Item item, @Nullable ZonedDateTime date, State state) {


### PR DESCRIPTION
Fixes #16844
Regression of #15869
Related to openhab/openhab-core#4267