### PR TITLE
[hdpowerview] Improvements to SDDP discovery

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
 
 	<feature name="openhab-binding-hdpowerview" description="HD PowerView Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<feature>openhab-core-config-discovery-sddp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hdpowerview/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewHubDiscoveryParticipantSddp.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewHubDiscoveryParticipantSddp.java
@@ -39,24 +39,26 @@ import org.slf4j.LoggerFactory;
 public class HDPowerViewHubDiscoveryParticipantSddp implements SddpDiscoveryParticipant {
 
     private static final String LABEL_KEY = "discovery.hub.label";
+    private static final String HUNTER_DOUGLAS = "hunterdouglas:";
+    private static final String POWERVIEW_HUB_ID = "hub:powerview";
+    private static final String POWERVIEW_GEN3_ID = "powerview:gen3:gateway";
 
     private final Logger logger = LoggerFactory.getLogger(HDPowerViewHubDiscoveryParticipantSddp.class);
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
-        return Set.of(THING_TYPE_HUB);
+        return Set.of(THING_TYPE_HUB, THING_TYPE_GATEWAY);
     }
 
     @Override
     public @Nullable DiscoveryResult createResult(SddpDevice device) {
-        ThingUID thingUID = getThingUID(device);
+        final ThingUID thingUID = getThingUID(device);
         if (thingUID != null) {
-            String ipAddress = device.ipAddress;
             DiscoveryResult hub = DiscoveryResultBuilder.create(thingUID)
-                    .withProperty(HDPowerViewHubConfiguration.HOST, ipAddress)
+                    .withProperty(HDPowerViewHubConfiguration.HOST, device.ipAddress)
                     .withRepresentationProperty(HDPowerViewHubConfiguration.HOST)
-                    .withLabel(String.format("@text/%s [\"%s\"]", LABEL_KEY, ipAddress)).build();
-            logger.debug("SDDP discovered hub on host '{}'", ipAddress);
+                    .withLabel(String.format("@text/%s [\"%s\"]", LABEL_KEY, device.ipAddress)).build();
+            logger.debug("SDDP discovered hub/gateway '{}' on host '{}'", thingUID, device.ipAddress);
             return hub;
         }
         return null;
@@ -64,9 +66,14 @@ public class HDPowerViewHubDiscoveryParticipantSddp implements SddpDiscoveryPart
 
     @Override
     public @Nullable ThingUID getThingUID(SddpDevice device) {
-        String ipAddress = device.ipAddress;
-        if (VALID_IP_V4_ADDRESS.matcher(ipAddress).matches()) {
-            return new ThingUID(THING_TYPE_HUB, ipAddress.replace('.', '_'));
+        if (device.type.startsWith(HUNTER_DOUGLAS)) {
+            final ThingTypeUID bridgeTypeUID = device.type.contains(POWERVIEW_HUB_ID) ? THING_TYPE_HUB
+                    : device.type.contains(POWERVIEW_GEN3_ID) ? THING_TYPE_GATEWAY : null;
+            if (bridgeTypeUID != null) {
+                if (VALID_IP_V4_ADDRESS.matcher(device.ipAddress).matches()) {
+                    return new ThingUID(bridgeTypeUID, device.ipAddress.replace('.', '_'));
+                }
+            }
         }
         return null;
     }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewHubDiscoveryParticipantSddp.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewHubDiscoveryParticipantSddp.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hdpowerview.internal.discovery;
+
+import static org.openhab.binding.hdpowerview.internal.HDPowerViewBindingConstants.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hdpowerview.internal.config.HDPowerViewHubConfiguration;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.sddp.SddpDevice;
+import org.openhab.core.config.discovery.sddp.SddpDiscoveryParticipant;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discovers HD PowerView hubs by means of SDDP
+ *
+ * @author Andrew Fiddian-Green - Initial contribution
+ */
+@NonNullByDefault
+@Component
+public class HDPowerViewHubDiscoveryParticipantSddp implements SddpDiscoveryParticipant {
+
+    private static final String LABEL_KEY = "discovery.hub.label";
+
+    private final Logger logger = LoggerFactory.getLogger(HDPowerViewHubDiscoveryParticipantSddp.class);
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return Set.of(THING_TYPE_HUB);
+    }
+
+    @Override
+    public @Nullable DiscoveryResult createResult(SddpDevice device) {
+        ThingUID thingUID = getThingUID(device);
+        if (thingUID != null) {
+            String ipAddress = device.ipAddress;
+            DiscoveryResult hub = DiscoveryResultBuilder.create(thingUID)
+                    .withProperty(HDPowerViewHubConfiguration.HOST, ipAddress)
+                    .withRepresentationProperty(HDPowerViewHubConfiguration.HOST)
+                    .withLabel(String.format("@text/%s [\"%s\"]", LABEL_KEY, ipAddress)).build();
+            logger.debug("SDDP discovered hub on host '{}'", ipAddress);
+            return hub;
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable ThingUID getThingUID(SddpDevice device) {
+        String ipAddress = device.ipAddress;
+        if (VALID_IP_V4_ADDRESS.matcher(ipAddress).matches()) {
+            return new ThingUID(THING_TYPE_HUB, ipAddress.replace('.', '_'));
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/addon/addon.xml
@@ -32,7 +32,7 @@
 			<match-properties>
 				<match-property>
 					<name>type</name>
-					<regex>hunterdouglas:hub:powerview.*</regex>
+					<regex>hunterdouglas.*</regex>
 				</match-property>
 			</match-properties>
 		</discovery-method>


### PR DESCRIPTION
Makes the following improvements:
- Extend SDDP addon discovery to include Gen 3 gateways
- Add thing discovery via SDDP for both Gen1/2 hubs and Gen 3 gateways

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
