### PR TITLE
[boschshc] Bump Bouncy Castle Dependencies to 1.78.1

### DIFF
--- a/bundles/org.openhab.binding.boschshc/pom.xml
+++ b/bundles/org.openhab.binding.boschshc/pom.xml
@@ -14,23 +14,27 @@
 
   <name>openHAB Add-ons :: Bundles :: Bosch Smart Home Binding</name>
 
+  <properties>
+    <bouncycastle.version>1.78.1</bouncycastle.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcutil-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcutil-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This relates to the following issue and security alerts:
* https://github.com/openhab/openhab-addons/issues/16459
* https://github.com/openhab/openhab-addons/security/dependabot/81
* https://github.com/openhab/openhab-addons/security/dependabot/82
* https://github.com/openhab/openhab-addons/security/dependabot/83

The binding should not be affected by
https://github.com/openhab/openhab-addons/issues/16459. No detailed analysis was done for the remaining alerts, but the bumped version is not vulnerable anymore in any case.