### PR TITLE
[pegelonline] fix junit status race condition

### DIFF
--- a/bundles/org.openhab.binding.pegelonline/src/test/java/org/openhab/binding/pegelonline/internal/handler/PegelTest.java
+++ b/bundles/org.openhab.binding.pegelonline/src/test/java/org/openhab/binding/pegelonline/internal/handler/PegelTest.java
@@ -247,11 +247,20 @@ class PegelTest {
 
         tsi = callback.getThingStatus();
         assertNotNull(tsi);
-        assertEquals(ThingStatus.UNKNOWN, tsi.getStatus(), "Status");
-        assertEquals(ThingStatusDetail.NONE, tsi.getStatusDetail(), "Detail");
-        description = tsi.getDescription();
-        assertNotNull(description);
-        assertEquals("@text/pegelonline.handler.status.wait-feedback", description, "Description");
+        // In function initialize scheduler is started.
+        // If schedule took place status is ONLINE else UNKNOWN
+        switch (tsi.getStatus()) {
+            case UNKNOWN:
+                assertEquals(ThingStatusDetail.NONE, tsi.getStatusDetail(), "Detail");
+                description = tsi.getDescription();
+                assertNotNull(description);
+                assertEquals("@text/pegelonline.handler.status.wait-feedback", description, "Description");
+                break;
+            case ONLINE:
+                break;
+            default:
+                fail();
+        }
 
         handler.dispose();
         config = new Configuration();


### PR DESCRIPTION
Fix race condition which can occur during unit testing. 
`ThingStatus` can be `UNKNOWN` or `ONLINE` after initialize call, all other stati shall fail.
https://github.com/openhab/openhab-addons/pull/16831#issuecomment-2174157015