### PR TITLE
[emotiva] Remove discovery-methods because of missing listen port support in scanBroadcast

### DIFF
--- a/bundles/org.openhab.binding.emotiva/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.emotiva/src/main/resources/OH-INF/addon/addon.xml
@@ -17,14 +17,29 @@
 					<value>ipBroadcast</value>
 				</discovery-parameter>
 				<discovery-parameter>
+					<name>requestPlain</name>
+					<value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;&lt;emotivaPing
+						protocol=&quot;3.0&quot;/&gt;</value>
+				</discovery-parameter>
+				<discovery-parameter>
 					<name>destPort</name>
-					<value>7001</value>
+					<value>7000</value>
 				</discovery-parameter>
 				<discovery-parameter>
 					<name>timeoutMs</name>
 					<value>1000</value>
 				</discovery-parameter>
+				<discovery-parameter>
+					<name>listenPort</name>
+					<value>7001</value>
+				</discovery-parameter>
 			</discovery-parameters>
+			<match-properties>
+				<match-property>
+					<name>response</name>
+					<regex>.*</regex>
+				</match-property>
+			</match-properties>
 		</discovery-method>
 	</discovery-methods>
 

--- a/bundles/org.openhab.binding.emotiva/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.emotiva/src/main/resources/OH-INF/addon/addon.xml
@@ -8,39 +8,4 @@
 	<description>This is the binding for devices from the Emotiva Audio Corporation.</description>
 	<connection>local</connection>
 
-	<discovery-methods>
-		<discovery-method>
-			<service-type>ip</service-type>
-			<discovery-parameters>
-				<discovery-parameter>
-					<name>type</name>
-					<value>ipBroadcast</value>
-				</discovery-parameter>
-				<discovery-parameter>
-					<name>requestPlain</name>
-					<value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;&lt;emotivaPing
-						protocol=&quot;3.0&quot;/&gt;</value>
-				</discovery-parameter>
-				<discovery-parameter>
-					<name>destPort</name>
-					<value>7000</value>
-				</discovery-parameter>
-				<discovery-parameter>
-					<name>timeoutMs</name>
-					<value>1000</value>
-				</discovery-parameter>
-				<discovery-parameter>
-					<name>listenPort</name>
-					<value>7001</value>
-				</discovery-parameter>
-			</discovery-parameters>
-			<match-properties>
-				<match-property>
-					<name>response</name>
-					<regex>.*</regex>
-				</match-property>
-			</match-properties>
-		</discovery-method>
-	</discovery-methods>
-
 </addon:addon>


### PR DESCRIPTION
This PR removes discovery-methods declartion in the emotiva binding. The declariton was missing fields, and upon further invesrtigation, the scanBroadcast in IpAddonFinder.java does not support separate destination and listen ports, meaning a discovery via the IpAddonFinder will not work.