### PR TITLE
[hue] Add semantic tags for advanced light channels (API v2)

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/channels.xml
@@ -242,6 +242,10 @@
 		<label>Color XY Only</label>
 		<description>Set the color xy parameter of the light without changing other state parameters.</description>
 		<category>ColorLight</category>
+		<tags>
+			<tag>Control</tag>
+			<tag>Light</tag>
+		</tags>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
@@ -250,7 +254,11 @@
 		<label>Dimming Only</label>
 		<description>Set the dimming parameter of the light without changing other state parameters.</description>
 		<category>Light</category>
-		<state pattern="%.1f %%"/>
+		<tags>
+			<tag>Control</tag>
+			<tag>Light</tag>
+		</tags>
+		<state min="0" max="100" pattern="%.1f %%"/>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
@@ -259,6 +267,10 @@
 		<label>On/Off Only</label>
 		<description>Set the on/off parameter of the light without changing other state parameters.</description>
 		<category>Switch</category>
+		<tags>
+			<tag>Switch</tag>
+			<tag>Power</tag>
+		</tags>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 


### PR DESCRIPTION
For consistency with corresponding system channel types referenced by non-advanced channel variants:

https://github.com/openhab/openhab-core/blob/2aacdcd4e8a6f2dcc5dca83a28267cd0e44f6cd6/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java#L212-L228

https://github.com/openhab/openhab-core/blob/2aacdcd4e8a6f2dcc5dca83a28267cd0e44f6cd6/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java#L185-L191