### PR TITLE
[tr064] Support MACOnline channels configured via *.thing file.

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -256,20 +256,25 @@ The definition of the bridge and of the subdevices things is the following
 
 ```java
 Bridge tr064:fritzbox:rootuid "Root label" @ "location" [ host="192.168.1.1", user="user", password="passwd",
-                                                         phonebookInterval="0"]{
-    Thing subdeviceLan LAN "label LAN"   [ uuid="uuid:xxxxxxxx-xxxx-xxxx-yyyy-xxxxxxxxxxxx",
-                                                macOnline="XX:XX:XX:XX:XX:XX",  
-                                                          "YY:YY:YY:YY:YY:YY"]  
-    Thing subdevice WAN "label WAN"               [ uuid="uuid:xxxxxxxx-xxxx-xxxx-zzzz-xxxxxxxxxxxx"]
-    Thing subdevice WANCon "label WANConnection"  [ uuid="uuid:xxxxxxxx-xxxx-xxxx-wwww-xxxxxxxxxxxx"]
-    }
+                                                         phonebookInterval="0"]
+{
+  Thing subdeviceLan LAN "label LAN"   [ uuid="uuid:xxxxxxxx-xxxx-xxxx-yyyy-xxxxxxxxxxxx" ]
+  {
+    Channels:
+      Type macOnline : Laptop      [ mac="XX:XX:XX:XX:XX:XX" ]
+      Type macOnline : Workstation [ mac="YY:YY:YY:YY:YY:YY" ]
+  }
+
+  Thing subdevice WAN "label WAN"               [ uuid="uuid:xxxxxxxx-xxxx-xxxx-zzzz-xxxxxxxxxxxx" ]
+  Thing subdevice WANCon "label WANConnection"  [ uuid="uuid:xxxxxxxx-xxxx-xxxx-wwww-xxxxxxxxxxxx" ]
+}
 ```
 
-The channel are automatically generated and it is simpler to use the Main User Interface to copy the textual definition of the channel
+The channels can be then bound to items
 
 ```java
-Switch PresXX "[%s]" {channel="tr064:subdeviceLan:rootuid:LAN:macOnline_XX_3AXX_3AXX_3AXX_3AXX_3AXX"}
-Switch PresYY "[%s]" {channel="tr064:subdeviceLan:rootuid:LAN:macOnline_YY_3AYY_3AYY_3AYY_3AYY_3AYY"}
+Switch PresentLaptop      "[%s]" { channel="tr064:subdeviceLan:rootuid:LANDevices:Laptop" }
+Switch PresentWorkstation "[%s]" { channel="tr064:subdeviceLan:rootuid:LANDevices:Workstation" }
 ```
 
 Example `*.items` file using the `PHONEBOOK` profile for storing the name of a caller in an item. it matches 8 digits from the right of the "from" number (note the escaping of `:` to `_3A`):

--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/util/Util.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/util/Util.java
@@ -117,7 +117,7 @@ public class Util {
      * @return the requested argument object
      * @throws ChannelConfigException if not found
      */
-    private static SCPDArgumentType getArgument(SCPDActionType scpdAction, String argumentName, SCPDDirection direction)
+    public static SCPDArgumentType getArgument(SCPDActionType scpdAction, String argumentName, SCPDDirection direction)
             throws ChannelConfigException {
         return scpdAction.getArgumentList().stream()
                 .filter(argument -> argument.getName().equals(argumentName) && argument.getDirection() == direction)
@@ -135,7 +135,7 @@ public class Util {
      * @return the related state variable object for this argument
      * @throws ChannelConfigException if not found
      */
-    private static SCPDStateVariableType getStateVariable(SCPDScpdType serviceRoot, SCPDArgumentType scpdArgument)
+    public static SCPDStateVariableType getStateVariable(SCPDScpdType serviceRoot, SCPDArgumentType scpdArgument)
             throws ChannelConfigException {
         return serviceRoot.getServiceStateTable().stream()
                 .filter(stateVariable -> stateVariable.getName().equals(scpdArgument.getRelatedStateVariable()))
@@ -152,7 +152,7 @@ public class Util {
      * @return the requested action object
      * @throws ChannelConfigException if not found
      */
-    private static SCPDActionType getAction(SCPDScpdType serviceRoot, String actionName, String actionType)
+    public static SCPDActionType getAction(SCPDScpdType serviceRoot, String actionName, String actionType)
             throws ChannelConfigException {
         return serviceRoot.getActionList().stream().filter(action -> actionName.equals(action.getName())).findFirst()
                 .orElseThrow(() -> new ChannelConfigException(actionType + " '" + actionName + "' not found"));


### PR DESCRIPTION
This request allow to introduce named channels for MAC-Adresses. The case, one have a lot devices in a house, it will decrease a lot of head-banging, which device maps to which MAC address. May be it's of interest. Attention: the change may be not backward compatible.

Signed-off-by: Alexander Falkenstern <alexander.falkenstern@gmail.com>
