### PR TITLE
[jellyfin] Add support for 10.9.x Jellyfin Servers

### DIFF
--- a/bundles/org.openhab.binding.jellyfin/pom.xml
+++ b/bundles/org.openhab.binding.jellyfin/pom.xml
@@ -13,6 +13,7 @@
     <bnd.importpackage>
       !android.*,!com.android.*,!kotlin.internal.jdk7,!kotlin.internal.jdk8,!kotlin.reflect.*,!okhttp3.*,!okio.*
     </bnd.importpackage>
+    <jellyfin.sdk>1.4.7</jellyfin.sdk>
   </properties>
   <artifactId>org.openhab.binding.jellyfin</artifactId>
 
@@ -21,17 +22,17 @@
     <dependency>
       <groupId>org.jellyfin.sdk</groupId>
       <artifactId>jellyfin-core-jvm</artifactId>
-      <version>1.4.6</version>
+      <version>${jellyfin.sdk}</version>
     </dependency>
     <dependency>
       <groupId>org.jellyfin.sdk</groupId>
       <artifactId>jellyfin-api-jvm</artifactId>
-      <version>1.4.6</version>
+      <version>${jellyfin.sdk}</version>
     </dependency>
     <dependency>
       <groupId>org.jellyfin.sdk</groupId>
       <artifactId>jellyfin-model-jvm</artifactId>
-      <version>1.4.6</version>
+      <version>${jellyfin.sdk}</version>
     </dependency>
     <dependency>
       <groupId>io.ktor</groupId>


### PR DESCRIPTION
# Jellyfin SDK API update from 1.4.6 to 1.4.7

SDK 1.4.6 is not compatible with the most recent Jellyfin Server versions (10.9.x). This update adds compatibility for Jellyfin [10.9.x](https://github.com/jellyfin/jellyfin/tags).

➡️ resolves #16903 
---
## Additional Information & References
- [Jellyfin SDK 1.4.7 Release](https://github.com/jellyfin/jellyfin-sdk-kotlin/releases/tag/v1.4.7)
- [Jellyfin SDK PR 895](https://github.com/jellyfin/jellyfin-sdk-kotlin/pull/896)
- [Jellyfin Android TV Issue 3467](https://github.com/jellyfin/jellyfin-androidtv/issues/3467)

<!--
# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description, so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time before it is reviewed and processed by maintainers.
-->
