### PR TITLE
[max] Remove org.apache.commons from itest bnd.run

### DIFF
--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -62,7 +62,6 @@ Fragment-Host: org.openhab.binding.max
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
-	org.apache.commons.lang3;version='[3.14.0,3.14.1)',\
 	org.eclipse.jetty.http;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.io;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.security;version='[9.4.54,9.4.55)',\


### PR DESCRIPTION
Follow up to https://github.com/openhab/openhab-addons/pull/14413#issuecomment-2187373577