### PR TITLE
[energidataservice] Add language tab for Rule DSL examples

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/README.md
+++ b/bundles/org.openhab.binding.energidataservice/README.md
@@ -283,9 +283,17 @@ For this reason the resulting `Map` will not contain the keys `LowestPrice` and 
 
 Example:
 
-```javascript
+:::: tabs
+
+::: tab DSL
+
+```java
 var Map<String, Object> result = actions.calculateCheapestPeriod(now.toInstant(), now.plusHours(12).toInstant(), Duration.ofMinutes(90))
 ```
+
+:::
+
+::::
 
 #### `calculateCheapestPeriod` from Duration and Power
 
@@ -301,9 +309,17 @@ As a result the price is also included in the result.
 
 Example:
 
-```javascript
+:::: tabs
+
+::: tab DSL
+
+```java
 var Map<String, Object> result = actions.calculateCheapestPeriod(now.toInstant(), now.plusHours(12).toInstant(), Duration.ofMinutes(90), 250 | W)
 ```
+
+:::
+
+::::
 
 #### `calculateCheapestPeriod` from Power Phases
 
@@ -322,7 +338,11 @@ This can be considered as different phases of using power, so each list member r
 
 Example:
 
-```javascript
+:::: tabs
+
+::: tab DSL
+
+```java
 val ArrayList<Duration> durationPhases = new ArrayList<Duration>()
 durationPhases.add(Duration.ofMinutes(37))
 durationPhases.add(Duration.ofMinutes(8))
@@ -346,6 +366,10 @@ powerPhases.add(0 | W)
 var Map<String, Object> result = actions.calculateCheapestPeriod(now.toInstant(), now.plusHours(12).toInstant(), durationPhases, powerPhases)
 ```
 
+:::
+
+::::
+
 Please note that the total duration will be calculated automatically as a sum of provided duration phases.
 Therefore, if the total duration is longer than the sum of phase durations, the remaining duration must be provided as last item with a corresponding 0 W power item.
 This is to ensure that the full program will finish before the provided `latestEnd`.
@@ -368,7 +392,11 @@ Since a last phase may use no significant energy, the total duration must be pro
 
 Example:
 
-```javascript
+:::: tabs
+
+::: tab DSL
+
+```java
 val ArrayList<Duration> durationPhases = new ArrayList<Duration>()
 durationPhases.add(Duration.ofMinutes(37))
 durationPhases.add(Duration.ofMinutes(8))
@@ -381,6 +409,10 @@ durationPhases.add(Duration.ofMinutes(41))
 // 0.7 kWh is used in total (number of phases × energy used per phase)
 var Map<String, Object> result = actions.calculateCheapestPeriod(now.toInstant(), now.plusHours(12).toInstant(), Duration.ofMinutes(236), phases, 0.1 | kWh)
 ```
+
+:::
+
+::::
 
 ### `calculatePrice`
 
@@ -397,9 +429,17 @@ Returns `null` if the calculation cannot be performed due to missing price data 
 
 Example:
 
-```javascript
+:::: tabs
+
+::: tab DSL
+
+```java
 var price = actions.calculatePrice(now.toInstant(), now.plusHours(4).toInstant, 200 | W)
 ```
+
+:::
+
+::::
 
 ### `getPrices`
 
@@ -427,9 +467,17 @@ This logic ensures consistent and comparable results not affected by artifical c
 
 Example:
 
-```javascript
+:::: tabs
+
+::: tab DSL
+
+```java
 var priceMap = actions.getPrices("SpotPrice,GridTariff")
 ```
+
+:::
+
+::::
 
 ## Full Example
 


### PR DESCRIPTION
This PR:
- Adds language tab for DSL examples, so it's clear that these examples are DSL (and prepare for other languages).
- Fixes code fences for DSL (javascript → java).