### PR TITLE
[jellyfin] Add support for 10.9.x Jellyfin Servers

### DIFF
--- a/bundles/org.openhab.binding.jellyfin/pom.xml
+++ b/bundles/org.openhab.binding.jellyfin/pom.xml
@@ -11,6 +11,7 @@
     <bnd.importpackage>
       !android.*,!com.android.*,!kotlin.internal.jdk7,!kotlin.internal.jdk8,!kotlin.reflect.*,!okhttp3.*,!okio.*
     </bnd.importpackage>
+    <jellyfin.sdk>1.4.7</jellyfin.sdk>
   </properties>
   <artifactId>org.openhab.binding.jellyfin</artifactId>
 
@@ -19,17 +20,17 @@
     <dependency>
       <groupId>org.jellyfin.sdk</groupId>
       <artifactId>jellyfin-core-jvm</artifactId>
-      <version>1.4.6</version>
+      <version>${jellyfin.sdk}</version>
     </dependency>
     <dependency>
       <groupId>org.jellyfin.sdk</groupId>
       <artifactId>jellyfin-api-jvm</artifactId>
-      <version>1.4.6</version>
+      <version>${jellyfin.sdk}</version>
     </dependency>
     <dependency>
       <groupId>org.jellyfin.sdk</groupId>
       <artifactId>jellyfin-model-jvm</artifactId>
-      <version>1.4.6</version>
+      <version>${jellyfin.sdk}</version>
     </dependency>
     <dependency>
       <groupId>io.ktor</groupId>


### PR DESCRIPTION
# Jellyfin SDK API update from 1.4.6 to 1.4.7

SDK 1.4.6 is not compatible with the most recent Jellyfin Server versions (10.9.x). This update adds compatibility for Jellyfin [10.9.x](https://github.com/jellyfin/jellyfin/tags).

➡️ resolves #16903 
---
## Additional Information & References
- [Jellyfin SDK 1.4.7 Release](https://github.com/jellyfin/jellyfin-sdk-kotlin/releases/tag/v1.4.7)
- [Jellyfin SDK PR 895](https://github.com/jellyfin/jellyfin-sdk-kotlin/pull/896)
- [Jellyfin Android TV Issue 3467](https://github.com/jellyfin/jellyfin-androidtv/issues/3467)
---
- Backport (🍒 pick) of PR #16917 to 4.1.x
