### PR TITLE
[sonyprojector] Fix decoding of mac address

### DIFF
--- a/bundles/org.openhab.binding.sonyprojector/src/main/java/org/openhab/binding/sonyprojector/internal/communication/sdcp/SonyProjectorSdcpConnector.java
+++ b/bundles/org.openhab.binding.sonyprojector/src/main/java/org/openhab/binding/sonyprojector/internal/communication/sdcp/SonyProjectorSdcpConnector.java
@@ -320,6 +320,14 @@ public class SonyProjectorSdcpConnector extends SonyProjectorConnector {
      * @throws SonyProjectorException in case of any problem
      */
     public String getMacAddress() throws SonyProjectorException {
-        return new String(getSetting(SonyProjectorItem.MAC_ADDRESS), StandardCharsets.UTF_8);
+        String macAddress = "";
+        byte[] macBytes = getSetting(SonyProjectorItem.MAC_ADDRESS);
+        for (byte macByte : macBytes) {
+            if (!macAddress.isEmpty()) {
+                macAddress = macAddress + "-";
+            }
+            macAddress = macAddress + Integer.toHexString(macByte);
+        }
+        return macAddress.toLowerCase();
     }
 }


### PR DESCRIPTION
Decodes mac address as byte values rather than characters

Relates to the problem described in [#16964](https://github.com/openhab/openhab-addons/issues/16964#issuecomment-2199652869)

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>