### PR TITLE
[enocean] Fix temperature values for D2_50 eep

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_50/D2_50.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_50/D2_50.java
@@ -144,19 +144,20 @@ public class D2_50 extends _VLDMessage {
             case CHANNEL_AIRQUALITYVALUE2:
                 return new QuantityType<>((bytes[4] & 0x7f), Units.PERCENT);
             case CHANNEL_OUTDOORAIRTEMPERATURE:
-                return new QuantityType<>(-63 + (bytes[5] >>> 1), SIUnits.CELSIUS);
+                return new QuantityType<>(-63 + ((bytes[5] & 0xff) >>> 1), SIUnits.CELSIUS);
             case CHANNEL_SUPPLYAIRTEMPERATURE:
-                return new QuantityType<>(-63 + (bytes[6] >>> 2) + ((bytes[5] & 1) << 6), SIUnits.CELSIUS);
+                return new QuantityType<>(-63 + ((bytes[6] & 0xff) >>> 2) + ((bytes[5] & 1) << 6), SIUnits.CELSIUS);
             case CHANNEL_INDOORAIRTEMPERATURE:
-                return new QuantityType<>(-63 + (bytes[7] >>> 3) + ((bytes[6] & 0b11) << 5), SIUnits.CELSIUS);
+                return new QuantityType<>(-63 + ((bytes[7] & 0xff) >>> 3) + ((bytes[6] & 0b11) << 5), SIUnits.CELSIUS);
             case CHANNEL_EXHAUSTAIRTEMPERATURE:
-                return new QuantityType<>(-63 + (bytes[8] >>> 4) + ((bytes[7] & 0b111) << 4), SIUnits.CELSIUS);
+                return new QuantityType<>(-63 + ((bytes[8] & 0xff) >>> 4) + ((bytes[7] & 0b111) << 4), SIUnits.CELSIUS);
             case CHANNEL_SUPPLYAIRFANAIRFLOWRATE:
-                return new QuantityType<>((bytes[9] >>> 2) + ((bytes[8] & 0b1111) << 6), Units.CUBICMETRE_PER_MINUTE);
+                return new QuantityType<>(((bytes[9] & 0xff) >>> 2) + ((bytes[8] & 0b1111) << 6),
+                        Units.CUBICMETRE_PER_MINUTE);
             case CHANNEL_EXHAUSTAIRFANAIRFLOWRATE:
                 return new QuantityType<>((bytes[10] & 0xff) + ((bytes[9] & 0b11) << 8), Units.CUBICMETRE_PER_MINUTE);
             case CHANNEL_SUPPLYFANSPEED:
-                return new DecimalType((bytes[12] >>> 4) + (bytes[11] << 4));
+                return new DecimalType(((bytes[12] & 0xff) >>> 4) + (bytes[11] << 4));
             case CHANNEL_EXHAUSTFANSPEED:
                 return new DecimalType((bytes[13] & 0xff) + ((bytes[12] & 0b1111) << 8));
         }


### PR DESCRIPTION
Fixes #16974

There is a problem with parsing the data send from fan devices using EEP D2_50 (like Dimplex)
When the value is with leading bite - 1 is converted to a number < 0 and then to unsined int which leads to a very big value for OutdorAirTempareture channel.

Looking at the code I thing this could also happen to other channels so I added a fix for them `& 0xff`
