### PR TITLE
[sonyprojector] Fix edge case in mac address decoding

### DIFF
--- a/bundles/org.openhab.binding.sonyprojector/src/main/java/org/openhab/binding/sonyprojector/internal/communication/sdcp/SonyProjectorSdcpConnector.java
+++ b/bundles/org.openhab.binding.sonyprojector/src/main/java/org/openhab/binding/sonyprojector/internal/communication/sdcp/SonyProjectorSdcpConnector.java
@@ -326,7 +326,7 @@ public class SonyProjectorSdcpConnector extends SonyProjectorConnector {
             if (!macAddress.isEmpty()) {
                 macAddress = macAddress + "-";
             }
-            macAddress = macAddress + Integer.toHexString(macByte);
+            macAddress = macAddress + String.format("%02x", macByte);
         }
         return macAddress.toLowerCase();
     }

--- a/bundles/org.openhab.binding.sonyprojector/src/main/java/org/openhab/binding/sonyprojector/internal/communication/sdcp/SonyProjectorSdcpConnector.java
+++ b/bundles/org.openhab.binding.sonyprojector/src/main/java/org/openhab/binding/sonyprojector/internal/communication/sdcp/SonyProjectorSdcpConnector.java
@@ -328,6 +328,6 @@ public class SonyProjectorSdcpConnector extends SonyProjectorConnector {
             }
             macAddress = macAddress + String.format("%02x", macByte);
         }
-        return macAddress.toLowerCase();
+        return macAddress;
     }
 }


### PR DESCRIPTION
In PR #16972 we fixed the decoding of mac addresses, but in the edge case that the mac byte value is less than 16, the fix fails because Integer.toHexString() does not produce leading zeros (i.e. the mac address appears wrongly as `12-34-5-67-89-0` instead of `12-34-05-67-89-00`)

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>