### PR TITLE
[growatt] Annotate ThingActions implementation as a Component

### DIFF
--- a/bundles/org.openhab.binding.growatt/src/main/java/org/openhab/binding/growatt/internal/action/GrowattActions.java
+++ b/bundles/org.openhab.binding.growatt/src/main/java/org/openhab/binding/growatt/internal/action/GrowattActions.java
@@ -20,6 +20,8 @@ import org.openhab.core.automation.annotation.RuleAction;
 import org.openhab.core.thing.binding.ThingActions;
 import org.openhab.core.thing.binding.ThingActionsScope;
 import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andrew Fiddian-Green - Initial contribution
  */
+@Component(scope = ServiceScope.PROTOTYPE, service = GrowattActions.class)
 @ThingActionsScope(name = "growatt")
 @NonNullByDefault
 public class GrowattActions implements ThingActions {


### PR DESCRIPTION
The ThingActions implementation must be annotated as a Component

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
