### PR TITLE
[meater] Fix broken cloud communication

### DIFF
--- a/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/api/MeaterRestAPI.java
+++ b/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/api/MeaterRestAPI.java
@@ -106,7 +106,6 @@ public class MeaterRestAPI {
                     .method(HttpMethod.POST) //
                     .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS) //
                     .header(HttpHeader.ACCEPT, JSON_CONTENT_TYPE) //
-                    .header(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE) //
                     .agent(userAgent) //
                     .content(new StringContentProvider(json), JSON_CONTENT_TYPE);
 
@@ -142,7 +141,6 @@ public class MeaterRestAPI {
                             .method(HttpMethod.GET) //
                             .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                             .header(HttpHeader.AUTHORIZATION, "Bearer " + authToken)
-                            .header(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE)
                             .header(HttpHeader.ACCEPT, JSON_CONTENT_TYPE)
                             .header(HttpHeader.ACCEPT_LANGUAGE, localeProvider.getLocale().getLanguage())
                             .agent(userAgent);

--- a/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/api/MeaterRestAPI.java
+++ b/bundles/org.openhab.binding.meater/src/main/java/org/openhab/binding/meater/internal/api/MeaterRestAPI.java
@@ -35,6 +35,7 @@ import org.openhab.binding.meater.internal.dto.MeaterProbeDTO.Device;
 import org.openhab.binding.meater.internal.exceptions.MeaterAuthenticationException;
 import org.openhab.binding.meater.internal.exceptions.MeaterException;
 import org.openhab.core.i18n.LocaleProvider;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +64,7 @@ public class MeaterRestAPI {
     private final Gson gson;
     private final HttpClient httpClient;
     private final MeaterBridgeConfiguration configuration;
+    private final String userAgent;
     private String authToken = "";
     private LocaleProvider localeProvider;
 
@@ -72,42 +74,43 @@ public class MeaterRestAPI {
         this.configuration = configuration;
         this.httpClient = httpClient;
         this.localeProvider = localeProvider;
+        userAgent = "openHAB/" + FrameworkUtil.getBundle(this.getClass()).getVersion().toString();
     }
 
-    public boolean refresh(Map<String, MeaterProbeDTO.Device> meaterProbeThings) {
-        try {
-            MeaterProbeDTO dto = getDevices(MeaterProbeDTO.class);
-            if (dto != null) {
-                List<Device> devices = dto.getData().getDevices();
-                if (devices != null) {
-                    if (!devices.isEmpty()) {
-                        for (Device meaterProbe : devices) {
-                            meaterProbeThings.put(meaterProbe.id, meaterProbe);
-                        }
-                    } else {
-                        meaterProbeThings.clear();
+    public void refresh(Map<String, MeaterProbeDTO.Device> meaterProbeThings) throws MeaterException {
+        MeaterProbeDTO dto = getDevices(MeaterProbeDTO.class);
+        if (dto != null) {
+            List<Device> devices = dto.getData().getDevices();
+            if (devices != null) {
+                if (!devices.isEmpty()) {
+                    for (Device meaterProbe : devices) {
+                        meaterProbeThings.put(meaterProbe.id, meaterProbe);
                     }
-                    return true;
+                } else {
+                    meaterProbeThings.clear();
                 }
             }
-        } catch (MeaterException e) {
-            logger.warn("Failed to refresh! {}", e.getMessage());
         }
-        return false;
     }
 
     private void login() throws MeaterException {
         try {
             // Login
-            String json = "{ \"email\": \"" + configuration.email + "\",  \"password\": \"" + configuration.password
-                    + "\" }";
-            Request request = httpClient.newRequest(API_ENDPOINT + LOGIN).method(HttpMethod.POST)
-                    .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            request.header(HttpHeader.ACCEPT, JSON_CONTENT_TYPE);
-            request.header(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE);
-            request.content(new StringContentProvider(json), JSON_CONTENT_TYPE);
+            String json = """
+                    {
+                        "email": "%s",
+                        "password": "%s"
+                    }
+                    """.formatted(configuration.email, configuration.password);
+            Request request = httpClient.newRequest(API_ENDPOINT + LOGIN) //
+                    .method(HttpMethod.POST) //
+                    .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS) //
+                    .header(HttpHeader.ACCEPT, JSON_CONTENT_TYPE) //
+                    .header(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE) //
+                    .agent(userAgent) //
+                    .content(new StringContentProvider(json), JSON_CONTENT_TYPE);
 
-            logger.trace("{}.", request.toString());
+            logger.trace("{}", request.toString());
 
             ContentResponse httpResponse = request.send();
             if (!HttpStatus.isSuccess(httpResponse.getStatus())) {
@@ -135,24 +138,26 @@ public class MeaterRestAPI {
         try {
             for (int i = 0; i < MAX_RETRIES; i++) {
                 try {
-                    Request request = httpClient.newRequest(API_ENDPOINT + uri).method(HttpMethod.GET)
-                            .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                    request.header(HttpHeader.AUTHORIZATION, "Bearer " + authToken);
-                    request.header(HttpHeader.ACCEPT, JSON_CONTENT_TYPE);
-                    request.header(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE);
-                    request.header(HttpHeader.ACCEPT_LANGUAGE, localeProvider.getLocale().getLanguage());
+                    Request request = httpClient.newRequest(API_ENDPOINT + uri) //
+                            .method(HttpMethod.GET) //
+                            .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                            .header(HttpHeader.AUTHORIZATION, "Bearer " + authToken)
+                            .header(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE)
+                            .header(HttpHeader.ACCEPT, JSON_CONTENT_TYPE)
+                            .header(HttpHeader.ACCEPT_LANGUAGE, localeProvider.getLocale().getLanguage())
+                            .agent(userAgent);
 
                     ContentResponse response = request.send();
                     String content = response.getContentAsString();
                     logger.trace("API response: {}", content);
 
-                    if (response.getStatus() == HttpStatus.UNAUTHORIZED_401) {
+                    int status = response.getStatus();
+                    if (status == HttpStatus.UNAUTHORIZED_401) {
                         // This will currently not happen because "WWW-Authenticate" header is missing; see below.
                         logger.debug("getFromApi failed, authentication failed, HTTP status: 401");
                         throw new MeaterAuthenticationException("Authentication failed");
-                    } else if (!HttpStatus.isSuccess(response.getStatus())) {
-                        logger.debug("getFromApi failed, HTTP status: {}", response.getStatus());
-                        throw new MeaterException("Failed to fetch from API!");
+                    } else if (!HttpStatus.isSuccess(status)) {
+                        throw new MeaterException(HttpStatus.getCode(status).getMessage());
                     } else {
                         return content;
                     }
@@ -160,7 +165,7 @@ public class MeaterRestAPI {
                     logger.debug("TimeoutException error in get: {}", e.getMessage());
                 }
             }
-            throw new MeaterException("Failed to fetch from API!");
+            throw new MeaterException("Failed to fetch from API");
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof HttpResponseException httpResponseException) {
@@ -201,7 +206,7 @@ public class MeaterRestAPI {
         }
 
         if (json.isEmpty()) {
-            throw new MeaterException("JSON from API is empty!");
+            throw new MeaterException("JSON from API is empty");
         } else {
             try {
                 return gson.fromJson(json, dto);


### PR DESCRIPTION
The binding is currently broken because the cloud service started to reject HTTP GET requests having a `Content-Type` header but no content.

Tested when creating a cook for first probe:

![image](https://github.com/openhab/openhab-addons/assets/19519842/b7c27b7f-17d2-424c-aaec-a8fe60949ba9)
(the other three probes are still offline because of apption-labs/meater-cloud-public-rest-api#7)

```
2024-07-04 23:39:49.953 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'meater:meaterapi:block' changed from UNKNOWN to ONLINE
2024-07-04 23:46:22.314 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Meater_Probe1_InternalTemperature' changed from 97.3 °C to 22.8 °C
2024-07-04 23:46:22.316 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'meater:meaterprobe:block:probe1' changed from OFFLINE (COMMUNICATION_ERROR): MEATER stegetermometer er offline to ONLINE
2024-07-04 23:46:22.317 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Meater_Probe1_AmbientTemperature' changed from 158.7 °C to 22.8 °C
2024-07-04 23:46:22.317 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Meater_Probe1_CookName' changed from NULL to Ribeye
2024-07-04 23:46:22.318 [INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'Meater_Probe1_CookState' changed from NULL to Configured
```

Also tested while still having the error (the HTTP status description is now provided for the Thing status):
```
2024-07-04 17:14:06.059 [TRACE] [ng.meater.internal.api.MeaterRestAPI] - API response: {"status":"Bad Request","statusCode":400,"message":"Invalid JSON","help":"https://github.com/apption-labs/meater-cloud-public-rest-api"}
2024-07-04 17:14:06.060 [INFO ] [ab.event.ThingStatusInfoChangedEvent] - Thing 'meater:meaterapi:9b9d1ee318' changed from UNKNOWN to OFFLINE (COMMUNICATION_ERROR): Bad Request
```

This strange warning is no longer logged:
```
2024-07-02 22:47:37.206 [WARN ] [ng.meater.internal.api.MeaterRestAPI] - Failed to refresh! Failed to fetch class="afterFrom marked"> from API!
```

Fixes #16982