### PR TITLE
[jrubyscripting] Upgrade to JRuby 9.4.8.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.4.6.0</jruby.version>
+    <jruby.version>9.4.8.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Build the addon with JRuby 9.4.8.0 release.

Ruby Compatibility
- Fixed a bug in the bytecode JIT causing patterns to execute incorrect branches. [#8283](https://github.com/jruby/jruby/issues/8283), [#8284](https://github.com/jruby/jruby/pull/8284)

Standard Library
- jruby-openssl is updated to 0.15.0, with updated Bouncy Castle libraries to avoid CVEs in older versions.
- uri is updated to 0.12.2, mitigating CVE-2023-36617.
- net-ftp is updated to 0.3.7 with restored functionality on JRuby.

Bug fixes as listed in the announcement: https://www.jruby.org/2024/07/02/jruby-9-4-8-0.html
