### PR TITLE
[shelly] Revise fix for Gen1 initialization problem for manually created Things

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -1562,7 +1562,7 @@ See notes on discovery of Shelly BLU devices above.
 
 ## Shelly BLU Gateway (thing-type: shellyblugw)
 
-There no no additional channels beside the device group.
+There are no additional channels beside the device group.
 
 
 ## Shelly Wall Displays

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -86,7 +86,7 @@ The binding provides the same feature set across all devices as good as possible
 | shellyplusplug       | Shelly Plug-S                                            | SNPL-00112EU                 |
 | shellyplusplug       | Shelly Plug-IT                                           | SNPL-00110IT                 |
 | shellyplusplug       | Shelly Plug-UK                                           | SNPL-00112UK                 |
-| shellyplusplug       | Shelly Plug-US                                           | SNPL-00116US                 |
+| shellyplusplugus     | Shelly Plug-US                                           | SNPL-00116US                 |
 | shellyplusi4         | Shelly Plus i4 with 4x AC input                          | SNSN-0024X                   |
 | shellyplusi4dc       | Shelly Plus i4 with 4x DC input                          | SNSN-0D24X                   |
 | shellyplusht         | Shelly Plus HT with temperature + humidity sensor        | SNSN-0013A                   |
@@ -94,6 +94,7 @@ The binding provides the same feature set across all devices as good as possible
 | shellyplussmoke      | Shelly Plus Smoke sensor                                 | SNSN-0031Z                   |
 | shellypluswdus       | Shelly Plus Wall Dimmer US                               | SNDM-0013US                  |
 | shellywalldisplay    | Shelly Plus Wall Display                                 | SAWD-0A1XX10EU1              |
+| shellyblugw          | SHelly BLU Gateway                                       | SNGW-BT01                    |
 
 ### Generation 2 Plus Mini series (incl. Gen 3)
 
@@ -130,8 +131,8 @@ The binding provides the same feature set across all devices as good as possible
 
 | thing-type        | Model                                                  | Vendor ID |
 | ----------------- | ------------------------------------------------------ | --------- |
-| shellydevice      | A password protected Shelly device or an unknown type  |                     |
-| shellyunknown     | An unknown Shelly device / model has been detected     |                     |
+| shellydevice      | A password protected Shelly device or an unknown type  |           |
+| shellyunknown     | An unknown Shelly device / model has been detected     |           |
 
 
 ## Binding Configuration
@@ -1564,7 +1565,7 @@ See notes on discovery of Shelly BLU devices above.
 | Group   | Channel       | Type     | read-only | Description                                             |
 | ------- | ------------- | -------- | --------- | ------------------------------------------------------- |
 
-There no no additional channels beside device group.
+There no no additional channels beside the device group.
 
 
 ## Shelly Wall Displays

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -74,7 +74,6 @@ The binding provides the same feature set across all devices as good as possible
 | shellybutton2     | Shelly Button 2                                        | SHBTN-2             |
 | shellysense       | Shelly Motion and IR Controller                        | SHSEN-1             |
 | shellytrv         | Shelly TRV                                             | SHTRV-01            |
-| shellydevice      | A password protected Shelly device or an unknown type  |                     |
 
 ### Generation 2 Plus series
 
@@ -115,6 +114,7 @@ The binding provides the same feature set across all devices as good as possible
 | shellypro2pm-roller | Shelly Pro 2 PM with 2x relay + power meter, roller mode | SPSW-002PE16EU, SPSW-102PE16EU, SPSW-202PE16EU |
 | shellypro3          | Shelly Pro 3 with 3x relay (dry contacts)                | SPSW-003XE16EU                                 |
 | shellypro3em        | Shelly Pro 3 with 3 integrated power meters              | SPEM-003CEBEU                                  |
+| shellyproem50       | Shelly Pro EM50 with 3 integrated power meters           | SPEM-002CEBEU50                                |
 | shellypro4pm        | Shelly Pro 4 PM with 4x relay + power meter              | SPSW-004PE16EU, SPSW-104PE16EU                 |
 
 ### Shelly BLU
@@ -125,6 +125,14 @@ The binding provides the same feature set across all devices as good as possible
 | shellybludw       | Shelly BLU Door/Windows                                | SBDW      |
 | shellyblumotion   | Shelly BLU Motion                                      | SBMO      |
 | shellybluht       | Shelly BLU H&T                                         | SBMO      |
+
+### Special thing types
+
+| thing-type        | Model                                                  | Vendor ID |
+| ----------------- | ------------------------------------------------------ | --------- |
+| shellydevice      | A password protected Shelly device or an unknown type  |                     |
+| shellyunknown     | An unknown Shelly device / model has been detected     |                     |
+
 
 ## Binding Configuration
 
@@ -1550,6 +1558,14 @@ See notes on discovery of Shelly BLU devices above.
 |         | lastUpdate    | DateTime | yes       | Timestamp of the last update (any sensor value changed) |
 | battery | batteryLevel  | Number   | yes       | Battery Level in %                                      |
 |         | lowBattery    | Switch   | yes       | Low battery alert (< 20%)                               |
+
+## Shelly BLU Gateway (thing-type: shellyblugw)
+
+| Group   | Channel       | Type     | read-only | Description                                             |
+| ------- | ------------- | -------- | --------- | ------------------------------------------------------- |
+
+There no no additional channels beside device group.
+
 
 ## Shelly Wall Displays
 

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -127,7 +127,7 @@ The binding provides the same feature set across all devices as good as possible
 | shellyblumotion   | Shelly BLU Motion                                      | SBMO      |
 | shellybluht       | Shelly BLU H&T                                         | SBMO      |
 
-### Special thing types
+### Special Thing Types
 
 | thing-type        | Model                                                  | Vendor ID |
 | ----------------- | ------------------------------------------------------ | --------- |
@@ -1561,9 +1561,6 @@ See notes on discovery of Shelly BLU devices above.
 |         | lowBattery    | Switch   | yes       | Low battery alert (< 20%)                               |
 
 ## Shelly BLU Gateway (thing-type: shellyblugw)
-
-| Group   | Channel       | Type     | read-only | Description                                             |
-| ------- | ------------- | -------- | --------- | ------------------------------------------------------- |
 
 There no no additional channels beside the device group.
 

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -1564,7 +1564,6 @@ See notes on discovery of Shelly BLU devices above.
 
 There are no additional channels beside the device group.
 
-
 ## Shelly Wall Displays
 
 | Group   | Channel     | Type     | read-only | Description                                                                       |

--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -134,7 +134,6 @@ The binding provides the same feature set across all devices as good as possible
 | shellydevice      | A password protected Shelly device or an unknown type  |           |
 | shellyunknown     | An unknown Shelly device / model has been detected     |           |
 
-
 ## Binding Configuration
 
 The binding has the following configuration options:

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -405,7 +405,8 @@ public class ShellyDeviceProfile {
 
     public static boolean isGeneration2(String thingType) {
         return thingType.startsWith("shellyplus") || thingType.startsWith("shellypro") || thingType.contains("mini")
-                || (thingType.startsWith("shelly") && thingType.contains("g3")) || isBluSeries(thingType);
+                || thingType.startsWith("shellywall") || (thingType.startsWith("shelly") && thingType.contains("g3"))
+                || isBluSeries(thingType);
     }
 
     public static boolean isBluSeries(String thingType) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -205,7 +205,6 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
         }
 
         ShellySettingsDevice device = profile.device;
-        profile.isGen2 = device.gen == 2;
         if (config.serviceName.isEmpty()) {
             config.serviceName = getString(profile.device.hostname);
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -153,13 +153,17 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         this.config = getConfigAs(ShellyThingConfiguration.class);
         this.httpClient = httpClient;
 
-        Map<String, String> properties = thing.getProperties();
-        String gen = getString(properties.get(PROPERTY_DEV_GEN));
+        // Create thing handler depending on device generation
         String thingType = getThingType();
         blu = ShellyDeviceProfile.isBluSeries(thingType);
-        gen2 = "2".equals(gen) || "3".equals(gen) || blu || ShellyDeviceProfile.isGeneration2(thingType);
-        this.api = !blu ? !gen2 ? new Shelly1HttpApi(thingName, this) : new Shelly2ApiRpc(thingName, thingTable, this)
-                : new ShellyBluApi(thingName, thingTable, this);
+        gen2 = ShellyDeviceProfile.isGeneration2(thingType);
+        if (blu) {
+            this.api = new ShellyBluApi(thingName, thingTable, this);
+        } else if (gen2) {
+            this.api = new Shelly2ApiRpc(thingName, thingTable, this);
+        } else {
+            this.api = new Shelly1HttpApi(thingName, this);
+        }
         if (gen2) {
             config.eventsCoIoT = false;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -156,8 +156,8 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
         Map<String, String> properties = thing.getProperties();
         String gen = getString(properties.get(PROPERTY_DEV_GEN));
         String thingType = getThingType();
-        gen2 = !"1".equals(gen) || ShellyDeviceProfile.isGeneration2(thingType);
         blu = ShellyDeviceProfile.isBluSeries(thingType);
+        gen2 = "2".equals(gen) || "3".equals(gen) || blu || ShellyDeviceProfile.isGeneration2(thingType);
         this.api = !blu ? !gen2 ? new Shelly1HttpApi(thingName, this) : new Shelly2ApiRpc(thingName, thingTable, this)
                 : new ShellyBluApi(thingName, thingTable, this);
         if (gen2) {


### PR DESCRIPTION
This PR replaces #17009 with a more solid solution supporting gen 1/2/3 devices discovered by UI for defined in a .things file