### PR TITLE
[homekit] fix optional characteristics

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -228,6 +228,25 @@ public abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
         return this.services;
     }
 
+    public void addService(Service service) {
+        services.add(service);
+
+        var serviceClass = service.getClass();
+        rawCharacteristics.values().forEach(characteristic -> {
+            // belongs on the accessory information service
+            if (characteristic.getClass() == NameCharacteristic.class) {
+                return;
+            }
+            try {
+                // if the service supports adding this characteristic as optional, add it!
+                serviceClass.getMethod("addOptionalCharacteristic", characteristic.getClass()).invoke(service,
+                        characteristic);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                // the service doesn't support this optional characteristic; ignore it
+            }
+        });
+    }
+
     protected HomekitAccessoryUpdater getUpdater() {
         return updater;
     }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAirQualitySensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAirQualitySensorImpl.java
@@ -45,7 +45,7 @@ public class HomekitAirQualitySensorImpl extends AbstractHomekitAccessoryImpl im
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new AirQualityService(this));
+        addService(new AirQualityService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitBasicFanImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitBasicFanImpl.java
@@ -45,7 +45,7 @@ class HomekitBasicFanImpl extends AbstractHomekitAccessoryImpl implements BasicF
     @Override
     public void init() throws HomekitException {
         super.init();
-        this.getServices().add(new BasicFanService(this));
+        addService(new BasicFanService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitBatteryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitBatteryImpl.java
@@ -62,7 +62,7 @@ public class HomekitBatteryImpl extends AbstractHomekitAccessoryImpl implements 
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new BatteryService(this));
+        addService(new BatteryService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCarbonDioxideSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCarbonDioxideSensorImpl.java
@@ -46,7 +46,7 @@ public class HomekitCarbonDioxideSensorImpl extends AbstractHomekitAccessoryImpl
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new CarbonDioxideSensorService(this));
+        addService(new CarbonDioxideSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCarbonMonoxideSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCarbonMonoxideSensorImpl.java
@@ -46,7 +46,7 @@ public class HomekitCarbonMonoxideSensorImpl extends AbstractHomekitAccessoryImp
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new CarbonMonoxideSensorService(this));
+        addService(new CarbonMonoxideSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitContactSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitContactSensorImpl.java
@@ -44,7 +44,7 @@ public class HomekitContactSensorImpl extends AbstractHomekitAccessoryImpl imple
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new ContactSensorService(this));
+        addService(new ContactSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitDoorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitDoorImpl.java
@@ -41,7 +41,7 @@ public class HomekitDoorImpl extends AbstractHomekitPositionAccessoryImpl implem
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new DoorService(this));
+        addService(new DoorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitFanImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitFanImpl.java
@@ -43,7 +43,7 @@ class HomekitFanImpl extends AbstractHomekitAccessoryImpl implements FanAccessor
     @Override
     public void init() throws HomekitException {
         super.init();
-        this.getServices().add(new FanService(this));
+        addService(new FanService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitFaucetImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitFaucetImpl.java
@@ -43,7 +43,7 @@ class HomekitFaucetImpl extends AbstractHomekitAccessoryImpl implements FaucetAc
     @Override
     public void init() throws HomekitException {
         super.init();
-        this.getServices().add(new FaucetService(this));
+        addService(new FaucetService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitFilterMaintenanceImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitFilterMaintenanceImpl.java
@@ -45,7 +45,7 @@ public class HomekitFilterMaintenanceImpl extends AbstractHomekitAccessoryImpl i
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new FilterMaintenanceService(this));
+        addService(new FilterMaintenanceService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitGarageDoorOpenerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitGarageDoorOpenerImpl.java
@@ -55,7 +55,7 @@ public class HomekitGarageDoorOpenerImpl extends AbstractHomekitAccessoryImpl im
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new GarageDoorOpenerService(this));
+        addService(new GarageDoorOpenerService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitHeaterCoolerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitHeaterCoolerImpl.java
@@ -73,10 +73,10 @@ public class HomekitHeaterCoolerImpl extends AbstractHomekitAccessoryImpl implem
     public void init() throws HomekitException {
         super.init();
         final HeaterCoolerService service = new HeaterCoolerService(this);
+        addService(service);
         service.addOptionalCharacteristic(new TemperatureDisplayUnitCharacteristic(this::getTemperatureDisplayUnit,
                 this::setTemperatureDisplayUnit, this::subscribeTemperatureDisplayUnit,
                 this::unsubscribeTemperatureDisplayUnit));
-        getServices().add(service);
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitHumiditySensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitHumiditySensorImpl.java
@@ -43,7 +43,7 @@ public class HomekitHumiditySensorImpl extends AbstractHomekitAccessoryImpl impl
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new HumiditySensorService(this));
+        addService(new HumiditySensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitInputSourceImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitInputSourceImpl.java
@@ -28,10 +28,8 @@ import io.github.hapjava.characteristics.impl.common.IsConfiguredCharacteristic;
 import io.github.hapjava.characteristics.impl.common.IsConfiguredEnum;
 import io.github.hapjava.characteristics.impl.inputsource.CurrentVisibilityStateCharacteristic;
 import io.github.hapjava.characteristics.impl.inputsource.CurrentVisibilityStateEnum;
-import io.github.hapjava.characteristics.impl.inputsource.InputDeviceTypeCharacteristic;
 import io.github.hapjava.characteristics.impl.inputsource.InputSourceTypeCharacteristic;
 import io.github.hapjava.characteristics.impl.inputsource.InputSourceTypeEnum;
-import io.github.hapjava.characteristics.impl.inputsource.TargetVisibilityStateCharacteristic;
 import io.github.hapjava.services.impl.InputSourceService;
 
 /**
@@ -78,18 +76,16 @@ public class HomekitInputSourceImpl extends AbstractHomekitAccessoryImpl {
                         () -> CompletableFuture.completedFuture(CurrentVisibilityStateEnum.SHOWN), v -> {
                         }, () -> {
                         }));
-        var identifierCharacteristic = getCharacteristic(IdentifierCharacteristic.class)
-                .orElseGet(() -> new IdentifierCharacteristic(() -> CompletableFuture.completedFuture(1)));
 
         var service = new InputSourceService(configuredNameCharacteristic, inputSourceTypeCharacteristic,
                 isConfiguredCharacteristic, currentVisibilityStateCharacteristic);
 
-        service.addOptionalCharacteristic(identifierCharacteristic);
-        getCharacteristic(InputDeviceTypeCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        getCharacteristic(TargetVisibilityStateCharacteristic.class)
-                .ifPresent(c -> service.addOptionalCharacteristic(c));
+        var identifierCharacteristic = getCharacteristic(IdentifierCharacteristic.class);
+        if (identifierCharacteristic.isEmpty()) {
+            service.addOptionalCharacteristic(new IdentifierCharacteristic(() -> CompletableFuture.completedFuture(1)));
+        }
 
-        getServices().add(service);
+        addService(service);
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitIrrigationSystemImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitIrrigationSystemImpl.java
@@ -55,7 +55,7 @@ public class HomekitIrrigationSystemImpl extends AbstractHomekitAccessoryImpl im
         inUseMapping = createMapping(HomekitCharacteristicType.INUSE_STATUS, InUseEnum.class);
         programModeMap = HomekitCharacteristicFactory
                 .createMapping(getCharacteristic(HomekitCharacteristicType.PROGRAM_MODE).get(), ProgramModeEnum.class);
-        getServices().add(new IrrigationSystemService(this));
+        addService(new IrrigationSystemService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitIrrigationSystemImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitIrrigationSystemImpl.java
@@ -73,7 +73,7 @@ public class HomekitIrrigationSystemImpl extends AbstractHomekitAccessoryImpl im
         final var finalEnum = serviceLabelEnum;
         var serviceLabelNamespace = getCharacteristic(ServiceLabelNamespaceCharacteristic.class).orElseGet(
                 () -> new ServiceLabelNamespaceCharacteristic(() -> CompletableFuture.completedFuture(finalEnum)));
-        getServices().add(new ServiceLabelService(serviceLabelNamespace));
+        addService(new ServiceLabelService(serviceLabelNamespace));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLeakSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLeakSensorImpl.java
@@ -44,7 +44,7 @@ public class HomekitLeakSensorImpl extends AbstractHomekitAccessoryImpl implemen
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new LeakSensorService(this));
+        addService(new LeakSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightSensorImpl.java
@@ -46,7 +46,7 @@ public class HomekitLightSensorImpl extends AbstractHomekitAccessoryImpl impleme
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new LightSensorService(this));
+        addService(new LightSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
@@ -44,7 +44,7 @@ class HomekitLightbulbImpl extends AbstractHomekitAccessoryImpl implements Light
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new LightbulbService(this));
+        addService(new LightbulbService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
@@ -49,7 +49,7 @@ public class HomekitLockImpl extends AbstractHomekitAccessoryImpl implements Loc
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new LockMechanismService(this));
+        addService(new LockMechanismService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitMicrophoneImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitMicrophoneImpl.java
@@ -42,7 +42,7 @@ public class HomekitMicrophoneImpl extends AbstractHomekitAccessoryImpl implemen
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new MicrophoneService(this));
+        addService(new MicrophoneService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitMotionSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitMotionSensorImpl.java
@@ -41,7 +41,7 @@ public class HomekitMotionSensorImpl extends AbstractHomekitAccessoryImpl implem
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new MotionSensorService(this));
+        addService(new MotionSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitOccupancySensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitOccupancySensorImpl.java
@@ -44,7 +44,7 @@ public class HomekitOccupancySensorImpl extends AbstractHomekitAccessoryImpl imp
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new OccupancySensorService(this));
+        addService(new OccupancySensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitOutletImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitOutletImpl.java
@@ -43,7 +43,7 @@ public class HomekitOutletImpl extends AbstractHomekitAccessoryImpl implements O
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new OutletService(this));
+        addService(new OutletService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSecuritySystemImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSecuritySystemImpl.java
@@ -59,7 +59,7 @@ public class HomekitSecuritySystemImpl extends AbstractHomekitAccessoryImpl impl
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new SecuritySystemService(this));
+        addService(new SecuritySystemService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSlatImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSlatImpl.java
@@ -49,7 +49,7 @@ public class HomekitSlatImpl extends AbstractHomekitAccessoryImpl implements Sla
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new SlatService(this));
+        addService(new SlatService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSmartSpeakerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSmartSpeakerImpl.java
@@ -48,7 +48,7 @@ public class HomekitSmartSpeakerImpl extends AbstractHomekitAccessoryImpl implem
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new SmartSpeakerService(this));
+        addService(new SmartSpeakerService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSmokeSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSmokeSensorImpl.java
@@ -44,7 +44,7 @@ public class HomekitSmokeSensorImpl extends AbstractHomekitAccessoryImpl impleme
     @Override
     public void init() throws HomekitException {
         super.init();
-        this.getServices().add(new SmokeSensorService(this));
+        addService(new SmokeSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSpeakerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSpeakerImpl.java
@@ -42,7 +42,7 @@ public class HomekitSpeakerImpl extends AbstractHomekitAccessoryImpl implements 
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new SpeakerService(this));
+        addService(new SpeakerService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSwitchImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitSwitchImpl.java
@@ -43,7 +43,7 @@ public class HomekitSwitchImpl extends AbstractHomekitAccessoryImpl implements S
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new SwitchService(this));
+        addService(new SwitchService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTelevisionImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTelevisionImpl.java
@@ -24,15 +24,9 @@ import org.openhab.io.homekit.internal.HomekitTaggedItem;
 import io.github.hapjava.characteristics.impl.common.ActiveCharacteristic;
 import io.github.hapjava.characteristics.impl.common.ActiveIdentifierCharacteristic;
 import io.github.hapjava.characteristics.impl.common.ConfiguredNameCharacteristic;
-import io.github.hapjava.characteristics.impl.lightbulb.BrightnessCharacteristic;
-import io.github.hapjava.characteristics.impl.television.ClosedCaptionsCharacteristic;
-import io.github.hapjava.characteristics.impl.television.CurrentMediaStateCharacteristic;
-import io.github.hapjava.characteristics.impl.television.PictureModeCharacteristic;
-import io.github.hapjava.characteristics.impl.television.PowerModeCharacteristic;
 import io.github.hapjava.characteristics.impl.television.RemoteKeyCharacteristic;
 import io.github.hapjava.characteristics.impl.television.SleepDiscoveryModeCharacteristic;
 import io.github.hapjava.characteristics.impl.television.SleepDiscoveryModeEnum;
-import io.github.hapjava.characteristics.impl.television.TargetMediaStateCharacteristic;
 import io.github.hapjava.services.impl.TelevisionService;
 
 /**
@@ -81,13 +75,6 @@ public class HomekitTelevisionImpl extends AbstractHomekitAccessoryImpl {
                 activeIdentifierCharacteristic, configuredNameCharacteristic, remoteKeyCharacteristic,
                 sleepDiscoveryModeCharacteristic);
 
-        getCharacteristic(BrightnessCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        getCharacteristic(PowerModeCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        getCharacteristic(ClosedCaptionsCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        getCharacteristic(CurrentMediaStateCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        getCharacteristic(TargetMediaStateCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        getCharacteristic(PictureModeCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-
-        getServices().add(service);
+        addService(service);
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTelevisionSpeakerImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTelevisionSpeakerImpl.java
@@ -13,7 +13,6 @@
 package org.openhab.io.homekit.internal.accessories;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -25,7 +24,6 @@ import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
 import io.github.hapjava.characteristics.impl.audio.MuteCharacteristic;
 import io.github.hapjava.characteristics.impl.audio.VolumeCharacteristic;
-import io.github.hapjava.characteristics.impl.common.ActiveCharacteristic;
 import io.github.hapjava.characteristics.impl.televisionspeaker.VolumeControlTypeCharacteristic;
 import io.github.hapjava.characteristics.impl.televisionspeaker.VolumeControlTypeEnum;
 import io.github.hapjava.characteristics.impl.televisionspeaker.VolumeSelectorCharacteristic;
@@ -61,6 +59,8 @@ public class HomekitTelevisionSpeakerImpl extends AbstractHomekitAccessoryImpl {
         var volumeCharacteristic = getCharacteristic(VolumeCharacteristic.class);
         var volumeSelectorCharacteristic = getCharacteristic(VolumeSelectorCharacteristic.class);
 
+        var service = new TelevisionSpeakerService(muteCharacteristic);
+
         if (volumeControlTypeCharacteristic.isEmpty()) {
             VolumeControlTypeEnum type;
             if (volumeCharacteristic.isPresent()) {
@@ -70,18 +70,12 @@ public class HomekitTelevisionSpeakerImpl extends AbstractHomekitAccessoryImpl {
             } else {
                 type = VolumeControlTypeEnum.NONE;
             }
-            volumeControlTypeCharacteristic = Optional
-                    .of(new VolumeControlTypeCharacteristic(() -> CompletableFuture.completedFuture(type), v -> {
+            service.addOptionalCharacteristic(
+                    new VolumeControlTypeCharacteristic(() -> CompletableFuture.completedFuture(type), v -> {
                     }, () -> {
                     }));
         }
 
-        var service = new TelevisionSpeakerService(muteCharacteristic);
-
-        getCharacteristic(ActiveCharacteristic.class).ifPresent(c -> service.addOptionalCharacteristic(c));
-        volumeCharacteristic.ifPresent(c -> service.addOptionalCharacteristic(c));
-        service.addOptionalCharacteristic(volumeControlTypeCharacteristic.get());
-
-        getServices().add(service);
+        addService(service);
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
@@ -44,7 +44,7 @@ class HomekitTemperatureSensorImpl extends AbstractHomekitAccessoryImpl implemen
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new TemperatureSensorService(this));
+        addService(new TemperatureSensorService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -73,7 +73,7 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
     @Override
     public void init() throws HomekitException {
         super.init();
-        this.getServices().add(new ThermostatService(this));
+        addService(new ThermostatService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitValveImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitValveImpl.java
@@ -87,8 +87,11 @@ public class HomekitValveImpl extends AbstractHomekitAccessoryImpl implements Va
     public void init() throws HomekitException {
         super.init();
         ValveService service = new ValveService(this);
-        getServices().add(service);
-        if (homekitTimer) {
+        addService(service);
+
+        var remainingDurationCharacteristic = getCharacteristic(RemainingDurationCharacteristic.class);
+
+        if (homekitTimer && remainingDurationCharacteristic.isEmpty()) {
             addRemainingDurationCharacteristic(getRootAccessory(), getUpdater(), service);
         }
         String valveTypeConfig = getAccessoryConfiguration(CONFIG_VALVE_TYPE, "GENERIC");

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitWindowCoveringImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitWindowCoveringImpl.java
@@ -41,7 +41,7 @@ public class HomekitWindowCoveringImpl extends AbstractHomekitPositionAccessoryI
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new WindowCoveringService(this));
+        addService(new WindowCoveringService(this));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitWindowImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitWindowImpl.java
@@ -41,7 +41,7 @@ public class HomekitWindowImpl extends AbstractHomekitPositionAccessoryImpl impl
     @Override
     public void init() throws HomekitException {
         super.init();
-        getServices().add(new WindowService(this));
+        addService(new WindowService(this));
     }
 
     @Override


### PR DESCRIPTION
https://github.com/openhab/openhab-addons/pull/17031 broke optional characteristics, because it deferred the initial service creation for all accessories until after optional characteristics have been found (in order to insert the accessory information service first). so make sure to add them when the service is actually added.

some complex services (mostly Television related) have required, optional, and synthesized characteristics. take advantage of the new adding of optional characteristics, but take care not to add a synthesized optional characteristic when an explicit one exists

