### PR TITLE
[mongodb] Disable failing MongoDBPersistenceServiceTest

### DIFF
--- a/bundles/org.openhab.persistence.mongodb/src/test/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.mongodb/src/test/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceServiceTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -62,6 +63,7 @@ import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
  *
  * @author René Ulbricht - Initial contribution
  */
+@Disabled("Fails on CPUs without AVX support, see: https://github.com/openhab/openhab-addons/issues/17046")
 public class MongoDBPersistenceServiceTest {
 
     /**


### PR DESCRIPTION
It causes Jenkins CI builds to fail, see #17046