### PR TITLE
[mongodb] Fixes #17046 CI Build fails on new systems - complaining CPU does not support AVX

### DIFF
--- a/bundles/org.openhab.persistence.mongodb/src/test/java/org/openhab/persistence/mongodb/internal/DataCreationHelper.java
+++ b/bundles/org.openhab.persistence.mongodb/src/test/java/org/openhab/persistence/mongodb/internal/DataCreationHelper.java
@@ -15,6 +15,9 @@ package org.openhab.persistence.mongodb.internal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -225,6 +228,26 @@ public class DataCreationHelper {
     }
 
     /**
+     * Checks if the current system supports AVX (Advanced Vector Extensions).
+     * AVX is a set of CPU instructions that can greatly improve performance for certain operations.
+     *
+     * @return true if AVX is supported, false otherwise
+     */
+    public static boolean isAVXSupported() {
+        try (BufferedReader reader = new BufferedReader(new FileReader("/proc/cpuinfo"))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.toLowerCase().contains("avx")) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        return false;
+    }
+
+    /**
      * Provides a stream of arguments to be used for parameterized tests.
      *
      * Each argument is a DatabaseTestContainer instance. Some instances use a MemoryBackend,
@@ -234,7 +257,7 @@ public class DataCreationHelper {
      * @return A stream of Arguments, each containing a DatabaseTestContainer instance.
      */
     public static Stream<Arguments> provideDatabaseBackends() {
-        if (DockerClientFactory.instance().isDockerAvailable()) {
+        if (DockerClientFactory.instance().isDockerAvailable() && isAVXSupported()) {
             // If Docker is available, create a stream of Arguments with all backends
             return Stream.of(
                     // Create a DatabaseTestContainer with a MemoryBackend

--- a/bundles/org.openhab.persistence.mongodb/src/test/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.mongodb/src/test/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceServiceTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -63,7 +62,6 @@ import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
  *
  * @author René Ulbricht - Initial contribution
  */
-@Disabled("Fails on CPUs without AVX support, see: https://github.com/openhab/openhab-addons/issues/17046")
 public class MongoDBPersistenceServiceTest {
 
     /**


### PR DESCRIPTION
# CI Build fails on new systems - complaining CPU does not support AVX

# Description

On the former CI Build, the build did exclude the tests using testcontainer, since there was no docker available. Obviously it is now, but the CPU does not support the AVX instruction set. So testcontainer fail.
Needed to change the way, to check whether to run the tests - so checked whether AVX is there...

# Testing
just run and see whether the build fails on the CI system...
