### PR TITLE
[atlona] Supress unecessary INFO and WARN logging

### DIFF
--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/net/SocketChannelSession.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/net/SocketChannelSession.java
@@ -204,7 +204,7 @@ public class SocketChannelSession implements SocketSession {
             if (isRunning.getAndSet(false)) {
                 try {
                     if (!running.await(5, TimeUnit.SECONDS)) {
-                        logger.warn("Waited too long for response reader to finish");
+                        logger.debug("Waited too long for response reader to finish");
                     }
                 } catch (InterruptedException e) {
                     // Do nothing
@@ -321,7 +321,7 @@ public class SocketChannelSession implements SocketSession {
                 if (processingThread != null && Thread.currentThread() != processingThread) {
                     try {
                         if (!running.await(5, TimeUnit.SECONDS)) {
-                            logger.warn("Waited too long for dispatcher to finish");
+                            logger.debug("Waited too long for dispatcher to finish");
                         }
                     } catch (InterruptedException e) {
                         // do nothing
@@ -358,7 +358,7 @@ public class SocketChannelSession implements SocketSession {
                                     listener.responseReceived(stringResponse);
                                 }
                             } catch (Exception e) {
-                                logger.warn("Exception occurred processing the response '{}': ", response, e);
+                                logger.debug("Exception occurred processing the response '{}': ", response, e);
                             }
                         } else if (response instanceof Exception exceptionResponse) {
                             logger.debug("Dispatching exception: {}", response);
@@ -368,7 +368,7 @@ public class SocketChannelSession implements SocketSession {
                                 listener.responseException(exceptionResponse);
                             }
                         } else {
-                            logger.warn("Unknown response class: {}", response);
+                            logger.debug("Unknown response class: {}", response);
                         }
                     }
                 } catch (InterruptedException e) {

--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Handler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Handler.java
@@ -577,7 +577,7 @@ public class AtlonaPro3Handler extends AtlonaHandler<AtlonaPro3Capabilities> {
         if (retryConnection == null) {
             final AtlonaPro3Config config = getAtlonaConfig();
             if (config != null) {
-                logger.info("Will try to reconnect in {} seconds", config.getRetryPolling());
+                logger.debug("Will try to reconnect in {} seconds", config.getRetryPolling());
                 retryConnection = this.scheduler.schedule(() -> {
                     retryConnection = null;
                     connect();

--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
@@ -769,10 +769,10 @@ class AtlonaPro3PortocolHandler {
                             AtlonaPro3Constants.CHANNEL_POWER), OnOffType.OFF);
                     break;
                 default:
-                    logger.warn("Invalid power response: '{}'", resp);
+                    logger.debug("Invalid power response: '{}'", resp);
             }
         } else {
-            logger.warn("Invalid power response: '{}'", resp);
+            logger.debug("Invalid power response: '{}'", resp);
         }
     }
 
@@ -790,7 +790,7 @@ class AtlonaPro3PortocolHandler {
             version = m.group(1);
             callback.setProperty(AtlonaPro3Constants.PROPERTY_VERSION, version);
         } else {
-            logger.warn("Invalid version response: '{}'", resp);
+            logger.debug("Invalid version response: '{}'", resp);
         }
     }
 
@@ -808,7 +808,7 @@ class AtlonaPro3PortocolHandler {
             modelType = resp;
             callback.setProperty(AtlonaPro3Constants.PROPERTY_TYPE, modelType);
         } else {
-            logger.warn("Invalid Type response: '{}'", resp);
+            logger.debug("Invalid Type response: '{}'", resp);
         }
     }
 
@@ -845,13 +845,13 @@ class AtlonaPro3PortocolHandler {
                                 portNbr, AtlonaPro3Constants.CHANNEL_PORTPOWER), OnOffType.OFF);
                         break;
                     default:
-                        logger.warn("Invalid port power response: '{}'", resp);
+                        logger.debug("Invalid port power response: '{}'", resp);
                 }
             } catch (NumberFormatException e) {
-                logger.warn("Invalid port power (can't parse number): '{}'", resp);
+                logger.debug("Invalid port power (can't parse number): '{}'", resp);
             }
         } else {
-            logger.warn("Invalid port power response: '{}'", resp);
+            logger.debug("Invalid port power response: '{}'", resp);
         }
     }
 
@@ -885,7 +885,7 @@ class AtlonaPro3PortocolHandler {
                 callback.stateChanged(AtlonaPro3Utilities.createChannelID(AtlonaPro3Constants.GROUP_PORT, outPort,
                         AtlonaPro3Constants.CHANNEL_PORTOUTPUT), new DecimalType(inPort));
             } catch (NumberFormatException e) {
-                logger.warn("Invalid port output response (can't parse number): '{}'", resp);
+                logger.debug("Invalid port output response (can't parse number): '{}'", resp);
             }
         }
     }
@@ -918,10 +918,10 @@ class AtlonaPro3PortocolHandler {
                             hdmiPortNbr, AtlonaPro3Constants.CHANNEL_PORTMIRRORENABLED), OnOffType.ON);
                 }
             } catch (NumberFormatException e) {
-                logger.warn("Invalid mirror response (can't parse number): '{}'", resp);
+                logger.debug("Invalid mirror response (can't parse number): '{}'", resp);
             }
         } else {
-            logger.warn("Invalid mirror response: '{}'", resp);
+            logger.debug("Invalid mirror response: '{}'", resp);
         }
     }
 
@@ -941,10 +941,10 @@ class AtlonaPro3PortocolHandler {
                 callback.stateChanged(AtlonaPro3Utilities.createChannelID(AtlonaPro3Constants.GROUP_MIRROR, hdmiPortNbr,
                         AtlonaPro3Constants.CHANNEL_PORTMIRROR), new DecimalType(0));
             } catch (NumberFormatException e) {
-                logger.warn("Invalid unmirror response (can't parse number): '{}'", resp);
+                logger.debug("Invalid unmirror response (can't parse number): '{}'", resp);
             }
         } else {
-            logger.warn("Invalid unmirror response: '{}'", resp);
+            logger.debug("Invalid unmirror response: '{}'", resp);
         }
     }
 
@@ -965,10 +965,10 @@ class AtlonaPro3PortocolHandler {
                 callback.stateChanged(AtlonaPro3Utilities.createChannelID(AtlonaPro3Constants.GROUP_VOLUME, portNbr,
                         AtlonaPro3Constants.CHANNEL_VOLUME), new DecimalType(level));
             } catch (NumberFormatException e) {
-                logger.warn("Invalid volume response (can't parse number): '{}'", resp);
+                logger.debug("Invalid volume response (can't parse number): '{}'", resp);
             }
         } else {
-            logger.warn("Invalid volume response: '{}'", resp);
+            logger.debug("Invalid volume response: '{}'", resp);
         }
     }
 
@@ -995,13 +995,13 @@ class AtlonaPro3PortocolHandler {
                                 portNbr, AtlonaPro3Constants.CHANNEL_VOLUME_MUTE), OnOffType.OFF);
                         break;
                     default:
-                        logger.warn("Invalid volume mute response: '{}'", resp);
+                        logger.debug("Invalid volume mute response: '{}'", resp);
                 }
             } catch (NumberFormatException e) {
-                logger.warn("Invalid volume mute (can't parse number): '{}'", resp);
+                logger.debug("Invalid volume mute (can't parse number): '{}'", resp);
             }
         } else {
-            logger.warn("Invalid volume mute response: '{}'", resp);
+            logger.debug("Invalid volume mute response: '{}'", resp);
         }
     }
 


### PR DESCRIPTION
After a power outage my Atlona switch did not get an IP and as a result the binding was spamming the log with reconnect messages every 10 seconds.

![image](https://github.com/user-attachments/assets/a6cd6d68-1836-47d7-bd9f-cce7b932967f)

This PR changes almost all existing logging calls to use DEBUG instead.