### PR TITLE
[bluetooth.bluez] Handle UnsatisfiedLinkError on Windows (and macOS)

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/DeviceManagerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/DeviceManagerFactory.java
@@ -81,7 +81,7 @@ public class DeviceManagerFactory {
                 // Exception caused by first call to the library
                 try {
                     return DeviceManager.createInstance(false);
-                } catch (DBusException ex) {
+                } catch (DBusException | UnsatisfiedLinkError ex) {
                     // we might be on a system without DBus, such as macOS or Windows
                     logger.debug("Failed to initialize DeviceManager: {}", ex.getMessage());
                     return null;


### PR DESCRIPTION
Resolves #17035 

Handles UnsatisfiedLinkError on Windows (and macOS).

Signed-off-by: AndrewFG <software@whitebear.ch>
