### PR TITLE
[bluetooth.bluez] Sync bluez-dbus-osgi to version 0.1.4

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/NOTICE
+++ b/bundles/org.openhab.binding.bluetooth.bluez/NOTICE
@@ -14,7 +14,7 @@ https://github.com/openhab/openhab-addons
 
 == Third-party Content
 
-BlueZ-DBus Version: 0.1.3
+BlueZ-DBus Version: 0.1.4
 * License:  MIT License
 * Project: https://github.com/hypfvieh/bluez-dbus
 * Source: https://github.com/hypfvieh/bluez-dbus

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-binding-bluetooth-bluez" description="Bluetooth Binding Bluez" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.1.3</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.1.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>
 	</feature>

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -2,7 +2,7 @@
 	<feature name="openhab-binding-bluetooth" description="Bluetooth Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
-		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.1.3</bundle>
+		<bundle dependency="true">mvn:com.github.hypfvieh/bluez-dbus-osgi/0.1.4</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.airthings/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.am43/${project.version}</bundle>


### PR DESCRIPTION
Multiple declarations of the same dependency. They should be aligned. 

For reference: https://github.com/openhab/openhab-addons/issues/17112#issuecomment-2241556862