### PR TITLE
[samsungtv] Adjust logging when TV is off

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
@@ -198,7 +198,10 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
                 // @Nullable
                 String response = HttpUtil.executeUrl("GET", uri.toURL().toString(), 500);
                 properties = Optional.ofNullable(new Gson().fromJson(response, TVProperties.class));
-            } catch (JsonSyntaxException | URISyntaxException | IOException e) {
+            } catch (IOException e) {
+                logger.debug("{}: Cannot connect to TV: {}", host, e.getMessage());
+                properties = Optional.empty();
+            } catch (JsonSyntaxException | URISyntaxException e) {
                 logger.warn("{}: Cannot connect to TV: {}", host, e.getMessage());
                 properties = Optional.empty();
             }
@@ -229,7 +232,7 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
         } catch (InterruptedException | ExecutionException e) {
             logger.warn("{}: Cannot get TVProperties: {}", host, e.getMessage());
         }
-        logger.warn("{}: Cannot get TVProperties, return Empty properties", host);
+        logger.debug("{}: Cannot get TVProperties, return Empty properties", host);
         return new TVProperties();
     }
 


### PR DESCRIPTION
As the `Thing` is already set to offline later on, there is no need to also log to warn level that the device is unreachable / timeout for getting the TV Properties. debug is good enough.

Fixes: https://github.com/openhab/openhab-addons/issues/17118