### PR TITLE
[astro] Use the existing ChannelUID instance to check the linked state

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/handler/AstroThingHandler.java
@@ -167,8 +167,8 @@ public abstract class AstroThingHandler extends BaseThingHandler {
      */
     public void publishChannelIfLinked(ChannelUID channelUID) {
         Planet planet = getPlanet();
-        if (isLinked(channelUID.getId()) && planet != null) {
-            final Channel channel = getThing().getChannel(channelUID.getId());
+        if (isLinked(channelUID) && planet != null) {
+            final Channel channel = getThing().getChannel(channelUID);
             if (channel == null) {
                 logger.error("Cannot find channel for {}", channelUID);
                 return;
@@ -272,8 +272,8 @@ public abstract class AstroThingHandler extends BaseThingHandler {
     private boolean isPositionalChannelLinked() {
         List<String> positionalChannels = Arrays.asList(getPositionalChannelIds());
         for (Channel channel : getThing().getChannels()) {
-            String id = channel.getUID().getId();
-            if (isLinked(id) && positionalChannels.contains(id)) {
+            ChannelUID id = channel.getUID();
+            if (isLinked(id) && positionalChannels.contains(id.getId())) {
                 return true;
             }
         }

--- a/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/handler/test/AstroCommandTest.java
+++ b/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/handler/test/AstroCommandTest.java
@@ -59,7 +59,7 @@ public class AstroCommandTest {
         Thing thing = mock(Thing.class);
         when(thing.getConfiguration()).thenReturn(thingConfiguration);
         when(thing.getUID()).thenReturn(thingUID);
-        when(thing.getChannel(DEFAULT_TEST_CHANNEL_ID)).thenReturn(channel);
+        when(thing.getChannel(channelUID)).thenReturn(channel);
 
         ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
         CronScheduler cronScheduler = mock(CronScheduler.class);


### PR DESCRIPTION
This PR will avoid creation of a new ChannelUID instances to check linked state of the channel.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>