### PR TITLE
[homekit] Fix thermostats with auto mode and only target temperature

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -83,13 +83,6 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl {
 
         var targetHeatingCoolingStateCharacteristic = getCharacteristic(TargetHeatingCoolingStateCharacteristic.class)
                 .get();
-        if (Arrays.stream(targetHeatingCoolingStateCharacteristic.getValidValues())
-                .anyMatch(v -> v.equals(TargetHeatingCoolingStateEnum.AUTO))
-                && (!coolingThresholdTemperatureCharacteristic.isPresent()
-                        || !heatingThresholdTemperatureCharacteristic.isPresent())) {
-            throw new HomekitException(
-                    "Both HeatingThresholdTemperature and CoolingThresholdTemperature must be provided if AUTO mode is allowed.");
-        }
 
         // TargetTemperature not provided; simulate by forwarding to HeatingThresholdTemperature and
         // CoolingThresholdTemperature


### PR DESCRIPTION
Allow configuring such an accessory, and it's up to the user to be okay with how the Home app deals with it.

Fixes #17131