### PR TITLE
[homekit] Don't pre-fill enums from switches if metadata has enum values

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -339,13 +339,24 @@ public class HomekitCharacteristicFactory {
         @Nullable
         T offEnumValue = null, onEnumValue = null;
 
+        var configuration = item.getConfiguration();
+        boolean configurationDefinesEnumValues = false;
+        if (configuration != null && !configuration.isEmpty()) {
+            for (var k : klazz.getEnumConstants()) {
+                if (configuration.containsKey(k.toString())) {
+                    configurationDefinesEnumValues = true;
+                    break;
+                }
+            }
+        }
+
         for (var k : klazz.getEnumConstants()) {
             if (numberType) {
                 int code = k.getCode();
-                if ((switchType || contactType) && code == 0) {
+                if ((switchType || contactType) && code == 0 && !configurationDefinesEnumValues) {
                     map.put(k, inverted ? onValue : offValue);
                     offEnumValue = k;
-                } else if ((switchType || contactType) && code == 1) {
+                } else if ((switchType || contactType) && code == 1 && !configurationDefinesEnumValues) {
                     map.put(k, inverted ? offValue : onValue);
                     onEnumValue = k;
                 } else if (percentType && code == 0) {
@@ -359,8 +370,7 @@ public class HomekitCharacteristicFactory {
                 map.put(k, k.toString());
             }
         }
-        var configuration = item.getConfiguration();
-        if (configuration != null) {
+        if (configuration != null && !configuration.isEmpty()) {
             map.forEach((k, current_value) -> {
                 final Object newValue = configuration.get(k.toString());
                 if (newValue instanceof String || newValue instanceof Number) {


### PR DESCRIPTION
This is especially important when linking a many-valued enum (such as CurrentHeatingCoolingState) to a switch, and you want to use a value beyond 0 and 1 (i.e. OFF (0) and COOL (2)).

Fixes #16791
