### PR TITLE
[daikin] Update channels immediately after a successful API command

### DIFF
--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinWebTargets.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinWebTargets.java
@@ -15,7 +15,6 @@ package org.openhab.binding.daikin.internal;
 import java.io.EOFException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -33,7 +32,6 @@ import org.openhab.binding.daikin.internal.api.DemandControl;
 import org.openhab.binding.daikin.internal.api.EnergyInfoDayAndWeek;
 import org.openhab.binding.daikin.internal.api.EnergyInfoYear;
 import org.openhab.binding.daikin.internal.api.Enums.SpecialMode;
-import org.openhab.binding.daikin.internal.api.InfoParser;
 import org.openhab.binding.daikin.internal.api.SensorInfo;
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseBasicInfo;
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseControlInfo;
@@ -119,9 +117,7 @@ public class DaikinWebTargets {
 
     public boolean setControlInfo(ControlInfo info) throws DaikinCommunicationException {
         Map<String, String> queryParams = info.getParamString();
-        String result = invoke(setControlInfoUri, queryParams);
-        Map<String, String> responseMap = InfoParser.parse(result);
-        return Optional.ofNullable(responseMap.get("ret")).orElse("").equals("OK");
+        return isSuccessful(invoke(setControlInfoUri, queryParams));
     }
 
     public SensorInfo getSensorInfo() throws DaikinCommunicationException {
@@ -146,7 +142,7 @@ public class DaikinWebTargets {
         return EnergyInfoDayAndWeek.parse(response);
     }
 
-    public void setSpecialMode(SpecialMode newMode) throws DaikinCommunicationException {
+    public boolean setSpecialMode(SpecialMode newMode) throws DaikinCommunicationException {
         Map<String, String> queryParams = new HashMap<>();
         if (newMode == SpecialMode.NORMAL) {
             queryParams.put("set_spmode", "0");
@@ -160,17 +156,23 @@ public class DaikinWebTargets {
             queryParams.put("spmode_kind", newMode.getValue());
         }
         String response = invoke(setSpecialModeUri, queryParams);
-        if (!response.contains("ret=OK")) {
+        if (isSuccessful(response)) {
+            return true;
+        } else {
             logger.warn("Error setting special mode. Response: '{}'", response);
+            return false;
         }
     }
 
-    public void setStreamerMode(boolean state) throws DaikinCommunicationException {
+    public boolean setStreamerMode(boolean state) throws DaikinCommunicationException {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("en_streamer", state ? "1" : "0");
         String response = invoke(setSpecialModeUri, queryParams);
-        if (!response.contains("ret=OK")) {
+        if (isSuccessful(response)) {
+            return true;
+        } else {
             logger.warn("Error setting streamer mode. Response: '{}'", response);
+            return false;
         }
     }
 
@@ -181,9 +183,7 @@ public class DaikinWebTargets {
 
     public boolean setDemandControl(DemandControl info) throws DaikinCommunicationException {
         Map<String, String> queryParams = info.getParamString();
-        String result = invoke(setDemandControlUri, queryParams);
-        Map<String, String> responseMap = InfoParser.parse(result);
-        return Optional.ofNullable(responseMap.get("ret")).orElse("").equals("OK");
+        return isSuccessful(invoke(setDemandControlUri, queryParams));
     }
 
     // Daikin Airbase API
@@ -192,9 +192,9 @@ public class DaikinWebTargets {
         return AirbaseControlInfo.parse(response);
     }
 
-    public void setAirbaseControlInfo(AirbaseControlInfo info) throws DaikinCommunicationException {
+    public boolean setAirbaseControlInfo(AirbaseControlInfo info) throws DaikinCommunicationException {
         Map<String, String> queryParams = info.getParamString();
-        invoke(setAirbaseControlInfoUri, queryParams);
+        return isSuccessful(invoke(setAirbaseControlInfoUri, queryParams));
     }
 
     public SensorInfo getAirbaseSensorInfo() throws DaikinCommunicationException {
@@ -217,9 +217,13 @@ public class DaikinWebTargets {
         return AirbaseZoneInfo.parse(response);
     }
 
-    public void setAirbaseZoneInfo(AirbaseZoneInfo zoneinfo) throws DaikinCommunicationException {
+    public boolean setAirbaseZoneInfo(AirbaseZoneInfo zoneinfo) throws DaikinCommunicationException {
         Map<String, String> queryParams = zoneinfo.getParamString();
-        invoke(setAirbaseZoneInfoUri, queryParams);
+        return isSuccessful(invoke(setAirbaseZoneInfoUri, queryParams));
+    }
+
+    private boolean isSuccessful(String response) {
+        return response.contains("ret=OK");
     }
 
     private String invoke(String uri) throws DaikinCommunicationException {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -129,7 +129,6 @@ public class Enums {
         HEAT("heat"),
         OFF("off");
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(HomekitMode.class);
         private final String value;
 
         HomekitMode(String value) {
@@ -138,6 +137,15 @@ public class Enums {
 
         public String getValue() {
             return value;
+        }
+
+        public static HomekitMode fromValue(String value) throws IllegalArgumentException {
+            for (HomekitMode m : HomekitMode.values()) {
+                if (m.getValue().equals(value)) {
+                    return m;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected HomekitMode value of \"" + value + "\"");
         }
     }
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -138,15 +138,6 @@ public class Enums {
         public String getValue() {
             return value;
         }
-
-        public static HomekitMode fromValue(String value) throws IllegalArgumentException {
-            for (HomekitMode m : HomekitMode.values()) {
-                if (m.getValue().equals(value)) {
-                    return m;
-                }
-            }
-            throw new IllegalArgumentException("Unexpected HomekitMode value of \"" + value + "\"");
-        }
     }
 
     public enum AdvancedMode {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -235,7 +235,7 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
 
     private boolean changeHomekitMode(String homekitmode) throws DaikinCommunicationException {
         try {
-            HomekitMode mode = HomekitMode.fromValue(homekitmode);
+            HomekitMode mode = HomekitMode.valueOf(homekitmode.toUpperCase());
             boolean power = mode != HomekitMode.OFF;
             if (!changePower(power)) {
                 return false;

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -70,13 +70,13 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
     // Abstract methods to be overridden by specific Daikin implementation class
     protected abstract void pollStatus() throws DaikinCommunicationException;
 
-    protected abstract void changePower(boolean power) throws DaikinCommunicationException;
+    protected abstract boolean changePower(boolean power) throws DaikinCommunicationException;
 
-    protected abstract void changeSetPoint(double newTemperature) throws DaikinCommunicationException;
+    protected abstract boolean changeSetPoint(double newTemperature) throws DaikinCommunicationException;
 
-    protected abstract void changeMode(String mode) throws DaikinCommunicationException;
+    protected abstract boolean changeMode(String mode) throws DaikinCommunicationException;
 
-    protected abstract void changeFanSpeed(String fanSpeed) throws DaikinCommunicationException;
+    protected abstract boolean changeFanSpeed(String fanSpeed) throws DaikinCommunicationException;
 
     // Power, Temp, Fan and Mode are handled in this base class. Override this to handle additional channels.
     protected abstract boolean handleCommandInternal(ChannelUID channelUID, Command command)
@@ -104,31 +104,54 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
             switch (channelUID.getId()) {
                 case DaikinBindingConstants.CHANNEL_AC_POWER:
                     if (command instanceof OnOffType onOffCommand) {
-                        changePower(onOffCommand.equals(OnOffType.ON));
+                        if (changePower(onOffCommand.equals(OnOffType.ON))) {
+                            updateState(channelUID, onOffCommand);
+                        }
                         return;
                     }
                     break;
                 case DaikinBindingConstants.CHANNEL_AC_TEMP:
-                    if (changeSetPoint(command)) {
-                        return;
+                    double newTemperature;
+                    State newState = UnDefType.UNDEF;
+                    if (command instanceof DecimalType decimalCommand) {
+                        newTemperature = decimalCommand.doubleValue();
+                        newState = decimalCommand;
+                    } else if (command instanceof QuantityType) {
+                        QuantityType<Temperature> quantityCommand = (QuantityType<Temperature>) command;
+                        newTemperature = quantityCommand.toUnit(SIUnits.CELSIUS).doubleValue();
+                        newState = quantityCommand;
+                    } else {
+                        break; // Exit switch statement but proceed to log about unsupported command type
                     }
-                    break;
+
+                    // Only half degree increments are allowed, all others are silently rejected by the A/C units
+                    newTemperature = Math.round(newTemperature * 2) / 2.0;
+                    if (changeSetPoint(newTemperature)) {
+                        updateState(channelUID, newState);
+                    }
+                    return; // return here and don't log about wrong type below
                 case DaikinBindingConstants.CHANNEL_AIRBASE_AC_FAN_SPEED:
                 case DaikinBindingConstants.CHANNEL_AC_FAN_SPEED:
                     if (command instanceof StringType stringCommand) {
-                        changeFanSpeed(stringCommand.toString());
+                        if (changeFanSpeed(stringCommand.toString())) {
+                            updateState(channelUID, stringCommand);
+                        }
                         return;
                     }
                     break;
                 case DaikinBindingConstants.CHANNEL_AC_HOMEKITMODE:
-                    if (command instanceof StringType) {
-                        changeHomekitMode(command.toString());
+                    if (command instanceof StringType stringCommand) {
+                        if (changeHomekitMode(stringCommand.toString())) {
+                            updateState(DaikinBindingConstants.CHANNEL_AC_HOMEKITMODE, stringCommand);
+                        }
                         return;
                     }
                     break;
                 case DaikinBindingConstants.CHANNEL_AC_MODE:
                     if (command instanceof StringType stringCommand) {
-                        changeMode(stringCommand.toString());
+                        if (changeMode(stringCommand.toString())) {
+                            updateState(channelUID, stringCommand);
+                        }
                         return;
                     }
                     break;
@@ -210,37 +233,37 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
                 maybeTemperature.<State> map(t -> new QuantityType<>(t, SIUnits.CELSIUS)).orElse(UnDefType.UNDEF)));
     }
 
-    /**
-     * @return true if the command was of an expected type, false otherwise
-     */
-    private boolean changeSetPoint(Command command) throws DaikinCommunicationException {
-        double newTemperature;
-        if (command instanceof DecimalType decimalCommand) {
-            newTemperature = decimalCommand.doubleValue();
-        } else if (command instanceof QuantityType) {
-            newTemperature = ((QuantityType<Temperature>) command).toUnit(SIUnits.CELSIUS).doubleValue();
-        } else {
-            return false;
-        }
-
-        // Only half degree increments are allowed, all others are silently rejected by the A/C units
-        newTemperature = Math.round(newTemperature * 2) / 2.0;
-        changeSetPoint(newTemperature);
-        return true;
-    }
-
-    private void changeHomekitMode(String homekitmode) throws DaikinCommunicationException {
-        if (HomekitMode.OFF.getValue().equals(homekitmode)) {
-            changePower(false);
-        } else {
-            changePower(true);
-            if (HomekitMode.AUTO.getValue().equals(homekitmode)) {
-                changeMode("AUTO");
-            } else if (HomekitMode.HEAT.getValue().equals(homekitmode)) {
-                changeMode("HEAT");
-            } else if (HomekitMode.COOL.getValue().equals(homekitmode)) {
-                changeMode("COLD");
+    private boolean changeHomekitMode(String homekitmode) throws DaikinCommunicationException {
+        try {
+            HomekitMode mode = HomekitMode.fromValue(homekitmode);
+            boolean power = mode != HomekitMode.OFF;
+            if (!changePower(power)) {
+                return false;
             }
+
+            boolean changeModeSuccess = false;
+            updateState(DaikinBindingConstants.CHANNEL_AC_POWER, OnOffType.from(power));
+
+            String newMode = switch (mode) {
+                case AUTO -> "AUTO";
+                case HEAT -> "HEAT";
+                case COOL -> "COLD";
+                case OFF -> null;
+            };
+
+            if (newMode == null) {
+                return true;
+            }
+
+            if (changeMode(newMode)) {
+                updateState(DaikinBindingConstants.CHANNEL_AC_MODE, new StringType(newMode));
+                return true;
+            }
+
+            return false;
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid homekit mode: {}", homekitmode);
+            return false;
         }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.daikin/src/main/resources/OH-INF/thing/thing-types.xml
@@ -94,6 +94,7 @@
 		<label>Power</label>
 		<description>Power for the AC unit</description>
 		<category>Switch</category>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-settemp">
@@ -102,6 +103,7 @@
 		<description>The set point temperature</description>
 		<category>Temperature</category>
 		<state pattern="%.1f %unit%" step="0.5"/>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-indoortemp">
@@ -141,6 +143,7 @@
 				<option value="FAN">fan</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-homekitmode">
@@ -155,6 +158,7 @@
 				<option value="off">Off</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-fan">
@@ -172,6 +176,7 @@
 				<option value="LEVEL_5">level 5</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-fandir">
@@ -186,6 +191,7 @@
 				<option value="VERTICAL_AND_HORIZONTAL">vertical and horizontal</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-cmpfrequency" advanced="true">
@@ -205,12 +211,14 @@
 				<option value="POWERFUL">Powerful</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-streamer" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Streamer</label>
 		<description>Streamer Mode</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="acunit-energyheatingtoday" advanced="true">
@@ -442,6 +450,7 @@
 				<option value="MANUAL">Manual</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 	<channel-type id="acunit-demandcontrolmaxpower" advanced="true">
 		<item-type>Dimmer</item-type>
@@ -449,65 +458,76 @@
 		<description>The maximum power for demand control in percent. Allowed range is between 40% and 100% in increments of
 			5%.</description>
 		<state pattern="%d %%" min="40" max="100" step="5"></state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 	<channel-type id="acunit-demandcontrolschedule" advanced="true">
 		<item-type>String</item-type>
 		<label>Demand Control Schedule</label>
 		<description>The demand control schedule in JSON format.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-fan">
 		<item-type>String</item-type>
 		<label>Fan</label>
 		<description>Current fan speed setting of the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone1">
 		<item-type>Switch</item-type>
 		<label>Zone 1</label>
 		<description>Zone 1 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone2">
 		<item-type>Switch</item-type>
 		<label>Zone 2</label>
 		<description>Zone 2 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone3">
 		<item-type>Switch</item-type>
 		<label>Zone 3</label>
 		<description>Zone 3 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone4">
 		<item-type>Switch</item-type>
 		<label>Zone 4</label>
 		<description>Zone 4 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone5">
 		<item-type>Switch</item-type>
 		<label>Zone 5</label>
 		<description>Zone 5 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone6">
 		<item-type>Switch</item-type>
 		<label>Zone 6</label>
 		<description>Zone 6 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone7">
 		<item-type>Switch</item-type>
 		<label>Zone 7</label>
 		<description>Zone 7 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone8">
 		<item-type>Switch</item-type>
 		<label>Zone 8</label>
 		<description>Zone 8 for the AC unit</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
This was requested in https://github.com/openhab/openhab-addons/issues/16479#issuecomment-2249747109

In summary, when sending an API call to change something, the device will return a `ret=OK` if it accepted the values that we've set. Therefore, we should know the updated value already, without having to wait for the next poll. We therefore update the relevant channel immediately.

This helps for when changing something requires immediate feedback, such as increasing/decreasing the set temperature. Previously, the only way to get a smooth user experience is by relying on autoupdate.

