### PR TITLE
[homekit] Fix duplicate name characteristic errors

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -451,6 +451,10 @@ public abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
             return;
         }
         rawCharacteristics.put(characteristic.getClass(), characteristic);
+        // belongs on the accessory information service
+        if (characteristic.getClass() == NameCharacteristic.class) {
+            return;
+        }
         var service = getPrimaryService();
         if (service != null) {
             // find the corresponding add method at service and call it.


### PR DESCRIPTION
Depending on how the accessory initializes, optional characteristics may be added before or after the service. For IrrigationSystem, it's added before optional characteristics. Because Name is special (it belons on the AccessoryInformationService for the primary service, and on the service itself for others), we need to be careful to not add it to the primary service. It will get moved to the accessory service later if the accessory ends up being a secondary service on a composite accessory.

Fixes #15387

