### PR TITLE
[homekit] Adjust default ranges for some characteristics

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -186,6 +186,26 @@ import io.github.hapjava.characteristics.impl.windowcovering.TargetVerticalTiltA
  */
 @NonNullByDefault
 public class HomekitCharacteristicFactory {
+    // These values represent ranges that do not match the defaults that are part of
+    // the HAP specification/the defaults in HAP-Java, but nonetheless are commonly
+    // encountered in consumer-grade devices. So we define our own default min/max so
+    // that users don't have to override the default unnecessarily.
+
+    // HAP default is 50-400 mired/2500-20,000 K. These numbers represent
+    // the warmest and coolest bulbs I could reasonably find at general
+    // purpose retailers.
+    public static final int COLOR_TEMPERATURE_MIN_MIREDS = 107; // 9300 K
+    public static final int COLOR_TEMPERATURE_MAX_MIREDS = 556; // 1800 K
+    // HAP default is 0 °C, but it's very common for outdoor temperatures and/or
+    // refrigation devices to go below freezing.
+    // Lowest recorded temperature on Earth is -89.2 °C. This is just a nice round number.
+    public static final int CURRENT_TEMPERATURE_MIN_CELSIUS = -100;
+    // HAP default is 0.0001 lx, but this is commonly rounded to 0 by many devices
+    public static final int CURRENT_AMBIENT_LIGHT_LEVEL_MIN_LUX = 0;
+    // HAP default is 100k
+    // https://en.wikipedia.org/wiki/Daylight#Intensity_in_different_conditions
+    public static final int CURRENT_AMBIENT_LIGHT_LEVEL_MAX_LUX = 120000;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(HomekitCharacteristicFactory.class);
 
     // List of optional characteristics and corresponding method to create them.
@@ -759,14 +779,10 @@ public class HomekitCharacteristicFactory {
             HomekitAccessoryUpdater updater) {
         final boolean inverted = taggedItem.isInverted();
 
-        // 9300 K
-        int minValue = taggedItem
-                .getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE, new QuantityType(107, Units.MIRED), false)
-                .intValue();
-        // 1800 K
-        int maxValue = taggedItem
-                .getConfigurationAsQuantity(HomekitTaggedItem.MAX_VALUE, new QuantityType(556, Units.MIRED), false)
-                .intValue();
+        int minValue = taggedItem.getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE,
+                new QuantityType(COLOR_TEMPERATURE_MIN_MIREDS, Units.MIRED), false).intValue();
+        int maxValue = taggedItem.getConfigurationAsQuantity(HomekitTaggedItem.MAX_VALUE,
+                new QuantityType(COLOR_TEMPERATURE_MAX_MIREDS, Units.MIRED), false).intValue();
 
         // It's common to swap these if you're providing in Kelvin instead of mired
         if (minValue > maxValue) {
@@ -898,12 +914,9 @@ public class HomekitCharacteristicFactory {
 
     private static CurrentTemperatureCharacteristic createCurrentTemperatureCharacteristic(HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
-        double minValue = taggedItem
-                .getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE,
-                        Objects.requireNonNull(
-                                new QuantityType(-100, SIUnits.CELSIUS).toUnit(getSystemTemperatureUnit())),
-                        false)
-                .toUnit(SIUnits.CELSIUS).doubleValue();
+        double minValue = taggedItem.getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE, Objects.requireNonNull(
+                new QuantityType(CURRENT_TEMPERATURE_MIN_CELSIUS, SIUnits.CELSIUS).toUnit(getSystemTemperatureUnit())),
+                false).toUnit(SIUnits.CELSIUS).doubleValue();
         double maxValue = taggedItem
                 .getConfigurationAsQuantity(HomekitTaggedItem.MAX_VALUE,
                         Objects.requireNonNull(

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -759,13 +759,13 @@ public class HomekitCharacteristicFactory {
             HomekitAccessoryUpdater updater) {
         final boolean inverted = taggedItem.isInverted();
 
+        // 9300 K
         int minValue = taggedItem
-                .getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE,
-                        new QuantityType(ColorTemperatureCharacteristic.DEFAULT_MIN_VALUE, Units.MIRED), false)
+                .getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE, new QuantityType(107, Units.MIRED), false)
                 .intValue();
+        // 1800 K
         int maxValue = taggedItem
-                .getConfigurationAsQuantity(HomekitTaggedItem.MAX_VALUE,
-                        new QuantityType(ColorTemperatureCharacteristic.DEFAULT_MAX_VALUE, Units.MIRED), false)
+                .getConfigurationAsQuantity(HomekitTaggedItem.MAX_VALUE, new QuantityType(556, Units.MIRED), false)
                 .intValue();
 
         // It's common to swap these if you're providing in Kelvin instead of mired
@@ -901,8 +901,7 @@ public class HomekitCharacteristicFactory {
         double minValue = taggedItem
                 .getConfigurationAsQuantity(HomekitTaggedItem.MIN_VALUE,
                         Objects.requireNonNull(
-                                new QuantityType(CurrentTemperatureCharacteristic.DEFAULT_MIN_VALUE, SIUnits.CELSIUS)
-                                        .toUnit(getSystemTemperatureUnit())),
+                                new QuantityType(-100, SIUnits.CELSIUS).toUnit(getSystemTemperatureUnit())),
                         false)
                 .toUnit(SIUnits.CELSIUS).doubleValue();
         double maxValue = taggedItem

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightSensorImpl.java
@@ -29,7 +29,6 @@ import org.openhab.io.homekit.internal.HomekitTaggedItem;
 import io.github.hapjava.accessories.LightSensorAccessory;
 import io.github.hapjava.characteristics.Characteristic;
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
-import io.github.hapjava.characteristics.impl.lightsensor.CurrentAmbientLightLevelCharacteristic;
 import io.github.hapjava.services.impl.LightSensorService;
 
 /**
@@ -61,13 +60,13 @@ public class HomekitLightSensorImpl extends AbstractHomekitAccessoryImpl impleme
     @Override
     public double getMinCurrentAmbientLightLevel() {
         return getAccessoryConfiguration(HomekitCharacteristicType.LIGHT_LEVEL, HomekitTaggedItem.MIN_VALUE,
-                BigDecimal.valueOf(CurrentAmbientLightLevelCharacteristic.DEFAULT_MIN_VALUE)).doubleValue();
+                BigDecimal.valueOf(0)).doubleValue();
     }
 
     @Override
     public double getMaxCurrentAmbientLightLevel() {
         return getAccessoryConfiguration(HomekitCharacteristicType.LIGHT_LEVEL, HomekitTaggedItem.MAX_VALUE,
-                BigDecimal.valueOf(CurrentAmbientLightLevelCharacteristic.DEFAULT_MAX_VALUE)).doubleValue();
+                BigDecimal.valueOf(120000)).doubleValue(); // https://en.wikipedia.org/wiki/Daylight#Intensity_in_different_conditions
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightSensorImpl.java
@@ -60,13 +60,13 @@ public class HomekitLightSensorImpl extends AbstractHomekitAccessoryImpl impleme
     @Override
     public double getMinCurrentAmbientLightLevel() {
         return getAccessoryConfiguration(HomekitCharacteristicType.LIGHT_LEVEL, HomekitTaggedItem.MIN_VALUE,
-                BigDecimal.valueOf(0)).doubleValue();
+                BigDecimal.valueOf(HomekitCharacteristicFactory.CURRENT_AMBIENT_LIGHT_LEVEL_MIN_LUX)).doubleValue();
     }
 
     @Override
     public double getMaxCurrentAmbientLightLevel() {
         return getAccessoryConfiguration(HomekitCharacteristicType.LIGHT_LEVEL, HomekitTaggedItem.MAX_VALUE,
-                BigDecimal.valueOf(120000)).doubleValue(); // https://en.wikipedia.org/wiki/Daylight#Intensity_in_different_conditions
+                BigDecimal.valueOf(HomekitCharacteristicFactory.CURRENT_AMBIENT_LIGHT_LEVEL_MAX_LUX)).doubleValue();
     }
 
     @Override


### PR DESCRIPTION
Fixes #15818

 * Illuminance can obviously get down to 0, instead of 0.0001lx (especially if your sensor only reports integer values)
 * Raise Illuminance ceiling slightly (from 100k lx)
 * Adjust default range of Color Temperature to the warmest and coolest bulbs I could find on Amazon (for settable characteristics, you don't want to have too large of a range because HomeKit will often use those ranges to determine the scale of the slider). Original is 50-400 mired/2500-20000 K
 * Lower min value of current temperature from 0°C to -100°C (going below freezing is not unusual. lowest recorded temperature on earth is -89.2°C. I just chose a nice round number)
