### PR TITLE
[dbquery] Fix dependency issues and bump to newer version libs

### DIFF
--- a/bundles/org.openhab.binding.dbquery/pom.xml
+++ b/bundles/org.openhab.binding.dbquery/pom.xml
@@ -18,6 +18,9 @@
     <bnd.importpackage>
       !javax.annotation;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*
     </bnd.importpackage>
+    <influx2.version>7.0.0</influx2.version>
+    <io.reactivex.rxjava3>3.1.8</io.reactivex.rxjava3>
+    <retrofit.version>2.10.0</retrofit.version>
   </properties>
 
   <dependencies>
@@ -25,27 +28,59 @@
     <dependency>
       <groupId>com.influxdb</groupId>
       <artifactId>influxdb-client-java</artifactId>
-      <version>1.6.0</version>
+      <version>${influx2.version}</version>
     </dependency>
     <dependency>
       <artifactId>influxdb-client-core</artifactId>
       <groupId>com.influxdb</groupId>
-      <version>1.6.0</version>
+      <version>${influx2.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.influxdb</groupId>
+      <artifactId>influxdb-client-utils</artifactId>
+      <version>${influx2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.influxdb</groupId>
+      <artifactId>flux-dsl</artifactId>
+      <version>${influx2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.influxdb</groupId>
+      <artifactId>influxdb-client-flux</artifactId>
+      <version>${influx2.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-gson</artifactId>
-      <groupId>com.squareup.retrofit2</groupId>
-      <version>2.5.0</version>
+      <version>${retrofit.version}</version>
     </dependency>
     <dependency>
-      <artifactId>converter-scalars</artifactId>
       <groupId>com.squareup.retrofit2</groupId>
-      <version>2.5.0</version>
+      <artifactId>converter-scalars</artifactId>
+      <version>${retrofit.version}</version>
     </dependency>
+    <dependency>
+      <artifactId>retrofit</artifactId>
+      <groupId>com.squareup.retrofit2</groupId>
+      <version>${retrofit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>adapter-rxjava3</artifactId>
+      <version>${retrofit.version}</version>
+    </dependency>
+
     <dependency> <!-- also used for querydb library -->
       <artifactId>gson</artifactId>
       <groupId>com.google.code.gson</groupId>
       <version>${gson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <artifactId>gson-fire</artifactId>
@@ -67,7 +102,7 @@
     <dependency>
       <artifactId>commons-csv</artifactId>
       <groupId>org.apache.commons</groupId>
-      <version>1.6</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <artifactId>json</artifactId>
@@ -80,34 +115,29 @@
       <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
-      <artifactId>retrofit</artifactId>
-      <groupId>com.squareup.retrofit2</groupId>
-      <version>2.6.2</version>
-    </dependency>
-    <dependency>
-      <artifactId>jsr305</artifactId>
-      <groupId>com.google.code.findbugs</groupId>
-      <version>3.0.2</version>
-    </dependency>
-    <dependency>
       <artifactId>logging-interceptor</artifactId>
       <groupId>com.squareup.okhttp3</groupId>
       <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
-      <groupId>io.reactivex.rxjava2</groupId>
-      <version>2.2.17</version>
+      <version>${io.reactivex.rxjava3}</version>
     </dependency>
     <dependency>
       <artifactId>reactive-streams</artifactId>
       <groupId>org.reactivestreams</groupId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
+      <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <groupId>io.swagger</groupId>
-      <version>1.5.22</version>
+      <version>2.2.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
     </dependency>
     <!-- end influxdb-client-java -->
   </dependencies>

--- a/bundles/org.openhab.binding.dbquery/src/main/resources/OH-INF/thing/influx2-bridge.xml
+++ b/bundles/org.openhab.binding.dbquery/src/main/resources/OH-INF/thing/influx2-bridge.xml
@@ -12,7 +12,7 @@
 				<context>url</context>
 				<label>Url</label>
 				<description>Database url</description>
-				<default>http://localhost:9999</default>
+				<default>http://localhost:8086</default>
 			</parameter>
 			<parameter name="user" type="text" required="true">
 				<label>Username</label>

--- a/bundles/org.openhab.binding.dbquery/src/test/java/org/openhab/binding/dbquery/internal/Value2StateConverterTest.java
+++ b/bundles/org.openhab.binding.dbquery/src/test/java/org/openhab/binding/dbquery/internal/Value2StateConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.dbquery.internal;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 

--- a/bundles/org.openhab.binding.dbquery/src/test/java/org/openhab/binding/dbquery/internal/domain/QueryResultJSONEncoderTest.java
+++ b/bundles/org.openhab.binding.dbquery/src/test/java/org/openhab/binding/dbquery/internal/domain/QueryResultJSONEncoderTest.java
@@ -14,10 +14,8 @@ package org.openhab.binding.dbquery.internal.domain;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.*;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -34,6 +32,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 /**
@@ -45,13 +44,12 @@ class QueryResultJSONEncoderTest {
     public static final double TOLERANCE = 0.001d;
     private final DBQueryJSONEncoder instance = new DBQueryJSONEncoder();
     private final Gson gson = new Gson();
-    private final JsonParser jsonParser = new JsonParser();
 
     @Test
     void givenQueryResultIsSerializedToJson() {
-        String json = instance.encode(givenQueryResultWithResults());
-
-        assertThat(jsonParser.parse(json), notNullValue());
+        JsonObject jsonObjectAlt = JsonParser.parseString(instance.encode(givenQueryResultWithResults()))
+                .getAsJsonObject();
+        assertThat(jsonObjectAlt.isJsonNull(), org.hamcrest.CoreMatchers.is(false));
     }
 
     @Test


### PR DESCRIPTION
+ Update libraries to newer versions and fix thing staying on UNKNOWN status as reported in closes #17064
+ Changed the default port to 8086 to match the default. See https://github.com/influxdata/telegraf/issues/8080
+ Removed some depreciated code in the tests.

Need users to help test this as now instead of saying UNKNOWN it reports to me that it gets a refused attempt as I have V1.8 database and this binding requires V2.0 as minimum.

http://pcmus.com/openhab/org.openhab.binding.dbquery-4.3.0-SNAPSHOT.zip