### PR TITLE
[freeboxos] Fix triggering of event firmware_updated

### DIFF
--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/FreeDeviceIntf.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/FreeDeviceIntf.java
@@ -36,11 +36,16 @@ public interface FreeDeviceIntf extends ApiConsumerIntf {
     default long checkUptimeAndFirmware(long newUptime, long oldUptime, String firmwareVersion) {
         if (newUptime < oldUptime) {
             triggerChannel(getEventChannelUID(), "restarted");
+        }
+        if (oldUptime < 0 || newUptime < oldUptime) {
             Map<String, String> properties = editProperties();
-            if (!firmwareVersion.equals(properties.get(Thing.PROPERTY_FIRMWARE_VERSION))) {
+            String property = properties.get(Thing.PROPERTY_FIRMWARE_VERSION);
+            if (!firmwareVersion.equals(property)) {
                 properties.put(Thing.PROPERTY_FIRMWARE_VERSION, firmwareVersion);
                 updateProperties(properties);
-                triggerChannel(getEventChannelUID(), "firmware_updated");
+                if (property != null) {
+                    triggerChannel(getEventChannelUID(), "firmware_updated");
+                }
             }
         }
         return newUptime;


### PR DESCRIPTION
Also update the firmware property when the player is reachable for the first time.
Do not trigger the event firmware_updated when just first setting the firmware property.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>