### PR TITLE
[shelly] Fix BLU Discovery when Shelly Cloud Bluetooth Gateway is enabled

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiInterface.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiInterface.java
@@ -112,7 +112,7 @@ public interface ShellyApiInterface {
 
     boolean setBluetooth(boolean enable) throws ShellyApiException;
 
-    String deviceReboot() throws ShellyApiException;
+    void deviceReboot() throws ShellyApiException;
 
     String setDebug(boolean enabled) throws ShellyApiException;
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
@@ -357,8 +357,8 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
     }
 
     @Override
-    public String deviceReboot() throws ShellyApiException {
-        return callApi(SHELLY_URL_RESTART, String.class);
+    public void deviceReboot() throws ShellyApiException {
+        callApi(SHELLY_URL_RESTART, String.class);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -14,6 +14,8 @@ package org.openhab.binding.shelly.internal.api2;
 
 import java.util.ArrayList;
 
+import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DevConfigBle.Shelly2DevConfigBleObserver;
+import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DevConfigBle.Shelly2DevConfigBleRpc;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2DeviceStatus.Shelly2DeviceStatusResult;
 import org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.Shelly2RpcBaseMessage.Shelly2RpcMessageError;
 
@@ -166,11 +168,21 @@ public class Shelly2ApiJsonDTO {
     public static final String SHELLY2_POWERLED_MATCH = "match_output";
     public static final String SHELLY2_POWERLED_INVERT = "inverted_output";
 
-    public class Shelly2DevConfigBle {
+    public static class Shelly2DevConfigBle {
+        public static class Shelly2DevConfigBleRpc {
+            public Boolean enable;
+        }
+
+        public static class Shelly2DevConfigBleObserver {
+            public Boolean enable;
+        }
+
         public Boolean enable;
+        public Shelly2DevConfigBleRpc rpc;
+        public Shelly2DevConfigBleObserver observer;
     }
 
-    public class Shelly2DevConfigEth {
+    public static class Shelly2DevConfigEth {
         public Boolean enable;
         public String ipv4mode;
         public String ip;
@@ -921,6 +933,10 @@ public class Shelly2ApiJsonDTO {
         public Boolean sysLedEnable;
         @SerializedName("power_led")
         public String powerLed;
+
+        // BLE
+        public Shelly2DevConfigBleRpc rpc;
+        public Shelly2DevConfigBleObserver observer;
     }
 
     public static class Shelly2RpcRequest {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -92,7 +92,6 @@ public class ShellyBluApi extends Shelly2ApiRpc {
         if (!initialized) {
             initialized = true;
             connected = false;
-        } else {
         }
     }
 
@@ -162,10 +161,6 @@ public class ShellyBluApi extends Shelly2ApiRpc {
                 profile.settings.inputs.add(settings);
             }
             profile.status = deviceStatus;
-        }
-
-        if (!connected) {
-            throw new ShellyApiException("BLU Device not yet connected");
         }
 
         profile.initialized = true;


### PR DESCRIPTION
The binding's gateway script could not get access to the BLE observer in case the Shelly Cloud Bluetooth Gateway is enabled. Therefore no discovery results will be passed to openHAB.

The binding now checks the device settings and adjust them if nessecary.
