### PR TITLE
[aWATTar] add aWATTar API class

### DIFF
--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/AwattarPrice.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/AwattarPrice.java
@@ -20,6 +20,12 @@ import org.openhab.binding.awattar.internal.handler.TimeRange;
  *
  * @author Wolfgang Klimt - initial contribution
  * @author Jan N. Klug - Refactored to record
+ *
+ * @param netPrice the net price in €/kWh
+ * @param grossPrice the gross price in €/kWh
+ * @param netTotal the net total price in €
+ * @param grossTotal the gross total price in €
+ * @param timerange the time range of the price
  */
 @NonNullByDefault
 public record AwattarPrice(double netPrice, double grossPrice, double netTotal, double grossTotal,

--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/api/AwattarApi.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/api/AwattarApi.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.awattar.internal.api;
+
+import static org.eclipse.jetty.http.HttpMethod.GET;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.openhab.binding.awattar.internal.AwattarBridgeConfiguration;
+import org.openhab.binding.awattar.internal.AwattarPrice;
+import org.openhab.binding.awattar.internal.dto.AwattarApiData;
+import org.openhab.binding.awattar.internal.dto.Datum;
+import org.openhab.binding.awattar.internal.handler.TimeRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * The {@link AwattarApi} class is responsible for encapsulating the aWATTar API
+ * and providing the data to the bridge.
+ *
+ * @author Thomas Leber - Initial contribution
+ */
+@NonNullByDefault
+public class AwattarApi {
+    private final Logger logger = LoggerFactory.getLogger(AwattarApi.class);
+
+    private static final String URL_DE = "https://api.awattar.de/v1/marketdata";
+    private static final String URL_AT = "https://api.awattar.at/v1/marketdata";
+    private String url = URL_DE;
+
+    private final HttpClient httpClient;
+
+    private double vatFactor;
+    private double basePrice;
+
+    private ZoneId zone;
+
+    private Gson gson;
+
+    /**
+     * Generic exception for the aWATTar API.
+     */
+    public class AwattarApiException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public AwattarApiException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Constructor for the aWATTar API.
+     *
+     * @param httpClient the HTTP client to use
+     * @param zone the time zone to use
+     */
+    public AwattarApi(HttpClient httpClient, ZoneId zone, AwattarBridgeConfiguration config) {
+        this.zone = zone;
+        this.httpClient = httpClient;
+
+        this.gson = new Gson();
+
+        vatFactor = 1 + (config.vatPercent / 100);
+        basePrice = config.basePrice;
+
+        if (config.country.equals("DE")) {
+            this.url = URL_DE;
+        } else if (config.country.equals("AT")) {
+            this.url = URL_AT;
+        } else {
+            throw new IllegalArgumentException("Country code must be 'DE' or 'AT'");
+        }
+    }
+
+    /**
+     * Get the data from the aWATTar API.
+     * The data is returned as a sorted set of {@link AwattarPrice} objects.
+     * The data is requested from now minus one day to now plus three days.
+     *
+     * @return the data as a sorted set of {@link AwattarPrice} objects
+     * @throws AwattarApiException
+     * @throws InterruptedException if the thread is interrupted
+     * @throws TimeoutException if the request times out
+     * @throws ExecutionException if the request fails
+     * @throws EmptyDataResponseException if the response is empty
+     */
+    public SortedSet<AwattarPrice> getData() throws AwattarApiException {
+        try {
+            // we start one day in the past to cover ranges that already started yesterday
+            ZonedDateTime zdt = LocalDate.now(zone).atStartOfDay(zone).minusDays(1);
+            long start = zdt.toInstant().toEpochMilli();
+            // Starting from midnight yesterday we add three days so that the range covers
+            // the whole next day.
+            zdt = zdt.plusDays(3);
+            long end = zdt.toInstant().toEpochMilli();
+
+            StringBuilder request = new StringBuilder(url);
+            request.append("?start=").append(start).append("&end=").append(end);
+
+            logger.trace("aWATTar API request: = '{}'", request);
+            ContentResponse contentResponse = httpClient.newRequest(request.toString()).method(GET)
+                    .timeout(10, TimeUnit.SECONDS).send();
+            int httpStatus = contentResponse.getStatus();
+            String content = contentResponse.getContentAsString();
+            logger.trace("aWATTar API response: status = {}, content = '{}'", httpStatus, content);
+
+            if (content == null) {
+                throw new AwattarApiException("@text/error.empty.data");
+            } else if (httpStatus == OK_200) {
+                SortedSet<AwattarPrice> result = new TreeSet<>(Comparator.comparing(AwattarPrice::timerange));
+
+                AwattarApiData apiData = gson.fromJson(content, AwattarApiData.class);
+
+                for (Datum d : apiData.data) {
+                    // the API returns prices in €/MWh, we need €ct/kWh -> divide by 10 (100/1000)
+                    double netMarket = d.marketprice / 10.0;
+                    double grossMarket = netMarket * vatFactor;
+                    double netTotal = netMarket + basePrice;
+                    double grossTotal = netTotal * vatFactor;
+
+                    result.add(new AwattarPrice(netMarket, grossMarket, netTotal, grossTotal,
+                            new TimeRange(d.startTimestamp, d.endTimestamp)));
+                }
+
+                return result;
+            } else {
+                throw new AwattarApiException("@text/warn.awattar.statuscode" + httpStatus);
+            }
+        } catch (ExecutionException e) {
+            throw new AwattarApiException("@text/error.execution");
+        } catch (JsonSyntaxException e) {
+            throw new AwattarApiException("@text/error.json");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AwattarApiException("@text/error.interrupted");
+        } catch (TimeoutException e) {
+            throw new AwattarApiException("@text/error.timeout");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/handler/AwattarBestPriceHandler.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/handler/AwattarBestPriceHandler.java
@@ -99,7 +99,7 @@ public class AwattarBestPriceHandler extends BaseThingHandler {
                  * here
                  */
                 thingRefresher = scheduler.scheduleAtFixedRate(this::refreshChannels,
-                        getMillisToNextMinute(1, timeZoneProvider), THING_REFRESH_INTERVAL * 1000,
+                        getMillisToNextMinute(1, timeZoneProvider), THING_REFRESH_INTERVAL * 1000L,
                         TimeUnit.MILLISECONDS);
             }
         }

--- a/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/i18n/awattar.properties
+++ b/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/i18n/awattar.properties
@@ -29,7 +29,7 @@ thing-type.config.awattar.bestprice.length.description = The number of hours the
 thing-type.config.awattar.bestprice.consecutive.label = Consecutive
 thing-type.config.awattar.bestprice.consecutive.description = Do the hours need to be consecutive?
 thing-type.config.awattar.bestprice.inverted.label = Inverted
-thing-type.config.awattar.bestprice.inverted.description = Invert the search for the highest price
+thing-type.config.awattar.bestprice.inverted.description = Invert the search to the highest price.
 
 # channel types
 channel-type.awattar.price.label = ct/kWh
@@ -167,7 +167,7 @@ error.json=Invalid JSON response from aWATTar API
 error.interrupted=Communication interrupted
 error.execution=Execution error
 error.timeout=Timeout retrieving prices from aWATTar API
-error.invalid.data=No or invalid data received from aWATTar API
+error.empty.data=No or invalid data received from aWATTar API
 error.length.value=length needs to be > 0 and < duration.
 warn.awattar.statuscode=aWATTar server did not respond with status code 200
 error.start.value=Invalid start value

--- a/bundles/org.openhab.binding.awattar/src/test/java/org/openhab/binding/awattar/internal/api/AwattarApiTest.java
+++ b/bundles/org.openhab.binding.awattar/src/test/java/org/openhab/binding/awattar/internal/api/AwattarApiTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.awattar.internal.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.awattar.internal.AwattarBridgeConfiguration;
+import org.openhab.binding.awattar.internal.AwattarPrice;
+import org.openhab.binding.awattar.internal.api.AwattarApi.AwattarApiException;
+import org.openhab.binding.awattar.internal.handler.AwattarBridgeHandler;
+import org.openhab.binding.awattar.internal.handler.AwattarBridgeHandlerTest;
+import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.test.java.JavaTest;
+
+/**
+ * The {@link AwattarBridgeHandlerTest} contains tests for the
+ * {@link AwattarBridgeHandler}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
+class AwattarApiTest extends JavaTest {
+    // API Mocks
+    private @Mock @NonNullByDefault({}) HttpClient httpClientMock;
+    private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
+    private @Mock @NonNullByDefault({}) Request requestMock;
+    private @Mock @NonNullByDefault({}) ContentResponse contentResponseMock;
+    private @Mock @NonNullByDefault({}) AwattarBridgeConfiguration config;
+
+    // sut
+    private @NonNullByDefault({}) AwattarApi api;
+
+    @BeforeEach
+    public void setUp() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        try (InputStream inputStream = AwattarApiTest.class.getResourceAsStream("api_response.json")) {
+            if (inputStream == null) {
+                throw new IOException("inputstream is null");
+            }
+            byte[] bytes = inputStream.readAllBytes();
+            if (bytes == null) {
+                throw new IOException("Resulting byte-array empty");
+            }
+            when(contentResponseMock.getContentAsString()).thenReturn(new String(bytes, StandardCharsets.UTF_8));
+        }
+        when(contentResponseMock.getStatus()).thenReturn(HttpStatus.OK_200);
+        when(httpClientMock.newRequest(anyString())).thenReturn(requestMock);
+        when(requestMock.method(HttpMethod.GET)).thenReturn(requestMock);
+        when(requestMock.timeout(10, TimeUnit.SECONDS)).thenReturn(requestMock);
+        when(requestMock.send()).thenReturn(contentResponseMock);
+
+        when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.of("GMT+2"));
+
+        config.basePrice = 0.0;
+        config.vatPercent = 0.0;
+        config.country = "DE";
+
+        api = new AwattarApi(httpClientMock, ZoneId.of("GMT+2"), config);
+    }
+
+    @Test
+    void testDeUrl() throws AwattarApiException {
+        api.getData();
+
+        assertThat(httpClientMock.newRequest("https://api.awattar.de/v1/marketdata"), is(requestMock));
+    }
+
+    @Test
+    void testAtUrl() throws AwattarApiException {
+        config.country = "AT";
+        api = new AwattarApi(httpClientMock, ZoneId.of("GMT+2"), config);
+
+        api.getData();
+
+        assertThat(httpClientMock.newRequest("https://api.awattar.at/v1/marketdata"), is(requestMock));
+    }
+
+    @Test
+    void testInvalidCountry() {
+        config.country = "CH";
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> new AwattarApi(httpClientMock, ZoneId.of("GMT+2"), config));
+        assertThat(thrown.getMessage(), is("Country code must be 'DE' or 'AT'"));
+    }
+
+    @Test
+    void testPricesRetrieval() throws AwattarApiException {
+        SortedSet<AwattarPrice> prices = api.getData();
+
+        assertThat(prices, hasSize(72));
+
+        Objects.requireNonNull(prices);
+
+        // check if first and last element are correct
+        assertThat(prices.first().timerange().start(), is(1718316000000L));
+        assertThat(prices.last().timerange().end(), is(1718575200000L));
+    }
+
+    @Test
+    void testPricesRetrievalEmptyResponse() {
+        when(contentResponseMock.getContentAsString()).thenReturn(null);
+        when(contentResponseMock.getStatus()).thenReturn(HttpStatus.OK_200);
+
+        AwattarApiException thrown = assertThrows(AwattarApiException.class, () -> api.getData());
+        assertThat(thrown.getMessage(), is("@text/error.empty.data"));
+    }
+
+    @Test
+    void testPricesReturnNot200() {
+        when(contentResponseMock.getStatus()).thenReturn(HttpStatus.BAD_REQUEST_400);
+
+        AwattarApiException thrown = assertThrows(AwattarApiException.class, () -> api.getData());
+        assertThat(thrown.getMessage(), is("@text/warn.awattar.statuscode400"));
+    }
+}

--- a/bundles/org.openhab.binding.awattar/src/test/java/org/openhab/binding/awattar/internal/handler/AwattarBridgeHandlerRefreshTest.java
+++ b/bundles/org.openhab.binding.awattar/src/test/java/org/openhab/binding/awattar/internal/handler/AwattarBridgeHandlerRefreshTest.java
@@ -12,31 +12,30 @@
  */
 package org.openhab.binding.awattar.internal.handler;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.ZoneId;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ReflectionSupport;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openhab.binding.awattar.internal.AwattarBindingConstants;
+import org.openhab.binding.awattar.internal.api.AwattarApi;
+import org.openhab.binding.awattar.internal.api.AwattarApi.AwattarApiException;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.Bridge;
@@ -48,14 +47,15 @@ import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 
 /**
- * The {@link AwattarBridgeHandlerRefreshTest} contains tests for the {@link AwattarBridgeHandler} refresh logic.
+ * The {@link AwattarBridgeHandlerRefreshTest} contains tests for the
+ * {@link AwattarBridgeHandler} refresh logic.
  *
  * @author Thomas Leber - Initial contribution
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @NonNullByDefault
-public class AwattarBridgeHandlerRefreshTest extends JavaTest {
+class AwattarBridgeHandlerRefreshTest extends JavaTest {
     public static final ThingUID BRIDGE_UID = new ThingUID(AwattarBindingConstants.THING_TYPE_BRIDGE, "testBridge");
 
     // bridge mocks
@@ -63,8 +63,7 @@ public class AwattarBridgeHandlerRefreshTest extends JavaTest {
     private @Mock @NonNullByDefault({}) ThingHandlerCallback bridgeCallbackMock;
     private @Mock @NonNullByDefault({}) HttpClient httpClientMock;
     private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
-    private @Mock @NonNullByDefault({}) Request requestMock;
-    private @Mock @NonNullByDefault({}) ContentResponse contentResponseMock;
+    private @Mock @NonNullByDefault({}) AwattarApi awattarApiMock;
 
     // best price handler mocks
     private @Mock @NonNullByDefault({}) Thing bestpriceMock;
@@ -73,22 +72,7 @@ public class AwattarBridgeHandlerRefreshTest extends JavaTest {
     private @NonNullByDefault({}) AwattarBridgeHandler bridgeHandler;
 
     @BeforeEach
-    public void setUp() throws IOException, ExecutionException, InterruptedException, TimeoutException {
-        try (InputStream inputStream = AwattarBridgeHandlerRefreshTest.class.getResourceAsStream("api_response.json")) {
-            if (inputStream == null) {
-                throw new IOException("inputstream is null");
-            }
-            byte[] bytes = inputStream.readAllBytes();
-            if (bytes == null) {
-                throw new IOException("Resulting byte-array empty");
-            }
-            when(contentResponseMock.getContentAsString()).thenReturn(new String(bytes, StandardCharsets.UTF_8));
-        }
-        when(contentResponseMock.getStatus()).thenReturn(HttpStatus.OK_200);
-        when(httpClientMock.newRequest(anyString())).thenReturn(requestMock);
-        when(requestMock.method(HttpMethod.GET)).thenReturn(requestMock);
-        when(requestMock.timeout(10, TimeUnit.SECONDS)).thenReturn(requestMock);
-        when(requestMock.send()).thenReturn(contentResponseMock);
+    public void setUp() throws IllegalArgumentException, IllegalAccessException {
 
         when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.of("GMT+2"));
 
@@ -96,42 +80,79 @@ public class AwattarBridgeHandlerRefreshTest extends JavaTest {
         bridgeHandler = new AwattarBridgeHandler(bridgeMock, httpClientMock, timeZoneProviderMock);
         bridgeHandler.setCallback(bridgeCallbackMock);
 
-        when(bridgeMock.getHandler()).thenReturn(bridgeHandler);
+        List<Field> fields = ReflectionSupport.findFields(AwattarBridgeHandler.class,
+                field -> field.getName().equals("awattarApi"), HierarchyTraversalMode.BOTTOM_UP);
 
-        // other mocks
-        when(bestpriceMock.getBridgeUID()).thenReturn(BRIDGE_UID);
-
-        when(bestPriceCallbackMock.getBridge(any())).thenReturn(bridgeMock);
-        when(bestPriceCallbackMock.isChannelLinked(any())).thenReturn(true);
+        for (Field field : fields) {
+            field.setAccessible(true);
+            field.set(bridgeHandler, awattarApiMock);
+        }
     }
 
     /**
      * Test the refreshIfNeeded method with a bridge that is offline.
      *
      * @throws SecurityException
+     * @throws AwattarApiException
      */
     @Test
-    void testRefreshIfNeeded_ThingOffline() throws SecurityException {
+    void testRefreshIfNeeded_ThingOffline() throws SecurityException, AwattarApiException {
         when(bridgeMock.getStatus()).thenReturn(ThingStatus.OFFLINE);
 
         bridgeHandler.refreshIfNeeded();
 
         verify(bridgeCallbackMock).statusUpdated(bridgeMock,
                 new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
+        verify(awattarApiMock).getData();
     }
 
     /**
-     * Test the refreshIfNeeded method with a bridge that is online and the data is empty.
+     * Test the refreshIfNeeded method with a bridge that is online and the data is
+     * empty.
      *
      * @throws SecurityException
+     * @throws AwattarApiException
      */
     @Test
-    void testRefreshIfNeeded_DataEmptry() throws SecurityException {
+    void testRefreshIfNeeded_DataEmpty() throws SecurityException, AwattarApiException {
         when(bridgeMock.getStatus()).thenReturn(ThingStatus.ONLINE);
 
         bridgeHandler.refreshIfNeeded();
 
         verify(bridgeCallbackMock).statusUpdated(bridgeMock,
                 new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
+        verify(awattarApiMock).getData();
+    }
+
+    @Test
+    void testNeedRefresh_ThingOffline() throws SecurityException {
+        when(bridgeMock.getStatus()).thenReturn(ThingStatus.OFFLINE);
+
+        // get private method via reflection
+        Method method = ReflectionSupport.findMethod(AwattarBridgeHandler.class, "needRefresh", "").get();
+
+        boolean result = (boolean) ReflectionSupport.invokeMethod(method, bridgeHandler);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    void testNeedRefresh_DataEmpty() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+        when(bridgeMock.getStatus()).thenReturn(ThingStatus.ONLINE);
+
+        List<Field> fields = ReflectionSupport.findFields(AwattarBridgeHandler.class,
+                field -> field.getName().equals("prices"), HierarchyTraversalMode.BOTTOM_UP);
+
+        for (Field field : fields) {
+            field.setAccessible(true);
+            field.set(bridgeHandler, null);
+        }
+
+        // get private method via reflection
+        Method method = ReflectionSupport.findMethod(AwattarBridgeHandler.class, "needRefresh", "").get();
+
+        boolean result = (boolean) ReflectionSupport.invokeMethod(method, bridgeHandler);
+
+        assertThat(result, is(true));
     }
 }

--- a/bundles/org.openhab.binding.awattar/src/test/resources/org/openhab/binding/awattar/internal/api/api_response.json
+++ b/bundles/org.openhab.binding.awattar/src/test/resources/org/openhab/binding/awattar/internal/api/api_response.json
@@ -1,0 +1,438 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "start_timestamp": 1718316000000,
+      "end_timestamp": 1718319600000,
+      "marketprice": 83.13,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718319600000,
+      "end_timestamp": 1718323200000,
+      "marketprice": 71.45,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718323200000,
+      "end_timestamp": 1718326800000,
+      "marketprice": 63.93,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718326800000,
+      "end_timestamp": 1718330400000,
+      "marketprice": 59.53,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718330400000,
+      "end_timestamp": 1718334000000,
+      "marketprice": 55.82,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718334000000,
+      "end_timestamp": 1718337600000,
+      "marketprice": 64.22,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718337600000,
+      "end_timestamp": 1718341200000,
+      "marketprice": 85.01,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718341200000,
+      "end_timestamp": 1718344800000,
+      "marketprice": 100.95,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718344800000,
+      "end_timestamp": 1718348400000,
+      "marketprice": 104.99,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718348400000,
+      "end_timestamp": 1718352000000,
+      "marketprice": 102.54,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718352000000,
+      "end_timestamp": 1718355600000,
+      "marketprice": 82.18,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718355600000,
+      "end_timestamp": 1718359200000,
+      "marketprice": 68.1,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718359200000,
+      "end_timestamp": 1718362800000,
+      "marketprice": 60.88,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718362800000,
+      "end_timestamp": 1718366400000,
+      "marketprice": 47.46,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718366400000,
+      "end_timestamp": 1718370000000,
+      "marketprice": 40.74,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718370000000,
+      "end_timestamp": 1718373600000,
+      "marketprice": 41,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718373600000,
+      "end_timestamp": 1718377200000,
+      "marketprice": 60.31,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718377200000,
+      "end_timestamp": 1718380800000,
+      "marketprice": 75,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718380800000,
+      "end_timestamp": 1718384400000,
+      "marketprice": 90.98,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718384400000,
+      "end_timestamp": 1718388000000,
+      "marketprice": 136,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718388000000,
+      "end_timestamp": 1718391600000,
+      "marketprice": 127.31,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718391600000,
+      "end_timestamp": 1718395200000,
+      "marketprice": 117.12,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718395200000,
+      "end_timestamp": 1718398800000,
+      "marketprice": 83.41,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718398800000,
+      "end_timestamp": 1718402400000,
+      "marketprice": 59.42,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718402400000,
+      "end_timestamp": 1718406000000,
+      "marketprice": 60.68,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718406000000,
+      "end_timestamp": 1718409600000,
+      "marketprice": 41.04,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718409600000,
+      "end_timestamp": 1718413200000,
+      "marketprice": 29.97,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718413200000,
+      "end_timestamp": 1718416800000,
+      "marketprice": 28.86,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718416800000,
+      "end_timestamp": 1718420400000,
+      "marketprice": 22.51,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718420400000,
+      "end_timestamp": 1718424000000,
+      "marketprice": 10.04,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718424000000,
+      "end_timestamp": 1718427600000,
+      "marketprice": 1.54,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718427600000,
+      "end_timestamp": 1718431200000,
+      "marketprice": 0.09,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718431200000,
+      "end_timestamp": 1718434800000,
+      "marketprice": 0,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718434800000,
+      "end_timestamp": 1718438400000,
+      "marketprice": -0.06,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718438400000,
+      "end_timestamp": 1718442000000,
+      "marketprice": -10.08,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718442000000,
+      "end_timestamp": 1718445600000,
+      "marketprice": -29.04,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718445600000,
+      "end_timestamp": 1718449200000,
+      "marketprice": -44.92,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718449200000,
+      "end_timestamp": 1718452800000,
+      "marketprice": -65.46,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718452800000,
+      "end_timestamp": 1718456400000,
+      "marketprice": -80.01,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718456400000,
+      "end_timestamp": 1718460000000,
+      "marketprice": -56.23,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718460000000,
+      "end_timestamp": 1718463600000,
+      "marketprice": -29.53,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718463600000,
+      "end_timestamp": 1718467200000,
+      "marketprice": -4.84,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718467200000,
+      "end_timestamp": 1718470800000,
+      "marketprice": -0.01,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718470800000,
+      "end_timestamp": 1718474400000,
+      "marketprice": 40,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718474400000,
+      "end_timestamp": 1718478000000,
+      "marketprice": 84.28,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718478000000,
+      "end_timestamp": 1718481600000,
+      "marketprice": 79.92,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718481600000,
+      "end_timestamp": 1718485200000,
+      "marketprice": 64.3,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718485200000,
+      "end_timestamp": 1718488800000,
+      "marketprice": 40.4,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718488800000,
+      "end_timestamp": 1718492400000,
+      "marketprice": 24.91,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718492400000,
+      "end_timestamp": 1718496000000,
+      "marketprice": 10.36,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718496000000,
+      "end_timestamp": 1718499600000,
+      "marketprice": 4.92,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718499600000,
+      "end_timestamp": 1718503200000,
+      "marketprice": 2.92,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718503200000,
+      "end_timestamp": 1718506800000,
+      "marketprice": 2.19,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718506800000,
+      "end_timestamp": 1718510400000,
+      "marketprice": 2.53,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718510400000,
+      "end_timestamp": 1718514000000,
+      "marketprice": 2.95,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718514000000,
+      "end_timestamp": 1718517600000,
+      "marketprice": 0.69,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718517600000,
+      "end_timestamp": 1718521200000,
+      "marketprice": -0.02,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718521200000,
+      "end_timestamp": 1718524800000,
+      "marketprice": -1.28,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718524800000,
+      "end_timestamp": 1718528400000,
+      "marketprice": -10,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718528400000,
+      "end_timestamp": 1718532000000,
+      "marketprice": -13.33,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718532000000,
+      "end_timestamp": 1718535600000,
+      "marketprice": -20.01,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718535600000,
+      "end_timestamp": 1718539200000,
+      "marketprice": -30.01,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718539200000,
+      "end_timestamp": 1718542800000,
+      "marketprice": -35.67,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718542800000,
+      "end_timestamp": 1718546400000,
+      "marketprice": -29.04,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718546400000,
+      "end_timestamp": 1718550000000,
+      "marketprice": -10.14,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718550000000,
+      "end_timestamp": 1718553600000,
+      "marketprice": -2.34,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718553600000,
+      "end_timestamp": 1718557200000,
+      "marketprice": 56.22,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718557200000,
+      "end_timestamp": 1718560800000,
+      "marketprice": 99.65,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718560800000,
+      "end_timestamp": 1718564400000,
+      "marketprice": 119.15,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718564400000,
+      "end_timestamp": 1718568000000,
+      "marketprice": 124.28,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718568000000,
+      "end_timestamp": 1718571600000,
+      "marketprice": 120.34,
+      "unit": "Eur/MWh"
+    },
+    {
+      "start_timestamp": 1718571600000,
+      "end_timestamp": 1718575200000,
+      "marketprice": 94.44,
+      "unit": "Eur/MWh"
+    }
+  ],
+  "url": "/de/v1/marketdata"
+}


### PR DESCRIPTION
This PR introduces an class for the aWATTar API for future refactoring and testing.

The class is intended to encapsualtes the API access.

All current tests will still be positive but can later be split into API and Bridge tests.