### PR TITLE
[freeboxos] Remove veto policy on key-code channel

### DIFF
--- a/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/PlayerHandler.java
+++ b/bundles/org.openhab.binding.freeboxos/src/main/java/org/openhab/binding/freeboxos/internal/handler/PlayerHandler.java
@@ -88,14 +88,14 @@ public class PlayerHandler extends HostHandler {
             logger.warn("Player IP is unknown");
         } else if (VALID_REMOTE_KEYS.contains(aKey)) {
             String remoteCode = (String) getConfig().get(PlayerConfiguration.REMOTE_CODE);
-            if (remoteCode != null) {
+            if (remoteCode != null && !remoteCode.isBlank()) {
                 try {
                     getManager(PlayerManager.class).sendKey(ip.toCanonicalString(), remoteCode, aKey, longPress, count);
                 } catch (FreeboxException e) {
                     logger.warn("Error sending key: {}", e.getMessage());
                 }
             } else {
-                logger.warn("A remote code must be configured in the on the player thing.");
+                logger.warn("A remote code must be configured on the player thing.");
             }
         } else {
             logger.warn("Key '{}' is not a valid key expression", key);

--- a/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/thing/channel-types.xml
@@ -355,7 +355,6 @@
 				<option value="home">Home</option>
 			</options>
 		</state>
-		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="ip-address" advanced="true">


### PR DESCRIPTION
This allows to have as status the last command sent.

Also fix a typo in a log and enhance the check of the remoteCode parameter.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>