### PR TITLE
[rollershutterposition] Fix addon id

### DIFF
--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/addon/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon:addon id="regex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<addon:addon id="rollershutterposition" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 


### PR DESCRIPTION
Reported here:
https://community.openhab.org/t/add-ons-regex-addon-appears-with-wrong-name/157805

Regression of #14559