### PR TITLE
[ecovacs] Fix typo in ecovacs folder name

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/README.md
+++ b/bundles/org.openhab.binding.ecovacs/README.md
@@ -185,7 +185,7 @@ In such a case, please [create an issue on GitHub](https://github.com/openhab/op
 In addition to that, if the model is similar to an already supported one, you can try to add the support yourself (until getting an updated binding).
 For doing so, you can follow the following steps:
 
-- create the folder `<OPENHAB_USERDATA>/evocacs` (if not done previously)
+- create the folder `<OPENHAB_USERDATA>/ecovacs` (if not done previously)
 - create a file named `custom_device_descs.json`, whose format of that file is the same as [the built-in device list](https://raw.githubusercontent.com/openhab/openhab-addons/main/bundles/org.openhab.binding.ecovacs/src/main/resources/devices/supported_device_list.json)
 - for a model that is very similar to an existing one, create an entry with `modelName`, `deviceClass` (from the log line) and `deviceClassLink` (`deviceClass` of the similar model)
 - for other models, you can also try experimenting with creating a full entry, but it's likely that the binding code will need to be updated in that case


### PR DESCRIPTION
Fixed typo for "ecovacs" folder name in README.md instructions. 

# Title
[Ecovacs Binding] Fixed typo for ecovacs folder name in documentation

# Description
Basic documentation fix where ecovacs was spelled incorrectly.
