### PR TITLE
[org.openhab.binding.http] autorefesh after sending command to update…

### DIFF
--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpThingHandler.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpThingHandler.java
@@ -114,20 +114,19 @@ public class HttpThingHandler extends BaseThingHandler implements HttpStatusList
             return;
         }
 
+        String key = channelUrls.get(channelUID);
+        RefreshingUrlCache refreshingUrlCache = (key != null) ? urlHandlers.get(key) : null;
+
         if (command instanceof RefreshType) {
-            String key = channelUrls.get(channelUID);
-            if (key != null) {
-                RefreshingUrlCache refreshingUrlCache = urlHandlers.get(key);
-                if (refreshingUrlCache != null) {
-                    try {
-                        refreshingUrlCache.get().ifPresentOrElse(itemValueConverter::process, () -> {
-                            if (config.strictErrorHandling) {
-                                itemValueConverter.process(null);
-                            }
-                        });
-                    } catch (IllegalArgumentException | IllegalStateException e) {
-                        logger.warn("Failed processing REFRESH command for channel {}: {}", channelUID, e.getMessage());
-                    }
+            if (refreshingUrlCache != null) {
+                try {
+                    refreshingUrlCache.getCached().ifPresentOrElse(itemValueConverter::process, () -> {
+                        if (config.strictErrorHandling) {
+                            itemValueConverter.process(null);
+                        }
+                    });
+                } catch (IllegalArgumentException | IllegalStateException e) {
+                    logger.warn("Failed processing REFRESH command for channel {}: {}", channelUID, e.getMessage());
                 }
             }
         } else {
@@ -138,6 +137,9 @@ public class HttpThingHandler extends BaseThingHandler implements HttpStatusList
             } catch (IllegalStateException e) {
                 logger.debug("Writing to read-only channel {} not permitted", channelUID);
             }
+
+            if (refreshingUrlCache != null)
+                refreshingUrlCache.run(scheduler);
         }
     }
 
@@ -418,10 +420,14 @@ public class HttpThingHandler extends BaseThingHandler implements HttpStatusList
 
     private ChannelHandler createChannelHandler(AbstractTransformingChannelHandler.Factory factory, String commandUrl,
             ChannelUID channelUID, HttpChannelConfig channelConfig) {
-        return factory.create(state -> updateState(channelUID, state), command -> postCommand(channelUID, command),
+        return factory.create(
+                state -> updateState(channelUID, state),
+                command -> postCommand(channelUID, command),
                 command -> sendHttpValue(commandUrl, command),
                 new ChannelTransformation(channelConfig.stateTransformation),
-                new ChannelTransformation(channelConfig.commandTransformation), channelConfig);
+                new ChannelTransformation(channelConfig.commandTransformation),
+                channelConfig
+        );
     }
 
     private ChannelHandler createGenericChannelHandler(String commandUrl, ChannelUID channelUID,

--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/RefreshingUrlCache.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/RefreshingUrlCache.java
@@ -86,6 +86,11 @@ public class RefreshingUrlCache {
         logger.trace("Started refresh task for URL '{}' with interval {}s", url, refreshTime);
     }
 
+    public void run(ScheduledExecutorService executor) {
+        executor.schedule(() -> this.refresh(), 1, TimeUnit.SECONDS);
+        logger.trace("Started refresh task for URL '{}'", url);
+    }
+
     public void stop() {
         // clearing all listeners to prevent further updates
         consumers.clear();
@@ -151,7 +156,7 @@ public class RefreshingUrlCache {
         consumers.add(consumer);
     }
 
-    public Optional<ChannelHandlerContent> get() {
+    public Optional<ChannelHandlerContent> getCached() {
         return Optional.ofNullable(lastContent);
     }
 


### PR DESCRIPTION
Hello,

In my openhab configuration I have multiple items bound to the same channel and when sending command only one item gets updated and the rest are updated after the refresh timeout passes.

I have modified the code to force update after sending command

Thanks
Timotheos Constambeys