### PR TITLE
[goecharger] Update README.md

### DIFF
--- a/bundles/org.openhab.binding.goecharger/README.md
+++ b/bundles/org.openhab.binding.goecharger/README.md
@@ -9,7 +9,7 @@ This binding supports go-e Charger HOME+ with 7.4kW, 11kW or 22kW as well as go-
 ## Setup
 
 1) Install the binding
-2) Activate the local HTTP API in the Go-eCharger app (Settings --> Connection --> API Settings --> "Allow access to local HTTP API vX").
+2) Activate the local HTTP API in the go-e Charger app (Settings --> Connection --> API Settings --> "Allow access to local HTTP API vX").
 Please note that v1 is the default, but more functions (channels) are supported by the API v2. However, v2 has to be supported by your go-e Charger (details see below).
 3) Configure the thing (see below).
 

--- a/bundles/org.openhab.binding.goecharger/README.md
+++ b/bundles/org.openhab.binding.goecharger/README.md
@@ -1,13 +1,17 @@
-# Go-eCharger Binding
+# go-e Charger Binding
 
-This Binding controls and reads data from the [Go-eCharger](https://go-e.co/).
-It is a mobile wallbox for charging EVs and has an open REST API for reading data and configuration.
-The API must be activated in the Go-eCharger app.
+This Binding controls and reads data from the [go-e Charger](https://go-e.co/), which is a mobile wallbox for charging EVs and has an open REST API for reading data and configuration.
 
 ## Supported Things
 
-This binding supports Go-eCharger HOME+ with 7.4kW, 11kW or 22kW.
-The Go-eCharger HOMEfix with 11kW and 22kW is supported too.
+This binding supports go-e Charger HOME+ with 7.4kW, 11kW or 22kW as well as go-e Charger HOMEfix and go-e Charger Gemini with 11kW and 22kW.
+
+## Setup
+
+1) Install the binding
+2) Activate the local HTTP API in the Go-eCharger app (Settings --> Connection --> API Settings --> "Allow access to local HTTP API vX").
+Please note that v1 is the default, but more functions (channels) are supported by the API v2. However, v2 has to be supported by your go-e Charger (details see below).
+3) Configure the thing (see below).
 
 ## Thing Configuration
 
@@ -15,11 +19,11 @@ The thing has three configuration parameters:
 
 | Parameter       | Description                                   | Required |
 |-----------------|-----------------------------------------------|----------|
-| ip              | The IP-address of your Go-eCharger            | yes      |
+| ip              | The IP-address of your go-e Charger           | yes      |
 | apiVersion      | The API version to use (1=default or 2)       | no       |
 | refreshInterval | Interval to read data, default 5 (in seconds) | no       |
 
-The apiVersion 2 is only available for Go-eCharger with new hardware revision (CM-03).
+The apiVersion 2 is only available for go-e Charger with new hardware revision (CM-03, GM-10 and potentially others), which can be recognized with the serial number on the back of the device.
 
 ## Channels
 
@@ -47,8 +51,8 @@ Currently available channels are
 | transaction              | Number                   | 0 if no card, otherwise card ID                               | 2 (r/w)           |
 | allowCharging            | Switch                   | If `ON` charging is allowed                                   | 1 (r/w), 2 (r)    |
 | cableCurrent             | Number:ElectricCurrent   | Specifies the max current that can be charged with that cable | 1 (r), 2 (r)      |
-| temperature              | Number:Temperature       | Temperature of the curciuit board of the Go-eCharger          | 1 (r), 2 (r)      |
-| temperatureType2Port     | Number:Temperature       | Temperature of the type 2 port of the Go-eCharger             | 2 (r)             |
+| temperature              | Number:Temperature       | Temperature of the curciuit board of the go-e Charger          | 1 (r), 2 (r)      |
+| temperatureType2Port     | Number:Temperature       | Temperature of the type 2 port of the go-e Charger             | 2 (r)             |
 | firmware                 | String                   | Firmware Version                                              | 1 (r), 2 (r)      |
 | accessConfiguration      | String                   | Access configuration, for example OPEN, RFID ...              | 1 (r/w)           |
 | forceState               | Number                   | Force state  (Neutral=0, Off=1, On=2)                         | 2 (r/w)           |
@@ -91,7 +95,7 @@ String                     GoEChargerFirmware                   "Firmware"      
 String                     GoEChargerAccessConfiguration        "Access configuration"                  {channel="goecharger:goe:garage:accessConfiguration"}
 ```
 
-## Setting charge current of Go-eCharger based on photovoltaik output
+## Setting charge current of go-e Charger based on photovoltaik output
 
 You can easily define rules to charge with PV power alone.
 Here is a simple sample how such a rule could look like:
@@ -109,7 +113,7 @@ end
 Advanced example:
 
 ```java
-rule "Set charging limit for go-eCharger"
+rule "Set charging limit for go-e Charger"
 when
     Time cron "*/10 * * ? * *" // Trigger every 10 seconds
 then


### PR DESCRIPTION
# Title
[goecharger] Update README.md (name of chargers and setup instructions)

# Description
I got stuck connecting my charger, because I did not find any hint in the readme that elaborates the need to activate the local HTTP API on the app first. Added this hint with a short chapter.

At the same time, when adding information on the support for the new Gemini charger, I realized that go-e slightly changed the spelling of their products, which I updated too throughout the readme.

# Testing

Not needed (readme only)