### PR TITLE
[boschshc] Fix NPE during deserialization, make long polling more robust (#17190)

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/LongPolling.java
@@ -211,7 +211,7 @@ public class LongPolling {
      * @param subscriptionId Id of subscription the response is for
      * @param content Content of the response
      */
-    private void handleLongPollResponse(BoschHttpClient httpClient, String subscriptionId, String content) {
+    void handleLongPollResponse(BoschHttpClient httpClient, String subscriptionId, String content) {
         logger.debug("Long poll response: {}", content);
 
         try {
@@ -238,6 +238,10 @@ public class LongPolling {
         } catch (JsonSyntaxException e) {
             this.handleFailure.accept(
                     new LongPollingFailedException("Could not deserialize long poll response: '" + content + "'", e));
+            return;
+        } catch (Exception e) {
+            this.handleFailure.accept(
+                    new LongPollingFailedException("Error while handling long poll response: '" + content + "'", e));
             return;
         }
 

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/UserDefinedState.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/UserDefinedState.java
@@ -37,7 +37,7 @@ public class UserDefinedState extends BoschSHCServiceState {
     private boolean state;
 
     public UserDefinedState() {
-        super("UserDefinedState");
+        super("userDefinedState");
     }
 
     public String getId() {

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/UserDefinedStateTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/dto/UserDefinedStateTest.java
@@ -53,7 +53,7 @@ public class UserDefinedStateTest {
     @Test
     void testToString() {
         assertEquals(
-                String.format("UserDefinedState{id='%s', name='test user state', state=true, type='UserDefinedState'}",
+                String.format("UserDefinedState{id='%s', name='test user state', state=true, type='userDefinedState'}",
                         testId),
                 fixture.toString());
     }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/serialization/BoschServiceDataDeserializerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/serialization/BoschServiceDataDeserializerTest.java
@@ -12,22 +12,29 @@
  */
 package org.openhab.binding.boschshc.internal.serialization;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.DeviceServiceData;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.LongPollResult;
 import org.openhab.binding.boschshc.internal.devices.bridge.dto.Scenario;
+import org.openhab.binding.boschshc.internal.devices.bridge.dto.UserDefinedState;
+import org.openhab.binding.boschshc.internal.services.dto.BoschSHCServiceState;
 
 /**
  * Unit tests for {@link BoschServiceDataDeserializer}.
  *
  * @author Patrick Gell - Initial contribution
+ * @author David Pace - Added tests for all supported service data classes
  *
  */
 @NonNullByDefault
@@ -60,12 +67,104 @@ class BoschServiceDataDeserializerTest {
                 """;
 
         var longPollResult = GsonUtils.DEFAULT_GSON_INSTANCE.fromJson(resultJson, LongPollResult.class);
+        // note: when using assertThat() to check that the value is non-null, we get compiler warnings.
         assertNotNull(longPollResult);
-        assertEquals(2, longPollResult.result.size());
+        List<BoschSHCServiceState> results = longPollResult.result;
+        assertThat(results, is(notNullValue()));
+        assertThat(results, hasSize(2));
 
-        var resultClasses = new HashSet<>(longPollResult.result.stream().map(e -> e.getClass().getName()).toList());
-        assertEquals(2, resultClasses.size());
-        assertTrue(resultClasses.contains(DeviceServiceData.class.getName()));
-        assertTrue(resultClasses.contains(Scenario.class.getName()));
+        var resultClasses = new HashSet<>(results.stream().map(e -> e.getClass().getName()).toList());
+        assertThat(resultClasses, hasSize(2));
+        assertThat(resultClasses, containsInAnyOrder(DeviceServiceData.class.getName(), Scenario.class.getName()));
+    }
+
+    @Test
+    void testDeserializeDeletedDeviceServiceData() {
+        var resultJson = """
+                {
+                    "result": [
+                        {
+                            "@type": "DeviceServiceData",
+                            "deleted": true,
+                            "id": "CommunicationQuality",
+                            "deviceId": "hdm:ZigBee:30fb10fffe46d732"
+                        }
+                    ],
+                    "jsonrpc":"2.0"
+                }
+                """;
+
+        var longPollResult = GsonUtils.DEFAULT_GSON_INSTANCE.fromJson(resultJson, LongPollResult.class);
+        // note: when using assertThat() to check that the value is non-null, we get compiler warnings.
+        assertNotNull(longPollResult);
+        List<BoschSHCServiceState> results = longPollResult.result;
+        assertThat(results, is(notNullValue()));
+        assertThat(results, hasSize(1));
+
+        DeviceServiceData deviceServiceData = (DeviceServiceData) longPollResult.result.get(0);
+        assertThat(deviceServiceData.type, is("DeviceServiceData"));
+        assertThat(deviceServiceData.id, is("CommunicationQuality"));
+        assertThat(deviceServiceData.deviceId, is("hdm:ZigBee:30fb10fffe46d732"));
+    }
+
+    @Test
+    void testDeserializeScenarioTriggered() {
+        String resultJson = """
+                {
+                    "result": [
+                        {
+                            "@type": "scenarioTriggered",
+                            "name": "My Scenario",
+                            "id": "509bd737-eed0-40b7-8caa-e8686a714399",
+                            "lastTimeTriggered": "1693758693032"
+                        }
+                    ],
+                    "jsonrpc": "2.0"
+                }
+                """;
+
+        var longPollResult = GsonUtils.DEFAULT_GSON_INSTANCE.fromJson(resultJson, LongPollResult.class);
+        // note: when using assertThat() to check that the value is non-null, we get compiler warnings.
+        assertNotNull(longPollResult);
+        List<BoschSHCServiceState> results = longPollResult.result;
+        assertThat(results, is(notNullValue()));
+        assertThat(results, hasSize(1));
+
+        Scenario scenario = (Scenario) longPollResult.result.get(0);
+        assertThat(scenario.type, is("scenarioTriggered"));
+        assertThat(scenario.name, is("My Scenario"));
+        assertThat(scenario.id, is("509bd737-eed0-40b7-8caa-e8686a714399"));
+        assertThat(scenario.lastTimeTriggered, is("1693758693032"));
+    }
+
+    @Test
+    void testDeserializeUserDefinedState() {
+        String resultJson = """
+                {
+                    "result": [
+                        {
+                            "@type": "userDefinedState",
+                            "deleted": false,
+                            "name": "Test State",
+                            "id": "3d8023d6-69ca-4e79-89dd-7090295cefbf",
+                            "state": true
+                        }
+                    ],
+                    "jsonrpc": "2.0"
+                }
+                """;
+
+        var longPollResult = GsonUtils.DEFAULT_GSON_INSTANCE.fromJson(resultJson, LongPollResult.class);
+        // note: when using assertThat() to check that the value is non-null, we get compiler warnings.
+        assertNotNull(longPollResult);
+        List<BoschSHCServiceState> results = longPollResult.result;
+        assertThat(results, is(notNullValue()));
+        assertThat(results, hasSize(1));
+
+        UserDefinedState userDefinedState = (UserDefinedState) longPollResult.result.get(0);
+        assertThat(userDefinedState.type, is("userDefinedState"));
+        assertThat(userDefinedState.getName(), is("Test State"));
+        assertThat(userDefinedState.getId(), is("3d8023d6-69ca-4e79-89dd-7090295cefbf"));
+        assertThat(userDefinedState.isState(), is(true));
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/services/dto/BoschSHCServiceStateTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/services/dto/BoschSHCServiceStateTest.java
@@ -12,7 +12,12 @@
  */
 package org.openhab.binding.boschshc.internal.services.dto;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -85,8 +90,9 @@ class BoschSHCServiceStateTest {
     @Test
     void fromJsonReturnsUserStateServiceStateForValidJson() {
         var state = BoschSHCServiceState.fromJson(new JsonPrimitive("false"), UserStateServiceState.class);
-        assertNotEquals(null, state);
-        assertTrue(state.getClass().isAssignableFrom(UserStateServiceState.class));
-        assertFalse(state.isState());
+        // note: when using assertThat() to check that the value is non-null, we get compiler warnings.
+        assertNotNull(state);
+        assertThat(state, instanceOf(UserStateServiceState.class));
+        assertThat(state.isState(), is(false));
     }
 }


### PR DESCRIPTION
* Fix NPE while deserializing service data JSON objects
* Catch exceptions while handling long poll results
* Correct @type name for user-defined states
* Add unit tests and enhance existing unit tests

This was cherry-picked from `main`, but minor merge conflicts had to be resolved.