### PR TITLE
[roku] Add device communcation logging

### DIFF
--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
@@ -46,10 +46,9 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class RokuCommunicator {
-    private final Logger logger = LoggerFactory.getLogger(RokuCommunicator.class);
-
     private static final int REQUEST_TIMEOUT = 5000;
 
+    private final Logger logger = LoggerFactory.getLogger(RokuCommunicator.class);
     private final HttpClient httpClient;
 
     private final String urlKeyPress;

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
@@ -36,6 +36,8 @@ import org.openhab.binding.roku.internal.dto.Player;
 import org.openhab.binding.roku.internal.dto.TvChannel;
 import org.openhab.binding.roku.internal.dto.TvChannels;
 import org.openhab.binding.roku.internal.dto.TvChannels.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Methods for accessing the HTTP interface of the Roku
@@ -44,6 +46,8 @@ import org.openhab.binding.roku.internal.dto.TvChannels.Channel;
  */
 @NonNullByDefault
 public class RokuCommunicator {
+    private final Logger logger = LoggerFactory.getLogger(RokuCommunicator.class);
+
     private static final int REQUEST_TIMEOUT = 5000;
 
     private final HttpClient httpClient;
@@ -114,6 +118,9 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_DEVICE_INFO;
             if (ctx != null) {
                 final String response = getCommand(urlQryDevice);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Called {}, got response: {}", urlQryDevice, response);
+                }
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -140,6 +147,9 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_ACTIVE_APP;
             if (ctx != null) {
                 final String response = getCommand(urlQryActiveApp);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Called {}, got response: {}", urlQryActiveApp, response);
+                }
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -166,6 +176,9 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_APPS;
             if (ctx != null) {
                 final String response = getCommand(urlQryApps);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Called {}, got response: {}", urlQryApps, response);
+                }
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -192,6 +205,9 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_PLAYER;
             if (ctx != null) {
                 final String response = getCommand(urlQryPlayer);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Called {}, got response: {}", urlQryPlayer, response);
+                }
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -218,6 +234,9 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_TVCHANNEL;
             if (ctx != null) {
                 final String response = getCommand(urlQryActiveTvChannel);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Called {}, got response: {}", urlQryActiveTvChannel, response);
+                }
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -244,6 +263,9 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_TVCHANNELS;
             if (ctx != null) {
                 final String response = getCommand(urlQryTvChannels);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Called {}, got response: {}", urlQryTvChannels, response);
+                }
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -286,6 +308,9 @@ public class RokuCommunicator {
      */
     private void postCommand(String url) throws RokuHttpException {
         try {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Sending POST command: {}", url);
+            }
             httpClient.POST(url).method(HttpMethod.POST).timeout(REQUEST_TIMEOUT, TimeUnit.MILLISECONDS).send();
         } catch (TimeoutException | ExecutionException e) {
             throw new RokuHttpException("Error executing POST command, URL: " + url, e);

--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/communication/RokuCommunicator.java
@@ -118,9 +118,8 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_DEVICE_INFO;
             if (ctx != null) {
                 final String response = getCommand(urlQryDevice);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Called {}, got response: {}", urlQryDevice, response);
-                }
+                logger.trace("Called {}, got response: {}", urlQryDevice, response);
+
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -147,9 +146,8 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_ACTIVE_APP;
             if (ctx != null) {
                 final String response = getCommand(urlQryActiveApp);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Called {}, got response: {}", urlQryActiveApp, response);
-                }
+                logger.trace("Called {}, got response: {}", urlQryActiveApp, response);
+
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -176,9 +174,8 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_APPS;
             if (ctx != null) {
                 final String response = getCommand(urlQryApps);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Called {}, got response: {}", urlQryApps, response);
-                }
+                logger.trace("Called {}, got response: {}", urlQryApps, response);
+
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -205,9 +202,8 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_PLAYER;
             if (ctx != null) {
                 final String response = getCommand(urlQryPlayer);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Called {}, got response: {}", urlQryPlayer, response);
-                }
+                logger.trace("Called {}, got response: {}", urlQryPlayer, response);
+
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -234,9 +230,8 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_TVCHANNEL;
             if (ctx != null) {
                 final String response = getCommand(urlQryActiveTvChannel);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Called {}, got response: {}", urlQryActiveTvChannel, response);
-                }
+                logger.trace("Called {}, got response: {}", urlQryActiveTvChannel, response);
+
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -263,9 +258,8 @@ public class RokuCommunicator {
             JAXBContext ctx = JAXBUtils.JAXBCONTEXT_TVCHANNELS;
             if (ctx != null) {
                 final String response = getCommand(urlQryTvChannels);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Called {}, got response: {}", urlQryTvChannels, response);
-                }
+                logger.trace("Called {}, got response: {}", urlQryTvChannels, response);
+
                 Unmarshaller unmarshaller = ctx.createUnmarshaller();
                 if (unmarshaller != null) {
                     XMLStreamReader xsr = JAXBUtils.XMLINPUTFACTORY.createXMLStreamReader(new StringReader(response));
@@ -308,9 +302,7 @@ public class RokuCommunicator {
      */
     private void postCommand(String url) throws RokuHttpException {
         try {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Sending POST command: {}", url);
-            }
+            logger.trace("Sending POST command: {}", url);
             httpClient.POST(url).method(HttpMethod.POST).timeout(REQUEST_TIMEOUT, TimeUnit.MILLISECONDS).send();
         } catch (TimeoutException | ExecutionException e) {
             throw new RokuHttpException("Error executing POST command, URL: " + url, e);


### PR DESCRIPTION
While recently helping to troubleshoot an issue that a community member had with this binding, I realized that currently there is very little logging available besides when exceptions are thrown. Therefore, this PR adds TRACE logging for the http GET and POST requests sent to the Roku device.