### PR TITLE
[govee] Add H61C5 as supported device

### DIFF
--- a/bundles/org.openhab.binding.govee/README.md
+++ b/bundles/org.openhab.binding.govee/README.md
@@ -43,6 +43,7 @@ Here is a list of the supported devices (the ones marked with * have been tested
 - H61A1 RGBIC Neon Rope Light 2M
 - H61A2 RGBIC Neon Rope Light 5M
 - H61A3 RGBIC Neon Rope Light
+- H61C5 RGBIC LED Neon Rope Lights for Desks (*)
 - H61D3 Neon Rope Light 2 3M (*)
 - H61D5 Neon Rope Light 2 5M (*)
 - H61A5 Neon LED Strip Light 10


### PR DESCRIPTION
device confirmed to be working: https://community.openhab.org/t/govee-dreamcoulour-led-strips/84435/70