### PR TITLE
[AirGradient] Convert from AbstractDiscoveryService to AbstractThingHandlerDiscoveryService

### DIFF
--- a/bundles/org.openhab.binding.airgradient/src/main/java/org/openhab/binding/airgradient/internal/discovery/AirGradientLocationDiscoveryService.java
+++ b/bundles/org.openhab.binding.airgradient/src/main/java/org/openhab/binding/airgradient/internal/discovery/AirGradientLocationDiscoveryService.java
@@ -24,19 +24,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.airgradient.internal.communication.AirGradientCommunicationException;
 import org.openhab.binding.airgradient.internal.handler.AirGradientAPIHandler;
 import org.openhab.binding.airgradient.internal.handler.PollEventListener;
 import org.openhab.binding.airgradient.internal.model.Measure;
-import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BridgeHandler;
-import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -51,32 +50,31 @@ import org.slf4j.LoggerFactory;
  */
 @Component(scope = ServiceScope.PROTOTYPE, service = AirGradientLocationDiscoveryService.class)
 @NonNullByDefault
-public class AirGradientLocationDiscoveryService extends AbstractDiscoveryService
+public class AirGradientLocationDiscoveryService extends AbstractThingHandlerDiscoveryService<AirGradientAPIHandler>
         implements ThingHandlerService, PollEventListener {
 
     private final Logger logger = LoggerFactory.getLogger(AirGradientLocationDiscoveryService.class);
 
-    private @NonNullByDefault({}) AirGradientAPIHandler apiHandler;
-
     public AirGradientLocationDiscoveryService() {
-        super(Set.of(THING_TYPE_LOCATION), (int) SEARCH_TIME.getSeconds(), BACKGROUND_DISCOVERY);
+        super(AirGradientAPIHandler.class, Set.of(THING_TYPE_LOCATION), (int) SEARCH_TIME.getSeconds(),
+                BACKGROUND_DISCOVERY);
     }
 
     @Override
     protected void startBackgroundDiscovery() {
         logger.debug("Start AirGradient background discovery");
-        apiHandler.addPollEventListener(this);
+        getApiHandler().addPollEventListener(this);
     }
 
     @Override
     protected void stopBackgroundDiscovery() {
         logger.debug("Stopping AirGradient background discovery");
-        apiHandler.removePollEventListener(this);
+        getApiHandler().removePollEventListener(this);
     }
 
     @Override
     public void pollEvent(List<Measure> measures) {
-        BridgeHandler bridge = apiHandler.getThing().getHandler();
+        BridgeHandler bridge = getApiHandler().getThing().getHandler();
         if (bridge == null) {
             logger.debug("Missing bridge, can't discover sensors for unknown bridge.");
             return;
@@ -84,7 +82,7 @@ public class AirGradientLocationDiscoveryService extends AbstractDiscoveryServic
 
         ThingUID bridgeUid = bridge.getThing().getUID();
 
-        Set<String> registeredLocationIds = new HashSet<>(apiHandler.getRegisteredLocationIds());
+        Set<String> registeredLocationIds = new HashSet<>(getApiHandler().getRegisteredLocationIds());
         for (Measure measure : measures) {
             String id = measure.getLocationId();
             if (id.isEmpty()) {
@@ -123,32 +121,14 @@ public class AirGradientLocationDiscoveryService extends AbstractDiscoveryServic
     @Override
     protected void startScan() {
         try {
-            List<Measure> measures = apiHandler.getApiController().getMeasures();
+            List<Measure> measures = getApiHandler().getApiController().getMeasures();
             pollEvent(measures);
         } catch (AirGradientCommunicationException agce) {
             logger.warn("Failed discovery due to communication exception: {}", agce.getMessage());
         }
     }
 
-    @Override
-    public void setThingHandler(ThingHandler handler) {
-        if (handler instanceof AirGradientAPIHandler airGradientAPIHandler) {
-            this.apiHandler = airGradientAPIHandler;
-        }
-    }
-
-    @Override
-    public @Nullable ThingHandler getThingHandler() {
-        return apiHandler;
-    }
-
-    @Override
-    public void activate() {
-        super.activate(null);
-    }
-
-    @Override
-    public void deactivate() {
-        super.deactivate();
+    private AirGradientAPIHandler getApiHandler() {
+        return (@NonNull AirGradientAPIHandler) getThingHandler();
     }
 }

--- a/bundles/org.openhab.binding.airgradient/src/main/java/org/openhab/binding/airgradient/internal/discovery/AirGradientLocationDiscoveryService.java
+++ b/bundles/org.openhab.binding.airgradient/src/main/java/org/openhab/binding/airgradient/internal/discovery/AirGradientLocationDiscoveryService.java
@@ -36,7 +36,6 @@ import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BridgeHandler;
-import org.openhab.core.thing.binding.ThingHandlerService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 import org.slf4j.Logger;
@@ -51,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @Component(scope = ServiceScope.PROTOTYPE, service = AirGradientLocationDiscoveryService.class)
 @NonNullByDefault
 public class AirGradientLocationDiscoveryService extends AbstractThingHandlerDiscoveryService<AirGradientAPIHandler>
-        implements ThingHandlerService, PollEventListener {
+        implements PollEventListener {
 
     private final Logger logger = LoggerFactory.getLogger(AirGradientLocationDiscoveryService.class);
 


### PR DESCRIPTION
[AirGradient] Convert from AbstractDiscoveryService to AbstractThingHandlerDiscoveryService

Because we get NPE on apiHandler in 4.2.1 (not on 4.2.0).

This has been tested to not get the same NPE in 4.2.1, and is aligning the code to the new way to
write discovery services.

The reason AbstractDiscoveryService was used was to keep backwards compatibility when developing the
binding outside the code base and it was installed from the addon store.