### PR TITLE
Add J-N-K as code-owner to http and basicprofiles add-ons

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -153,7 +153,7 @@
 /bundles/org.openhab.binding.homematic/ @FStolte @gerrieg @mdicke2s
 /bundles/org.openhab.binding.homewizard/ @Daniel-42
 /bundles/org.openhab.binding.hpprinter/ @cossey
-/bundles/org.openhab.binding.http/ @openhab/add-ons-maintainers
+/bundles/org.openhab.binding.http/ @J-N-K
 /bundles/org.openhab.binding.hue/ @cweitkamp @andrewfg
 /bundles/org.openhab.binding.hydrawise/ @digitaldan
 /bundles/org.openhab.binding.hyperion/ @tavalin
@@ -432,6 +432,7 @@
 /bundles/org.openhab.persistence.mapdb/ @openhab/add-ons-maintainers
 /bundles/org.openhab.persistence.mongodb/ @openhab/add-ons-maintainers
 /bundles/org.openhab.persistence.rrd4j/ @openhab/add-ons-maintainers
+/bundles/org.openhab.transform.basicprofiles/ @J-N-K
 /bundles/org.openhab.transform.bin2json/ @paulianttila
 /bundles/org.openhab.transform.exec/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.jinja/ @jochen314


### PR DESCRIPTION
This was forgotten in #16282 and #16754.