### PR TITLE
[rollershutterposition] Fix parameter configuration through UI

### DIFF
--- a/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
+++ b/bundles/org.openhab.transform.rollershutterposition/src/main/resources/OH-INF/config/rollerShutterPosition.xml
@@ -4,7 +4,7 @@
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="profile:rollershutter:position">
+	<config-description uri="profile:transform:ROLLERSHUTTERPOSITION">
 		<parameter name="uptime" type="decimal" required="true">
 			<label>Up Time</label>
 			<description>Time it takes for roller shutter to fully open (in seconds).</description>


### PR DESCRIPTION
This pull request fixes the uri in the .xml config file to match other transform profiles. This addresses the bug #17340 where the parameters cannot be configured via the main ui.