### PR TITLE
[basicprofile] Fix statefilter check against item's value on the rhs

### DIFF
--- a/bundles/org.openhab.transform.basicprofiles/src/test/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfileTest.java
+++ b/bundles/org.openhab.transform.basicprofiles/src/test/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfileTest.java
@@ -615,7 +615,6 @@ public class StateFilterProfileTest {
         String linkedItemName = linkedItem.getName();
 
         String itemName = item.getName();
-        item.setState(state);
 
         when(mockContext.getConfiguration()).thenReturn(new Configuration(Map.of("conditions", operator + itemName)));
         when(mockItemRegistry.getItem(itemName)).thenReturn(item);
@@ -623,7 +622,13 @@ public class StateFilterProfileTest {
         when(mockItemChannelLink.getItemName()).thenReturn(linkedItemName);
 
         StateFilterProfile profile = new StateFilterProfile(mockCallback, mockContext, mockItemRegistry);
+        item.setState(UnDefType.UNDEF);
 
+        profile.onStateUpdateFromHandler(inputState);
+        reset(mockCallback);
+        when(mockCallback.getItemChannelLink()).thenReturn(mockItemChannelLink);
+
+        item.setState(state);
         profile.onStateUpdateFromHandler(inputState);
         verify(mockCallback, times(expected ? 1 : 0)).sendUpdate(eq(inputState));
     }


### PR DESCRIPTION
Fix a bug introduced in #17323: the item state on the right hand side is only evaluated on the first check execution.