### PR TITLE
[visualcrossing] Fix missing dimension

### DIFF
--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_01.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_01.items
@@ -37,3 +37,676 @@ String Day01_Stations "Stations" (Total_Weather_Data_Day01)["Point"] { channel="
 String Day01_Source "Source" (Total_Weather_Data_Day01)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
 Number Day01_Severe_Risk "Severe Risk" (Total_Weather_Data_Day01)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
 
+// Day01 - Hour00
+Group Total_Weather_Data_Day01_Hour00 "Hour 00" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour00_DateTime "DateTime" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-datetime"}
+DateTime Day01_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-timestamp"}
+Number:Temperature Day01_Hour00_Temperature "Temperature" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-temperature"}
+Number:Temperature Day01_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-feels-like"}
+Number Day01_Hour00_Humidity "Humidity" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-humidity"}
+Number:Temperature Day01_Hour00_Dew "Dew Point" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-dew"}
+Number:Length Day01_Hour00_Precip "Precipitation" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-precip"}
+Number:Dimensionless Day01_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-precip-prob"}
+String Day01_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-precip-type"}
+Number:Length Day01_Hour00_Snow "Snow" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-snow"}
+Number:Length Day01_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-snow-depth"}
+Number:Speed Day01_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-wind-gust"}
+Number:Speed Day01_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-wind-speed"}
+Number:Angle Day01_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-wind-dir"}
+Number:Pressure Day01_Hour00_Pressure "Pressure" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-pressure"}
+Number:Length Day01_Hour00_Visibility "Visibility" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-visibility"}
+Number:Dimensionless Day01_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-cloud-cover"}
+Number:Intensity Day01_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-solar-radiation"}
+Number Day01_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-solar-energy"}
+Number Day01_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-uv-index"}
+Number Day01_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-severe-risk"}
+String Day01_Hour00_Conditions "Conditions" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-conditions"}
+String Day01_Hour00_Icon "Icon" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-icon"}
+String Day01_Hour00_Stations "Stations" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-stations"}
+String Day01_Hour00_Source "Source" (Total_Weather_Data_Day01_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour00-source"}
+
+// Day01 - Hour01
+Group Total_Weather_Data_Day01_Hour01 "Hour 01" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour01_DateTime "DateTime" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-datetime"}
+DateTime Day01_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-timestamp"}
+Number:Temperature Day01_Hour01_Temperature "Temperature" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-temperature"}
+Number:Temperature Day01_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-feels-like"}
+Number Day01_Hour01_Humidity "Humidity" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-humidity"}
+Number:Temperature Day01_Hour01_Dew "Dew Point" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-dew"}
+Number:Length Day01_Hour01_Precip "Precipitation" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-precip"}
+Number:Dimensionless Day01_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-precip-prob"}
+String Day01_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-precip-type"}
+Number:Length Day01_Hour01_Snow "Snow" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-snow"}
+Number:Length Day01_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-snow-depth"}
+Number:Speed Day01_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-wind-gust"}
+Number:Speed Day01_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-wind-speed"}
+Number:Angle Day01_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-wind-dir"}
+Number:Pressure Day01_Hour01_Pressure "Pressure" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-pressure"}
+Number:Length Day01_Hour01_Visibility "Visibility" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-visibility"}
+Number:Dimensionless Day01_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-cloud-cover"}
+Number:Intensity Day01_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-solar-radiation"}
+Number Day01_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-solar-energy"}
+Number Day01_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-uv-index"}
+Number Day01_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-severe-risk"}
+String Day01_Hour01_Conditions "Conditions" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-conditions"}
+String Day01_Hour01_Icon "Icon" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-icon"}
+String Day01_Hour01_Stations "Stations" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-stations"}
+String Day01_Hour01_Source "Source" (Total_Weather_Data_Day01_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour01-source"}
+
+// Day01 - Hour02
+Group Total_Weather_Data_Day01_Hour02 "Hour 02" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour02_DateTime "DateTime" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-datetime"}
+DateTime Day01_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-timestamp"}
+Number:Temperature Day01_Hour02_Temperature "Temperature" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-temperature"}
+Number:Temperature Day01_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-feels-like"}
+Number Day01_Hour02_Humidity "Humidity" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-humidity"}
+Number:Temperature Day01_Hour02_Dew "Dew Point" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-dew"}
+Number:Length Day01_Hour02_Precip "Precipitation" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-precip"}
+Number:Dimensionless Day01_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-precip-prob"}
+String Day01_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-precip-type"}
+Number:Length Day01_Hour02_Snow "Snow" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-snow"}
+Number:Length Day01_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-snow-depth"}
+Number:Speed Day01_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-wind-gust"}
+Number:Speed Day01_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-wind-speed"}
+Number:Angle Day01_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-wind-dir"}
+Number:Pressure Day01_Hour02_Pressure "Pressure" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-pressure"}
+Number:Length Day01_Hour02_Visibility "Visibility" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-visibility"}
+Number:Dimensionless Day01_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-cloud-cover"}
+Number:Intensity Day01_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-solar-radiation"}
+Number Day01_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-solar-energy"}
+Number Day01_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-uv-index"}
+Number Day01_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-severe-risk"}
+String Day01_Hour02_Conditions "Conditions" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-conditions"}
+String Day01_Hour02_Icon "Icon" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-icon"}
+String Day01_Hour02_Stations "Stations" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-stations"}
+String Day01_Hour02_Source "Source" (Total_Weather_Data_Day01_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour02-source"}
+
+// Day01 - Hour03
+Group Total_Weather_Data_Day01_Hour03 "Hour 03" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour03_DateTime "DateTime" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-datetime"}
+DateTime Day01_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-timestamp"}
+Number:Temperature Day01_Hour03_Temperature "Temperature" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-temperature"}
+Number:Temperature Day01_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-feels-like"}
+Number Day01_Hour03_Humidity "Humidity" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-humidity"}
+Number:Temperature Day01_Hour03_Dew "Dew Point" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-dew"}
+Number:Length Day01_Hour03_Precip "Precipitation" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-precip"}
+Number:Dimensionless Day01_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-precip-prob"}
+String Day01_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-precip-type"}
+Number:Length Day01_Hour03_Snow "Snow" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-snow"}
+Number:Length Day01_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-snow-depth"}
+Number:Speed Day01_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-wind-gust"}
+Number:Speed Day01_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-wind-speed"}
+Number:Angle Day01_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-wind-dir"}
+Number:Pressure Day01_Hour03_Pressure "Pressure" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-pressure"}
+Number:Length Day01_Hour03_Visibility "Visibility" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-visibility"}
+Number:Dimensionless Day01_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-cloud-cover"}
+Number:Intensity Day01_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-solar-radiation"}
+Number Day01_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-solar-energy"}
+Number Day01_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-uv-index"}
+Number Day01_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-severe-risk"}
+String Day01_Hour03_Conditions "Conditions" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-conditions"}
+String Day01_Hour03_Icon "Icon" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-icon"}
+String Day01_Hour03_Stations "Stations" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-stations"}
+String Day01_Hour03_Source "Source" (Total_Weather_Data_Day01_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour03-source"}
+
+// Day01 - Hour04
+Group Total_Weather_Data_Day01_Hour04 "Hour 04" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour04_DateTime "DateTime" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-datetime"}
+DateTime Day01_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-timestamp"}
+Number:Temperature Day01_Hour04_Temperature "Temperature" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-temperature"}
+Number:Temperature Day01_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-feels-like"}
+Number Day01_Hour04_Humidity "Humidity" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-humidity"}
+Number:Temperature Day01_Hour04_Dew "Dew Point" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-dew"}
+Number:Length Day01_Hour04_Precip "Precipitation" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-precip"}
+Number:Dimensionless Day01_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-precip-prob"}
+String Day01_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-precip-type"}
+Number:Length Day01_Hour04_Snow "Snow" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-snow"}
+Number:Length Day01_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-snow-depth"}
+Number:Speed Day01_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-wind-gust"}
+Number:Speed Day01_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-wind-speed"}
+Number:Angle Day01_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-wind-dir"}
+Number:Pressure Day01_Hour04_Pressure "Pressure" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-pressure"}
+Number:Length Day01_Hour04_Visibility "Visibility" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-visibility"}
+Number:Dimensionless Day01_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-cloud-cover"}
+Number:Intensity Day01_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-solar-radiation"}
+Number Day01_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-solar-energy"}
+Number Day01_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-uv-index"}
+Number Day01_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-severe-risk"}
+String Day01_Hour04_Conditions "Conditions" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-conditions"}
+String Day01_Hour04_Icon "Icon" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-icon"}
+String Day01_Hour04_Stations "Stations" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-stations"}
+String Day01_Hour04_Source "Source" (Total_Weather_Data_Day01_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour04-source"}
+
+// Day01 - Hour05
+Group Total_Weather_Data_Day01_Hour05 "Hour 05" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour05_DateTime "DateTime" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-datetime"}
+DateTime Day01_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-timestamp"}
+Number:Temperature Day01_Hour05_Temperature "Temperature" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-temperature"}
+Number:Temperature Day01_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-feels-like"}
+Number Day01_Hour05_Humidity "Humidity" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-humidity"}
+Number:Temperature Day01_Hour05_Dew "Dew Point" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-dew"}
+Number:Length Day01_Hour05_Precip "Precipitation" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-precip"}
+Number:Dimensionless Day01_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-precip-prob"}
+String Day01_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-precip-type"}
+Number:Length Day01_Hour05_Snow "Snow" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-snow"}
+Number:Length Day01_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-snow-depth"}
+Number:Speed Day01_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-wind-gust"}
+Number:Speed Day01_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-wind-speed"}
+Number:Angle Day01_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-wind-dir"}
+Number:Pressure Day01_Hour05_Pressure "Pressure" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-pressure"}
+Number:Length Day01_Hour05_Visibility "Visibility" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-visibility"}
+Number:Dimensionless Day01_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-cloud-cover"}
+Number:Intensity Day01_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-solar-radiation"}
+Number Day01_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-solar-energy"}
+Number Day01_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-uv-index"}
+Number Day01_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-severe-risk"}
+String Day01_Hour05_Conditions "Conditions" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-conditions"}
+String Day01_Hour05_Icon "Icon" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-icon"}
+String Day01_Hour05_Stations "Stations" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-stations"}
+String Day01_Hour05_Source "Source" (Total_Weather_Data_Day01_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour05-source"}
+
+// Day01 - Hour06
+Group Total_Weather_Data_Day01_Hour06 "Hour 06" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour06_DateTime "DateTime" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-datetime"}
+DateTime Day01_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-timestamp"}
+Number:Temperature Day01_Hour06_Temperature "Temperature" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-temperature"}
+Number:Temperature Day01_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-feels-like"}
+Number Day01_Hour06_Humidity "Humidity" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-humidity"}
+Number:Temperature Day01_Hour06_Dew "Dew Point" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-dew"}
+Number:Length Day01_Hour06_Precip "Precipitation" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-precip"}
+Number:Dimensionless Day01_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-precip-prob"}
+String Day01_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-precip-type"}
+Number:Length Day01_Hour06_Snow "Snow" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-snow"}
+Number:Length Day01_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-snow-depth"}
+Number:Speed Day01_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-wind-gust"}
+Number:Speed Day01_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-wind-speed"}
+Number:Angle Day01_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-wind-dir"}
+Number:Pressure Day01_Hour06_Pressure "Pressure" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-pressure"}
+Number:Length Day01_Hour06_Visibility "Visibility" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-visibility"}
+Number:Dimensionless Day01_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-cloud-cover"}
+Number:Intensity Day01_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-solar-radiation"}
+Number Day01_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-solar-energy"}
+Number Day01_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-uv-index"}
+Number Day01_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-severe-risk"}
+String Day01_Hour06_Conditions "Conditions" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-conditions"}
+String Day01_Hour06_Icon "Icon" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-icon"}
+String Day01_Hour06_Stations "Stations" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-stations"}
+String Day01_Hour06_Source "Source" (Total_Weather_Data_Day01_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour06-source"}
+
+// Day01 - Hour07
+Group Total_Weather_Data_Day01_Hour07 "Hour 07" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour07_DateTime "DateTime" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-datetime"}
+DateTime Day01_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-timestamp"}
+Number:Temperature Day01_Hour07_Temperature "Temperature" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-temperature"}
+Number:Temperature Day01_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-feels-like"}
+Number Day01_Hour07_Humidity "Humidity" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-humidity"}
+Number:Temperature Day01_Hour07_Dew "Dew Point" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-dew"}
+Number:Length Day01_Hour07_Precip "Precipitation" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-precip"}
+Number:Dimensionless Day01_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-precip-prob"}
+String Day01_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-precip-type"}
+Number:Length Day01_Hour07_Snow "Snow" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-snow"}
+Number:Length Day01_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-snow-depth"}
+Number:Speed Day01_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-wind-gust"}
+Number:Speed Day01_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-wind-speed"}
+Number:Angle Day01_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-wind-dir"}
+Number:Pressure Day01_Hour07_Pressure "Pressure" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-pressure"}
+Number:Length Day01_Hour07_Visibility "Visibility" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-visibility"}
+Number:Dimensionless Day01_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-cloud-cover"}
+Number:Intensity Day01_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-solar-radiation"}
+Number Day01_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-solar-energy"}
+Number Day01_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-uv-index"}
+Number Day01_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-severe-risk"}
+String Day01_Hour07_Conditions "Conditions" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-conditions"}
+String Day01_Hour07_Icon "Icon" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-icon"}
+String Day01_Hour07_Stations "Stations" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-stations"}
+String Day01_Hour07_Source "Source" (Total_Weather_Data_Day01_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour07-source"}
+
+// Day01 - Hour08
+Group Total_Weather_Data_Day01_Hour08 "Hour 08" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour08_DateTime "DateTime" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-datetime"}
+DateTime Day01_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-timestamp"}
+Number:Temperature Day01_Hour08_Temperature "Temperature" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-temperature"}
+Number:Temperature Day01_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-feels-like"}
+Number Day01_Hour08_Humidity "Humidity" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-humidity"}
+Number:Temperature Day01_Hour08_Dew "Dew Point" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-dew"}
+Number:Length Day01_Hour08_Precip "Precipitation" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-precip"}
+Number:Dimensionless Day01_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-precip-prob"}
+String Day01_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-precip-type"}
+Number:Length Day01_Hour08_Snow "Snow" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-snow"}
+Number:Length Day01_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-snow-depth"}
+Number:Speed Day01_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-wind-gust"}
+Number:Speed Day01_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-wind-speed"}
+Number:Angle Day01_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-wind-dir"}
+Number:Pressure Day01_Hour08_Pressure "Pressure" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-pressure"}
+Number:Length Day01_Hour08_Visibility "Visibility" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-visibility"}
+Number:Dimensionless Day01_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-cloud-cover"}
+Number:Intensity Day01_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-solar-radiation"}
+Number Day01_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-solar-energy"}
+Number Day01_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-uv-index"}
+Number Day01_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-severe-risk"}
+String Day01_Hour08_Conditions "Conditions" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-conditions"}
+String Day01_Hour08_Icon "Icon" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-icon"}
+String Day01_Hour08_Stations "Stations" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-stations"}
+String Day01_Hour08_Source "Source" (Total_Weather_Data_Day01_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour08-source"}
+
+// Day01 - Hour09
+Group Total_Weather_Data_Day01_Hour09 "Hour 09" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour09_DateTime "DateTime" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-datetime"}
+DateTime Day01_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-timestamp"}
+Number:Temperature Day01_Hour09_Temperature "Temperature" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-temperature"}
+Number:Temperature Day01_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-feels-like"}
+Number Day01_Hour09_Humidity "Humidity" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-humidity"}
+Number:Temperature Day01_Hour09_Dew "Dew Point" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-dew"}
+Number:Length Day01_Hour09_Precip "Precipitation" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-precip"}
+Number:Dimensionless Day01_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-precip-prob"}
+String Day01_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-precip-type"}
+Number:Length Day01_Hour09_Snow "Snow" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-snow"}
+Number:Length Day01_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-snow-depth"}
+Number:Speed Day01_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-wind-gust"}
+Number:Speed Day01_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-wind-speed"}
+Number:Angle Day01_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-wind-dir"}
+Number:Pressure Day01_Hour09_Pressure "Pressure" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-pressure"}
+Number:Length Day01_Hour09_Visibility "Visibility" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-visibility"}
+Number:Dimensionless Day01_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-cloud-cover"}
+Number:Intensity Day01_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-solar-radiation"}
+Number Day01_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-solar-energy"}
+Number Day01_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-uv-index"}
+Number Day01_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-severe-risk"}
+String Day01_Hour09_Conditions "Conditions" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-conditions"}
+String Day01_Hour09_Icon "Icon" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-icon"}
+String Day01_Hour09_Stations "Stations" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-stations"}
+String Day01_Hour09_Source "Source" (Total_Weather_Data_Day01_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour09-source"}
+
+// Day01 - Hour10
+Group Total_Weather_Data_Day01_Hour10 "Hour 10" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour10_DateTime "DateTime" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-datetime"}
+DateTime Day01_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-timestamp"}
+Number:Temperature Day01_Hour10_Temperature "Temperature" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-temperature"}
+Number:Temperature Day01_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-feels-like"}
+Number Day01_Hour10_Humidity "Humidity" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-humidity"}
+Number:Temperature Day01_Hour10_Dew "Dew Point" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-dew"}
+Number:Length Day01_Hour10_Precip "Precipitation" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-precip"}
+Number:Dimensionless Day01_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-precip-prob"}
+String Day01_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-precip-type"}
+Number:Length Day01_Hour10_Snow "Snow" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-snow"}
+Number:Length Day01_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-snow-depth"}
+Number:Speed Day01_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-wind-gust"}
+Number:Speed Day01_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-wind-speed"}
+Number:Angle Day01_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-wind-dir"}
+Number:Pressure Day01_Hour10_Pressure "Pressure" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-pressure"}
+Number:Length Day01_Hour10_Visibility "Visibility" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-visibility"}
+Number:Dimensionless Day01_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-cloud-cover"}
+Number:Intensity Day01_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-solar-radiation"}
+Number Day01_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-solar-energy"}
+Number Day01_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-uv-index"}
+Number Day01_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-severe-risk"}
+String Day01_Hour10_Conditions "Conditions" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-conditions"}
+String Day01_Hour10_Icon "Icon" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-icon"}
+String Day01_Hour10_Stations "Stations" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-stations"}
+String Day01_Hour10_Source "Source" (Total_Weather_Data_Day01_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour10-source"}
+
+// Day01 - Hour11
+Group Total_Weather_Data_Day01_Hour11 "Hour 11" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour11_DateTime "DateTime" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-datetime"}
+DateTime Day01_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-timestamp"}
+Number:Temperature Day01_Hour11_Temperature "Temperature" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-temperature"}
+Number:Temperature Day01_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-feels-like"}
+Number Day01_Hour11_Humidity "Humidity" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-humidity"}
+Number:Temperature Day01_Hour11_Dew "Dew Point" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-dew"}
+Number:Length Day01_Hour11_Precip "Precipitation" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-precip"}
+Number:Dimensionless Day01_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-precip-prob"}
+String Day01_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-precip-type"}
+Number:Length Day01_Hour11_Snow "Snow" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-snow"}
+Number:Length Day01_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-snow-depth"}
+Number:Speed Day01_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-wind-gust"}
+Number:Speed Day01_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-wind-speed"}
+Number:Angle Day01_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-wind-dir"}
+Number:Pressure Day01_Hour11_Pressure "Pressure" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-pressure"}
+Number:Length Day01_Hour11_Visibility "Visibility" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-visibility"}
+Number:Dimensionless Day01_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-cloud-cover"}
+Number:Intensity Day01_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-solar-radiation"}
+Number Day01_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-solar-energy"}
+Number Day01_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-uv-index"}
+Number Day01_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-severe-risk"}
+String Day01_Hour11_Conditions "Conditions" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-conditions"}
+String Day01_Hour11_Icon "Icon" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-icon"}
+String Day01_Hour11_Stations "Stations" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-stations"}
+String Day01_Hour11_Source "Source" (Total_Weather_Data_Day01_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour11-source"}
+
+// Day01 - Hour12
+Group Total_Weather_Data_Day01_Hour12 "Hour 12" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour12_DateTime "DateTime" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-datetime"}
+DateTime Day01_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-timestamp"}
+Number:Temperature Day01_Hour12_Temperature "Temperature" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-temperature"}
+Number:Temperature Day01_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-feels-like"}
+Number Day01_Hour12_Humidity "Humidity" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-humidity"}
+Number:Temperature Day01_Hour12_Dew "Dew Point" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-dew"}
+Number:Length Day01_Hour12_Precip "Precipitation" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-precip"}
+Number:Dimensionless Day01_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-precip-prob"}
+String Day01_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-precip-type"}
+Number:Length Day01_Hour12_Snow "Snow" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-snow"}
+Number:Length Day01_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-snow-depth"}
+Number:Speed Day01_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-wind-gust"}
+Number:Speed Day01_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-wind-speed"}
+Number:Angle Day01_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-wind-dir"}
+Number:Pressure Day01_Hour12_Pressure "Pressure" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-pressure"}
+Number:Length Day01_Hour12_Visibility "Visibility" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-visibility"}
+Number:Dimensionless Day01_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-cloud-cover"}
+Number:Intensity Day01_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-solar-radiation"}
+Number Day01_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-solar-energy"}
+Number Day01_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-uv-index"}
+Number Day01_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-severe-risk"}
+String Day01_Hour12_Conditions "Conditions" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-conditions"}
+String Day01_Hour12_Icon "Icon" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-icon"}
+String Day01_Hour12_Stations "Stations" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-stations"}
+String Day01_Hour12_Source "Source" (Total_Weather_Data_Day01_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour12-source"}
+
+// Day01 - Hour13
+Group Total_Weather_Data_Day01_Hour13 "Hour 13" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour13_DateTime "DateTime" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-datetime"}
+DateTime Day01_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-timestamp"}
+Number:Temperature Day01_Hour13_Temperature "Temperature" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-temperature"}
+Number:Temperature Day01_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-feels-like"}
+Number Day01_Hour13_Humidity "Humidity" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-humidity"}
+Number:Temperature Day01_Hour13_Dew "Dew Point" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-dew"}
+Number:Length Day01_Hour13_Precip "Precipitation" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-precip"}
+Number:Dimensionless Day01_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-precip-prob"}
+String Day01_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-precip-type"}
+Number:Length Day01_Hour13_Snow "Snow" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-snow"}
+Number:Length Day01_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-snow-depth"}
+Number:Speed Day01_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-wind-gust"}
+Number:Speed Day01_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-wind-speed"}
+Number:Angle Day01_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-wind-dir"}
+Number:Pressure Day01_Hour13_Pressure "Pressure" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-pressure"}
+Number:Length Day01_Hour13_Visibility "Visibility" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-visibility"}
+Number:Dimensionless Day01_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-cloud-cover"}
+Number:Intensity Day01_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-solar-radiation"}
+Number Day01_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-solar-energy"}
+Number Day01_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-uv-index"}
+Number Day01_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-severe-risk"}
+String Day01_Hour13_Conditions "Conditions" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-conditions"}
+String Day01_Hour13_Icon "Icon" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-icon"}
+String Day01_Hour13_Stations "Stations" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-stations"}
+String Day01_Hour13_Source "Source" (Total_Weather_Data_Day01_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour13-source"}
+
+// Day01 - Hour14
+Group Total_Weather_Data_Day01_Hour14 "Hour 14" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour14_DateTime "DateTime" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-datetime"}
+DateTime Day01_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-timestamp"}
+Number:Temperature Day01_Hour14_Temperature "Temperature" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-temperature"}
+Number:Temperature Day01_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-feels-like"}
+Number Day01_Hour14_Humidity "Humidity" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-humidity"}
+Number:Temperature Day01_Hour14_Dew "Dew Point" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-dew"}
+Number:Length Day01_Hour14_Precip "Precipitation" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-precip"}
+Number:Dimensionless Day01_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-precip-prob"}
+String Day01_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-precip-type"}
+Number:Length Day01_Hour14_Snow "Snow" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-snow"}
+Number:Length Day01_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-snow-depth"}
+Number:Speed Day01_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-wind-gust"}
+Number:Speed Day01_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-wind-speed"}
+Number:Angle Day01_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-wind-dir"}
+Number:Pressure Day01_Hour14_Pressure "Pressure" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-pressure"}
+Number:Length Day01_Hour14_Visibility "Visibility" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-visibility"}
+Number:Dimensionless Day01_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-cloud-cover"}
+Number:Intensity Day01_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-solar-radiation"}
+Number Day01_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-solar-energy"}
+Number Day01_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-uv-index"}
+Number Day01_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-severe-risk"}
+String Day01_Hour14_Conditions "Conditions" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-conditions"}
+String Day01_Hour14_Icon "Icon" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-icon"}
+String Day01_Hour14_Stations "Stations" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-stations"}
+String Day01_Hour14_Source "Source" (Total_Weather_Data_Day01_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour14-source"}
+
+// Day01 - Hour15
+Group Total_Weather_Data_Day01_Hour15 "Hour 15" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour15_DateTime "DateTime" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-datetime"}
+DateTime Day01_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-timestamp"}
+Number:Temperature Day01_Hour15_Temperature "Temperature" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-temperature"}
+Number:Temperature Day01_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-feels-like"}
+Number Day01_Hour15_Humidity "Humidity" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-humidity"}
+Number:Temperature Day01_Hour15_Dew "Dew Point" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-dew"}
+Number:Length Day01_Hour15_Precip "Precipitation" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-precip"}
+Number:Dimensionless Day01_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-precip-prob"}
+String Day01_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-precip-type"}
+Number:Length Day01_Hour15_Snow "Snow" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-snow"}
+Number:Length Day01_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-snow-depth"}
+Number:Speed Day01_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-wind-gust"}
+Number:Speed Day01_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-wind-speed"}
+Number:Angle Day01_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-wind-dir"}
+Number:Pressure Day01_Hour15_Pressure "Pressure" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-pressure"}
+Number:Length Day01_Hour15_Visibility "Visibility" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-visibility"}
+Number:Dimensionless Day01_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-cloud-cover"}
+Number:Intensity Day01_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-solar-radiation"}
+Number Day01_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-solar-energy"}
+Number Day01_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-uv-index"}
+Number Day01_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-severe-risk"}
+String Day01_Hour15_Conditions "Conditions" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-conditions"}
+String Day01_Hour15_Icon "Icon" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-icon"}
+String Day01_Hour15_Stations "Stations" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-stations"}
+String Day01_Hour15_Source "Source" (Total_Weather_Data_Day01_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour15-source"}
+
+// Day01 - Hour16
+Group Total_Weather_Data_Day01_Hour16 "Hour 16" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour16_DateTime "DateTime" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-datetime"}
+DateTime Day01_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-timestamp"}
+Number:Temperature Day01_Hour16_Temperature "Temperature" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-temperature"}
+Number:Temperature Day01_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-feels-like"}
+Number Day01_Hour16_Humidity "Humidity" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-humidity"}
+Number:Temperature Day01_Hour16_Dew "Dew Point" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-dew"}
+Number:Length Day01_Hour16_Precip "Precipitation" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-precip"}
+Number:Dimensionless Day01_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-precip-prob"}
+String Day01_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-precip-type"}
+Number:Length Day01_Hour16_Snow "Snow" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-snow"}
+Number:Length Day01_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-snow-depth"}
+Number:Speed Day01_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-wind-gust"}
+Number:Speed Day01_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-wind-speed"}
+Number:Angle Day01_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-wind-dir"}
+Number:Pressure Day01_Hour16_Pressure "Pressure" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-pressure"}
+Number:Length Day01_Hour16_Visibility "Visibility" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-visibility"}
+Number:Dimensionless Day01_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-cloud-cover"}
+Number:Intensity Day01_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-solar-radiation"}
+Number Day01_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-solar-energy"}
+Number Day01_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-uv-index"}
+Number Day01_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-severe-risk"}
+String Day01_Hour16_Conditions "Conditions" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-conditions"}
+String Day01_Hour16_Icon "Icon" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-icon"}
+String Day01_Hour16_Stations "Stations" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-stations"}
+String Day01_Hour16_Source "Source" (Total_Weather_Data_Day01_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour16-source"}
+
+// Day01 - Hour17
+Group Total_Weather_Data_Day01_Hour17 "Hour 17" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour17_DateTime "DateTime" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-datetime"}
+DateTime Day01_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-timestamp"}
+Number:Temperature Day01_Hour17_Temperature "Temperature" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-temperature"}
+Number:Temperature Day01_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-feels-like"}
+Number Day01_Hour17_Humidity "Humidity" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-humidity"}
+Number:Temperature Day01_Hour17_Dew "Dew Point" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-dew"}
+Number:Length Day01_Hour17_Precip "Precipitation" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-precip"}
+Number:Dimensionless Day01_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-precip-prob"}
+String Day01_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-precip-type"}
+Number:Length Day01_Hour17_Snow "Snow" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-snow"}
+Number:Length Day01_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-snow-depth"}
+Number:Speed Day01_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-wind-gust"}
+Number:Speed Day01_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-wind-speed"}
+Number:Angle Day01_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-wind-dir"}
+Number:Pressure Day01_Hour17_Pressure "Pressure" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-pressure"}
+Number:Length Day01_Hour17_Visibility "Visibility" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-visibility"}
+Number:Dimensionless Day01_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-cloud-cover"}
+Number:Intensity Day01_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-solar-radiation"}
+Number Day01_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-solar-energy"}
+Number Day01_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-uv-index"}
+Number Day01_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-severe-risk"}
+String Day01_Hour17_Conditions "Conditions" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-conditions"}
+String Day01_Hour17_Icon "Icon" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-icon"}
+String Day01_Hour17_Stations "Stations" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-stations"}
+String Day01_Hour17_Source "Source" (Total_Weather_Data_Day01_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour17-source"}
+
+// Day01 - Hour18
+Group Total_Weather_Data_Day01_Hour18 "Hour 18" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour18_DateTime "DateTime" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-datetime"}
+DateTime Day01_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-timestamp"}
+Number:Temperature Day01_Hour18_Temperature "Temperature" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-temperature"}
+Number:Temperature Day01_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-feels-like"}
+Number Day01_Hour18_Humidity "Humidity" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-humidity"}
+Number:Temperature Day01_Hour18_Dew "Dew Point" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-dew"}
+Number:Length Day01_Hour18_Precip "Precipitation" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-precip"}
+Number:Dimensionless Day01_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-precip-prob"}
+String Day01_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-precip-type"}
+Number:Length Day01_Hour18_Snow "Snow" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-snow"}
+Number:Length Day01_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-snow-depth"}
+Number:Speed Day01_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-wind-gust"}
+Number:Speed Day01_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-wind-speed"}
+Number:Angle Day01_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-wind-dir"}
+Number:Pressure Day01_Hour18_Pressure "Pressure" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-pressure"}
+Number:Length Day01_Hour18_Visibility "Visibility" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-visibility"}
+Number:Dimensionless Day01_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-cloud-cover"}
+Number:Intensity Day01_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-solar-radiation"}
+Number Day01_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-solar-energy"}
+Number Day01_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-uv-index"}
+Number Day01_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-severe-risk"}
+String Day01_Hour18_Conditions "Conditions" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-conditions"}
+String Day01_Hour18_Icon "Icon" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-icon"}
+String Day01_Hour18_Stations "Stations" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-stations"}
+String Day01_Hour18_Source "Source" (Total_Weather_Data_Day01_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour18-source"}
+
+// Day01 - Hour19
+Group Total_Weather_Data_Day01_Hour19 "Hour 19" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour19_DateTime "DateTime" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-datetime"}
+DateTime Day01_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-timestamp"}
+Number:Temperature Day01_Hour19_Temperature "Temperature" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-temperature"}
+Number:Temperature Day01_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-feels-like"}
+Number Day01_Hour19_Humidity "Humidity" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-humidity"}
+Number:Temperature Day01_Hour19_Dew "Dew Point" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-dew"}
+Number:Length Day01_Hour19_Precip "Precipitation" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-precip"}
+Number:Dimensionless Day01_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-precip-prob"}
+String Day01_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-precip-type"}
+Number:Length Day01_Hour19_Snow "Snow" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-snow"}
+Number:Length Day01_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-snow-depth"}
+Number:Speed Day01_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-wind-gust"}
+Number:Speed Day01_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-wind-speed"}
+Number:Angle Day01_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-wind-dir"}
+Number:Pressure Day01_Hour19_Pressure "Pressure" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-pressure"}
+Number:Length Day01_Hour19_Visibility "Visibility" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-visibility"}
+Number:Dimensionless Day01_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-cloud-cover"}
+Number:Intensity Day01_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-solar-radiation"}
+Number Day01_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-solar-energy"}
+Number Day01_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-uv-index"}
+Number Day01_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-severe-risk"}
+String Day01_Hour19_Conditions "Conditions" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-conditions"}
+String Day01_Hour19_Icon "Icon" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-icon"}
+String Day01_Hour19_Stations "Stations" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-stations"}
+String Day01_Hour19_Source "Source" (Total_Weather_Data_Day01_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour19-source"}
+
+// Day01 - Hour20
+Group Total_Weather_Data_Day01_Hour20 "Hour 20" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour20_DateTime "DateTime" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-datetime"}
+DateTime Day01_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-timestamp"}
+Number:Temperature Day01_Hour20_Temperature "Temperature" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-temperature"}
+Number:Temperature Day01_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-feels-like"}
+Number Day01_Hour20_Humidity "Humidity" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-humidity"}
+Number:Temperature Day01_Hour20_Dew "Dew Point" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-dew"}
+Number:Length Day01_Hour20_Precip "Precipitation" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-precip"}
+Number:Dimensionless Day01_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-precip-prob"}
+String Day01_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-precip-type"}
+Number:Length Day01_Hour20_Snow "Snow" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-snow"}
+Number:Length Day01_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-snow-depth"}
+Number:Speed Day01_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-wind-gust"}
+Number:Speed Day01_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-wind-speed"}
+Number:Angle Day01_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-wind-dir"}
+Number:Pressure Day01_Hour20_Pressure "Pressure" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-pressure"}
+Number:Length Day01_Hour20_Visibility "Visibility" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-visibility"}
+Number:Dimensionless Day01_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-cloud-cover"}
+Number:Intensity Day01_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-solar-radiation"}
+Number Day01_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-solar-energy"}
+Number Day01_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-uv-index"}
+Number Day01_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-severe-risk"}
+String Day01_Hour20_Conditions "Conditions" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-conditions"}
+String Day01_Hour20_Icon "Icon" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-icon"}
+String Day01_Hour20_Stations "Stations" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-stations"}
+String Day01_Hour20_Source "Source" (Total_Weather_Data_Day01_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour20-source"}
+
+// Day01 - Hour21
+Group Total_Weather_Data_Day01_Hour21 "Hour 21" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour21_DateTime "DateTime" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-datetime"}
+DateTime Day01_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-timestamp"}
+Number:Temperature Day01_Hour21_Temperature "Temperature" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-temperature"}
+Number:Temperature Day01_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-feels-like"}
+Number Day01_Hour21_Humidity "Humidity" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-humidity"}
+Number:Temperature Day01_Hour21_Dew "Dew Point" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-dew"}
+Number:Length Day01_Hour21_Precip "Precipitation" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-precip"}
+Number:Dimensionless Day01_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-precip-prob"}
+String Day01_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-precip-type"}
+Number:Length Day01_Hour21_Snow "Snow" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-snow"}
+Number:Length Day01_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-snow-depth"}
+Number:Speed Day01_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-wind-gust"}
+Number:Speed Day01_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-wind-speed"}
+Number:Angle Day01_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-wind-dir"}
+Number:Pressure Day01_Hour21_Pressure "Pressure" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-pressure"}
+Number:Length Day01_Hour21_Visibility "Visibility" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-visibility"}
+Number:Dimensionless Day01_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-cloud-cover"}
+Number:Intensity Day01_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-solar-radiation"}
+Number Day01_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-solar-energy"}
+Number Day01_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-uv-index"}
+Number Day01_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-severe-risk"}
+String Day01_Hour21_Conditions "Conditions" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-conditions"}
+String Day01_Hour21_Icon "Icon" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-icon"}
+String Day01_Hour21_Stations "Stations" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-stations"}
+String Day01_Hour21_Source "Source" (Total_Weather_Data_Day01_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour21-source"}
+
+// Day01 - Hour22
+Group Total_Weather_Data_Day01_Hour22 "Hour 22" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour22_DateTime "DateTime" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-datetime"}
+DateTime Day01_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-timestamp"}
+Number:Temperature Day01_Hour22_Temperature "Temperature" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-temperature"}
+Number:Temperature Day01_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-feels-like"}
+Number Day01_Hour22_Humidity "Humidity" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-humidity"}
+Number:Temperature Day01_Hour22_Dew "Dew Point" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-dew"}
+Number:Length Day01_Hour22_Precip "Precipitation" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-precip"}
+Number:Dimensionless Day01_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-precip-prob"}
+String Day01_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-precip-type"}
+Number:Length Day01_Hour22_Snow "Snow" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-snow"}
+Number:Length Day01_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-snow-depth"}
+Number:Speed Day01_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-wind-gust"}
+Number:Speed Day01_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-wind-speed"}
+Number:Angle Day01_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-wind-dir"}
+Number:Pressure Day01_Hour22_Pressure "Pressure" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-pressure"}
+Number:Length Day01_Hour22_Visibility "Visibility" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-visibility"}
+Number:Dimensionless Day01_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-cloud-cover"}
+Number:Intensity Day01_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-solar-radiation"}
+Number Day01_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-solar-energy"}
+Number Day01_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-uv-index"}
+Number Day01_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-severe-risk"}
+String Day01_Hour22_Conditions "Conditions" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-conditions"}
+String Day01_Hour22_Icon "Icon" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-icon"}
+String Day01_Hour22_Stations "Stations" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-stations"}
+String Day01_Hour22_Source "Source" (Total_Weather_Data_Day01_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour22-source"}
+
+// Day01 - Hour23
+Group Total_Weather_Data_Day01_Hour23 "Hour 23" (Total_Weather_Data_Day01) [ "Equipment" ] 
+String Day01_Hour23_DateTime "DateTime" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-datetime"}
+DateTime Day01_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-timestamp"}
+Number:Temperature Day01_Hour23_Temperature "Temperature" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-temperature"}
+Number:Temperature Day01_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-feels-like"}
+Number Day01_Hour23_Humidity "Humidity" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-humidity"}
+Number:Temperature Day01_Hour23_Dew "Dew Point" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-dew"}
+Number:Length Day01_Hour23_Precip "Precipitation" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-precip"}
+Number:Dimensionless Day01_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-precip-prob"}
+String Day01_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-precip-type"}
+Number:Length Day01_Hour23_Snow "Snow" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-snow"}
+Number:Length Day01_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-snow-depth"}
+Number:Speed Day01_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-wind-gust"}
+Number:Speed Day01_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-wind-speed"}
+Number:Angle Day01_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-wind-dir"}
+Number:Pressure Day01_Hour23_Pressure "Pressure" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-pressure"}
+Number:Length Day01_Hour23_Visibility "Visibility" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-visibility"}
+Number:Dimensionless Day01_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-cloud-cover"}
+Number:Intensity Day01_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-solar-radiation"}
+Number Day01_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-solar-energy"}
+Number Day01_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-uv-index"}
+Number Day01_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-severe-risk"}
+String Day01_Hour23_Conditions "Conditions" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-conditions"}
+String Day01_Hour23_Icon "Icon" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-icon"}
+String Day01_Hour23_Stations "Stations" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-stations"}
+String Day01_Hour23_Source "Source" (Total_Weather_Data_Day01_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day01#hour23-source"}
+
+

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_02.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_02.items
@@ -1,39 +1,712 @@
 // Day02
 Group Total_Weather_Data_Day02 "Day T+02" (Total_Weather_Data) [ "Equipment" ] 
-String Day02_DateTime "Time" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day02_Timestamp "Timestamp" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day02_Temperature "Temperature" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day02_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day02_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day02_FeelsLike "Feels Like" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day02_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day02_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day02_Dew "Dew Point" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day02_Humidity "Humidity" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day02_Precip "Precipitation" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day02_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day02_Precip_Type "Precipitation Type" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day02_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day02_Snow "Snow" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day02_Snow_Depth "Snow Depth" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day02_Wind_Gust "Wind Gust" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day02_Wind_Speed "Wind Speed" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day02_Wind_Dir "Wind Direction" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day02_Pressure "Pressure" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day02_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day02_Visibility "Visibility" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day02_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day02_Solar_Energy "Solar Energy" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day02_UV_Index "UV Index" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day02_Sunrise "Sunrise" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day02_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day02_Sunset "Sunset" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day02_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day02_Moon_Phase "Moon Phase" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day02_Conditions "Conditions" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day02_Description "Description" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day02_Icon "Icon" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day02_Stations "Stations" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day02_Source "Source" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day02_Severe_Risk "Severe Risk" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day02_DateTime "Time" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#datetime" }
+DateTime Day02_Timestamp "Timestamp" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#timestamp" }
+Number:Temperature Day02_Temperature "Temperature" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#temperature" }
+Number:Temperature Day02_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#temperature-min" }
+Number:Temperature Day02_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#temperature-max" }
+Number:Temperature Day02_FeelsLike "Feels Like" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#feels-like" }
+Number:Temperature Day02_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#feels-like-min" }
+Number:Temperature Day02_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#feels-like-max" }
+Number:Temperature Day02_Dew "Dew Point" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#dew" }
+Number Day02_Humidity "Humidity" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#humidity" }
+Number:Length Day02_Precip "Precipitation" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#precip" }
+Number Day02_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#precip-prob" }
+String Day02_Precip_Type "Precipitation Type" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#precip-type" }
+Number Day02_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#precip-cover" }
+Number:Length Day02_Snow "Snow" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#snow" }
+Number:Length Day02_Snow_Depth "Snow Depth" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#snow-depth" }
+Number:Speed Day02_Wind_Gust "Wind Gust" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#wind-gust" }
+Number:Speed Day02_Wind_Speed "Wind Speed" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#wind-speed" }
+Number:Angle Day02_Wind_Dir "Wind Direction" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#wind-dir" }
+Number:Pressure Day02_Pressure "Pressure" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#pressure" }
+Number Day02_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#cloud-cover" }
+Number:Length Day02_Visibility "Visibility" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#visibility" }
+Number:Intensity Day02_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#solar-radiation" }
+Number Day02_Solar_Energy "Solar Energy" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#solar-energy" }
+Number Day02_UV_Index "UV Index" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#uv-index" }
+String Day02_Sunrise "Sunrise" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#sunrise" }
+DateTime Day02_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#sunrise-epoch" }
+String Day02_Sunset "Sunset" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#sunset" }
+DateTime Day02_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#sunset-epoch" }
+Number Day02_Moon_Phase "Moon Phase" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#moon-phase" }
+String Day02_Conditions "Conditions" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#conditions" }
+String Day02_Description "Description" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#description" }
+String Day02_Icon "Icon" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#icon" }
+String Day02_Stations "Stations" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#stations" }
+String Day02_Source "Source" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#source" }
+Number Day02_Severe_Risk "Severe Risk" (Total_Weather_Data_Day02)["Point"] { channel="visualcrossing:weather:default_config:day02#severe-risk" }
+
+// Day02 - Hour00
+Group Total_Weather_Data_Day02_Hour00 "Hour 00" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour00_DateTime "DateTime" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-datetime"}
+DateTime Day02_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-timestamp"}
+Number:Temperature Day02_Hour00_Temperature "Temperature" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-temperature"}
+Number:Temperature Day02_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-feels-like"}
+Number Day02_Hour00_Humidity "Humidity" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-humidity"}
+Number:Temperature Day02_Hour00_Dew "Dew Point" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-dew"}
+Number:Length Day02_Hour00_Precip "Precipitation" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-precip"}
+Number:Dimensionless Day02_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-precip-prob"}
+String Day02_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-precip-type"}
+Number:Length Day02_Hour00_Snow "Snow" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-snow"}
+Number:Length Day02_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-snow-depth"}
+Number:Speed Day02_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-wind-gust"}
+Number:Speed Day02_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-wind-speed"}
+Number:Angle Day02_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-wind-dir"}
+Number:Pressure Day02_Hour00_Pressure "Pressure" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-pressure"}
+Number:Length Day02_Hour00_Visibility "Visibility" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-visibility"}
+Number:Dimensionless Day02_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-cloud-cover"}
+Number:Intensity Day02_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-solar-radiation"}
+Number Day02_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-solar-energy"}
+Number Day02_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-uv-index"}
+Number Day02_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-severe-risk"}
+String Day02_Hour00_Conditions "Conditions" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-conditions"}
+String Day02_Hour00_Icon "Icon" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-icon"}
+String Day02_Hour00_Stations "Stations" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-stations"}
+String Day02_Hour00_Source "Source" (Total_Weather_Data_Day02_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour00-source"}
+
+// Day02 - Hour01
+Group Total_Weather_Data_Day02_Hour01 "Hour 01" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour01_DateTime "DateTime" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-datetime"}
+DateTime Day02_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-timestamp"}
+Number:Temperature Day02_Hour01_Temperature "Temperature" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-temperature"}
+Number:Temperature Day02_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-feels-like"}
+Number Day02_Hour01_Humidity "Humidity" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-humidity"}
+Number:Temperature Day02_Hour01_Dew "Dew Point" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-dew"}
+Number:Length Day02_Hour01_Precip "Precipitation" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-precip"}
+Number:Dimensionless Day02_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-precip-prob"}
+String Day02_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-precip-type"}
+Number:Length Day02_Hour01_Snow "Snow" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-snow"}
+Number:Length Day02_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-snow-depth"}
+Number:Speed Day02_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-wind-gust"}
+Number:Speed Day02_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-wind-speed"}
+Number:Angle Day02_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-wind-dir"}
+Number:Pressure Day02_Hour01_Pressure "Pressure" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-pressure"}
+Number:Length Day02_Hour01_Visibility "Visibility" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-visibility"}
+Number:Dimensionless Day02_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-cloud-cover"}
+Number:Intensity Day02_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-solar-radiation"}
+Number Day02_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-solar-energy"}
+Number Day02_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-uv-index"}
+Number Day02_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-severe-risk"}
+String Day02_Hour01_Conditions "Conditions" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-conditions"}
+String Day02_Hour01_Icon "Icon" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-icon"}
+String Day02_Hour01_Stations "Stations" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-stations"}
+String Day02_Hour01_Source "Source" (Total_Weather_Data_Day02_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour01-source"}
+
+// Day02 - Hour02
+Group Total_Weather_Data_Day02_Hour02 "Hour 02" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour02_DateTime "DateTime" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-datetime"}
+DateTime Day02_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-timestamp"}
+Number:Temperature Day02_Hour02_Temperature "Temperature" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-temperature"}
+Number:Temperature Day02_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-feels-like"}
+Number Day02_Hour02_Humidity "Humidity" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-humidity"}
+Number:Temperature Day02_Hour02_Dew "Dew Point" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-dew"}
+Number:Length Day02_Hour02_Precip "Precipitation" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-precip"}
+Number:Dimensionless Day02_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-precip-prob"}
+String Day02_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-precip-type"}
+Number:Length Day02_Hour02_Snow "Snow" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-snow"}
+Number:Length Day02_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-snow-depth"}
+Number:Speed Day02_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-wind-gust"}
+Number:Speed Day02_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-wind-speed"}
+Number:Angle Day02_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-wind-dir"}
+Number:Pressure Day02_Hour02_Pressure "Pressure" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-pressure"}
+Number:Length Day02_Hour02_Visibility "Visibility" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-visibility"}
+Number:Dimensionless Day02_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-cloud-cover"}
+Number:Intensity Day02_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-solar-radiation"}
+Number Day02_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-solar-energy"}
+Number Day02_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-uv-index"}
+Number Day02_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-severe-risk"}
+String Day02_Hour02_Conditions "Conditions" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-conditions"}
+String Day02_Hour02_Icon "Icon" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-icon"}
+String Day02_Hour02_Stations "Stations" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-stations"}
+String Day02_Hour02_Source "Source" (Total_Weather_Data_Day02_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour02-source"}
+
+// Day02 - Hour03
+Group Total_Weather_Data_Day02_Hour03 "Hour 03" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour03_DateTime "DateTime" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-datetime"}
+DateTime Day02_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-timestamp"}
+Number:Temperature Day02_Hour03_Temperature "Temperature" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-temperature"}
+Number:Temperature Day02_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-feels-like"}
+Number Day02_Hour03_Humidity "Humidity" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-humidity"}
+Number:Temperature Day02_Hour03_Dew "Dew Point" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-dew"}
+Number:Length Day02_Hour03_Precip "Precipitation" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-precip"}
+Number:Dimensionless Day02_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-precip-prob"}
+String Day02_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-precip-type"}
+Number:Length Day02_Hour03_Snow "Snow" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-snow"}
+Number:Length Day02_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-snow-depth"}
+Number:Speed Day02_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-wind-gust"}
+Number:Speed Day02_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-wind-speed"}
+Number:Angle Day02_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-wind-dir"}
+Number:Pressure Day02_Hour03_Pressure "Pressure" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-pressure"}
+Number:Length Day02_Hour03_Visibility "Visibility" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-visibility"}
+Number:Dimensionless Day02_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-cloud-cover"}
+Number:Intensity Day02_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-solar-radiation"}
+Number Day02_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-solar-energy"}
+Number Day02_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-uv-index"}
+Number Day02_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-severe-risk"}
+String Day02_Hour03_Conditions "Conditions" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-conditions"}
+String Day02_Hour03_Icon "Icon" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-icon"}
+String Day02_Hour03_Stations "Stations" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-stations"}
+String Day02_Hour03_Source "Source" (Total_Weather_Data_Day02_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour03-source"}
+
+// Day02 - Hour04
+Group Total_Weather_Data_Day02_Hour04 "Hour 04" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour04_DateTime "DateTime" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-datetime"}
+DateTime Day02_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-timestamp"}
+Number:Temperature Day02_Hour04_Temperature "Temperature" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-temperature"}
+Number:Temperature Day02_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-feels-like"}
+Number Day02_Hour04_Humidity "Humidity" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-humidity"}
+Number:Temperature Day02_Hour04_Dew "Dew Point" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-dew"}
+Number:Length Day02_Hour04_Precip "Precipitation" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-precip"}
+Number:Dimensionless Day02_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-precip-prob"}
+String Day02_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-precip-type"}
+Number:Length Day02_Hour04_Snow "Snow" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-snow"}
+Number:Length Day02_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-snow-depth"}
+Number:Speed Day02_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-wind-gust"}
+Number:Speed Day02_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-wind-speed"}
+Number:Angle Day02_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-wind-dir"}
+Number:Pressure Day02_Hour04_Pressure "Pressure" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-pressure"}
+Number:Length Day02_Hour04_Visibility "Visibility" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-visibility"}
+Number:Dimensionless Day02_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-cloud-cover"}
+Number:Intensity Day02_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-solar-radiation"}
+Number Day02_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-solar-energy"}
+Number Day02_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-uv-index"}
+Number Day02_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-severe-risk"}
+String Day02_Hour04_Conditions "Conditions" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-conditions"}
+String Day02_Hour04_Icon "Icon" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-icon"}
+String Day02_Hour04_Stations "Stations" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-stations"}
+String Day02_Hour04_Source "Source" (Total_Weather_Data_Day02_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour04-source"}
+
+// Day02 - Hour05
+Group Total_Weather_Data_Day02_Hour05 "Hour 05" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour05_DateTime "DateTime" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-datetime"}
+DateTime Day02_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-timestamp"}
+Number:Temperature Day02_Hour05_Temperature "Temperature" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-temperature"}
+Number:Temperature Day02_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-feels-like"}
+Number Day02_Hour05_Humidity "Humidity" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-humidity"}
+Number:Temperature Day02_Hour05_Dew "Dew Point" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-dew"}
+Number:Length Day02_Hour05_Precip "Precipitation" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-precip"}
+Number:Dimensionless Day02_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-precip-prob"}
+String Day02_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-precip-type"}
+Number:Length Day02_Hour05_Snow "Snow" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-snow"}
+Number:Length Day02_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-snow-depth"}
+Number:Speed Day02_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-wind-gust"}
+Number:Speed Day02_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-wind-speed"}
+Number:Angle Day02_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-wind-dir"}
+Number:Pressure Day02_Hour05_Pressure "Pressure" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-pressure"}
+Number:Length Day02_Hour05_Visibility "Visibility" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-visibility"}
+Number:Dimensionless Day02_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-cloud-cover"}
+Number:Intensity Day02_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-solar-radiation"}
+Number Day02_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-solar-energy"}
+Number Day02_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-uv-index"}
+Number Day02_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-severe-risk"}
+String Day02_Hour05_Conditions "Conditions" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-conditions"}
+String Day02_Hour05_Icon "Icon" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-icon"}
+String Day02_Hour05_Stations "Stations" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-stations"}
+String Day02_Hour05_Source "Source" (Total_Weather_Data_Day02_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour05-source"}
+
+// Day02 - Hour06
+Group Total_Weather_Data_Day02_Hour06 "Hour 06" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour06_DateTime "DateTime" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-datetime"}
+DateTime Day02_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-timestamp"}
+Number:Temperature Day02_Hour06_Temperature "Temperature" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-temperature"}
+Number:Temperature Day02_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-feels-like"}
+Number Day02_Hour06_Humidity "Humidity" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-humidity"}
+Number:Temperature Day02_Hour06_Dew "Dew Point" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-dew"}
+Number:Length Day02_Hour06_Precip "Precipitation" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-precip"}
+Number:Dimensionless Day02_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-precip-prob"}
+String Day02_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-precip-type"}
+Number:Length Day02_Hour06_Snow "Snow" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-snow"}
+Number:Length Day02_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-snow-depth"}
+Number:Speed Day02_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-wind-gust"}
+Number:Speed Day02_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-wind-speed"}
+Number:Angle Day02_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-wind-dir"}
+Number:Pressure Day02_Hour06_Pressure "Pressure" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-pressure"}
+Number:Length Day02_Hour06_Visibility "Visibility" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-visibility"}
+Number:Dimensionless Day02_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-cloud-cover"}
+Number:Intensity Day02_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-solar-radiation"}
+Number Day02_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-solar-energy"}
+Number Day02_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-uv-index"}
+Number Day02_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-severe-risk"}
+String Day02_Hour06_Conditions "Conditions" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-conditions"}
+String Day02_Hour06_Icon "Icon" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-icon"}
+String Day02_Hour06_Stations "Stations" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-stations"}
+String Day02_Hour06_Source "Source" (Total_Weather_Data_Day02_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour06-source"}
+
+// Day02 - Hour07
+Group Total_Weather_Data_Day02_Hour07 "Hour 07" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour07_DateTime "DateTime" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-datetime"}
+DateTime Day02_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-timestamp"}
+Number:Temperature Day02_Hour07_Temperature "Temperature" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-temperature"}
+Number:Temperature Day02_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-feels-like"}
+Number Day02_Hour07_Humidity "Humidity" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-humidity"}
+Number:Temperature Day02_Hour07_Dew "Dew Point" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-dew"}
+Number:Length Day02_Hour07_Precip "Precipitation" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-precip"}
+Number:Dimensionless Day02_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-precip-prob"}
+String Day02_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-precip-type"}
+Number:Length Day02_Hour07_Snow "Snow" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-snow"}
+Number:Length Day02_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-snow-depth"}
+Number:Speed Day02_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-wind-gust"}
+Number:Speed Day02_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-wind-speed"}
+Number:Angle Day02_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-wind-dir"}
+Number:Pressure Day02_Hour07_Pressure "Pressure" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-pressure"}
+Number:Length Day02_Hour07_Visibility "Visibility" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-visibility"}
+Number:Dimensionless Day02_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-cloud-cover"}
+Number:Intensity Day02_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-solar-radiation"}
+Number Day02_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-solar-energy"}
+Number Day02_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-uv-index"}
+Number Day02_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-severe-risk"}
+String Day02_Hour07_Conditions "Conditions" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-conditions"}
+String Day02_Hour07_Icon "Icon" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-icon"}
+String Day02_Hour07_Stations "Stations" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-stations"}
+String Day02_Hour07_Source "Source" (Total_Weather_Data_Day02_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour07-source"}
+
+// Day02 - Hour08
+Group Total_Weather_Data_Day02_Hour08 "Hour 08" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour08_DateTime "DateTime" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-datetime"}
+DateTime Day02_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-timestamp"}
+Number:Temperature Day02_Hour08_Temperature "Temperature" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-temperature"}
+Number:Temperature Day02_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-feels-like"}
+Number Day02_Hour08_Humidity "Humidity" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-humidity"}
+Number:Temperature Day02_Hour08_Dew "Dew Point" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-dew"}
+Number:Length Day02_Hour08_Precip "Precipitation" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-precip"}
+Number:Dimensionless Day02_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-precip-prob"}
+String Day02_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-precip-type"}
+Number:Length Day02_Hour08_Snow "Snow" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-snow"}
+Number:Length Day02_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-snow-depth"}
+Number:Speed Day02_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-wind-gust"}
+Number:Speed Day02_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-wind-speed"}
+Number:Angle Day02_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-wind-dir"}
+Number:Pressure Day02_Hour08_Pressure "Pressure" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-pressure"}
+Number:Length Day02_Hour08_Visibility "Visibility" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-visibility"}
+Number:Dimensionless Day02_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-cloud-cover"}
+Number:Intensity Day02_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-solar-radiation"}
+Number Day02_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-solar-energy"}
+Number Day02_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-uv-index"}
+Number Day02_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-severe-risk"}
+String Day02_Hour08_Conditions "Conditions" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-conditions"}
+String Day02_Hour08_Icon "Icon" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-icon"}
+String Day02_Hour08_Stations "Stations" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-stations"}
+String Day02_Hour08_Source "Source" (Total_Weather_Data_Day02_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour08-source"}
+
+// Day02 - Hour09
+Group Total_Weather_Data_Day02_Hour09 "Hour 09" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour09_DateTime "DateTime" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-datetime"}
+DateTime Day02_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-timestamp"}
+Number:Temperature Day02_Hour09_Temperature "Temperature" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-temperature"}
+Number:Temperature Day02_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-feels-like"}
+Number Day02_Hour09_Humidity "Humidity" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-humidity"}
+Number:Temperature Day02_Hour09_Dew "Dew Point" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-dew"}
+Number:Length Day02_Hour09_Precip "Precipitation" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-precip"}
+Number:Dimensionless Day02_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-precip-prob"}
+String Day02_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-precip-type"}
+Number:Length Day02_Hour09_Snow "Snow" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-snow"}
+Number:Length Day02_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-snow-depth"}
+Number:Speed Day02_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-wind-gust"}
+Number:Speed Day02_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-wind-speed"}
+Number:Angle Day02_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-wind-dir"}
+Number:Pressure Day02_Hour09_Pressure "Pressure" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-pressure"}
+Number:Length Day02_Hour09_Visibility "Visibility" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-visibility"}
+Number:Dimensionless Day02_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-cloud-cover"}
+Number:Intensity Day02_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-solar-radiation"}
+Number Day02_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-solar-energy"}
+Number Day02_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-uv-index"}
+Number Day02_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-severe-risk"}
+String Day02_Hour09_Conditions "Conditions" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-conditions"}
+String Day02_Hour09_Icon "Icon" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-icon"}
+String Day02_Hour09_Stations "Stations" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-stations"}
+String Day02_Hour09_Source "Source" (Total_Weather_Data_Day02_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour09-source"}
+
+// Day02 - Hour10
+Group Total_Weather_Data_Day02_Hour10 "Hour 10" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour10_DateTime "DateTime" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-datetime"}
+DateTime Day02_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-timestamp"}
+Number:Temperature Day02_Hour10_Temperature "Temperature" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-temperature"}
+Number:Temperature Day02_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-feels-like"}
+Number Day02_Hour10_Humidity "Humidity" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-humidity"}
+Number:Temperature Day02_Hour10_Dew "Dew Point" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-dew"}
+Number:Length Day02_Hour10_Precip "Precipitation" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-precip"}
+Number:Dimensionless Day02_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-precip-prob"}
+String Day02_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-precip-type"}
+Number:Length Day02_Hour10_Snow "Snow" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-snow"}
+Number:Length Day02_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-snow-depth"}
+Number:Speed Day02_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-wind-gust"}
+Number:Speed Day02_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-wind-speed"}
+Number:Angle Day02_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-wind-dir"}
+Number:Pressure Day02_Hour10_Pressure "Pressure" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-pressure"}
+Number:Length Day02_Hour10_Visibility "Visibility" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-visibility"}
+Number:Dimensionless Day02_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-cloud-cover"}
+Number:Intensity Day02_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-solar-radiation"}
+Number Day02_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-solar-energy"}
+Number Day02_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-uv-index"}
+Number Day02_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-severe-risk"}
+String Day02_Hour10_Conditions "Conditions" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-conditions"}
+String Day02_Hour10_Icon "Icon" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-icon"}
+String Day02_Hour10_Stations "Stations" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-stations"}
+String Day02_Hour10_Source "Source" (Total_Weather_Data_Day02_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour10-source"}
+
+// Day02 - Hour11
+Group Total_Weather_Data_Day02_Hour11 "Hour 11" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour11_DateTime "DateTime" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-datetime"}
+DateTime Day02_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-timestamp"}
+Number:Temperature Day02_Hour11_Temperature "Temperature" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-temperature"}
+Number:Temperature Day02_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-feels-like"}
+Number Day02_Hour11_Humidity "Humidity" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-humidity"}
+Number:Temperature Day02_Hour11_Dew "Dew Point" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-dew"}
+Number:Length Day02_Hour11_Precip "Precipitation" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-precip"}
+Number:Dimensionless Day02_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-precip-prob"}
+String Day02_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-precip-type"}
+Number:Length Day02_Hour11_Snow "Snow" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-snow"}
+Number:Length Day02_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-snow-depth"}
+Number:Speed Day02_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-wind-gust"}
+Number:Speed Day02_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-wind-speed"}
+Number:Angle Day02_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-wind-dir"}
+Number:Pressure Day02_Hour11_Pressure "Pressure" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-pressure"}
+Number:Length Day02_Hour11_Visibility "Visibility" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-visibility"}
+Number:Dimensionless Day02_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-cloud-cover"}
+Number:Intensity Day02_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-solar-radiation"}
+Number Day02_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-solar-energy"}
+Number Day02_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-uv-index"}
+Number Day02_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-severe-risk"}
+String Day02_Hour11_Conditions "Conditions" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-conditions"}
+String Day02_Hour11_Icon "Icon" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-icon"}
+String Day02_Hour11_Stations "Stations" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-stations"}
+String Day02_Hour11_Source "Source" (Total_Weather_Data_Day02_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour11-source"}
+
+// Day02 - Hour12
+Group Total_Weather_Data_Day02_Hour12 "Hour 12" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour12_DateTime "DateTime" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-datetime"}
+DateTime Day02_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-timestamp"}
+Number:Temperature Day02_Hour12_Temperature "Temperature" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-temperature"}
+Number:Temperature Day02_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-feels-like"}
+Number Day02_Hour12_Humidity "Humidity" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-humidity"}
+Number:Temperature Day02_Hour12_Dew "Dew Point" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-dew"}
+Number:Length Day02_Hour12_Precip "Precipitation" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-precip"}
+Number:Dimensionless Day02_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-precip-prob"}
+String Day02_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-precip-type"}
+Number:Length Day02_Hour12_Snow "Snow" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-snow"}
+Number:Length Day02_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-snow-depth"}
+Number:Speed Day02_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-wind-gust"}
+Number:Speed Day02_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-wind-speed"}
+Number:Angle Day02_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-wind-dir"}
+Number:Pressure Day02_Hour12_Pressure "Pressure" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-pressure"}
+Number:Length Day02_Hour12_Visibility "Visibility" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-visibility"}
+Number:Dimensionless Day02_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-cloud-cover"}
+Number:Intensity Day02_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-solar-radiation"}
+Number Day02_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-solar-energy"}
+Number Day02_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-uv-index"}
+Number Day02_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-severe-risk"}
+String Day02_Hour12_Conditions "Conditions" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-conditions"}
+String Day02_Hour12_Icon "Icon" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-icon"}
+String Day02_Hour12_Stations "Stations" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-stations"}
+String Day02_Hour12_Source "Source" (Total_Weather_Data_Day02_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour12-source"}
+
+// Day02 - Hour13
+Group Total_Weather_Data_Day02_Hour13 "Hour 13" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour13_DateTime "DateTime" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-datetime"}
+DateTime Day02_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-timestamp"}
+Number:Temperature Day02_Hour13_Temperature "Temperature" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-temperature"}
+Number:Temperature Day02_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-feels-like"}
+Number Day02_Hour13_Humidity "Humidity" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-humidity"}
+Number:Temperature Day02_Hour13_Dew "Dew Point" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-dew"}
+Number:Length Day02_Hour13_Precip "Precipitation" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-precip"}
+Number:Dimensionless Day02_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-precip-prob"}
+String Day02_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-precip-type"}
+Number:Length Day02_Hour13_Snow "Snow" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-snow"}
+Number:Length Day02_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-snow-depth"}
+Number:Speed Day02_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-wind-gust"}
+Number:Speed Day02_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-wind-speed"}
+Number:Angle Day02_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-wind-dir"}
+Number:Pressure Day02_Hour13_Pressure "Pressure" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-pressure"}
+Number:Length Day02_Hour13_Visibility "Visibility" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-visibility"}
+Number:Dimensionless Day02_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-cloud-cover"}
+Number:Intensity Day02_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-solar-radiation"}
+Number Day02_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-solar-energy"}
+Number Day02_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-uv-index"}
+Number Day02_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-severe-risk"}
+String Day02_Hour13_Conditions "Conditions" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-conditions"}
+String Day02_Hour13_Icon "Icon" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-icon"}
+String Day02_Hour13_Stations "Stations" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-stations"}
+String Day02_Hour13_Source "Source" (Total_Weather_Data_Day02_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour13-source"}
+
+// Day02 - Hour14
+Group Total_Weather_Data_Day02_Hour14 "Hour 14" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour14_DateTime "DateTime" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-datetime"}
+DateTime Day02_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-timestamp"}
+Number:Temperature Day02_Hour14_Temperature "Temperature" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-temperature"}
+Number:Temperature Day02_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-feels-like"}
+Number Day02_Hour14_Humidity "Humidity" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-humidity"}
+Number:Temperature Day02_Hour14_Dew "Dew Point" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-dew"}
+Number:Length Day02_Hour14_Precip "Precipitation" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-precip"}
+Number:Dimensionless Day02_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-precip-prob"}
+String Day02_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-precip-type"}
+Number:Length Day02_Hour14_Snow "Snow" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-snow"}
+Number:Length Day02_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-snow-depth"}
+Number:Speed Day02_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-wind-gust"}
+Number:Speed Day02_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-wind-speed"}
+Number:Angle Day02_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-wind-dir"}
+Number:Pressure Day02_Hour14_Pressure "Pressure" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-pressure"}
+Number:Length Day02_Hour14_Visibility "Visibility" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-visibility"}
+Number:Dimensionless Day02_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-cloud-cover"}
+Number:Intensity Day02_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-solar-radiation"}
+Number Day02_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-solar-energy"}
+Number Day02_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-uv-index"}
+Number Day02_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-severe-risk"}
+String Day02_Hour14_Conditions "Conditions" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-conditions"}
+String Day02_Hour14_Icon "Icon" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-icon"}
+String Day02_Hour14_Stations "Stations" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-stations"}
+String Day02_Hour14_Source "Source" (Total_Weather_Data_Day02_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour14-source"}
+
+// Day02 - Hour15
+Group Total_Weather_Data_Day02_Hour15 "Hour 15" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour15_DateTime "DateTime" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-datetime"}
+DateTime Day02_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-timestamp"}
+Number:Temperature Day02_Hour15_Temperature "Temperature" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-temperature"}
+Number:Temperature Day02_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-feels-like"}
+Number Day02_Hour15_Humidity "Humidity" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-humidity"}
+Number:Temperature Day02_Hour15_Dew "Dew Point" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-dew"}
+Number:Length Day02_Hour15_Precip "Precipitation" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-precip"}
+Number:Dimensionless Day02_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-precip-prob"}
+String Day02_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-precip-type"}
+Number:Length Day02_Hour15_Snow "Snow" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-snow"}
+Number:Length Day02_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-snow-depth"}
+Number:Speed Day02_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-wind-gust"}
+Number:Speed Day02_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-wind-speed"}
+Number:Angle Day02_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-wind-dir"}
+Number:Pressure Day02_Hour15_Pressure "Pressure" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-pressure"}
+Number:Length Day02_Hour15_Visibility "Visibility" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-visibility"}
+Number:Dimensionless Day02_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-cloud-cover"}
+Number:Intensity Day02_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-solar-radiation"}
+Number Day02_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-solar-energy"}
+Number Day02_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-uv-index"}
+Number Day02_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-severe-risk"}
+String Day02_Hour15_Conditions "Conditions" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-conditions"}
+String Day02_Hour15_Icon "Icon" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-icon"}
+String Day02_Hour15_Stations "Stations" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-stations"}
+String Day02_Hour15_Source "Source" (Total_Weather_Data_Day02_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour15-source"}
+
+// Day02 - Hour16
+Group Total_Weather_Data_Day02_Hour16 "Hour 16" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour16_DateTime "DateTime" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-datetime"}
+DateTime Day02_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-timestamp"}
+Number:Temperature Day02_Hour16_Temperature "Temperature" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-temperature"}
+Number:Temperature Day02_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-feels-like"}
+Number Day02_Hour16_Humidity "Humidity" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-humidity"}
+Number:Temperature Day02_Hour16_Dew "Dew Point" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-dew"}
+Number:Length Day02_Hour16_Precip "Precipitation" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-precip"}
+Number:Dimensionless Day02_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-precip-prob"}
+String Day02_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-precip-type"}
+Number:Length Day02_Hour16_Snow "Snow" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-snow"}
+Number:Length Day02_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-snow-depth"}
+Number:Speed Day02_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-wind-gust"}
+Number:Speed Day02_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-wind-speed"}
+Number:Angle Day02_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-wind-dir"}
+Number:Pressure Day02_Hour16_Pressure "Pressure" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-pressure"}
+Number:Length Day02_Hour16_Visibility "Visibility" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-visibility"}
+Number:Dimensionless Day02_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-cloud-cover"}
+Number:Intensity Day02_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-solar-radiation"}
+Number Day02_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-solar-energy"}
+Number Day02_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-uv-index"}
+Number Day02_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-severe-risk"}
+String Day02_Hour16_Conditions "Conditions" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-conditions"}
+String Day02_Hour16_Icon "Icon" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-icon"}
+String Day02_Hour16_Stations "Stations" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-stations"}
+String Day02_Hour16_Source "Source" (Total_Weather_Data_Day02_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour16-source"}
+
+// Day02 - Hour17
+Group Total_Weather_Data_Day02_Hour17 "Hour 17" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour17_DateTime "DateTime" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-datetime"}
+DateTime Day02_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-timestamp"}
+Number:Temperature Day02_Hour17_Temperature "Temperature" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-temperature"}
+Number:Temperature Day02_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-feels-like"}
+Number Day02_Hour17_Humidity "Humidity" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-humidity"}
+Number:Temperature Day02_Hour17_Dew "Dew Point" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-dew"}
+Number:Length Day02_Hour17_Precip "Precipitation" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-precip"}
+Number:Dimensionless Day02_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-precip-prob"}
+String Day02_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-precip-type"}
+Number:Length Day02_Hour17_Snow "Snow" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-snow"}
+Number:Length Day02_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-snow-depth"}
+Number:Speed Day02_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-wind-gust"}
+Number:Speed Day02_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-wind-speed"}
+Number:Angle Day02_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-wind-dir"}
+Number:Pressure Day02_Hour17_Pressure "Pressure" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-pressure"}
+Number:Length Day02_Hour17_Visibility "Visibility" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-visibility"}
+Number:Dimensionless Day02_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-cloud-cover"}
+Number:Intensity Day02_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-solar-radiation"}
+Number Day02_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-solar-energy"}
+Number Day02_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-uv-index"}
+Number Day02_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-severe-risk"}
+String Day02_Hour17_Conditions "Conditions" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-conditions"}
+String Day02_Hour17_Icon "Icon" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-icon"}
+String Day02_Hour17_Stations "Stations" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-stations"}
+String Day02_Hour17_Source "Source" (Total_Weather_Data_Day02_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour17-source"}
+
+// Day02 - Hour18
+Group Total_Weather_Data_Day02_Hour18 "Hour 18" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour18_DateTime "DateTime" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-datetime"}
+DateTime Day02_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-timestamp"}
+Number:Temperature Day02_Hour18_Temperature "Temperature" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-temperature"}
+Number:Temperature Day02_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-feels-like"}
+Number Day02_Hour18_Humidity "Humidity" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-humidity"}
+Number:Temperature Day02_Hour18_Dew "Dew Point" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-dew"}
+Number:Length Day02_Hour18_Precip "Precipitation" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-precip"}
+Number:Dimensionless Day02_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-precip-prob"}
+String Day02_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-precip-type"}
+Number:Length Day02_Hour18_Snow "Snow" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-snow"}
+Number:Length Day02_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-snow-depth"}
+Number:Speed Day02_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-wind-gust"}
+Number:Speed Day02_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-wind-speed"}
+Number:Angle Day02_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-wind-dir"}
+Number:Pressure Day02_Hour18_Pressure "Pressure" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-pressure"}
+Number:Length Day02_Hour18_Visibility "Visibility" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-visibility"}
+Number:Dimensionless Day02_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-cloud-cover"}
+Number:Intensity Day02_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-solar-radiation"}
+Number Day02_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-solar-energy"}
+Number Day02_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-uv-index"}
+Number Day02_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-severe-risk"}
+String Day02_Hour18_Conditions "Conditions" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-conditions"}
+String Day02_Hour18_Icon "Icon" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-icon"}
+String Day02_Hour18_Stations "Stations" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-stations"}
+String Day02_Hour18_Source "Source" (Total_Weather_Data_Day02_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour18-source"}
+
+// Day02 - Hour19
+Group Total_Weather_Data_Day02_Hour19 "Hour 19" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour19_DateTime "DateTime" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-datetime"}
+DateTime Day02_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-timestamp"}
+Number:Temperature Day02_Hour19_Temperature "Temperature" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-temperature"}
+Number:Temperature Day02_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-feels-like"}
+Number Day02_Hour19_Humidity "Humidity" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-humidity"}
+Number:Temperature Day02_Hour19_Dew "Dew Point" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-dew"}
+Number:Length Day02_Hour19_Precip "Precipitation" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-precip"}
+Number:Dimensionless Day02_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-precip-prob"}
+String Day02_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-precip-type"}
+Number:Length Day02_Hour19_Snow "Snow" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-snow"}
+Number:Length Day02_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-snow-depth"}
+Number:Speed Day02_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-wind-gust"}
+Number:Speed Day02_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-wind-speed"}
+Number:Angle Day02_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-wind-dir"}
+Number:Pressure Day02_Hour19_Pressure "Pressure" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-pressure"}
+Number:Length Day02_Hour19_Visibility "Visibility" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-visibility"}
+Number:Dimensionless Day02_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-cloud-cover"}
+Number:Intensity Day02_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-solar-radiation"}
+Number Day02_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-solar-energy"}
+Number Day02_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-uv-index"}
+Number Day02_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-severe-risk"}
+String Day02_Hour19_Conditions "Conditions" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-conditions"}
+String Day02_Hour19_Icon "Icon" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-icon"}
+String Day02_Hour19_Stations "Stations" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-stations"}
+String Day02_Hour19_Source "Source" (Total_Weather_Data_Day02_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour19-source"}
+
+// Day02 - Hour20
+Group Total_Weather_Data_Day02_Hour20 "Hour 20" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour20_DateTime "DateTime" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-datetime"}
+DateTime Day02_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-timestamp"}
+Number:Temperature Day02_Hour20_Temperature "Temperature" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-temperature"}
+Number:Temperature Day02_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-feels-like"}
+Number Day02_Hour20_Humidity "Humidity" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-humidity"}
+Number:Temperature Day02_Hour20_Dew "Dew Point" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-dew"}
+Number:Length Day02_Hour20_Precip "Precipitation" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-precip"}
+Number:Dimensionless Day02_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-precip-prob"}
+String Day02_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-precip-type"}
+Number:Length Day02_Hour20_Snow "Snow" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-snow"}
+Number:Length Day02_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-snow-depth"}
+Number:Speed Day02_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-wind-gust"}
+Number:Speed Day02_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-wind-speed"}
+Number:Angle Day02_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-wind-dir"}
+Number:Pressure Day02_Hour20_Pressure "Pressure" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-pressure"}
+Number:Length Day02_Hour20_Visibility "Visibility" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-visibility"}
+Number:Dimensionless Day02_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-cloud-cover"}
+Number:Intensity Day02_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-solar-radiation"}
+Number Day02_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-solar-energy"}
+Number Day02_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-uv-index"}
+Number Day02_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-severe-risk"}
+String Day02_Hour20_Conditions "Conditions" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-conditions"}
+String Day02_Hour20_Icon "Icon" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-icon"}
+String Day02_Hour20_Stations "Stations" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-stations"}
+String Day02_Hour20_Source "Source" (Total_Weather_Data_Day02_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour20-source"}
+
+// Day02 - Hour21
+Group Total_Weather_Data_Day02_Hour21 "Hour 21" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour21_DateTime "DateTime" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-datetime"}
+DateTime Day02_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-timestamp"}
+Number:Temperature Day02_Hour21_Temperature "Temperature" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-temperature"}
+Number:Temperature Day02_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-feels-like"}
+Number Day02_Hour21_Humidity "Humidity" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-humidity"}
+Number:Temperature Day02_Hour21_Dew "Dew Point" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-dew"}
+Number:Length Day02_Hour21_Precip "Precipitation" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-precip"}
+Number:Dimensionless Day02_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-precip-prob"}
+String Day02_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-precip-type"}
+Number:Length Day02_Hour21_Snow "Snow" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-snow"}
+Number:Length Day02_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-snow-depth"}
+Number:Speed Day02_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-wind-gust"}
+Number:Speed Day02_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-wind-speed"}
+Number:Angle Day02_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-wind-dir"}
+Number:Pressure Day02_Hour21_Pressure "Pressure" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-pressure"}
+Number:Length Day02_Hour21_Visibility "Visibility" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-visibility"}
+Number:Dimensionless Day02_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-cloud-cover"}
+Number:Intensity Day02_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-solar-radiation"}
+Number Day02_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-solar-energy"}
+Number Day02_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-uv-index"}
+Number Day02_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-severe-risk"}
+String Day02_Hour21_Conditions "Conditions" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-conditions"}
+String Day02_Hour21_Icon "Icon" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-icon"}
+String Day02_Hour21_Stations "Stations" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-stations"}
+String Day02_Hour21_Source "Source" (Total_Weather_Data_Day02_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour21-source"}
+
+// Day02 - Hour22
+Group Total_Weather_Data_Day02_Hour22 "Hour 22" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour22_DateTime "DateTime" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-datetime"}
+DateTime Day02_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-timestamp"}
+Number:Temperature Day02_Hour22_Temperature "Temperature" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-temperature"}
+Number:Temperature Day02_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-feels-like"}
+Number Day02_Hour22_Humidity "Humidity" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-humidity"}
+Number:Temperature Day02_Hour22_Dew "Dew Point" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-dew"}
+Number:Length Day02_Hour22_Precip "Precipitation" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-precip"}
+Number:Dimensionless Day02_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-precip-prob"}
+String Day02_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-precip-type"}
+Number:Length Day02_Hour22_Snow "Snow" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-snow"}
+Number:Length Day02_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-snow-depth"}
+Number:Speed Day02_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-wind-gust"}
+Number:Speed Day02_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-wind-speed"}
+Number:Angle Day02_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-wind-dir"}
+Number:Pressure Day02_Hour22_Pressure "Pressure" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-pressure"}
+Number:Length Day02_Hour22_Visibility "Visibility" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-visibility"}
+Number:Dimensionless Day02_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-cloud-cover"}
+Number:Intensity Day02_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-solar-radiation"}
+Number Day02_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-solar-energy"}
+Number Day02_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-uv-index"}
+Number Day02_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-severe-risk"}
+String Day02_Hour22_Conditions "Conditions" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-conditions"}
+String Day02_Hour22_Icon "Icon" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-icon"}
+String Day02_Hour22_Stations "Stations" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-stations"}
+String Day02_Hour22_Source "Source" (Total_Weather_Data_Day02_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour22-source"}
+
+// Day02 - Hour23
+Group Total_Weather_Data_Day02_Hour23 "Hour 23" (Total_Weather_Data_Day02) [ "Equipment" ] 
+String Day02_Hour23_DateTime "DateTime" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-datetime"}
+DateTime Day02_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-timestamp"}
+Number:Temperature Day02_Hour23_Temperature "Temperature" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-temperature"}
+Number:Temperature Day02_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-feels-like"}
+Number Day02_Hour23_Humidity "Humidity" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-humidity"}
+Number:Temperature Day02_Hour23_Dew "Dew Point" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-dew"}
+Number:Length Day02_Hour23_Precip "Precipitation" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-precip"}
+Number:Dimensionless Day02_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-precip-prob"}
+String Day02_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-precip-type"}
+Number:Length Day02_Hour23_Snow "Snow" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-snow"}
+Number:Length Day02_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-snow-depth"}
+Number:Speed Day02_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-wind-gust"}
+Number:Speed Day02_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-wind-speed"}
+Number:Angle Day02_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-wind-dir"}
+Number:Pressure Day02_Hour23_Pressure "Pressure" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-pressure"}
+Number:Length Day02_Hour23_Visibility "Visibility" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-visibility"}
+Number:Dimensionless Day02_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-cloud-cover"}
+Number:Intensity Day02_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-solar-radiation"}
+Number Day02_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-solar-energy"}
+Number Day02_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-uv-index"}
+Number Day02_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-severe-risk"}
+String Day02_Hour23_Conditions "Conditions" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-conditions"}
+String Day02_Hour23_Icon "Icon" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-icon"}
+String Day02_Hour23_Stations "Stations" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-stations"}
+String Day02_Hour23_Source "Source" (Total_Weather_Data_Day02_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day02#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_03.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_03.items
@@ -1,39 +1,712 @@
 // Day03
 Group Total_Weather_Data_Day03 "Day T+03" (Total_Weather_Data) [ "Equipment" ] 
-String Day03_DateTime "Time" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day03_Timestamp "Timestamp" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day03_Temperature "Temperature" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day03_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day03_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day03_FeelsLike "Feels Like" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day03_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day03_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day03_Dew "Dew Point" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day03_Humidity "Humidity" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day03_Precip "Precipitation" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day03_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day03_Precip_Type "Precipitation Type" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day03_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day03_Snow "Snow" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day03_Snow_Depth "Snow Depth" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day03_Wind_Gust "Wind Gust" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day03_Wind_Speed "Wind Speed" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day03_Wind_Dir "Wind Direction" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day03_Pressure "Pressure" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day03_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day03_Visibility "Visibility" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day03_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day03_Solar_Energy "Solar Energy" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day03_UV_Index "UV Index" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day03_Sunrise "Sunrise" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day03_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day03_Sunset "Sunset" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day03_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day03_Moon_Phase "Moon Phase" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day03_Conditions "Conditions" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day03_Description "Description" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day03_Icon "Icon" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day03_Stations "Stations" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day03_Source "Source" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day03_Severe_Risk "Severe Risk" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day03_DateTime "Time" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#datetime" }
+DateTime Day03_Timestamp "Timestamp" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#timestamp" }
+Number:Temperature Day03_Temperature "Temperature" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#temperature" }
+Number:Temperature Day03_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#temperature-min" }
+Number:Temperature Day03_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#temperature-max" }
+Number:Temperature Day03_FeelsLike "Feels Like" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#feels-like" }
+Number:Temperature Day03_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#feels-like-min" }
+Number:Temperature Day03_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#feels-like-max" }
+Number:Temperature Day03_Dew "Dew Point" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#dew" }
+Number Day03_Humidity "Humidity" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#humidity" }
+Number:Length Day03_Precip "Precipitation" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#precip" }
+Number Day03_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#precip-prob" }
+String Day03_Precip_Type "Precipitation Type" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#precip-type" }
+Number Day03_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#precip-cover" }
+Number:Length Day03_Snow "Snow" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#snow" }
+Number:Length Day03_Snow_Depth "Snow Depth" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#snow-depth" }
+Number:Speed Day03_Wind_Gust "Wind Gust" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#wind-gust" }
+Number:Speed Day03_Wind_Speed "Wind Speed" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#wind-speed" }
+Number:Angle Day03_Wind_Dir "Wind Direction" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#wind-dir" }
+Number:Pressure Day03_Pressure "Pressure" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#pressure" }
+Number Day03_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#cloud-cover" }
+Number:Length Day03_Visibility "Visibility" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#visibility" }
+Number:Intensity Day03_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#solar-radiation" }
+Number Day03_Solar_Energy "Solar Energy" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#solar-energy" }
+Number Day03_UV_Index "UV Index" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#uv-index" }
+String Day03_Sunrise "Sunrise" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#sunrise" }
+DateTime Day03_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#sunrise-epoch" }
+String Day03_Sunset "Sunset" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#sunset" }
+DateTime Day03_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#sunset-epoch" }
+Number Day03_Moon_Phase "Moon Phase" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#moon-phase" }
+String Day03_Conditions "Conditions" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#conditions" }
+String Day03_Description "Description" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#description" }
+String Day03_Icon "Icon" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#icon" }
+String Day03_Stations "Stations" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#stations" }
+String Day03_Source "Source" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#source" }
+Number Day03_Severe_Risk "Severe Risk" (Total_Weather_Data_Day03)["Point"] { channel="visualcrossing:weather:default_config:day03#severe-risk" }
+
+// Day03 - Hour00
+Group Total_Weather_Data_Day03_Hour00 "Hour 00" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour00_DateTime "DateTime" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-datetime"}
+DateTime Day03_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-timestamp"}
+Number:Temperature Day03_Hour00_Temperature "Temperature" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-temperature"}
+Number:Temperature Day03_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-feels-like"}
+Number Day03_Hour00_Humidity "Humidity" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-humidity"}
+Number:Temperature Day03_Hour00_Dew "Dew Point" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-dew"}
+Number:Length Day03_Hour00_Precip "Precipitation" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-precip"}
+Number:Dimensionless Day03_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-precip-prob"}
+String Day03_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-precip-type"}
+Number:Length Day03_Hour00_Snow "Snow" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-snow"}
+Number:Length Day03_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-snow-depth"}
+Number:Speed Day03_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-wind-gust"}
+Number:Speed Day03_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-wind-speed"}
+Number:Angle Day03_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-wind-dir"}
+Number:Pressure Day03_Hour00_Pressure "Pressure" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-pressure"}
+Number:Length Day03_Hour00_Visibility "Visibility" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-visibility"}
+Number:Dimensionless Day03_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-cloud-cover"}
+Number:Intensity Day03_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-solar-radiation"}
+Number Day03_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-solar-energy"}
+Number Day03_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-uv-index"}
+Number Day03_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-severe-risk"}
+String Day03_Hour00_Conditions "Conditions" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-conditions"}
+String Day03_Hour00_Icon "Icon" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-icon"}
+String Day03_Hour00_Stations "Stations" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-stations"}
+String Day03_Hour00_Source "Source" (Total_Weather_Data_Day03_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour00-source"}
+
+// Day03 - Hour01
+Group Total_Weather_Data_Day03_Hour01 "Hour 01" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour01_DateTime "DateTime" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-datetime"}
+DateTime Day03_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-timestamp"}
+Number:Temperature Day03_Hour01_Temperature "Temperature" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-temperature"}
+Number:Temperature Day03_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-feels-like"}
+Number Day03_Hour01_Humidity "Humidity" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-humidity"}
+Number:Temperature Day03_Hour01_Dew "Dew Point" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-dew"}
+Number:Length Day03_Hour01_Precip "Precipitation" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-precip"}
+Number:Dimensionless Day03_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-precip-prob"}
+String Day03_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-precip-type"}
+Number:Length Day03_Hour01_Snow "Snow" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-snow"}
+Number:Length Day03_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-snow-depth"}
+Number:Speed Day03_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-wind-gust"}
+Number:Speed Day03_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-wind-speed"}
+Number:Angle Day03_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-wind-dir"}
+Number:Pressure Day03_Hour01_Pressure "Pressure" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-pressure"}
+Number:Length Day03_Hour01_Visibility "Visibility" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-visibility"}
+Number:Dimensionless Day03_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-cloud-cover"}
+Number:Intensity Day03_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-solar-radiation"}
+Number Day03_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-solar-energy"}
+Number Day03_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-uv-index"}
+Number Day03_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-severe-risk"}
+String Day03_Hour01_Conditions "Conditions" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-conditions"}
+String Day03_Hour01_Icon "Icon" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-icon"}
+String Day03_Hour01_Stations "Stations" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-stations"}
+String Day03_Hour01_Source "Source" (Total_Weather_Data_Day03_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour01-source"}
+
+// Day03 - Hour02
+Group Total_Weather_Data_Day03_Hour02 "Hour 02" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour02_DateTime "DateTime" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-datetime"}
+DateTime Day03_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-timestamp"}
+Number:Temperature Day03_Hour02_Temperature "Temperature" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-temperature"}
+Number:Temperature Day03_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-feels-like"}
+Number Day03_Hour02_Humidity "Humidity" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-humidity"}
+Number:Temperature Day03_Hour02_Dew "Dew Point" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-dew"}
+Number:Length Day03_Hour02_Precip "Precipitation" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-precip"}
+Number:Dimensionless Day03_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-precip-prob"}
+String Day03_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-precip-type"}
+Number:Length Day03_Hour02_Snow "Snow" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-snow"}
+Number:Length Day03_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-snow-depth"}
+Number:Speed Day03_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-wind-gust"}
+Number:Speed Day03_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-wind-speed"}
+Number:Angle Day03_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-wind-dir"}
+Number:Pressure Day03_Hour02_Pressure "Pressure" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-pressure"}
+Number:Length Day03_Hour02_Visibility "Visibility" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-visibility"}
+Number:Dimensionless Day03_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-cloud-cover"}
+Number:Intensity Day03_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-solar-radiation"}
+Number Day03_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-solar-energy"}
+Number Day03_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-uv-index"}
+Number Day03_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-severe-risk"}
+String Day03_Hour02_Conditions "Conditions" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-conditions"}
+String Day03_Hour02_Icon "Icon" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-icon"}
+String Day03_Hour02_Stations "Stations" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-stations"}
+String Day03_Hour02_Source "Source" (Total_Weather_Data_Day03_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour02-source"}
+
+// Day03 - Hour03
+Group Total_Weather_Data_Day03_Hour03 "Hour 03" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour03_DateTime "DateTime" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-datetime"}
+DateTime Day03_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-timestamp"}
+Number:Temperature Day03_Hour03_Temperature "Temperature" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-temperature"}
+Number:Temperature Day03_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-feels-like"}
+Number Day03_Hour03_Humidity "Humidity" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-humidity"}
+Number:Temperature Day03_Hour03_Dew "Dew Point" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-dew"}
+Number:Length Day03_Hour03_Precip "Precipitation" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-precip"}
+Number:Dimensionless Day03_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-precip-prob"}
+String Day03_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-precip-type"}
+Number:Length Day03_Hour03_Snow "Snow" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-snow"}
+Number:Length Day03_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-snow-depth"}
+Number:Speed Day03_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-wind-gust"}
+Number:Speed Day03_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-wind-speed"}
+Number:Angle Day03_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-wind-dir"}
+Number:Pressure Day03_Hour03_Pressure "Pressure" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-pressure"}
+Number:Length Day03_Hour03_Visibility "Visibility" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-visibility"}
+Number:Dimensionless Day03_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-cloud-cover"}
+Number:Intensity Day03_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-solar-radiation"}
+Number Day03_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-solar-energy"}
+Number Day03_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-uv-index"}
+Number Day03_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-severe-risk"}
+String Day03_Hour03_Conditions "Conditions" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-conditions"}
+String Day03_Hour03_Icon "Icon" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-icon"}
+String Day03_Hour03_Stations "Stations" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-stations"}
+String Day03_Hour03_Source "Source" (Total_Weather_Data_Day03_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour03-source"}
+
+// Day03 - Hour04
+Group Total_Weather_Data_Day03_Hour04 "Hour 04" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour04_DateTime "DateTime" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-datetime"}
+DateTime Day03_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-timestamp"}
+Number:Temperature Day03_Hour04_Temperature "Temperature" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-temperature"}
+Number:Temperature Day03_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-feels-like"}
+Number Day03_Hour04_Humidity "Humidity" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-humidity"}
+Number:Temperature Day03_Hour04_Dew "Dew Point" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-dew"}
+Number:Length Day03_Hour04_Precip "Precipitation" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-precip"}
+Number:Dimensionless Day03_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-precip-prob"}
+String Day03_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-precip-type"}
+Number:Length Day03_Hour04_Snow "Snow" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-snow"}
+Number:Length Day03_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-snow-depth"}
+Number:Speed Day03_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-wind-gust"}
+Number:Speed Day03_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-wind-speed"}
+Number:Angle Day03_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-wind-dir"}
+Number:Pressure Day03_Hour04_Pressure "Pressure" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-pressure"}
+Number:Length Day03_Hour04_Visibility "Visibility" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-visibility"}
+Number:Dimensionless Day03_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-cloud-cover"}
+Number:Intensity Day03_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-solar-radiation"}
+Number Day03_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-solar-energy"}
+Number Day03_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-uv-index"}
+Number Day03_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-severe-risk"}
+String Day03_Hour04_Conditions "Conditions" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-conditions"}
+String Day03_Hour04_Icon "Icon" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-icon"}
+String Day03_Hour04_Stations "Stations" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-stations"}
+String Day03_Hour04_Source "Source" (Total_Weather_Data_Day03_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour04-source"}
+
+// Day03 - Hour05
+Group Total_Weather_Data_Day03_Hour05 "Hour 05" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour05_DateTime "DateTime" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-datetime"}
+DateTime Day03_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-timestamp"}
+Number:Temperature Day03_Hour05_Temperature "Temperature" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-temperature"}
+Number:Temperature Day03_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-feels-like"}
+Number Day03_Hour05_Humidity "Humidity" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-humidity"}
+Number:Temperature Day03_Hour05_Dew "Dew Point" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-dew"}
+Number:Length Day03_Hour05_Precip "Precipitation" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-precip"}
+Number:Dimensionless Day03_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-precip-prob"}
+String Day03_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-precip-type"}
+Number:Length Day03_Hour05_Snow "Snow" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-snow"}
+Number:Length Day03_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-snow-depth"}
+Number:Speed Day03_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-wind-gust"}
+Number:Speed Day03_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-wind-speed"}
+Number:Angle Day03_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-wind-dir"}
+Number:Pressure Day03_Hour05_Pressure "Pressure" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-pressure"}
+Number:Length Day03_Hour05_Visibility "Visibility" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-visibility"}
+Number:Dimensionless Day03_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-cloud-cover"}
+Number:Intensity Day03_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-solar-radiation"}
+Number Day03_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-solar-energy"}
+Number Day03_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-uv-index"}
+Number Day03_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-severe-risk"}
+String Day03_Hour05_Conditions "Conditions" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-conditions"}
+String Day03_Hour05_Icon "Icon" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-icon"}
+String Day03_Hour05_Stations "Stations" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-stations"}
+String Day03_Hour05_Source "Source" (Total_Weather_Data_Day03_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour05-source"}
+
+// Day03 - Hour06
+Group Total_Weather_Data_Day03_Hour06 "Hour 06" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour06_DateTime "DateTime" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-datetime"}
+DateTime Day03_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-timestamp"}
+Number:Temperature Day03_Hour06_Temperature "Temperature" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-temperature"}
+Number:Temperature Day03_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-feels-like"}
+Number Day03_Hour06_Humidity "Humidity" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-humidity"}
+Number:Temperature Day03_Hour06_Dew "Dew Point" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-dew"}
+Number:Length Day03_Hour06_Precip "Precipitation" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-precip"}
+Number:Dimensionless Day03_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-precip-prob"}
+String Day03_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-precip-type"}
+Number:Length Day03_Hour06_Snow "Snow" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-snow"}
+Number:Length Day03_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-snow-depth"}
+Number:Speed Day03_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-wind-gust"}
+Number:Speed Day03_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-wind-speed"}
+Number:Angle Day03_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-wind-dir"}
+Number:Pressure Day03_Hour06_Pressure "Pressure" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-pressure"}
+Number:Length Day03_Hour06_Visibility "Visibility" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-visibility"}
+Number:Dimensionless Day03_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-cloud-cover"}
+Number:Intensity Day03_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-solar-radiation"}
+Number Day03_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-solar-energy"}
+Number Day03_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-uv-index"}
+Number Day03_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-severe-risk"}
+String Day03_Hour06_Conditions "Conditions" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-conditions"}
+String Day03_Hour06_Icon "Icon" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-icon"}
+String Day03_Hour06_Stations "Stations" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-stations"}
+String Day03_Hour06_Source "Source" (Total_Weather_Data_Day03_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour06-source"}
+
+// Day03 - Hour07
+Group Total_Weather_Data_Day03_Hour07 "Hour 07" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour07_DateTime "DateTime" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-datetime"}
+DateTime Day03_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-timestamp"}
+Number:Temperature Day03_Hour07_Temperature "Temperature" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-temperature"}
+Number:Temperature Day03_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-feels-like"}
+Number Day03_Hour07_Humidity "Humidity" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-humidity"}
+Number:Temperature Day03_Hour07_Dew "Dew Point" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-dew"}
+Number:Length Day03_Hour07_Precip "Precipitation" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-precip"}
+Number:Dimensionless Day03_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-precip-prob"}
+String Day03_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-precip-type"}
+Number:Length Day03_Hour07_Snow "Snow" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-snow"}
+Number:Length Day03_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-snow-depth"}
+Number:Speed Day03_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-wind-gust"}
+Number:Speed Day03_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-wind-speed"}
+Number:Angle Day03_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-wind-dir"}
+Number:Pressure Day03_Hour07_Pressure "Pressure" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-pressure"}
+Number:Length Day03_Hour07_Visibility "Visibility" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-visibility"}
+Number:Dimensionless Day03_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-cloud-cover"}
+Number:Intensity Day03_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-solar-radiation"}
+Number Day03_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-solar-energy"}
+Number Day03_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-uv-index"}
+Number Day03_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-severe-risk"}
+String Day03_Hour07_Conditions "Conditions" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-conditions"}
+String Day03_Hour07_Icon "Icon" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-icon"}
+String Day03_Hour07_Stations "Stations" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-stations"}
+String Day03_Hour07_Source "Source" (Total_Weather_Data_Day03_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour07-source"}
+
+// Day03 - Hour08
+Group Total_Weather_Data_Day03_Hour08 "Hour 08" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour08_DateTime "DateTime" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-datetime"}
+DateTime Day03_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-timestamp"}
+Number:Temperature Day03_Hour08_Temperature "Temperature" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-temperature"}
+Number:Temperature Day03_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-feels-like"}
+Number Day03_Hour08_Humidity "Humidity" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-humidity"}
+Number:Temperature Day03_Hour08_Dew "Dew Point" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-dew"}
+Number:Length Day03_Hour08_Precip "Precipitation" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-precip"}
+Number:Dimensionless Day03_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-precip-prob"}
+String Day03_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-precip-type"}
+Number:Length Day03_Hour08_Snow "Snow" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-snow"}
+Number:Length Day03_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-snow-depth"}
+Number:Speed Day03_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-wind-gust"}
+Number:Speed Day03_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-wind-speed"}
+Number:Angle Day03_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-wind-dir"}
+Number:Pressure Day03_Hour08_Pressure "Pressure" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-pressure"}
+Number:Length Day03_Hour08_Visibility "Visibility" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-visibility"}
+Number:Dimensionless Day03_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-cloud-cover"}
+Number:Intensity Day03_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-solar-radiation"}
+Number Day03_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-solar-energy"}
+Number Day03_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-uv-index"}
+Number Day03_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-severe-risk"}
+String Day03_Hour08_Conditions "Conditions" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-conditions"}
+String Day03_Hour08_Icon "Icon" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-icon"}
+String Day03_Hour08_Stations "Stations" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-stations"}
+String Day03_Hour08_Source "Source" (Total_Weather_Data_Day03_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour08-source"}
+
+// Day03 - Hour09
+Group Total_Weather_Data_Day03_Hour09 "Hour 09" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour09_DateTime "DateTime" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-datetime"}
+DateTime Day03_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-timestamp"}
+Number:Temperature Day03_Hour09_Temperature "Temperature" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-temperature"}
+Number:Temperature Day03_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-feels-like"}
+Number Day03_Hour09_Humidity "Humidity" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-humidity"}
+Number:Temperature Day03_Hour09_Dew "Dew Point" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-dew"}
+Number:Length Day03_Hour09_Precip "Precipitation" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-precip"}
+Number:Dimensionless Day03_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-precip-prob"}
+String Day03_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-precip-type"}
+Number:Length Day03_Hour09_Snow "Snow" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-snow"}
+Number:Length Day03_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-snow-depth"}
+Number:Speed Day03_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-wind-gust"}
+Number:Speed Day03_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-wind-speed"}
+Number:Angle Day03_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-wind-dir"}
+Number:Pressure Day03_Hour09_Pressure "Pressure" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-pressure"}
+Number:Length Day03_Hour09_Visibility "Visibility" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-visibility"}
+Number:Dimensionless Day03_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-cloud-cover"}
+Number:Intensity Day03_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-solar-radiation"}
+Number Day03_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-solar-energy"}
+Number Day03_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-uv-index"}
+Number Day03_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-severe-risk"}
+String Day03_Hour09_Conditions "Conditions" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-conditions"}
+String Day03_Hour09_Icon "Icon" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-icon"}
+String Day03_Hour09_Stations "Stations" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-stations"}
+String Day03_Hour09_Source "Source" (Total_Weather_Data_Day03_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour09-source"}
+
+// Day03 - Hour10
+Group Total_Weather_Data_Day03_Hour10 "Hour 10" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour10_DateTime "DateTime" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-datetime"}
+DateTime Day03_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-timestamp"}
+Number:Temperature Day03_Hour10_Temperature "Temperature" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-temperature"}
+Number:Temperature Day03_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-feels-like"}
+Number Day03_Hour10_Humidity "Humidity" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-humidity"}
+Number:Temperature Day03_Hour10_Dew "Dew Point" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-dew"}
+Number:Length Day03_Hour10_Precip "Precipitation" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-precip"}
+Number:Dimensionless Day03_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-precip-prob"}
+String Day03_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-precip-type"}
+Number:Length Day03_Hour10_Snow "Snow" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-snow"}
+Number:Length Day03_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-snow-depth"}
+Number:Speed Day03_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-wind-gust"}
+Number:Speed Day03_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-wind-speed"}
+Number:Angle Day03_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-wind-dir"}
+Number:Pressure Day03_Hour10_Pressure "Pressure" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-pressure"}
+Number:Length Day03_Hour10_Visibility "Visibility" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-visibility"}
+Number:Dimensionless Day03_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-cloud-cover"}
+Number:Intensity Day03_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-solar-radiation"}
+Number Day03_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-solar-energy"}
+Number Day03_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-uv-index"}
+Number Day03_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-severe-risk"}
+String Day03_Hour10_Conditions "Conditions" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-conditions"}
+String Day03_Hour10_Icon "Icon" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-icon"}
+String Day03_Hour10_Stations "Stations" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-stations"}
+String Day03_Hour10_Source "Source" (Total_Weather_Data_Day03_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour10-source"}
+
+// Day03 - Hour11
+Group Total_Weather_Data_Day03_Hour11 "Hour 11" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour11_DateTime "DateTime" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-datetime"}
+DateTime Day03_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-timestamp"}
+Number:Temperature Day03_Hour11_Temperature "Temperature" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-temperature"}
+Number:Temperature Day03_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-feels-like"}
+Number Day03_Hour11_Humidity "Humidity" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-humidity"}
+Number:Temperature Day03_Hour11_Dew "Dew Point" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-dew"}
+Number:Length Day03_Hour11_Precip "Precipitation" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-precip"}
+Number:Dimensionless Day03_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-precip-prob"}
+String Day03_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-precip-type"}
+Number:Length Day03_Hour11_Snow "Snow" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-snow"}
+Number:Length Day03_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-snow-depth"}
+Number:Speed Day03_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-wind-gust"}
+Number:Speed Day03_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-wind-speed"}
+Number:Angle Day03_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-wind-dir"}
+Number:Pressure Day03_Hour11_Pressure "Pressure" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-pressure"}
+Number:Length Day03_Hour11_Visibility "Visibility" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-visibility"}
+Number:Dimensionless Day03_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-cloud-cover"}
+Number:Intensity Day03_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-solar-radiation"}
+Number Day03_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-solar-energy"}
+Number Day03_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-uv-index"}
+Number Day03_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-severe-risk"}
+String Day03_Hour11_Conditions "Conditions" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-conditions"}
+String Day03_Hour11_Icon "Icon" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-icon"}
+String Day03_Hour11_Stations "Stations" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-stations"}
+String Day03_Hour11_Source "Source" (Total_Weather_Data_Day03_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour11-source"}
+
+// Day03 - Hour12
+Group Total_Weather_Data_Day03_Hour12 "Hour 12" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour12_DateTime "DateTime" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-datetime"}
+DateTime Day03_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-timestamp"}
+Number:Temperature Day03_Hour12_Temperature "Temperature" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-temperature"}
+Number:Temperature Day03_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-feels-like"}
+Number Day03_Hour12_Humidity "Humidity" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-humidity"}
+Number:Temperature Day03_Hour12_Dew "Dew Point" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-dew"}
+Number:Length Day03_Hour12_Precip "Precipitation" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-precip"}
+Number:Dimensionless Day03_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-precip-prob"}
+String Day03_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-precip-type"}
+Number:Length Day03_Hour12_Snow "Snow" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-snow"}
+Number:Length Day03_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-snow-depth"}
+Number:Speed Day03_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-wind-gust"}
+Number:Speed Day03_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-wind-speed"}
+Number:Angle Day03_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-wind-dir"}
+Number:Pressure Day03_Hour12_Pressure "Pressure" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-pressure"}
+Number:Length Day03_Hour12_Visibility "Visibility" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-visibility"}
+Number:Dimensionless Day03_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-cloud-cover"}
+Number:Intensity Day03_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-solar-radiation"}
+Number Day03_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-solar-energy"}
+Number Day03_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-uv-index"}
+Number Day03_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-severe-risk"}
+String Day03_Hour12_Conditions "Conditions" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-conditions"}
+String Day03_Hour12_Icon "Icon" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-icon"}
+String Day03_Hour12_Stations "Stations" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-stations"}
+String Day03_Hour12_Source "Source" (Total_Weather_Data_Day03_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour12-source"}
+
+// Day03 - Hour13
+Group Total_Weather_Data_Day03_Hour13 "Hour 13" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour13_DateTime "DateTime" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-datetime"}
+DateTime Day03_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-timestamp"}
+Number:Temperature Day03_Hour13_Temperature "Temperature" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-temperature"}
+Number:Temperature Day03_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-feels-like"}
+Number Day03_Hour13_Humidity "Humidity" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-humidity"}
+Number:Temperature Day03_Hour13_Dew "Dew Point" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-dew"}
+Number:Length Day03_Hour13_Precip "Precipitation" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-precip"}
+Number:Dimensionless Day03_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-precip-prob"}
+String Day03_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-precip-type"}
+Number:Length Day03_Hour13_Snow "Snow" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-snow"}
+Number:Length Day03_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-snow-depth"}
+Number:Speed Day03_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-wind-gust"}
+Number:Speed Day03_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-wind-speed"}
+Number:Angle Day03_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-wind-dir"}
+Number:Pressure Day03_Hour13_Pressure "Pressure" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-pressure"}
+Number:Length Day03_Hour13_Visibility "Visibility" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-visibility"}
+Number:Dimensionless Day03_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-cloud-cover"}
+Number:Intensity Day03_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-solar-radiation"}
+Number Day03_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-solar-energy"}
+Number Day03_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-uv-index"}
+Number Day03_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-severe-risk"}
+String Day03_Hour13_Conditions "Conditions" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-conditions"}
+String Day03_Hour13_Icon "Icon" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-icon"}
+String Day03_Hour13_Stations "Stations" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-stations"}
+String Day03_Hour13_Source "Source" (Total_Weather_Data_Day03_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour13-source"}
+
+// Day03 - Hour14
+Group Total_Weather_Data_Day03_Hour14 "Hour 14" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour14_DateTime "DateTime" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-datetime"}
+DateTime Day03_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-timestamp"}
+Number:Temperature Day03_Hour14_Temperature "Temperature" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-temperature"}
+Number:Temperature Day03_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-feels-like"}
+Number Day03_Hour14_Humidity "Humidity" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-humidity"}
+Number:Temperature Day03_Hour14_Dew "Dew Point" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-dew"}
+Number:Length Day03_Hour14_Precip "Precipitation" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-precip"}
+Number:Dimensionless Day03_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-precip-prob"}
+String Day03_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-precip-type"}
+Number:Length Day03_Hour14_Snow "Snow" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-snow"}
+Number:Length Day03_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-snow-depth"}
+Number:Speed Day03_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-wind-gust"}
+Number:Speed Day03_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-wind-speed"}
+Number:Angle Day03_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-wind-dir"}
+Number:Pressure Day03_Hour14_Pressure "Pressure" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-pressure"}
+Number:Length Day03_Hour14_Visibility "Visibility" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-visibility"}
+Number:Dimensionless Day03_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-cloud-cover"}
+Number:Intensity Day03_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-solar-radiation"}
+Number Day03_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-solar-energy"}
+Number Day03_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-uv-index"}
+Number Day03_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-severe-risk"}
+String Day03_Hour14_Conditions "Conditions" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-conditions"}
+String Day03_Hour14_Icon "Icon" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-icon"}
+String Day03_Hour14_Stations "Stations" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-stations"}
+String Day03_Hour14_Source "Source" (Total_Weather_Data_Day03_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour14-source"}
+
+// Day03 - Hour15
+Group Total_Weather_Data_Day03_Hour15 "Hour 15" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour15_DateTime "DateTime" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-datetime"}
+DateTime Day03_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-timestamp"}
+Number:Temperature Day03_Hour15_Temperature "Temperature" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-temperature"}
+Number:Temperature Day03_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-feels-like"}
+Number Day03_Hour15_Humidity "Humidity" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-humidity"}
+Number:Temperature Day03_Hour15_Dew "Dew Point" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-dew"}
+Number:Length Day03_Hour15_Precip "Precipitation" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-precip"}
+Number:Dimensionless Day03_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-precip-prob"}
+String Day03_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-precip-type"}
+Number:Length Day03_Hour15_Snow "Snow" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-snow"}
+Number:Length Day03_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-snow-depth"}
+Number:Speed Day03_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-wind-gust"}
+Number:Speed Day03_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-wind-speed"}
+Number:Angle Day03_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-wind-dir"}
+Number:Pressure Day03_Hour15_Pressure "Pressure" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-pressure"}
+Number:Length Day03_Hour15_Visibility "Visibility" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-visibility"}
+Number:Dimensionless Day03_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-cloud-cover"}
+Number:Intensity Day03_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-solar-radiation"}
+Number Day03_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-solar-energy"}
+Number Day03_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-uv-index"}
+Number Day03_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-severe-risk"}
+String Day03_Hour15_Conditions "Conditions" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-conditions"}
+String Day03_Hour15_Icon "Icon" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-icon"}
+String Day03_Hour15_Stations "Stations" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-stations"}
+String Day03_Hour15_Source "Source" (Total_Weather_Data_Day03_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour15-source"}
+
+// Day03 - Hour16
+Group Total_Weather_Data_Day03_Hour16 "Hour 16" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour16_DateTime "DateTime" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-datetime"}
+DateTime Day03_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-timestamp"}
+Number:Temperature Day03_Hour16_Temperature "Temperature" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-temperature"}
+Number:Temperature Day03_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-feels-like"}
+Number Day03_Hour16_Humidity "Humidity" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-humidity"}
+Number:Temperature Day03_Hour16_Dew "Dew Point" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-dew"}
+Number:Length Day03_Hour16_Precip "Precipitation" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-precip"}
+Number:Dimensionless Day03_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-precip-prob"}
+String Day03_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-precip-type"}
+Number:Length Day03_Hour16_Snow "Snow" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-snow"}
+Number:Length Day03_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-snow-depth"}
+Number:Speed Day03_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-wind-gust"}
+Number:Speed Day03_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-wind-speed"}
+Number:Angle Day03_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-wind-dir"}
+Number:Pressure Day03_Hour16_Pressure "Pressure" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-pressure"}
+Number:Length Day03_Hour16_Visibility "Visibility" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-visibility"}
+Number:Dimensionless Day03_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-cloud-cover"}
+Number:Intensity Day03_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-solar-radiation"}
+Number Day03_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-solar-energy"}
+Number Day03_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-uv-index"}
+Number Day03_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-severe-risk"}
+String Day03_Hour16_Conditions "Conditions" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-conditions"}
+String Day03_Hour16_Icon "Icon" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-icon"}
+String Day03_Hour16_Stations "Stations" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-stations"}
+String Day03_Hour16_Source "Source" (Total_Weather_Data_Day03_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour16-source"}
+
+// Day03 - Hour17
+Group Total_Weather_Data_Day03_Hour17 "Hour 17" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour17_DateTime "DateTime" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-datetime"}
+DateTime Day03_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-timestamp"}
+Number:Temperature Day03_Hour17_Temperature "Temperature" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-temperature"}
+Number:Temperature Day03_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-feels-like"}
+Number Day03_Hour17_Humidity "Humidity" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-humidity"}
+Number:Temperature Day03_Hour17_Dew "Dew Point" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-dew"}
+Number:Length Day03_Hour17_Precip "Precipitation" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-precip"}
+Number:Dimensionless Day03_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-precip-prob"}
+String Day03_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-precip-type"}
+Number:Length Day03_Hour17_Snow "Snow" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-snow"}
+Number:Length Day03_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-snow-depth"}
+Number:Speed Day03_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-wind-gust"}
+Number:Speed Day03_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-wind-speed"}
+Number:Angle Day03_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-wind-dir"}
+Number:Pressure Day03_Hour17_Pressure "Pressure" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-pressure"}
+Number:Length Day03_Hour17_Visibility "Visibility" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-visibility"}
+Number:Dimensionless Day03_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-cloud-cover"}
+Number:Intensity Day03_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-solar-radiation"}
+Number Day03_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-solar-energy"}
+Number Day03_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-uv-index"}
+Number Day03_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-severe-risk"}
+String Day03_Hour17_Conditions "Conditions" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-conditions"}
+String Day03_Hour17_Icon "Icon" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-icon"}
+String Day03_Hour17_Stations "Stations" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-stations"}
+String Day03_Hour17_Source "Source" (Total_Weather_Data_Day03_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour17-source"}
+
+// Day03 - Hour18
+Group Total_Weather_Data_Day03_Hour18 "Hour 18" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour18_DateTime "DateTime" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-datetime"}
+DateTime Day03_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-timestamp"}
+Number:Temperature Day03_Hour18_Temperature "Temperature" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-temperature"}
+Number:Temperature Day03_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-feels-like"}
+Number Day03_Hour18_Humidity "Humidity" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-humidity"}
+Number:Temperature Day03_Hour18_Dew "Dew Point" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-dew"}
+Number:Length Day03_Hour18_Precip "Precipitation" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-precip"}
+Number:Dimensionless Day03_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-precip-prob"}
+String Day03_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-precip-type"}
+Number:Length Day03_Hour18_Snow "Snow" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-snow"}
+Number:Length Day03_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-snow-depth"}
+Number:Speed Day03_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-wind-gust"}
+Number:Speed Day03_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-wind-speed"}
+Number:Angle Day03_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-wind-dir"}
+Number:Pressure Day03_Hour18_Pressure "Pressure" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-pressure"}
+Number:Length Day03_Hour18_Visibility "Visibility" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-visibility"}
+Number:Dimensionless Day03_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-cloud-cover"}
+Number:Intensity Day03_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-solar-radiation"}
+Number Day03_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-solar-energy"}
+Number Day03_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-uv-index"}
+Number Day03_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-severe-risk"}
+String Day03_Hour18_Conditions "Conditions" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-conditions"}
+String Day03_Hour18_Icon "Icon" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-icon"}
+String Day03_Hour18_Stations "Stations" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-stations"}
+String Day03_Hour18_Source "Source" (Total_Weather_Data_Day03_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour18-source"}
+
+// Day03 - Hour19
+Group Total_Weather_Data_Day03_Hour19 "Hour 19" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour19_DateTime "DateTime" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-datetime"}
+DateTime Day03_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-timestamp"}
+Number:Temperature Day03_Hour19_Temperature "Temperature" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-temperature"}
+Number:Temperature Day03_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-feels-like"}
+Number Day03_Hour19_Humidity "Humidity" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-humidity"}
+Number:Temperature Day03_Hour19_Dew "Dew Point" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-dew"}
+Number:Length Day03_Hour19_Precip "Precipitation" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-precip"}
+Number:Dimensionless Day03_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-precip-prob"}
+String Day03_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-precip-type"}
+Number:Length Day03_Hour19_Snow "Snow" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-snow"}
+Number:Length Day03_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-snow-depth"}
+Number:Speed Day03_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-wind-gust"}
+Number:Speed Day03_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-wind-speed"}
+Number:Angle Day03_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-wind-dir"}
+Number:Pressure Day03_Hour19_Pressure "Pressure" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-pressure"}
+Number:Length Day03_Hour19_Visibility "Visibility" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-visibility"}
+Number:Dimensionless Day03_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-cloud-cover"}
+Number:Intensity Day03_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-solar-radiation"}
+Number Day03_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-solar-energy"}
+Number Day03_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-uv-index"}
+Number Day03_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-severe-risk"}
+String Day03_Hour19_Conditions "Conditions" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-conditions"}
+String Day03_Hour19_Icon "Icon" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-icon"}
+String Day03_Hour19_Stations "Stations" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-stations"}
+String Day03_Hour19_Source "Source" (Total_Weather_Data_Day03_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour19-source"}
+
+// Day03 - Hour20
+Group Total_Weather_Data_Day03_Hour20 "Hour 20" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour20_DateTime "DateTime" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-datetime"}
+DateTime Day03_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-timestamp"}
+Number:Temperature Day03_Hour20_Temperature "Temperature" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-temperature"}
+Number:Temperature Day03_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-feels-like"}
+Number Day03_Hour20_Humidity "Humidity" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-humidity"}
+Number:Temperature Day03_Hour20_Dew "Dew Point" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-dew"}
+Number:Length Day03_Hour20_Precip "Precipitation" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-precip"}
+Number:Dimensionless Day03_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-precip-prob"}
+String Day03_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-precip-type"}
+Number:Length Day03_Hour20_Snow "Snow" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-snow"}
+Number:Length Day03_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-snow-depth"}
+Number:Speed Day03_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-wind-gust"}
+Number:Speed Day03_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-wind-speed"}
+Number:Angle Day03_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-wind-dir"}
+Number:Pressure Day03_Hour20_Pressure "Pressure" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-pressure"}
+Number:Length Day03_Hour20_Visibility "Visibility" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-visibility"}
+Number:Dimensionless Day03_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-cloud-cover"}
+Number:Intensity Day03_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-solar-radiation"}
+Number Day03_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-solar-energy"}
+Number Day03_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-uv-index"}
+Number Day03_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-severe-risk"}
+String Day03_Hour20_Conditions "Conditions" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-conditions"}
+String Day03_Hour20_Icon "Icon" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-icon"}
+String Day03_Hour20_Stations "Stations" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-stations"}
+String Day03_Hour20_Source "Source" (Total_Weather_Data_Day03_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour20-source"}
+
+// Day03 - Hour21
+Group Total_Weather_Data_Day03_Hour21 "Hour 21" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour21_DateTime "DateTime" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-datetime"}
+DateTime Day03_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-timestamp"}
+Number:Temperature Day03_Hour21_Temperature "Temperature" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-temperature"}
+Number:Temperature Day03_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-feels-like"}
+Number Day03_Hour21_Humidity "Humidity" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-humidity"}
+Number:Temperature Day03_Hour21_Dew "Dew Point" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-dew"}
+Number:Length Day03_Hour21_Precip "Precipitation" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-precip"}
+Number:Dimensionless Day03_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-precip-prob"}
+String Day03_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-precip-type"}
+Number:Length Day03_Hour21_Snow "Snow" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-snow"}
+Number:Length Day03_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-snow-depth"}
+Number:Speed Day03_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-wind-gust"}
+Number:Speed Day03_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-wind-speed"}
+Number:Angle Day03_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-wind-dir"}
+Number:Pressure Day03_Hour21_Pressure "Pressure" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-pressure"}
+Number:Length Day03_Hour21_Visibility "Visibility" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-visibility"}
+Number:Dimensionless Day03_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-cloud-cover"}
+Number:Intensity Day03_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-solar-radiation"}
+Number Day03_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-solar-energy"}
+Number Day03_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-uv-index"}
+Number Day03_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-severe-risk"}
+String Day03_Hour21_Conditions "Conditions" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-conditions"}
+String Day03_Hour21_Icon "Icon" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-icon"}
+String Day03_Hour21_Stations "Stations" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-stations"}
+String Day03_Hour21_Source "Source" (Total_Weather_Data_Day03_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour21-source"}
+
+// Day03 - Hour22
+Group Total_Weather_Data_Day03_Hour22 "Hour 22" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour22_DateTime "DateTime" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-datetime"}
+DateTime Day03_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-timestamp"}
+Number:Temperature Day03_Hour22_Temperature "Temperature" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-temperature"}
+Number:Temperature Day03_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-feels-like"}
+Number Day03_Hour22_Humidity "Humidity" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-humidity"}
+Number:Temperature Day03_Hour22_Dew "Dew Point" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-dew"}
+Number:Length Day03_Hour22_Precip "Precipitation" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-precip"}
+Number:Dimensionless Day03_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-precip-prob"}
+String Day03_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-precip-type"}
+Number:Length Day03_Hour22_Snow "Snow" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-snow"}
+Number:Length Day03_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-snow-depth"}
+Number:Speed Day03_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-wind-gust"}
+Number:Speed Day03_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-wind-speed"}
+Number:Angle Day03_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-wind-dir"}
+Number:Pressure Day03_Hour22_Pressure "Pressure" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-pressure"}
+Number:Length Day03_Hour22_Visibility "Visibility" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-visibility"}
+Number:Dimensionless Day03_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-cloud-cover"}
+Number:Intensity Day03_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-solar-radiation"}
+Number Day03_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-solar-energy"}
+Number Day03_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-uv-index"}
+Number Day03_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-severe-risk"}
+String Day03_Hour22_Conditions "Conditions" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-conditions"}
+String Day03_Hour22_Icon "Icon" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-icon"}
+String Day03_Hour22_Stations "Stations" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-stations"}
+String Day03_Hour22_Source "Source" (Total_Weather_Data_Day03_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour22-source"}
+
+// Day03 - Hour23
+Group Total_Weather_Data_Day03_Hour23 "Hour 23" (Total_Weather_Data_Day03) [ "Equipment" ] 
+String Day03_Hour23_DateTime "DateTime" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-datetime"}
+DateTime Day03_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-timestamp"}
+Number:Temperature Day03_Hour23_Temperature "Temperature" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-temperature"}
+Number:Temperature Day03_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-feels-like"}
+Number Day03_Hour23_Humidity "Humidity" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-humidity"}
+Number:Temperature Day03_Hour23_Dew "Dew Point" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-dew"}
+Number:Length Day03_Hour23_Precip "Precipitation" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-precip"}
+Number:Dimensionless Day03_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-precip-prob"}
+String Day03_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-precip-type"}
+Number:Length Day03_Hour23_Snow "Snow" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-snow"}
+Number:Length Day03_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-snow-depth"}
+Number:Speed Day03_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-wind-gust"}
+Number:Speed Day03_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-wind-speed"}
+Number:Angle Day03_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-wind-dir"}
+Number:Pressure Day03_Hour23_Pressure "Pressure" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-pressure"}
+Number:Length Day03_Hour23_Visibility "Visibility" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-visibility"}
+Number:Dimensionless Day03_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-cloud-cover"}
+Number:Intensity Day03_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-solar-radiation"}
+Number Day03_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-solar-energy"}
+Number Day03_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-uv-index"}
+Number Day03_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-severe-risk"}
+String Day03_Hour23_Conditions "Conditions" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-conditions"}
+String Day03_Hour23_Icon "Icon" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-icon"}
+String Day03_Hour23_Stations "Stations" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-stations"}
+String Day03_Hour23_Source "Source" (Total_Weather_Data_Day03_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day03#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_04.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_04.items
@@ -1,39 +1,712 @@
 // Day04
 Group Total_Weather_Data_Day04 "Day T+04" (Total_Weather_Data) [ "Equipment" ] 
-String Day04_DateTime "Time" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day04_Timestamp "Timestamp" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day04_Temperature "Temperature" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day04_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day04_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day04_FeelsLike "Feels Like" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day04_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day04_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day04_Dew "Dew Point" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day04_Humidity "Humidity" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day04_Precip "Precipitation" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day04_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day04_Precip_Type "Precipitation Type" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day04_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day04_Snow "Snow" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day04_Snow_Depth "Snow Depth" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day04_Wind_Gust "Wind Gust" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day04_Wind_Speed "Wind Speed" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day04_Wind_Dir "Wind Direction" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day04_Pressure "Pressure" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day04_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day04_Visibility "Visibility" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day04_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day04_Solar_Energy "Solar Energy" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day04_UV_Index "UV Index" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day04_Sunrise "Sunrise" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day04_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day04_Sunset "Sunset" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day04_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day04_Moon_Phase "Moon Phase" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day04_Conditions "Conditions" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day04_Description "Description" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day04_Icon "Icon" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day04_Stations "Stations" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day04_Source "Source" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day04_Severe_Risk "Severe Risk" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day04_DateTime "Time" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#datetime" }
+DateTime Day04_Timestamp "Timestamp" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#timestamp" }
+Number:Temperature Day04_Temperature "Temperature" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#temperature" }
+Number:Temperature Day04_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#temperature-min" }
+Number:Temperature Day04_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#temperature-max" }
+Number:Temperature Day04_FeelsLike "Feels Like" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#feels-like" }
+Number:Temperature Day04_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#feels-like-min" }
+Number:Temperature Day04_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#feels-like-max" }
+Number:Temperature Day04_Dew "Dew Point" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#dew" }
+Number Day04_Humidity "Humidity" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#humidity" }
+Number:Length Day04_Precip "Precipitation" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#precip" }
+Number Day04_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#precip-prob" }
+String Day04_Precip_Type "Precipitation Type" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#precip-type" }
+Number Day04_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#precip-cover" }
+Number:Length Day04_Snow "Snow" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#snow" }
+Number:Length Day04_Snow_Depth "Snow Depth" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#snow-depth" }
+Number:Speed Day04_Wind_Gust "Wind Gust" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#wind-gust" }
+Number:Speed Day04_Wind_Speed "Wind Speed" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#wind-speed" }
+Number:Angle Day04_Wind_Dir "Wind Direction" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#wind-dir" }
+Number:Pressure Day04_Pressure "Pressure" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#pressure" }
+Number Day04_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#cloud-cover" }
+Number:Length Day04_Visibility "Visibility" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#visibility" }
+Number:Intensity Day04_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#solar-radiation" }
+Number Day04_Solar_Energy "Solar Energy" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#solar-energy" }
+Number Day04_UV_Index "UV Index" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#uv-index" }
+String Day04_Sunrise "Sunrise" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#sunrise" }
+DateTime Day04_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#sunrise-epoch" }
+String Day04_Sunset "Sunset" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#sunset" }
+DateTime Day04_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#sunset-epoch" }
+Number Day04_Moon_Phase "Moon Phase" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#moon-phase" }
+String Day04_Conditions "Conditions" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#conditions" }
+String Day04_Description "Description" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#description" }
+String Day04_Icon "Icon" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#icon" }
+String Day04_Stations "Stations" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#stations" }
+String Day04_Source "Source" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#source" }
+Number Day04_Severe_Risk "Severe Risk" (Total_Weather_Data_Day04)["Point"] { channel="visualcrossing:weather:default_config:day04#severe-risk" }
+
+// Day04 - Hour00
+Group Total_Weather_Data_Day04_Hour00 "Hour 00" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour00_DateTime "DateTime" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-datetime"}
+DateTime Day04_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-timestamp"}
+Number:Temperature Day04_Hour00_Temperature "Temperature" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-temperature"}
+Number:Temperature Day04_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-feels-like"}
+Number Day04_Hour00_Humidity "Humidity" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-humidity"}
+Number:Temperature Day04_Hour00_Dew "Dew Point" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-dew"}
+Number:Length Day04_Hour00_Precip "Precipitation" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-precip"}
+Number:Dimensionless Day04_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-precip-prob"}
+String Day04_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-precip-type"}
+Number:Length Day04_Hour00_Snow "Snow" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-snow"}
+Number:Length Day04_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-snow-depth"}
+Number:Speed Day04_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-wind-gust"}
+Number:Speed Day04_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-wind-speed"}
+Number:Angle Day04_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-wind-dir"}
+Number:Pressure Day04_Hour00_Pressure "Pressure" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-pressure"}
+Number:Length Day04_Hour00_Visibility "Visibility" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-visibility"}
+Number:Dimensionless Day04_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-cloud-cover"}
+Number:Intensity Day04_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-solar-radiation"}
+Number Day04_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-solar-energy"}
+Number Day04_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-uv-index"}
+Number Day04_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-severe-risk"}
+String Day04_Hour00_Conditions "Conditions" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-conditions"}
+String Day04_Hour00_Icon "Icon" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-icon"}
+String Day04_Hour00_Stations "Stations" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-stations"}
+String Day04_Hour00_Source "Source" (Total_Weather_Data_Day04_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour00-source"}
+
+// Day04 - Hour01
+Group Total_Weather_Data_Day04_Hour01 "Hour 01" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour01_DateTime "DateTime" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-datetime"}
+DateTime Day04_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-timestamp"}
+Number:Temperature Day04_Hour01_Temperature "Temperature" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-temperature"}
+Number:Temperature Day04_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-feels-like"}
+Number Day04_Hour01_Humidity "Humidity" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-humidity"}
+Number:Temperature Day04_Hour01_Dew "Dew Point" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-dew"}
+Number:Length Day04_Hour01_Precip "Precipitation" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-precip"}
+Number:Dimensionless Day04_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-precip-prob"}
+String Day04_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-precip-type"}
+Number:Length Day04_Hour01_Snow "Snow" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-snow"}
+Number:Length Day04_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-snow-depth"}
+Number:Speed Day04_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-wind-gust"}
+Number:Speed Day04_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-wind-speed"}
+Number:Angle Day04_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-wind-dir"}
+Number:Pressure Day04_Hour01_Pressure "Pressure" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-pressure"}
+Number:Length Day04_Hour01_Visibility "Visibility" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-visibility"}
+Number:Dimensionless Day04_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-cloud-cover"}
+Number:Intensity Day04_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-solar-radiation"}
+Number Day04_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-solar-energy"}
+Number Day04_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-uv-index"}
+Number Day04_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-severe-risk"}
+String Day04_Hour01_Conditions "Conditions" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-conditions"}
+String Day04_Hour01_Icon "Icon" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-icon"}
+String Day04_Hour01_Stations "Stations" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-stations"}
+String Day04_Hour01_Source "Source" (Total_Weather_Data_Day04_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour01-source"}
+
+// Day04 - Hour02
+Group Total_Weather_Data_Day04_Hour02 "Hour 02" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour02_DateTime "DateTime" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-datetime"}
+DateTime Day04_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-timestamp"}
+Number:Temperature Day04_Hour02_Temperature "Temperature" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-temperature"}
+Number:Temperature Day04_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-feels-like"}
+Number Day04_Hour02_Humidity "Humidity" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-humidity"}
+Number:Temperature Day04_Hour02_Dew "Dew Point" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-dew"}
+Number:Length Day04_Hour02_Precip "Precipitation" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-precip"}
+Number:Dimensionless Day04_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-precip-prob"}
+String Day04_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-precip-type"}
+Number:Length Day04_Hour02_Snow "Snow" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-snow"}
+Number:Length Day04_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-snow-depth"}
+Number:Speed Day04_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-wind-gust"}
+Number:Speed Day04_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-wind-speed"}
+Number:Angle Day04_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-wind-dir"}
+Number:Pressure Day04_Hour02_Pressure "Pressure" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-pressure"}
+Number:Length Day04_Hour02_Visibility "Visibility" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-visibility"}
+Number:Dimensionless Day04_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-cloud-cover"}
+Number:Intensity Day04_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-solar-radiation"}
+Number Day04_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-solar-energy"}
+Number Day04_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-uv-index"}
+Number Day04_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-severe-risk"}
+String Day04_Hour02_Conditions "Conditions" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-conditions"}
+String Day04_Hour02_Icon "Icon" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-icon"}
+String Day04_Hour02_Stations "Stations" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-stations"}
+String Day04_Hour02_Source "Source" (Total_Weather_Data_Day04_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour02-source"}
+
+// Day04 - Hour03
+Group Total_Weather_Data_Day04_Hour03 "Hour 03" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour03_DateTime "DateTime" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-datetime"}
+DateTime Day04_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-timestamp"}
+Number:Temperature Day04_Hour03_Temperature "Temperature" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-temperature"}
+Number:Temperature Day04_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-feels-like"}
+Number Day04_Hour03_Humidity "Humidity" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-humidity"}
+Number:Temperature Day04_Hour03_Dew "Dew Point" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-dew"}
+Number:Length Day04_Hour03_Precip "Precipitation" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-precip"}
+Number:Dimensionless Day04_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-precip-prob"}
+String Day04_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-precip-type"}
+Number:Length Day04_Hour03_Snow "Snow" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-snow"}
+Number:Length Day04_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-snow-depth"}
+Number:Speed Day04_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-wind-gust"}
+Number:Speed Day04_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-wind-speed"}
+Number:Angle Day04_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-wind-dir"}
+Number:Pressure Day04_Hour03_Pressure "Pressure" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-pressure"}
+Number:Length Day04_Hour03_Visibility "Visibility" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-visibility"}
+Number:Dimensionless Day04_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-cloud-cover"}
+Number:Intensity Day04_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-solar-radiation"}
+Number Day04_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-solar-energy"}
+Number Day04_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-uv-index"}
+Number Day04_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-severe-risk"}
+String Day04_Hour03_Conditions "Conditions" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-conditions"}
+String Day04_Hour03_Icon "Icon" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-icon"}
+String Day04_Hour03_Stations "Stations" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-stations"}
+String Day04_Hour03_Source "Source" (Total_Weather_Data_Day04_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour03-source"}
+
+// Day04 - Hour04
+Group Total_Weather_Data_Day04_Hour04 "Hour 04" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour04_DateTime "DateTime" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-datetime"}
+DateTime Day04_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-timestamp"}
+Number:Temperature Day04_Hour04_Temperature "Temperature" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-temperature"}
+Number:Temperature Day04_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-feels-like"}
+Number Day04_Hour04_Humidity "Humidity" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-humidity"}
+Number:Temperature Day04_Hour04_Dew "Dew Point" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-dew"}
+Number:Length Day04_Hour04_Precip "Precipitation" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-precip"}
+Number:Dimensionless Day04_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-precip-prob"}
+String Day04_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-precip-type"}
+Number:Length Day04_Hour04_Snow "Snow" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-snow"}
+Number:Length Day04_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-snow-depth"}
+Number:Speed Day04_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-wind-gust"}
+Number:Speed Day04_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-wind-speed"}
+Number:Angle Day04_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-wind-dir"}
+Number:Pressure Day04_Hour04_Pressure "Pressure" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-pressure"}
+Number:Length Day04_Hour04_Visibility "Visibility" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-visibility"}
+Number:Dimensionless Day04_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-cloud-cover"}
+Number:Intensity Day04_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-solar-radiation"}
+Number Day04_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-solar-energy"}
+Number Day04_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-uv-index"}
+Number Day04_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-severe-risk"}
+String Day04_Hour04_Conditions "Conditions" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-conditions"}
+String Day04_Hour04_Icon "Icon" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-icon"}
+String Day04_Hour04_Stations "Stations" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-stations"}
+String Day04_Hour04_Source "Source" (Total_Weather_Data_Day04_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour04-source"}
+
+// Day04 - Hour05
+Group Total_Weather_Data_Day04_Hour05 "Hour 05" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour05_DateTime "DateTime" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-datetime"}
+DateTime Day04_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-timestamp"}
+Number:Temperature Day04_Hour05_Temperature "Temperature" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-temperature"}
+Number:Temperature Day04_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-feels-like"}
+Number Day04_Hour05_Humidity "Humidity" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-humidity"}
+Number:Temperature Day04_Hour05_Dew "Dew Point" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-dew"}
+Number:Length Day04_Hour05_Precip "Precipitation" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-precip"}
+Number:Dimensionless Day04_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-precip-prob"}
+String Day04_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-precip-type"}
+Number:Length Day04_Hour05_Snow "Snow" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-snow"}
+Number:Length Day04_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-snow-depth"}
+Number:Speed Day04_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-wind-gust"}
+Number:Speed Day04_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-wind-speed"}
+Number:Angle Day04_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-wind-dir"}
+Number:Pressure Day04_Hour05_Pressure "Pressure" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-pressure"}
+Number:Length Day04_Hour05_Visibility "Visibility" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-visibility"}
+Number:Dimensionless Day04_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-cloud-cover"}
+Number:Intensity Day04_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-solar-radiation"}
+Number Day04_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-solar-energy"}
+Number Day04_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-uv-index"}
+Number Day04_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-severe-risk"}
+String Day04_Hour05_Conditions "Conditions" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-conditions"}
+String Day04_Hour05_Icon "Icon" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-icon"}
+String Day04_Hour05_Stations "Stations" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-stations"}
+String Day04_Hour05_Source "Source" (Total_Weather_Data_Day04_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour05-source"}
+
+// Day04 - Hour06
+Group Total_Weather_Data_Day04_Hour06 "Hour 06" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour06_DateTime "DateTime" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-datetime"}
+DateTime Day04_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-timestamp"}
+Number:Temperature Day04_Hour06_Temperature "Temperature" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-temperature"}
+Number:Temperature Day04_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-feels-like"}
+Number Day04_Hour06_Humidity "Humidity" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-humidity"}
+Number:Temperature Day04_Hour06_Dew "Dew Point" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-dew"}
+Number:Length Day04_Hour06_Precip "Precipitation" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-precip"}
+Number:Dimensionless Day04_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-precip-prob"}
+String Day04_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-precip-type"}
+Number:Length Day04_Hour06_Snow "Snow" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-snow"}
+Number:Length Day04_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-snow-depth"}
+Number:Speed Day04_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-wind-gust"}
+Number:Speed Day04_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-wind-speed"}
+Number:Angle Day04_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-wind-dir"}
+Number:Pressure Day04_Hour06_Pressure "Pressure" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-pressure"}
+Number:Length Day04_Hour06_Visibility "Visibility" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-visibility"}
+Number:Dimensionless Day04_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-cloud-cover"}
+Number:Intensity Day04_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-solar-radiation"}
+Number Day04_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-solar-energy"}
+Number Day04_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-uv-index"}
+Number Day04_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-severe-risk"}
+String Day04_Hour06_Conditions "Conditions" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-conditions"}
+String Day04_Hour06_Icon "Icon" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-icon"}
+String Day04_Hour06_Stations "Stations" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-stations"}
+String Day04_Hour06_Source "Source" (Total_Weather_Data_Day04_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour06-source"}
+
+// Day04 - Hour07
+Group Total_Weather_Data_Day04_Hour07 "Hour 07" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour07_DateTime "DateTime" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-datetime"}
+DateTime Day04_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-timestamp"}
+Number:Temperature Day04_Hour07_Temperature "Temperature" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-temperature"}
+Number:Temperature Day04_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-feels-like"}
+Number Day04_Hour07_Humidity "Humidity" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-humidity"}
+Number:Temperature Day04_Hour07_Dew "Dew Point" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-dew"}
+Number:Length Day04_Hour07_Precip "Precipitation" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-precip"}
+Number:Dimensionless Day04_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-precip-prob"}
+String Day04_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-precip-type"}
+Number:Length Day04_Hour07_Snow "Snow" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-snow"}
+Number:Length Day04_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-snow-depth"}
+Number:Speed Day04_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-wind-gust"}
+Number:Speed Day04_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-wind-speed"}
+Number:Angle Day04_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-wind-dir"}
+Number:Pressure Day04_Hour07_Pressure "Pressure" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-pressure"}
+Number:Length Day04_Hour07_Visibility "Visibility" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-visibility"}
+Number:Dimensionless Day04_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-cloud-cover"}
+Number:Intensity Day04_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-solar-radiation"}
+Number Day04_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-solar-energy"}
+Number Day04_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-uv-index"}
+Number Day04_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-severe-risk"}
+String Day04_Hour07_Conditions "Conditions" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-conditions"}
+String Day04_Hour07_Icon "Icon" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-icon"}
+String Day04_Hour07_Stations "Stations" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-stations"}
+String Day04_Hour07_Source "Source" (Total_Weather_Data_Day04_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour07-source"}
+
+// Day04 - Hour08
+Group Total_Weather_Data_Day04_Hour08 "Hour 08" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour08_DateTime "DateTime" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-datetime"}
+DateTime Day04_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-timestamp"}
+Number:Temperature Day04_Hour08_Temperature "Temperature" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-temperature"}
+Number:Temperature Day04_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-feels-like"}
+Number Day04_Hour08_Humidity "Humidity" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-humidity"}
+Number:Temperature Day04_Hour08_Dew "Dew Point" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-dew"}
+Number:Length Day04_Hour08_Precip "Precipitation" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-precip"}
+Number:Dimensionless Day04_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-precip-prob"}
+String Day04_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-precip-type"}
+Number:Length Day04_Hour08_Snow "Snow" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-snow"}
+Number:Length Day04_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-snow-depth"}
+Number:Speed Day04_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-wind-gust"}
+Number:Speed Day04_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-wind-speed"}
+Number:Angle Day04_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-wind-dir"}
+Number:Pressure Day04_Hour08_Pressure "Pressure" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-pressure"}
+Number:Length Day04_Hour08_Visibility "Visibility" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-visibility"}
+Number:Dimensionless Day04_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-cloud-cover"}
+Number:Intensity Day04_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-solar-radiation"}
+Number Day04_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-solar-energy"}
+Number Day04_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-uv-index"}
+Number Day04_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-severe-risk"}
+String Day04_Hour08_Conditions "Conditions" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-conditions"}
+String Day04_Hour08_Icon "Icon" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-icon"}
+String Day04_Hour08_Stations "Stations" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-stations"}
+String Day04_Hour08_Source "Source" (Total_Weather_Data_Day04_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour08-source"}
+
+// Day04 - Hour09
+Group Total_Weather_Data_Day04_Hour09 "Hour 09" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour09_DateTime "DateTime" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-datetime"}
+DateTime Day04_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-timestamp"}
+Number:Temperature Day04_Hour09_Temperature "Temperature" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-temperature"}
+Number:Temperature Day04_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-feels-like"}
+Number Day04_Hour09_Humidity "Humidity" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-humidity"}
+Number:Temperature Day04_Hour09_Dew "Dew Point" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-dew"}
+Number:Length Day04_Hour09_Precip "Precipitation" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-precip"}
+Number:Dimensionless Day04_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-precip-prob"}
+String Day04_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-precip-type"}
+Number:Length Day04_Hour09_Snow "Snow" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-snow"}
+Number:Length Day04_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-snow-depth"}
+Number:Speed Day04_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-wind-gust"}
+Number:Speed Day04_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-wind-speed"}
+Number:Angle Day04_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-wind-dir"}
+Number:Pressure Day04_Hour09_Pressure "Pressure" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-pressure"}
+Number:Length Day04_Hour09_Visibility "Visibility" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-visibility"}
+Number:Dimensionless Day04_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-cloud-cover"}
+Number:Intensity Day04_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-solar-radiation"}
+Number Day04_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-solar-energy"}
+Number Day04_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-uv-index"}
+Number Day04_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-severe-risk"}
+String Day04_Hour09_Conditions "Conditions" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-conditions"}
+String Day04_Hour09_Icon "Icon" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-icon"}
+String Day04_Hour09_Stations "Stations" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-stations"}
+String Day04_Hour09_Source "Source" (Total_Weather_Data_Day04_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour09-source"}
+
+// Day04 - Hour10
+Group Total_Weather_Data_Day04_Hour10 "Hour 10" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour10_DateTime "DateTime" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-datetime"}
+DateTime Day04_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-timestamp"}
+Number:Temperature Day04_Hour10_Temperature "Temperature" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-temperature"}
+Number:Temperature Day04_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-feels-like"}
+Number Day04_Hour10_Humidity "Humidity" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-humidity"}
+Number:Temperature Day04_Hour10_Dew "Dew Point" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-dew"}
+Number:Length Day04_Hour10_Precip "Precipitation" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-precip"}
+Number:Dimensionless Day04_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-precip-prob"}
+String Day04_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-precip-type"}
+Number:Length Day04_Hour10_Snow "Snow" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-snow"}
+Number:Length Day04_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-snow-depth"}
+Number:Speed Day04_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-wind-gust"}
+Number:Speed Day04_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-wind-speed"}
+Number:Angle Day04_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-wind-dir"}
+Number:Pressure Day04_Hour10_Pressure "Pressure" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-pressure"}
+Number:Length Day04_Hour10_Visibility "Visibility" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-visibility"}
+Number:Dimensionless Day04_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-cloud-cover"}
+Number:Intensity Day04_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-solar-radiation"}
+Number Day04_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-solar-energy"}
+Number Day04_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-uv-index"}
+Number Day04_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-severe-risk"}
+String Day04_Hour10_Conditions "Conditions" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-conditions"}
+String Day04_Hour10_Icon "Icon" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-icon"}
+String Day04_Hour10_Stations "Stations" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-stations"}
+String Day04_Hour10_Source "Source" (Total_Weather_Data_Day04_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour10-source"}
+
+// Day04 - Hour11
+Group Total_Weather_Data_Day04_Hour11 "Hour 11" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour11_DateTime "DateTime" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-datetime"}
+DateTime Day04_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-timestamp"}
+Number:Temperature Day04_Hour11_Temperature "Temperature" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-temperature"}
+Number:Temperature Day04_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-feels-like"}
+Number Day04_Hour11_Humidity "Humidity" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-humidity"}
+Number:Temperature Day04_Hour11_Dew "Dew Point" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-dew"}
+Number:Length Day04_Hour11_Precip "Precipitation" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-precip"}
+Number:Dimensionless Day04_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-precip-prob"}
+String Day04_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-precip-type"}
+Number:Length Day04_Hour11_Snow "Snow" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-snow"}
+Number:Length Day04_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-snow-depth"}
+Number:Speed Day04_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-wind-gust"}
+Number:Speed Day04_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-wind-speed"}
+Number:Angle Day04_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-wind-dir"}
+Number:Pressure Day04_Hour11_Pressure "Pressure" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-pressure"}
+Number:Length Day04_Hour11_Visibility "Visibility" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-visibility"}
+Number:Dimensionless Day04_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-cloud-cover"}
+Number:Intensity Day04_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-solar-radiation"}
+Number Day04_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-solar-energy"}
+Number Day04_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-uv-index"}
+Number Day04_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-severe-risk"}
+String Day04_Hour11_Conditions "Conditions" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-conditions"}
+String Day04_Hour11_Icon "Icon" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-icon"}
+String Day04_Hour11_Stations "Stations" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-stations"}
+String Day04_Hour11_Source "Source" (Total_Weather_Data_Day04_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour11-source"}
+
+// Day04 - Hour12
+Group Total_Weather_Data_Day04_Hour12 "Hour 12" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour12_DateTime "DateTime" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-datetime"}
+DateTime Day04_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-timestamp"}
+Number:Temperature Day04_Hour12_Temperature "Temperature" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-temperature"}
+Number:Temperature Day04_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-feels-like"}
+Number Day04_Hour12_Humidity "Humidity" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-humidity"}
+Number:Temperature Day04_Hour12_Dew "Dew Point" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-dew"}
+Number:Length Day04_Hour12_Precip "Precipitation" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-precip"}
+Number:Dimensionless Day04_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-precip-prob"}
+String Day04_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-precip-type"}
+Number:Length Day04_Hour12_Snow "Snow" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-snow"}
+Number:Length Day04_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-snow-depth"}
+Number:Speed Day04_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-wind-gust"}
+Number:Speed Day04_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-wind-speed"}
+Number:Angle Day04_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-wind-dir"}
+Number:Pressure Day04_Hour12_Pressure "Pressure" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-pressure"}
+Number:Length Day04_Hour12_Visibility "Visibility" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-visibility"}
+Number:Dimensionless Day04_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-cloud-cover"}
+Number:Intensity Day04_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-solar-radiation"}
+Number Day04_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-solar-energy"}
+Number Day04_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-uv-index"}
+Number Day04_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-severe-risk"}
+String Day04_Hour12_Conditions "Conditions" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-conditions"}
+String Day04_Hour12_Icon "Icon" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-icon"}
+String Day04_Hour12_Stations "Stations" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-stations"}
+String Day04_Hour12_Source "Source" (Total_Weather_Data_Day04_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour12-source"}
+
+// Day04 - Hour13
+Group Total_Weather_Data_Day04_Hour13 "Hour 13" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour13_DateTime "DateTime" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-datetime"}
+DateTime Day04_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-timestamp"}
+Number:Temperature Day04_Hour13_Temperature "Temperature" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-temperature"}
+Number:Temperature Day04_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-feels-like"}
+Number Day04_Hour13_Humidity "Humidity" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-humidity"}
+Number:Temperature Day04_Hour13_Dew "Dew Point" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-dew"}
+Number:Length Day04_Hour13_Precip "Precipitation" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-precip"}
+Number:Dimensionless Day04_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-precip-prob"}
+String Day04_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-precip-type"}
+Number:Length Day04_Hour13_Snow "Snow" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-snow"}
+Number:Length Day04_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-snow-depth"}
+Number:Speed Day04_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-wind-gust"}
+Number:Speed Day04_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-wind-speed"}
+Number:Angle Day04_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-wind-dir"}
+Number:Pressure Day04_Hour13_Pressure "Pressure" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-pressure"}
+Number:Length Day04_Hour13_Visibility "Visibility" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-visibility"}
+Number:Dimensionless Day04_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-cloud-cover"}
+Number:Intensity Day04_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-solar-radiation"}
+Number Day04_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-solar-energy"}
+Number Day04_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-uv-index"}
+Number Day04_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-severe-risk"}
+String Day04_Hour13_Conditions "Conditions" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-conditions"}
+String Day04_Hour13_Icon "Icon" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-icon"}
+String Day04_Hour13_Stations "Stations" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-stations"}
+String Day04_Hour13_Source "Source" (Total_Weather_Data_Day04_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour13-source"}
+
+// Day04 - Hour14
+Group Total_Weather_Data_Day04_Hour14 "Hour 14" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour14_DateTime "DateTime" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-datetime"}
+DateTime Day04_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-timestamp"}
+Number:Temperature Day04_Hour14_Temperature "Temperature" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-temperature"}
+Number:Temperature Day04_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-feels-like"}
+Number Day04_Hour14_Humidity "Humidity" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-humidity"}
+Number:Temperature Day04_Hour14_Dew "Dew Point" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-dew"}
+Number:Length Day04_Hour14_Precip "Precipitation" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-precip"}
+Number:Dimensionless Day04_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-precip-prob"}
+String Day04_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-precip-type"}
+Number:Length Day04_Hour14_Snow "Snow" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-snow"}
+Number:Length Day04_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-snow-depth"}
+Number:Speed Day04_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-wind-gust"}
+Number:Speed Day04_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-wind-speed"}
+Number:Angle Day04_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-wind-dir"}
+Number:Pressure Day04_Hour14_Pressure "Pressure" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-pressure"}
+Number:Length Day04_Hour14_Visibility "Visibility" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-visibility"}
+Number:Dimensionless Day04_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-cloud-cover"}
+Number:Intensity Day04_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-solar-radiation"}
+Number Day04_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-solar-energy"}
+Number Day04_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-uv-index"}
+Number Day04_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-severe-risk"}
+String Day04_Hour14_Conditions "Conditions" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-conditions"}
+String Day04_Hour14_Icon "Icon" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-icon"}
+String Day04_Hour14_Stations "Stations" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-stations"}
+String Day04_Hour14_Source "Source" (Total_Weather_Data_Day04_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour14-source"}
+
+// Day04 - Hour15
+Group Total_Weather_Data_Day04_Hour15 "Hour 15" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour15_DateTime "DateTime" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-datetime"}
+DateTime Day04_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-timestamp"}
+Number:Temperature Day04_Hour15_Temperature "Temperature" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-temperature"}
+Number:Temperature Day04_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-feels-like"}
+Number Day04_Hour15_Humidity "Humidity" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-humidity"}
+Number:Temperature Day04_Hour15_Dew "Dew Point" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-dew"}
+Number:Length Day04_Hour15_Precip "Precipitation" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-precip"}
+Number:Dimensionless Day04_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-precip-prob"}
+String Day04_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-precip-type"}
+Number:Length Day04_Hour15_Snow "Snow" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-snow"}
+Number:Length Day04_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-snow-depth"}
+Number:Speed Day04_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-wind-gust"}
+Number:Speed Day04_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-wind-speed"}
+Number:Angle Day04_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-wind-dir"}
+Number:Pressure Day04_Hour15_Pressure "Pressure" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-pressure"}
+Number:Length Day04_Hour15_Visibility "Visibility" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-visibility"}
+Number:Dimensionless Day04_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-cloud-cover"}
+Number:Intensity Day04_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-solar-radiation"}
+Number Day04_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-solar-energy"}
+Number Day04_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-uv-index"}
+Number Day04_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-severe-risk"}
+String Day04_Hour15_Conditions "Conditions" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-conditions"}
+String Day04_Hour15_Icon "Icon" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-icon"}
+String Day04_Hour15_Stations "Stations" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-stations"}
+String Day04_Hour15_Source "Source" (Total_Weather_Data_Day04_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour15-source"}
+
+// Day04 - Hour16
+Group Total_Weather_Data_Day04_Hour16 "Hour 16" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour16_DateTime "DateTime" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-datetime"}
+DateTime Day04_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-timestamp"}
+Number:Temperature Day04_Hour16_Temperature "Temperature" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-temperature"}
+Number:Temperature Day04_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-feels-like"}
+Number Day04_Hour16_Humidity "Humidity" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-humidity"}
+Number:Temperature Day04_Hour16_Dew "Dew Point" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-dew"}
+Number:Length Day04_Hour16_Precip "Precipitation" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-precip"}
+Number:Dimensionless Day04_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-precip-prob"}
+String Day04_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-precip-type"}
+Number:Length Day04_Hour16_Snow "Snow" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-snow"}
+Number:Length Day04_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-snow-depth"}
+Number:Speed Day04_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-wind-gust"}
+Number:Speed Day04_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-wind-speed"}
+Number:Angle Day04_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-wind-dir"}
+Number:Pressure Day04_Hour16_Pressure "Pressure" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-pressure"}
+Number:Length Day04_Hour16_Visibility "Visibility" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-visibility"}
+Number:Dimensionless Day04_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-cloud-cover"}
+Number:Intensity Day04_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-solar-radiation"}
+Number Day04_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-solar-energy"}
+Number Day04_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-uv-index"}
+Number Day04_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-severe-risk"}
+String Day04_Hour16_Conditions "Conditions" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-conditions"}
+String Day04_Hour16_Icon "Icon" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-icon"}
+String Day04_Hour16_Stations "Stations" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-stations"}
+String Day04_Hour16_Source "Source" (Total_Weather_Data_Day04_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour16-source"}
+
+// Day04 - Hour17
+Group Total_Weather_Data_Day04_Hour17 "Hour 17" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour17_DateTime "DateTime" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-datetime"}
+DateTime Day04_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-timestamp"}
+Number:Temperature Day04_Hour17_Temperature "Temperature" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-temperature"}
+Number:Temperature Day04_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-feels-like"}
+Number Day04_Hour17_Humidity "Humidity" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-humidity"}
+Number:Temperature Day04_Hour17_Dew "Dew Point" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-dew"}
+Number:Length Day04_Hour17_Precip "Precipitation" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-precip"}
+Number:Dimensionless Day04_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-precip-prob"}
+String Day04_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-precip-type"}
+Number:Length Day04_Hour17_Snow "Snow" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-snow"}
+Number:Length Day04_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-snow-depth"}
+Number:Speed Day04_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-wind-gust"}
+Number:Speed Day04_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-wind-speed"}
+Number:Angle Day04_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-wind-dir"}
+Number:Pressure Day04_Hour17_Pressure "Pressure" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-pressure"}
+Number:Length Day04_Hour17_Visibility "Visibility" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-visibility"}
+Number:Dimensionless Day04_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-cloud-cover"}
+Number:Intensity Day04_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-solar-radiation"}
+Number Day04_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-solar-energy"}
+Number Day04_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-uv-index"}
+Number Day04_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-severe-risk"}
+String Day04_Hour17_Conditions "Conditions" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-conditions"}
+String Day04_Hour17_Icon "Icon" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-icon"}
+String Day04_Hour17_Stations "Stations" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-stations"}
+String Day04_Hour17_Source "Source" (Total_Weather_Data_Day04_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour17-source"}
+
+// Day04 - Hour18
+Group Total_Weather_Data_Day04_Hour18 "Hour 18" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour18_DateTime "DateTime" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-datetime"}
+DateTime Day04_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-timestamp"}
+Number:Temperature Day04_Hour18_Temperature "Temperature" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-temperature"}
+Number:Temperature Day04_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-feels-like"}
+Number Day04_Hour18_Humidity "Humidity" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-humidity"}
+Number:Temperature Day04_Hour18_Dew "Dew Point" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-dew"}
+Number:Length Day04_Hour18_Precip "Precipitation" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-precip"}
+Number:Dimensionless Day04_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-precip-prob"}
+String Day04_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-precip-type"}
+Number:Length Day04_Hour18_Snow "Snow" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-snow"}
+Number:Length Day04_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-snow-depth"}
+Number:Speed Day04_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-wind-gust"}
+Number:Speed Day04_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-wind-speed"}
+Number:Angle Day04_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-wind-dir"}
+Number:Pressure Day04_Hour18_Pressure "Pressure" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-pressure"}
+Number:Length Day04_Hour18_Visibility "Visibility" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-visibility"}
+Number:Dimensionless Day04_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-cloud-cover"}
+Number:Intensity Day04_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-solar-radiation"}
+Number Day04_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-solar-energy"}
+Number Day04_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-uv-index"}
+Number Day04_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-severe-risk"}
+String Day04_Hour18_Conditions "Conditions" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-conditions"}
+String Day04_Hour18_Icon "Icon" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-icon"}
+String Day04_Hour18_Stations "Stations" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-stations"}
+String Day04_Hour18_Source "Source" (Total_Weather_Data_Day04_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour18-source"}
+
+// Day04 - Hour19
+Group Total_Weather_Data_Day04_Hour19 "Hour 19" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour19_DateTime "DateTime" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-datetime"}
+DateTime Day04_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-timestamp"}
+Number:Temperature Day04_Hour19_Temperature "Temperature" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-temperature"}
+Number:Temperature Day04_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-feels-like"}
+Number Day04_Hour19_Humidity "Humidity" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-humidity"}
+Number:Temperature Day04_Hour19_Dew "Dew Point" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-dew"}
+Number:Length Day04_Hour19_Precip "Precipitation" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-precip"}
+Number:Dimensionless Day04_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-precip-prob"}
+String Day04_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-precip-type"}
+Number:Length Day04_Hour19_Snow "Snow" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-snow"}
+Number:Length Day04_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-snow-depth"}
+Number:Speed Day04_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-wind-gust"}
+Number:Speed Day04_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-wind-speed"}
+Number:Angle Day04_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-wind-dir"}
+Number:Pressure Day04_Hour19_Pressure "Pressure" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-pressure"}
+Number:Length Day04_Hour19_Visibility "Visibility" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-visibility"}
+Number:Dimensionless Day04_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-cloud-cover"}
+Number:Intensity Day04_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-solar-radiation"}
+Number Day04_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-solar-energy"}
+Number Day04_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-uv-index"}
+Number Day04_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-severe-risk"}
+String Day04_Hour19_Conditions "Conditions" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-conditions"}
+String Day04_Hour19_Icon "Icon" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-icon"}
+String Day04_Hour19_Stations "Stations" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-stations"}
+String Day04_Hour19_Source "Source" (Total_Weather_Data_Day04_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour19-source"}
+
+// Day04 - Hour20
+Group Total_Weather_Data_Day04_Hour20 "Hour 20" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour20_DateTime "DateTime" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-datetime"}
+DateTime Day04_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-timestamp"}
+Number:Temperature Day04_Hour20_Temperature "Temperature" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-temperature"}
+Number:Temperature Day04_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-feels-like"}
+Number Day04_Hour20_Humidity "Humidity" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-humidity"}
+Number:Temperature Day04_Hour20_Dew "Dew Point" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-dew"}
+Number:Length Day04_Hour20_Precip "Precipitation" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-precip"}
+Number:Dimensionless Day04_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-precip-prob"}
+String Day04_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-precip-type"}
+Number:Length Day04_Hour20_Snow "Snow" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-snow"}
+Number:Length Day04_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-snow-depth"}
+Number:Speed Day04_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-wind-gust"}
+Number:Speed Day04_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-wind-speed"}
+Number:Angle Day04_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-wind-dir"}
+Number:Pressure Day04_Hour20_Pressure "Pressure" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-pressure"}
+Number:Length Day04_Hour20_Visibility "Visibility" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-visibility"}
+Number:Dimensionless Day04_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-cloud-cover"}
+Number:Intensity Day04_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-solar-radiation"}
+Number Day04_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-solar-energy"}
+Number Day04_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-uv-index"}
+Number Day04_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-severe-risk"}
+String Day04_Hour20_Conditions "Conditions" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-conditions"}
+String Day04_Hour20_Icon "Icon" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-icon"}
+String Day04_Hour20_Stations "Stations" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-stations"}
+String Day04_Hour20_Source "Source" (Total_Weather_Data_Day04_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour20-source"}
+
+// Day04 - Hour21
+Group Total_Weather_Data_Day04_Hour21 "Hour 21" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour21_DateTime "DateTime" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-datetime"}
+DateTime Day04_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-timestamp"}
+Number:Temperature Day04_Hour21_Temperature "Temperature" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-temperature"}
+Number:Temperature Day04_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-feels-like"}
+Number Day04_Hour21_Humidity "Humidity" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-humidity"}
+Number:Temperature Day04_Hour21_Dew "Dew Point" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-dew"}
+Number:Length Day04_Hour21_Precip "Precipitation" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-precip"}
+Number:Dimensionless Day04_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-precip-prob"}
+String Day04_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-precip-type"}
+Number:Length Day04_Hour21_Snow "Snow" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-snow"}
+Number:Length Day04_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-snow-depth"}
+Number:Speed Day04_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-wind-gust"}
+Number:Speed Day04_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-wind-speed"}
+Number:Angle Day04_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-wind-dir"}
+Number:Pressure Day04_Hour21_Pressure "Pressure" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-pressure"}
+Number:Length Day04_Hour21_Visibility "Visibility" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-visibility"}
+Number:Dimensionless Day04_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-cloud-cover"}
+Number:Intensity Day04_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-solar-radiation"}
+Number Day04_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-solar-energy"}
+Number Day04_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-uv-index"}
+Number Day04_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-severe-risk"}
+String Day04_Hour21_Conditions "Conditions" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-conditions"}
+String Day04_Hour21_Icon "Icon" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-icon"}
+String Day04_Hour21_Stations "Stations" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-stations"}
+String Day04_Hour21_Source "Source" (Total_Weather_Data_Day04_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour21-source"}
+
+// Day04 - Hour22
+Group Total_Weather_Data_Day04_Hour22 "Hour 22" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour22_DateTime "DateTime" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-datetime"}
+DateTime Day04_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-timestamp"}
+Number:Temperature Day04_Hour22_Temperature "Temperature" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-temperature"}
+Number:Temperature Day04_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-feels-like"}
+Number Day04_Hour22_Humidity "Humidity" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-humidity"}
+Number:Temperature Day04_Hour22_Dew "Dew Point" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-dew"}
+Number:Length Day04_Hour22_Precip "Precipitation" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-precip"}
+Number:Dimensionless Day04_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-precip-prob"}
+String Day04_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-precip-type"}
+Number:Length Day04_Hour22_Snow "Snow" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-snow"}
+Number:Length Day04_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-snow-depth"}
+Number:Speed Day04_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-wind-gust"}
+Number:Speed Day04_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-wind-speed"}
+Number:Angle Day04_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-wind-dir"}
+Number:Pressure Day04_Hour22_Pressure "Pressure" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-pressure"}
+Number:Length Day04_Hour22_Visibility "Visibility" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-visibility"}
+Number:Dimensionless Day04_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-cloud-cover"}
+Number:Intensity Day04_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-solar-radiation"}
+Number Day04_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-solar-energy"}
+Number Day04_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-uv-index"}
+Number Day04_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-severe-risk"}
+String Day04_Hour22_Conditions "Conditions" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-conditions"}
+String Day04_Hour22_Icon "Icon" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-icon"}
+String Day04_Hour22_Stations "Stations" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-stations"}
+String Day04_Hour22_Source "Source" (Total_Weather_Data_Day04_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour22-source"}
+
+// Day04 - Hour23
+Group Total_Weather_Data_Day04_Hour23 "Hour 23" (Total_Weather_Data_Day04) [ "Equipment" ] 
+String Day04_Hour23_DateTime "DateTime" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-datetime"}
+DateTime Day04_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-timestamp"}
+Number:Temperature Day04_Hour23_Temperature "Temperature" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-temperature"}
+Number:Temperature Day04_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-feels-like"}
+Number Day04_Hour23_Humidity "Humidity" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-humidity"}
+Number:Temperature Day04_Hour23_Dew "Dew Point" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-dew"}
+Number:Length Day04_Hour23_Precip "Precipitation" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-precip"}
+Number:Dimensionless Day04_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-precip-prob"}
+String Day04_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-precip-type"}
+Number:Length Day04_Hour23_Snow "Snow" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-snow"}
+Number:Length Day04_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-snow-depth"}
+Number:Speed Day04_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-wind-gust"}
+Number:Speed Day04_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-wind-speed"}
+Number:Angle Day04_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-wind-dir"}
+Number:Pressure Day04_Hour23_Pressure "Pressure" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-pressure"}
+Number:Length Day04_Hour23_Visibility "Visibility" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-visibility"}
+Number:Dimensionless Day04_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-cloud-cover"}
+Number:Intensity Day04_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-solar-radiation"}
+Number Day04_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-solar-energy"}
+Number Day04_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-uv-index"}
+Number Day04_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-severe-risk"}
+String Day04_Hour23_Conditions "Conditions" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-conditions"}
+String Day04_Hour23_Icon "Icon" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-icon"}
+String Day04_Hour23_Stations "Stations" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-stations"}
+String Day04_Hour23_Source "Source" (Total_Weather_Data_Day04_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day04#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_05.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_05.items
@@ -1,39 +1,712 @@
 // Day05
 Group Total_Weather_Data_Day05 "Day T+05" (Total_Weather_Data) [ "Equipment" ] 
-String Day05_DateTime "Time" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day05_Timestamp "Timestamp" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day05_Temperature "Temperature" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day05_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day05_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day05_FeelsLike "Feels Like" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day05_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day05_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day05_Dew "Dew Point" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day05_Humidity "Humidity" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day05_Precip "Precipitation" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day05_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day05_Precip_Type "Precipitation Type" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day05_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day05_Snow "Snow" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day05_Snow_Depth "Snow Depth" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day05_Wind_Gust "Wind Gust" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day05_Wind_Speed "Wind Speed" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day05_Wind_Dir "Wind Direction" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day05_Pressure "Pressure" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day05_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day05_Visibility "Visibility" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day05_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day05_Solar_Energy "Solar Energy" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day05_UV_Index "UV Index" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day05_Sunrise "Sunrise" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day05_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day05_Sunset "Sunset" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day05_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day05_Moon_Phase "Moon Phase" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day05_Conditions "Conditions" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day05_Description "Description" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day05_Icon "Icon" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day05_Stations "Stations" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day05_Source "Source" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day05_Severe_Risk "Severe Risk" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day05_DateTime "Time" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#datetime" }
+DateTime Day05_Timestamp "Timestamp" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#timestamp" }
+Number:Temperature Day05_Temperature "Temperature" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#temperature" }
+Number:Temperature Day05_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#temperature-min" }
+Number:Temperature Day05_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#temperature-max" }
+Number:Temperature Day05_FeelsLike "Feels Like" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#feels-like" }
+Number:Temperature Day05_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#feels-like-min" }
+Number:Temperature Day05_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#feels-like-max" }
+Number:Temperature Day05_Dew "Dew Point" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#dew" }
+Number Day05_Humidity "Humidity" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#humidity" }
+Number:Length Day05_Precip "Precipitation" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#precip" }
+Number Day05_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#precip-prob" }
+String Day05_Precip_Type "Precipitation Type" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#precip-type" }
+Number Day05_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#precip-cover" }
+Number:Length Day05_Snow "Snow" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#snow" }
+Number:Length Day05_Snow_Depth "Snow Depth" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#snow-depth" }
+Number:Speed Day05_Wind_Gust "Wind Gust" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#wind-gust" }
+Number:Speed Day05_Wind_Speed "Wind Speed" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#wind-speed" }
+Number:Angle Day05_Wind_Dir "Wind Direction" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#wind-dir" }
+Number:Pressure Day05_Pressure "Pressure" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#pressure" }
+Number Day05_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#cloud-cover" }
+Number:Length Day05_Visibility "Visibility" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#visibility" }
+Number:Intensity Day05_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#solar-radiation" }
+Number Day05_Solar_Energy "Solar Energy" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#solar-energy" }
+Number Day05_UV_Index "UV Index" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#uv-index" }
+String Day05_Sunrise "Sunrise" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#sunrise" }
+DateTime Day05_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#sunrise-epoch" }
+String Day05_Sunset "Sunset" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#sunset" }
+DateTime Day05_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#sunset-epoch" }
+Number Day05_Moon_Phase "Moon Phase" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#moon-phase" }
+String Day05_Conditions "Conditions" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#conditions" }
+String Day05_Description "Description" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#description" }
+String Day05_Icon "Icon" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#icon" }
+String Day05_Stations "Stations" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#stations" }
+String Day05_Source "Source" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#source" }
+Number Day05_Severe_Risk "Severe Risk" (Total_Weather_Data_Day05)["Point"] { channel="visualcrossing:weather:default_config:day05#severe-risk" }
+
+// Day05 - Hour00
+Group Total_Weather_Data_Day05_Hour00 "Hour 00" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour00_DateTime "DateTime" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-datetime"}
+DateTime Day05_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-timestamp"}
+Number:Temperature Day05_Hour00_Temperature "Temperature" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-temperature"}
+Number:Temperature Day05_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-feels-like"}
+Number Day05_Hour00_Humidity "Humidity" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-humidity"}
+Number:Temperature Day05_Hour00_Dew "Dew Point" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-dew"}
+Number:Length Day05_Hour00_Precip "Precipitation" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-precip"}
+Number:Dimensionless Day05_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-precip-prob"}
+String Day05_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-precip-type"}
+Number:Length Day05_Hour00_Snow "Snow" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-snow"}
+Number:Length Day05_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-snow-depth"}
+Number:Speed Day05_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-wind-gust"}
+Number:Speed Day05_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-wind-speed"}
+Number:Angle Day05_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-wind-dir"}
+Number:Pressure Day05_Hour00_Pressure "Pressure" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-pressure"}
+Number:Length Day05_Hour00_Visibility "Visibility" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-visibility"}
+Number:Dimensionless Day05_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-cloud-cover"}
+Number:Intensity Day05_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-solar-radiation"}
+Number Day05_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-solar-energy"}
+Number Day05_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-uv-index"}
+Number Day05_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-severe-risk"}
+String Day05_Hour00_Conditions "Conditions" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-conditions"}
+String Day05_Hour00_Icon "Icon" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-icon"}
+String Day05_Hour00_Stations "Stations" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-stations"}
+String Day05_Hour00_Source "Source" (Total_Weather_Data_Day05_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour00-source"}
+
+// Day05 - Hour01
+Group Total_Weather_Data_Day05_Hour01 "Hour 01" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour01_DateTime "DateTime" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-datetime"}
+DateTime Day05_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-timestamp"}
+Number:Temperature Day05_Hour01_Temperature "Temperature" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-temperature"}
+Number:Temperature Day05_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-feels-like"}
+Number Day05_Hour01_Humidity "Humidity" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-humidity"}
+Number:Temperature Day05_Hour01_Dew "Dew Point" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-dew"}
+Number:Length Day05_Hour01_Precip "Precipitation" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-precip"}
+Number:Dimensionless Day05_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-precip-prob"}
+String Day05_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-precip-type"}
+Number:Length Day05_Hour01_Snow "Snow" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-snow"}
+Number:Length Day05_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-snow-depth"}
+Number:Speed Day05_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-wind-gust"}
+Number:Speed Day05_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-wind-speed"}
+Number:Angle Day05_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-wind-dir"}
+Number:Pressure Day05_Hour01_Pressure "Pressure" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-pressure"}
+Number:Length Day05_Hour01_Visibility "Visibility" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-visibility"}
+Number:Dimensionless Day05_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-cloud-cover"}
+Number:Intensity Day05_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-solar-radiation"}
+Number Day05_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-solar-energy"}
+Number Day05_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-uv-index"}
+Number Day05_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-severe-risk"}
+String Day05_Hour01_Conditions "Conditions" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-conditions"}
+String Day05_Hour01_Icon "Icon" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-icon"}
+String Day05_Hour01_Stations "Stations" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-stations"}
+String Day05_Hour01_Source "Source" (Total_Weather_Data_Day05_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour01-source"}
+
+// Day05 - Hour02
+Group Total_Weather_Data_Day05_Hour02 "Hour 02" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour02_DateTime "DateTime" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-datetime"}
+DateTime Day05_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-timestamp"}
+Number:Temperature Day05_Hour02_Temperature "Temperature" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-temperature"}
+Number:Temperature Day05_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-feels-like"}
+Number Day05_Hour02_Humidity "Humidity" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-humidity"}
+Number:Temperature Day05_Hour02_Dew "Dew Point" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-dew"}
+Number:Length Day05_Hour02_Precip "Precipitation" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-precip"}
+Number:Dimensionless Day05_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-precip-prob"}
+String Day05_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-precip-type"}
+Number:Length Day05_Hour02_Snow "Snow" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-snow"}
+Number:Length Day05_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-snow-depth"}
+Number:Speed Day05_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-wind-gust"}
+Number:Speed Day05_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-wind-speed"}
+Number:Angle Day05_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-wind-dir"}
+Number:Pressure Day05_Hour02_Pressure "Pressure" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-pressure"}
+Number:Length Day05_Hour02_Visibility "Visibility" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-visibility"}
+Number:Dimensionless Day05_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-cloud-cover"}
+Number:Intensity Day05_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-solar-radiation"}
+Number Day05_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-solar-energy"}
+Number Day05_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-uv-index"}
+Number Day05_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-severe-risk"}
+String Day05_Hour02_Conditions "Conditions" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-conditions"}
+String Day05_Hour02_Icon "Icon" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-icon"}
+String Day05_Hour02_Stations "Stations" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-stations"}
+String Day05_Hour02_Source "Source" (Total_Weather_Data_Day05_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour02-source"}
+
+// Day05 - Hour03
+Group Total_Weather_Data_Day05_Hour03 "Hour 03" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour03_DateTime "DateTime" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-datetime"}
+DateTime Day05_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-timestamp"}
+Number:Temperature Day05_Hour03_Temperature "Temperature" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-temperature"}
+Number:Temperature Day05_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-feels-like"}
+Number Day05_Hour03_Humidity "Humidity" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-humidity"}
+Number:Temperature Day05_Hour03_Dew "Dew Point" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-dew"}
+Number:Length Day05_Hour03_Precip "Precipitation" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-precip"}
+Number:Dimensionless Day05_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-precip-prob"}
+String Day05_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-precip-type"}
+Number:Length Day05_Hour03_Snow "Snow" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-snow"}
+Number:Length Day05_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-snow-depth"}
+Number:Speed Day05_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-wind-gust"}
+Number:Speed Day05_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-wind-speed"}
+Number:Angle Day05_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-wind-dir"}
+Number:Pressure Day05_Hour03_Pressure "Pressure" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-pressure"}
+Number:Length Day05_Hour03_Visibility "Visibility" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-visibility"}
+Number:Dimensionless Day05_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-cloud-cover"}
+Number:Intensity Day05_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-solar-radiation"}
+Number Day05_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-solar-energy"}
+Number Day05_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-uv-index"}
+Number Day05_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-severe-risk"}
+String Day05_Hour03_Conditions "Conditions" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-conditions"}
+String Day05_Hour03_Icon "Icon" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-icon"}
+String Day05_Hour03_Stations "Stations" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-stations"}
+String Day05_Hour03_Source "Source" (Total_Weather_Data_Day05_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour03-source"}
+
+// Day05 - Hour04
+Group Total_Weather_Data_Day05_Hour04 "Hour 04" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour04_DateTime "DateTime" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-datetime"}
+DateTime Day05_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-timestamp"}
+Number:Temperature Day05_Hour04_Temperature "Temperature" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-temperature"}
+Number:Temperature Day05_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-feels-like"}
+Number Day05_Hour04_Humidity "Humidity" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-humidity"}
+Number:Temperature Day05_Hour04_Dew "Dew Point" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-dew"}
+Number:Length Day05_Hour04_Precip "Precipitation" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-precip"}
+Number:Dimensionless Day05_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-precip-prob"}
+String Day05_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-precip-type"}
+Number:Length Day05_Hour04_Snow "Snow" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-snow"}
+Number:Length Day05_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-snow-depth"}
+Number:Speed Day05_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-wind-gust"}
+Number:Speed Day05_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-wind-speed"}
+Number:Angle Day05_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-wind-dir"}
+Number:Pressure Day05_Hour04_Pressure "Pressure" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-pressure"}
+Number:Length Day05_Hour04_Visibility "Visibility" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-visibility"}
+Number:Dimensionless Day05_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-cloud-cover"}
+Number:Intensity Day05_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-solar-radiation"}
+Number Day05_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-solar-energy"}
+Number Day05_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-uv-index"}
+Number Day05_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-severe-risk"}
+String Day05_Hour04_Conditions "Conditions" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-conditions"}
+String Day05_Hour04_Icon "Icon" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-icon"}
+String Day05_Hour04_Stations "Stations" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-stations"}
+String Day05_Hour04_Source "Source" (Total_Weather_Data_Day05_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour04-source"}
+
+// Day05 - Hour05
+Group Total_Weather_Data_Day05_Hour05 "Hour 05" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour05_DateTime "DateTime" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-datetime"}
+DateTime Day05_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-timestamp"}
+Number:Temperature Day05_Hour05_Temperature "Temperature" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-temperature"}
+Number:Temperature Day05_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-feels-like"}
+Number Day05_Hour05_Humidity "Humidity" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-humidity"}
+Number:Temperature Day05_Hour05_Dew "Dew Point" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-dew"}
+Number:Length Day05_Hour05_Precip "Precipitation" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-precip"}
+Number:Dimensionless Day05_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-precip-prob"}
+String Day05_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-precip-type"}
+Number:Length Day05_Hour05_Snow "Snow" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-snow"}
+Number:Length Day05_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-snow-depth"}
+Number:Speed Day05_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-wind-gust"}
+Number:Speed Day05_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-wind-speed"}
+Number:Angle Day05_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-wind-dir"}
+Number:Pressure Day05_Hour05_Pressure "Pressure" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-pressure"}
+Number:Length Day05_Hour05_Visibility "Visibility" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-visibility"}
+Number:Dimensionless Day05_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-cloud-cover"}
+Number:Intensity Day05_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-solar-radiation"}
+Number Day05_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-solar-energy"}
+Number Day05_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-uv-index"}
+Number Day05_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-severe-risk"}
+String Day05_Hour05_Conditions "Conditions" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-conditions"}
+String Day05_Hour05_Icon "Icon" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-icon"}
+String Day05_Hour05_Stations "Stations" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-stations"}
+String Day05_Hour05_Source "Source" (Total_Weather_Data_Day05_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour05-source"}
+
+// Day05 - Hour06
+Group Total_Weather_Data_Day05_Hour06 "Hour 06" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour06_DateTime "DateTime" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-datetime"}
+DateTime Day05_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-timestamp"}
+Number:Temperature Day05_Hour06_Temperature "Temperature" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-temperature"}
+Number:Temperature Day05_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-feels-like"}
+Number Day05_Hour06_Humidity "Humidity" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-humidity"}
+Number:Temperature Day05_Hour06_Dew "Dew Point" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-dew"}
+Number:Length Day05_Hour06_Precip "Precipitation" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-precip"}
+Number:Dimensionless Day05_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-precip-prob"}
+String Day05_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-precip-type"}
+Number:Length Day05_Hour06_Snow "Snow" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-snow"}
+Number:Length Day05_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-snow-depth"}
+Number:Speed Day05_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-wind-gust"}
+Number:Speed Day05_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-wind-speed"}
+Number:Angle Day05_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-wind-dir"}
+Number:Pressure Day05_Hour06_Pressure "Pressure" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-pressure"}
+Number:Length Day05_Hour06_Visibility "Visibility" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-visibility"}
+Number:Dimensionless Day05_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-cloud-cover"}
+Number:Intensity Day05_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-solar-radiation"}
+Number Day05_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-solar-energy"}
+Number Day05_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-uv-index"}
+Number Day05_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-severe-risk"}
+String Day05_Hour06_Conditions "Conditions" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-conditions"}
+String Day05_Hour06_Icon "Icon" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-icon"}
+String Day05_Hour06_Stations "Stations" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-stations"}
+String Day05_Hour06_Source "Source" (Total_Weather_Data_Day05_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour06-source"}
+
+// Day05 - Hour07
+Group Total_Weather_Data_Day05_Hour07 "Hour 07" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour07_DateTime "DateTime" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-datetime"}
+DateTime Day05_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-timestamp"}
+Number:Temperature Day05_Hour07_Temperature "Temperature" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-temperature"}
+Number:Temperature Day05_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-feels-like"}
+Number Day05_Hour07_Humidity "Humidity" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-humidity"}
+Number:Temperature Day05_Hour07_Dew "Dew Point" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-dew"}
+Number:Length Day05_Hour07_Precip "Precipitation" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-precip"}
+Number:Dimensionless Day05_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-precip-prob"}
+String Day05_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-precip-type"}
+Number:Length Day05_Hour07_Snow "Snow" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-snow"}
+Number:Length Day05_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-snow-depth"}
+Number:Speed Day05_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-wind-gust"}
+Number:Speed Day05_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-wind-speed"}
+Number:Angle Day05_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-wind-dir"}
+Number:Pressure Day05_Hour07_Pressure "Pressure" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-pressure"}
+Number:Length Day05_Hour07_Visibility "Visibility" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-visibility"}
+Number:Dimensionless Day05_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-cloud-cover"}
+Number:Intensity Day05_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-solar-radiation"}
+Number Day05_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-solar-energy"}
+Number Day05_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-uv-index"}
+Number Day05_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-severe-risk"}
+String Day05_Hour07_Conditions "Conditions" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-conditions"}
+String Day05_Hour07_Icon "Icon" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-icon"}
+String Day05_Hour07_Stations "Stations" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-stations"}
+String Day05_Hour07_Source "Source" (Total_Weather_Data_Day05_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour07-source"}
+
+// Day05 - Hour08
+Group Total_Weather_Data_Day05_Hour08 "Hour 08" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour08_DateTime "DateTime" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-datetime"}
+DateTime Day05_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-timestamp"}
+Number:Temperature Day05_Hour08_Temperature "Temperature" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-temperature"}
+Number:Temperature Day05_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-feels-like"}
+Number Day05_Hour08_Humidity "Humidity" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-humidity"}
+Number:Temperature Day05_Hour08_Dew "Dew Point" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-dew"}
+Number:Length Day05_Hour08_Precip "Precipitation" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-precip"}
+Number:Dimensionless Day05_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-precip-prob"}
+String Day05_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-precip-type"}
+Number:Length Day05_Hour08_Snow "Snow" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-snow"}
+Number:Length Day05_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-snow-depth"}
+Number:Speed Day05_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-wind-gust"}
+Number:Speed Day05_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-wind-speed"}
+Number:Angle Day05_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-wind-dir"}
+Number:Pressure Day05_Hour08_Pressure "Pressure" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-pressure"}
+Number:Length Day05_Hour08_Visibility "Visibility" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-visibility"}
+Number:Dimensionless Day05_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-cloud-cover"}
+Number:Intensity Day05_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-solar-radiation"}
+Number Day05_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-solar-energy"}
+Number Day05_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-uv-index"}
+Number Day05_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-severe-risk"}
+String Day05_Hour08_Conditions "Conditions" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-conditions"}
+String Day05_Hour08_Icon "Icon" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-icon"}
+String Day05_Hour08_Stations "Stations" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-stations"}
+String Day05_Hour08_Source "Source" (Total_Weather_Data_Day05_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour08-source"}
+
+// Day05 - Hour09
+Group Total_Weather_Data_Day05_Hour09 "Hour 09" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour09_DateTime "DateTime" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-datetime"}
+DateTime Day05_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-timestamp"}
+Number:Temperature Day05_Hour09_Temperature "Temperature" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-temperature"}
+Number:Temperature Day05_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-feels-like"}
+Number Day05_Hour09_Humidity "Humidity" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-humidity"}
+Number:Temperature Day05_Hour09_Dew "Dew Point" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-dew"}
+Number:Length Day05_Hour09_Precip "Precipitation" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-precip"}
+Number:Dimensionless Day05_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-precip-prob"}
+String Day05_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-precip-type"}
+Number:Length Day05_Hour09_Snow "Snow" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-snow"}
+Number:Length Day05_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-snow-depth"}
+Number:Speed Day05_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-wind-gust"}
+Number:Speed Day05_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-wind-speed"}
+Number:Angle Day05_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-wind-dir"}
+Number:Pressure Day05_Hour09_Pressure "Pressure" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-pressure"}
+Number:Length Day05_Hour09_Visibility "Visibility" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-visibility"}
+Number:Dimensionless Day05_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-cloud-cover"}
+Number:Intensity Day05_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-solar-radiation"}
+Number Day05_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-solar-energy"}
+Number Day05_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-uv-index"}
+Number Day05_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-severe-risk"}
+String Day05_Hour09_Conditions "Conditions" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-conditions"}
+String Day05_Hour09_Icon "Icon" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-icon"}
+String Day05_Hour09_Stations "Stations" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-stations"}
+String Day05_Hour09_Source "Source" (Total_Weather_Data_Day05_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour09-source"}
+
+// Day05 - Hour10
+Group Total_Weather_Data_Day05_Hour10 "Hour 10" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour10_DateTime "DateTime" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-datetime"}
+DateTime Day05_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-timestamp"}
+Number:Temperature Day05_Hour10_Temperature "Temperature" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-temperature"}
+Number:Temperature Day05_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-feels-like"}
+Number Day05_Hour10_Humidity "Humidity" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-humidity"}
+Number:Temperature Day05_Hour10_Dew "Dew Point" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-dew"}
+Number:Length Day05_Hour10_Precip "Precipitation" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-precip"}
+Number:Dimensionless Day05_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-precip-prob"}
+String Day05_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-precip-type"}
+Number:Length Day05_Hour10_Snow "Snow" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-snow"}
+Number:Length Day05_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-snow-depth"}
+Number:Speed Day05_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-wind-gust"}
+Number:Speed Day05_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-wind-speed"}
+Number:Angle Day05_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-wind-dir"}
+Number:Pressure Day05_Hour10_Pressure "Pressure" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-pressure"}
+Number:Length Day05_Hour10_Visibility "Visibility" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-visibility"}
+Number:Dimensionless Day05_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-cloud-cover"}
+Number:Intensity Day05_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-solar-radiation"}
+Number Day05_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-solar-energy"}
+Number Day05_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-uv-index"}
+Number Day05_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-severe-risk"}
+String Day05_Hour10_Conditions "Conditions" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-conditions"}
+String Day05_Hour10_Icon "Icon" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-icon"}
+String Day05_Hour10_Stations "Stations" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-stations"}
+String Day05_Hour10_Source "Source" (Total_Weather_Data_Day05_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour10-source"}
+
+// Day05 - Hour11
+Group Total_Weather_Data_Day05_Hour11 "Hour 11" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour11_DateTime "DateTime" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-datetime"}
+DateTime Day05_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-timestamp"}
+Number:Temperature Day05_Hour11_Temperature "Temperature" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-temperature"}
+Number:Temperature Day05_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-feels-like"}
+Number Day05_Hour11_Humidity "Humidity" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-humidity"}
+Number:Temperature Day05_Hour11_Dew "Dew Point" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-dew"}
+Number:Length Day05_Hour11_Precip "Precipitation" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-precip"}
+Number:Dimensionless Day05_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-precip-prob"}
+String Day05_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-precip-type"}
+Number:Length Day05_Hour11_Snow "Snow" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-snow"}
+Number:Length Day05_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-snow-depth"}
+Number:Speed Day05_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-wind-gust"}
+Number:Speed Day05_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-wind-speed"}
+Number:Angle Day05_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-wind-dir"}
+Number:Pressure Day05_Hour11_Pressure "Pressure" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-pressure"}
+Number:Length Day05_Hour11_Visibility "Visibility" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-visibility"}
+Number:Dimensionless Day05_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-cloud-cover"}
+Number:Intensity Day05_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-solar-radiation"}
+Number Day05_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-solar-energy"}
+Number Day05_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-uv-index"}
+Number Day05_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-severe-risk"}
+String Day05_Hour11_Conditions "Conditions" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-conditions"}
+String Day05_Hour11_Icon "Icon" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-icon"}
+String Day05_Hour11_Stations "Stations" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-stations"}
+String Day05_Hour11_Source "Source" (Total_Weather_Data_Day05_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour11-source"}
+
+// Day05 - Hour12
+Group Total_Weather_Data_Day05_Hour12 "Hour 12" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour12_DateTime "DateTime" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-datetime"}
+DateTime Day05_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-timestamp"}
+Number:Temperature Day05_Hour12_Temperature "Temperature" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-temperature"}
+Number:Temperature Day05_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-feels-like"}
+Number Day05_Hour12_Humidity "Humidity" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-humidity"}
+Number:Temperature Day05_Hour12_Dew "Dew Point" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-dew"}
+Number:Length Day05_Hour12_Precip "Precipitation" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-precip"}
+Number:Dimensionless Day05_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-precip-prob"}
+String Day05_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-precip-type"}
+Number:Length Day05_Hour12_Snow "Snow" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-snow"}
+Number:Length Day05_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-snow-depth"}
+Number:Speed Day05_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-wind-gust"}
+Number:Speed Day05_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-wind-speed"}
+Number:Angle Day05_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-wind-dir"}
+Number:Pressure Day05_Hour12_Pressure "Pressure" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-pressure"}
+Number:Length Day05_Hour12_Visibility "Visibility" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-visibility"}
+Number:Dimensionless Day05_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-cloud-cover"}
+Number:Intensity Day05_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-solar-radiation"}
+Number Day05_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-solar-energy"}
+Number Day05_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-uv-index"}
+Number Day05_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-severe-risk"}
+String Day05_Hour12_Conditions "Conditions" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-conditions"}
+String Day05_Hour12_Icon "Icon" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-icon"}
+String Day05_Hour12_Stations "Stations" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-stations"}
+String Day05_Hour12_Source "Source" (Total_Weather_Data_Day05_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour12-source"}
+
+// Day05 - Hour13
+Group Total_Weather_Data_Day05_Hour13 "Hour 13" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour13_DateTime "DateTime" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-datetime"}
+DateTime Day05_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-timestamp"}
+Number:Temperature Day05_Hour13_Temperature "Temperature" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-temperature"}
+Number:Temperature Day05_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-feels-like"}
+Number Day05_Hour13_Humidity "Humidity" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-humidity"}
+Number:Temperature Day05_Hour13_Dew "Dew Point" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-dew"}
+Number:Length Day05_Hour13_Precip "Precipitation" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-precip"}
+Number:Dimensionless Day05_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-precip-prob"}
+String Day05_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-precip-type"}
+Number:Length Day05_Hour13_Snow "Snow" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-snow"}
+Number:Length Day05_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-snow-depth"}
+Number:Speed Day05_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-wind-gust"}
+Number:Speed Day05_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-wind-speed"}
+Number:Angle Day05_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-wind-dir"}
+Number:Pressure Day05_Hour13_Pressure "Pressure" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-pressure"}
+Number:Length Day05_Hour13_Visibility "Visibility" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-visibility"}
+Number:Dimensionless Day05_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-cloud-cover"}
+Number:Intensity Day05_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-solar-radiation"}
+Number Day05_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-solar-energy"}
+Number Day05_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-uv-index"}
+Number Day05_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-severe-risk"}
+String Day05_Hour13_Conditions "Conditions" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-conditions"}
+String Day05_Hour13_Icon "Icon" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-icon"}
+String Day05_Hour13_Stations "Stations" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-stations"}
+String Day05_Hour13_Source "Source" (Total_Weather_Data_Day05_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour13-source"}
+
+// Day05 - Hour14
+Group Total_Weather_Data_Day05_Hour14 "Hour 14" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour14_DateTime "DateTime" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-datetime"}
+DateTime Day05_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-timestamp"}
+Number:Temperature Day05_Hour14_Temperature "Temperature" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-temperature"}
+Number:Temperature Day05_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-feels-like"}
+Number Day05_Hour14_Humidity "Humidity" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-humidity"}
+Number:Temperature Day05_Hour14_Dew "Dew Point" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-dew"}
+Number:Length Day05_Hour14_Precip "Precipitation" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-precip"}
+Number:Dimensionless Day05_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-precip-prob"}
+String Day05_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-precip-type"}
+Number:Length Day05_Hour14_Snow "Snow" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-snow"}
+Number:Length Day05_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-snow-depth"}
+Number:Speed Day05_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-wind-gust"}
+Number:Speed Day05_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-wind-speed"}
+Number:Angle Day05_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-wind-dir"}
+Number:Pressure Day05_Hour14_Pressure "Pressure" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-pressure"}
+Number:Length Day05_Hour14_Visibility "Visibility" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-visibility"}
+Number:Dimensionless Day05_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-cloud-cover"}
+Number:Intensity Day05_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-solar-radiation"}
+Number Day05_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-solar-energy"}
+Number Day05_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-uv-index"}
+Number Day05_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-severe-risk"}
+String Day05_Hour14_Conditions "Conditions" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-conditions"}
+String Day05_Hour14_Icon "Icon" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-icon"}
+String Day05_Hour14_Stations "Stations" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-stations"}
+String Day05_Hour14_Source "Source" (Total_Weather_Data_Day05_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour14-source"}
+
+// Day05 - Hour15
+Group Total_Weather_Data_Day05_Hour15 "Hour 15" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour15_DateTime "DateTime" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-datetime"}
+DateTime Day05_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-timestamp"}
+Number:Temperature Day05_Hour15_Temperature "Temperature" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-temperature"}
+Number:Temperature Day05_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-feels-like"}
+Number Day05_Hour15_Humidity "Humidity" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-humidity"}
+Number:Temperature Day05_Hour15_Dew "Dew Point" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-dew"}
+Number:Length Day05_Hour15_Precip "Precipitation" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-precip"}
+Number:Dimensionless Day05_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-precip-prob"}
+String Day05_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-precip-type"}
+Number:Length Day05_Hour15_Snow "Snow" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-snow"}
+Number:Length Day05_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-snow-depth"}
+Number:Speed Day05_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-wind-gust"}
+Number:Speed Day05_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-wind-speed"}
+Number:Angle Day05_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-wind-dir"}
+Number:Pressure Day05_Hour15_Pressure "Pressure" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-pressure"}
+Number:Length Day05_Hour15_Visibility "Visibility" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-visibility"}
+Number:Dimensionless Day05_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-cloud-cover"}
+Number:Intensity Day05_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-solar-radiation"}
+Number Day05_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-solar-energy"}
+Number Day05_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-uv-index"}
+Number Day05_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-severe-risk"}
+String Day05_Hour15_Conditions "Conditions" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-conditions"}
+String Day05_Hour15_Icon "Icon" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-icon"}
+String Day05_Hour15_Stations "Stations" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-stations"}
+String Day05_Hour15_Source "Source" (Total_Weather_Data_Day05_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour15-source"}
+
+// Day05 - Hour16
+Group Total_Weather_Data_Day05_Hour16 "Hour 16" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour16_DateTime "DateTime" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-datetime"}
+DateTime Day05_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-timestamp"}
+Number:Temperature Day05_Hour16_Temperature "Temperature" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-temperature"}
+Number:Temperature Day05_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-feels-like"}
+Number Day05_Hour16_Humidity "Humidity" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-humidity"}
+Number:Temperature Day05_Hour16_Dew "Dew Point" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-dew"}
+Number:Length Day05_Hour16_Precip "Precipitation" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-precip"}
+Number:Dimensionless Day05_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-precip-prob"}
+String Day05_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-precip-type"}
+Number:Length Day05_Hour16_Snow "Snow" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-snow"}
+Number:Length Day05_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-snow-depth"}
+Number:Speed Day05_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-wind-gust"}
+Number:Speed Day05_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-wind-speed"}
+Number:Angle Day05_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-wind-dir"}
+Number:Pressure Day05_Hour16_Pressure "Pressure" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-pressure"}
+Number:Length Day05_Hour16_Visibility "Visibility" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-visibility"}
+Number:Dimensionless Day05_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-cloud-cover"}
+Number:Intensity Day05_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-solar-radiation"}
+Number Day05_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-solar-energy"}
+Number Day05_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-uv-index"}
+Number Day05_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-severe-risk"}
+String Day05_Hour16_Conditions "Conditions" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-conditions"}
+String Day05_Hour16_Icon "Icon" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-icon"}
+String Day05_Hour16_Stations "Stations" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-stations"}
+String Day05_Hour16_Source "Source" (Total_Weather_Data_Day05_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour16-source"}
+
+// Day05 - Hour17
+Group Total_Weather_Data_Day05_Hour17 "Hour 17" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour17_DateTime "DateTime" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-datetime"}
+DateTime Day05_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-timestamp"}
+Number:Temperature Day05_Hour17_Temperature "Temperature" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-temperature"}
+Number:Temperature Day05_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-feels-like"}
+Number Day05_Hour17_Humidity "Humidity" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-humidity"}
+Number:Temperature Day05_Hour17_Dew "Dew Point" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-dew"}
+Number:Length Day05_Hour17_Precip "Precipitation" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-precip"}
+Number:Dimensionless Day05_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-precip-prob"}
+String Day05_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-precip-type"}
+Number:Length Day05_Hour17_Snow "Snow" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-snow"}
+Number:Length Day05_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-snow-depth"}
+Number:Speed Day05_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-wind-gust"}
+Number:Speed Day05_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-wind-speed"}
+Number:Angle Day05_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-wind-dir"}
+Number:Pressure Day05_Hour17_Pressure "Pressure" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-pressure"}
+Number:Length Day05_Hour17_Visibility "Visibility" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-visibility"}
+Number:Dimensionless Day05_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-cloud-cover"}
+Number:Intensity Day05_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-solar-radiation"}
+Number Day05_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-solar-energy"}
+Number Day05_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-uv-index"}
+Number Day05_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-severe-risk"}
+String Day05_Hour17_Conditions "Conditions" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-conditions"}
+String Day05_Hour17_Icon "Icon" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-icon"}
+String Day05_Hour17_Stations "Stations" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-stations"}
+String Day05_Hour17_Source "Source" (Total_Weather_Data_Day05_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour17-source"}
+
+// Day05 - Hour18
+Group Total_Weather_Data_Day05_Hour18 "Hour 18" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour18_DateTime "DateTime" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-datetime"}
+DateTime Day05_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-timestamp"}
+Number:Temperature Day05_Hour18_Temperature "Temperature" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-temperature"}
+Number:Temperature Day05_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-feels-like"}
+Number Day05_Hour18_Humidity "Humidity" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-humidity"}
+Number:Temperature Day05_Hour18_Dew "Dew Point" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-dew"}
+Number:Length Day05_Hour18_Precip "Precipitation" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-precip"}
+Number:Dimensionless Day05_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-precip-prob"}
+String Day05_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-precip-type"}
+Number:Length Day05_Hour18_Snow "Snow" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-snow"}
+Number:Length Day05_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-snow-depth"}
+Number:Speed Day05_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-wind-gust"}
+Number:Speed Day05_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-wind-speed"}
+Number:Angle Day05_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-wind-dir"}
+Number:Pressure Day05_Hour18_Pressure "Pressure" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-pressure"}
+Number:Length Day05_Hour18_Visibility "Visibility" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-visibility"}
+Number:Dimensionless Day05_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-cloud-cover"}
+Number:Intensity Day05_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-solar-radiation"}
+Number Day05_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-solar-energy"}
+Number Day05_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-uv-index"}
+Number Day05_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-severe-risk"}
+String Day05_Hour18_Conditions "Conditions" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-conditions"}
+String Day05_Hour18_Icon "Icon" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-icon"}
+String Day05_Hour18_Stations "Stations" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-stations"}
+String Day05_Hour18_Source "Source" (Total_Weather_Data_Day05_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour18-source"}
+
+// Day05 - Hour19
+Group Total_Weather_Data_Day05_Hour19 "Hour 19" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour19_DateTime "DateTime" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-datetime"}
+DateTime Day05_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-timestamp"}
+Number:Temperature Day05_Hour19_Temperature "Temperature" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-temperature"}
+Number:Temperature Day05_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-feels-like"}
+Number Day05_Hour19_Humidity "Humidity" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-humidity"}
+Number:Temperature Day05_Hour19_Dew "Dew Point" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-dew"}
+Number:Length Day05_Hour19_Precip "Precipitation" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-precip"}
+Number:Dimensionless Day05_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-precip-prob"}
+String Day05_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-precip-type"}
+Number:Length Day05_Hour19_Snow "Snow" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-snow"}
+Number:Length Day05_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-snow-depth"}
+Number:Speed Day05_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-wind-gust"}
+Number:Speed Day05_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-wind-speed"}
+Number:Angle Day05_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-wind-dir"}
+Number:Pressure Day05_Hour19_Pressure "Pressure" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-pressure"}
+Number:Length Day05_Hour19_Visibility "Visibility" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-visibility"}
+Number:Dimensionless Day05_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-cloud-cover"}
+Number:Intensity Day05_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-solar-radiation"}
+Number Day05_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-solar-energy"}
+Number Day05_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-uv-index"}
+Number Day05_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-severe-risk"}
+String Day05_Hour19_Conditions "Conditions" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-conditions"}
+String Day05_Hour19_Icon "Icon" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-icon"}
+String Day05_Hour19_Stations "Stations" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-stations"}
+String Day05_Hour19_Source "Source" (Total_Weather_Data_Day05_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour19-source"}
+
+// Day05 - Hour20
+Group Total_Weather_Data_Day05_Hour20 "Hour 20" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour20_DateTime "DateTime" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-datetime"}
+DateTime Day05_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-timestamp"}
+Number:Temperature Day05_Hour20_Temperature "Temperature" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-temperature"}
+Number:Temperature Day05_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-feels-like"}
+Number Day05_Hour20_Humidity "Humidity" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-humidity"}
+Number:Temperature Day05_Hour20_Dew "Dew Point" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-dew"}
+Number:Length Day05_Hour20_Precip "Precipitation" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-precip"}
+Number:Dimensionless Day05_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-precip-prob"}
+String Day05_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-precip-type"}
+Number:Length Day05_Hour20_Snow "Snow" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-snow"}
+Number:Length Day05_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-snow-depth"}
+Number:Speed Day05_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-wind-gust"}
+Number:Speed Day05_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-wind-speed"}
+Number:Angle Day05_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-wind-dir"}
+Number:Pressure Day05_Hour20_Pressure "Pressure" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-pressure"}
+Number:Length Day05_Hour20_Visibility "Visibility" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-visibility"}
+Number:Dimensionless Day05_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-cloud-cover"}
+Number:Intensity Day05_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-solar-radiation"}
+Number Day05_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-solar-energy"}
+Number Day05_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-uv-index"}
+Number Day05_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-severe-risk"}
+String Day05_Hour20_Conditions "Conditions" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-conditions"}
+String Day05_Hour20_Icon "Icon" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-icon"}
+String Day05_Hour20_Stations "Stations" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-stations"}
+String Day05_Hour20_Source "Source" (Total_Weather_Data_Day05_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour20-source"}
+
+// Day05 - Hour21
+Group Total_Weather_Data_Day05_Hour21 "Hour 21" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour21_DateTime "DateTime" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-datetime"}
+DateTime Day05_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-timestamp"}
+Number:Temperature Day05_Hour21_Temperature "Temperature" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-temperature"}
+Number:Temperature Day05_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-feels-like"}
+Number Day05_Hour21_Humidity "Humidity" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-humidity"}
+Number:Temperature Day05_Hour21_Dew "Dew Point" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-dew"}
+Number:Length Day05_Hour21_Precip "Precipitation" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-precip"}
+Number:Dimensionless Day05_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-precip-prob"}
+String Day05_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-precip-type"}
+Number:Length Day05_Hour21_Snow "Snow" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-snow"}
+Number:Length Day05_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-snow-depth"}
+Number:Speed Day05_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-wind-gust"}
+Number:Speed Day05_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-wind-speed"}
+Number:Angle Day05_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-wind-dir"}
+Number:Pressure Day05_Hour21_Pressure "Pressure" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-pressure"}
+Number:Length Day05_Hour21_Visibility "Visibility" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-visibility"}
+Number:Dimensionless Day05_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-cloud-cover"}
+Number:Intensity Day05_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-solar-radiation"}
+Number Day05_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-solar-energy"}
+Number Day05_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-uv-index"}
+Number Day05_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-severe-risk"}
+String Day05_Hour21_Conditions "Conditions" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-conditions"}
+String Day05_Hour21_Icon "Icon" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-icon"}
+String Day05_Hour21_Stations "Stations" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-stations"}
+String Day05_Hour21_Source "Source" (Total_Weather_Data_Day05_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour21-source"}
+
+// Day05 - Hour22
+Group Total_Weather_Data_Day05_Hour22 "Hour 22" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour22_DateTime "DateTime" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-datetime"}
+DateTime Day05_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-timestamp"}
+Number:Temperature Day05_Hour22_Temperature "Temperature" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-temperature"}
+Number:Temperature Day05_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-feels-like"}
+Number Day05_Hour22_Humidity "Humidity" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-humidity"}
+Number:Temperature Day05_Hour22_Dew "Dew Point" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-dew"}
+Number:Length Day05_Hour22_Precip "Precipitation" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-precip"}
+Number:Dimensionless Day05_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-precip-prob"}
+String Day05_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-precip-type"}
+Number:Length Day05_Hour22_Snow "Snow" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-snow"}
+Number:Length Day05_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-snow-depth"}
+Number:Speed Day05_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-wind-gust"}
+Number:Speed Day05_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-wind-speed"}
+Number:Angle Day05_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-wind-dir"}
+Number:Pressure Day05_Hour22_Pressure "Pressure" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-pressure"}
+Number:Length Day05_Hour22_Visibility "Visibility" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-visibility"}
+Number:Dimensionless Day05_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-cloud-cover"}
+Number:Intensity Day05_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-solar-radiation"}
+Number Day05_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-solar-energy"}
+Number Day05_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-uv-index"}
+Number Day05_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-severe-risk"}
+String Day05_Hour22_Conditions "Conditions" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-conditions"}
+String Day05_Hour22_Icon "Icon" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-icon"}
+String Day05_Hour22_Stations "Stations" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-stations"}
+String Day05_Hour22_Source "Source" (Total_Weather_Data_Day05_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour22-source"}
+
+// Day05 - Hour23
+Group Total_Weather_Data_Day05_Hour23 "Hour 23" (Total_Weather_Data_Day05) [ "Equipment" ] 
+String Day05_Hour23_DateTime "DateTime" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-datetime"}
+DateTime Day05_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-timestamp"}
+Number:Temperature Day05_Hour23_Temperature "Temperature" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-temperature"}
+Number:Temperature Day05_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-feels-like"}
+Number Day05_Hour23_Humidity "Humidity" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-humidity"}
+Number:Temperature Day05_Hour23_Dew "Dew Point" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-dew"}
+Number:Length Day05_Hour23_Precip "Precipitation" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-precip"}
+Number:Dimensionless Day05_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-precip-prob"}
+String Day05_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-precip-type"}
+Number:Length Day05_Hour23_Snow "Snow" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-snow"}
+Number:Length Day05_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-snow-depth"}
+Number:Speed Day05_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-wind-gust"}
+Number:Speed Day05_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-wind-speed"}
+Number:Angle Day05_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-wind-dir"}
+Number:Pressure Day05_Hour23_Pressure "Pressure" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-pressure"}
+Number:Length Day05_Hour23_Visibility "Visibility" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-visibility"}
+Number:Dimensionless Day05_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-cloud-cover"}
+Number:Intensity Day05_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-solar-radiation"}
+Number Day05_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-solar-energy"}
+Number Day05_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-uv-index"}
+Number Day05_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-severe-risk"}
+String Day05_Hour23_Conditions "Conditions" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-conditions"}
+String Day05_Hour23_Icon "Icon" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-icon"}
+String Day05_Hour23_Stations "Stations" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-stations"}
+String Day05_Hour23_Source "Source" (Total_Weather_Data_Day05_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day05#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_06.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_06.items
@@ -1,39 +1,712 @@
 // Day06
 Group Total_Weather_Data_Day06 "Day T+06" (Total_Weather_Data) [ "Equipment" ] 
-String Day06_DateTime "Time" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day06_Timestamp "Timestamp" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day06_Temperature "Temperature" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day06_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day06_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day06_FeelsLike "Feels Like" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day06_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day06_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day06_Dew "Dew Point" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day06_Humidity "Humidity" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day06_Precip "Precipitation" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day06_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day06_Precip_Type "Precipitation Type" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day06_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day06_Snow "Snow" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day06_Snow_Depth "Snow Depth" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day06_Wind_Gust "Wind Gust" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day06_Wind_Speed "Wind Speed" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day06_Wind_Dir "Wind Direction" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day06_Pressure "Pressure" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day06_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day06_Visibility "Visibility" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day06_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day06_Solar_Energy "Solar Energy" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day06_UV_Index "UV Index" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day06_Sunrise "Sunrise" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day06_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day06_Sunset "Sunset" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day06_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day06_Moon_Phase "Moon Phase" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day06_Conditions "Conditions" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day06_Description "Description" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day06_Icon "Icon" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day06_Stations "Stations" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day06_Source "Source" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day06_Severe_Risk "Severe Risk" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day06_DateTime "Time" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#datetime" }
+DateTime Day06_Timestamp "Timestamp" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#timestamp" }
+Number:Temperature Day06_Temperature "Temperature" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#temperature" }
+Number:Temperature Day06_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#temperature-min" }
+Number:Temperature Day06_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#temperature-max" }
+Number:Temperature Day06_FeelsLike "Feels Like" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#feels-like" }
+Number:Temperature Day06_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#feels-like-min" }
+Number:Temperature Day06_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#feels-like-max" }
+Number:Temperature Day06_Dew "Dew Point" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#dew" }
+Number Day06_Humidity "Humidity" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#humidity" }
+Number:Length Day06_Precip "Precipitation" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#precip" }
+Number Day06_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#precip-prob" }
+String Day06_Precip_Type "Precipitation Type" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#precip-type" }
+Number Day06_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#precip-cover" }
+Number:Length Day06_Snow "Snow" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#snow" }
+Number:Length Day06_Snow_Depth "Snow Depth" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#snow-depth" }
+Number:Speed Day06_Wind_Gust "Wind Gust" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#wind-gust" }
+Number:Speed Day06_Wind_Speed "Wind Speed" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#wind-speed" }
+Number:Angle Day06_Wind_Dir "Wind Direction" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#wind-dir" }
+Number:Pressure Day06_Pressure "Pressure" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#pressure" }
+Number Day06_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#cloud-cover" }
+Number:Length Day06_Visibility "Visibility" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#visibility" }
+Number:Intensity Day06_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#solar-radiation" }
+Number Day06_Solar_Energy "Solar Energy" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#solar-energy" }
+Number Day06_UV_Index "UV Index" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#uv-index" }
+String Day06_Sunrise "Sunrise" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#sunrise" }
+DateTime Day06_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#sunrise-epoch" }
+String Day06_Sunset "Sunset" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#sunset" }
+DateTime Day06_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#sunset-epoch" }
+Number Day06_Moon_Phase "Moon Phase" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#moon-phase" }
+String Day06_Conditions "Conditions" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#conditions" }
+String Day06_Description "Description" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#description" }
+String Day06_Icon "Icon" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#icon" }
+String Day06_Stations "Stations" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#stations" }
+String Day06_Source "Source" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#source" }
+Number Day06_Severe_Risk "Severe Risk" (Total_Weather_Data_Day06)["Point"] { channel="visualcrossing:weather:default_config:day06#severe-risk" }
+
+// Day06 - Hour00
+Group Total_Weather_Data_Day06_Hour00 "Hour 00" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour00_DateTime "DateTime" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-datetime"}
+DateTime Day06_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-timestamp"}
+Number:Temperature Day06_Hour00_Temperature "Temperature" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-temperature"}
+Number:Temperature Day06_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-feels-like"}
+Number Day06_Hour00_Humidity "Humidity" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-humidity"}
+Number:Temperature Day06_Hour00_Dew "Dew Point" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-dew"}
+Number:Length Day06_Hour00_Precip "Precipitation" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-precip"}
+Number:Dimensionless Day06_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-precip-prob"}
+String Day06_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-precip-type"}
+Number:Length Day06_Hour00_Snow "Snow" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-snow"}
+Number:Length Day06_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-snow-depth"}
+Number:Speed Day06_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-wind-gust"}
+Number:Speed Day06_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-wind-speed"}
+Number:Angle Day06_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-wind-dir"}
+Number:Pressure Day06_Hour00_Pressure "Pressure" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-pressure"}
+Number:Length Day06_Hour00_Visibility "Visibility" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-visibility"}
+Number:Dimensionless Day06_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-cloud-cover"}
+Number:Intensity Day06_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-solar-radiation"}
+Number Day06_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-solar-energy"}
+Number Day06_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-uv-index"}
+Number Day06_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-severe-risk"}
+String Day06_Hour00_Conditions "Conditions" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-conditions"}
+String Day06_Hour00_Icon "Icon" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-icon"}
+String Day06_Hour00_Stations "Stations" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-stations"}
+String Day06_Hour00_Source "Source" (Total_Weather_Data_Day06_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour00-source"}
+
+// Day06 - Hour01
+Group Total_Weather_Data_Day06_Hour01 "Hour 01" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour01_DateTime "DateTime" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-datetime"}
+DateTime Day06_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-timestamp"}
+Number:Temperature Day06_Hour01_Temperature "Temperature" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-temperature"}
+Number:Temperature Day06_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-feels-like"}
+Number Day06_Hour01_Humidity "Humidity" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-humidity"}
+Number:Temperature Day06_Hour01_Dew "Dew Point" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-dew"}
+Number:Length Day06_Hour01_Precip "Precipitation" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-precip"}
+Number:Dimensionless Day06_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-precip-prob"}
+String Day06_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-precip-type"}
+Number:Length Day06_Hour01_Snow "Snow" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-snow"}
+Number:Length Day06_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-snow-depth"}
+Number:Speed Day06_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-wind-gust"}
+Number:Speed Day06_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-wind-speed"}
+Number:Angle Day06_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-wind-dir"}
+Number:Pressure Day06_Hour01_Pressure "Pressure" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-pressure"}
+Number:Length Day06_Hour01_Visibility "Visibility" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-visibility"}
+Number:Dimensionless Day06_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-cloud-cover"}
+Number:Intensity Day06_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-solar-radiation"}
+Number Day06_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-solar-energy"}
+Number Day06_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-uv-index"}
+Number Day06_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-severe-risk"}
+String Day06_Hour01_Conditions "Conditions" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-conditions"}
+String Day06_Hour01_Icon "Icon" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-icon"}
+String Day06_Hour01_Stations "Stations" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-stations"}
+String Day06_Hour01_Source "Source" (Total_Weather_Data_Day06_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour01-source"}
+
+// Day06 - Hour02
+Group Total_Weather_Data_Day06_Hour02 "Hour 02" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour02_DateTime "DateTime" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-datetime"}
+DateTime Day06_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-timestamp"}
+Number:Temperature Day06_Hour02_Temperature "Temperature" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-temperature"}
+Number:Temperature Day06_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-feels-like"}
+Number Day06_Hour02_Humidity "Humidity" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-humidity"}
+Number:Temperature Day06_Hour02_Dew "Dew Point" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-dew"}
+Number:Length Day06_Hour02_Precip "Precipitation" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-precip"}
+Number:Dimensionless Day06_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-precip-prob"}
+String Day06_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-precip-type"}
+Number:Length Day06_Hour02_Snow "Snow" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-snow"}
+Number:Length Day06_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-snow-depth"}
+Number:Speed Day06_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-wind-gust"}
+Number:Speed Day06_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-wind-speed"}
+Number:Angle Day06_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-wind-dir"}
+Number:Pressure Day06_Hour02_Pressure "Pressure" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-pressure"}
+Number:Length Day06_Hour02_Visibility "Visibility" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-visibility"}
+Number:Dimensionless Day06_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-cloud-cover"}
+Number:Intensity Day06_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-solar-radiation"}
+Number Day06_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-solar-energy"}
+Number Day06_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-uv-index"}
+Number Day06_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-severe-risk"}
+String Day06_Hour02_Conditions "Conditions" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-conditions"}
+String Day06_Hour02_Icon "Icon" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-icon"}
+String Day06_Hour02_Stations "Stations" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-stations"}
+String Day06_Hour02_Source "Source" (Total_Weather_Data_Day06_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour02-source"}
+
+// Day06 - Hour03
+Group Total_Weather_Data_Day06_Hour03 "Hour 03" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour03_DateTime "DateTime" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-datetime"}
+DateTime Day06_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-timestamp"}
+Number:Temperature Day06_Hour03_Temperature "Temperature" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-temperature"}
+Number:Temperature Day06_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-feels-like"}
+Number Day06_Hour03_Humidity "Humidity" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-humidity"}
+Number:Temperature Day06_Hour03_Dew "Dew Point" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-dew"}
+Number:Length Day06_Hour03_Precip "Precipitation" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-precip"}
+Number:Dimensionless Day06_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-precip-prob"}
+String Day06_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-precip-type"}
+Number:Length Day06_Hour03_Snow "Snow" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-snow"}
+Number:Length Day06_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-snow-depth"}
+Number:Speed Day06_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-wind-gust"}
+Number:Speed Day06_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-wind-speed"}
+Number:Angle Day06_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-wind-dir"}
+Number:Pressure Day06_Hour03_Pressure "Pressure" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-pressure"}
+Number:Length Day06_Hour03_Visibility "Visibility" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-visibility"}
+Number:Dimensionless Day06_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-cloud-cover"}
+Number:Intensity Day06_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-solar-radiation"}
+Number Day06_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-solar-energy"}
+Number Day06_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-uv-index"}
+Number Day06_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-severe-risk"}
+String Day06_Hour03_Conditions "Conditions" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-conditions"}
+String Day06_Hour03_Icon "Icon" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-icon"}
+String Day06_Hour03_Stations "Stations" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-stations"}
+String Day06_Hour03_Source "Source" (Total_Weather_Data_Day06_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour03-source"}
+
+// Day06 - Hour04
+Group Total_Weather_Data_Day06_Hour04 "Hour 04" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour04_DateTime "DateTime" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-datetime"}
+DateTime Day06_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-timestamp"}
+Number:Temperature Day06_Hour04_Temperature "Temperature" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-temperature"}
+Number:Temperature Day06_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-feels-like"}
+Number Day06_Hour04_Humidity "Humidity" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-humidity"}
+Number:Temperature Day06_Hour04_Dew "Dew Point" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-dew"}
+Number:Length Day06_Hour04_Precip "Precipitation" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-precip"}
+Number:Dimensionless Day06_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-precip-prob"}
+String Day06_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-precip-type"}
+Number:Length Day06_Hour04_Snow "Snow" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-snow"}
+Number:Length Day06_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-snow-depth"}
+Number:Speed Day06_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-wind-gust"}
+Number:Speed Day06_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-wind-speed"}
+Number:Angle Day06_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-wind-dir"}
+Number:Pressure Day06_Hour04_Pressure "Pressure" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-pressure"}
+Number:Length Day06_Hour04_Visibility "Visibility" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-visibility"}
+Number:Dimensionless Day06_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-cloud-cover"}
+Number:Intensity Day06_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-solar-radiation"}
+Number Day06_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-solar-energy"}
+Number Day06_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-uv-index"}
+Number Day06_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-severe-risk"}
+String Day06_Hour04_Conditions "Conditions" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-conditions"}
+String Day06_Hour04_Icon "Icon" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-icon"}
+String Day06_Hour04_Stations "Stations" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-stations"}
+String Day06_Hour04_Source "Source" (Total_Weather_Data_Day06_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour04-source"}
+
+// Day06 - Hour05
+Group Total_Weather_Data_Day06_Hour05 "Hour 05" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour05_DateTime "DateTime" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-datetime"}
+DateTime Day06_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-timestamp"}
+Number:Temperature Day06_Hour05_Temperature "Temperature" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-temperature"}
+Number:Temperature Day06_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-feels-like"}
+Number Day06_Hour05_Humidity "Humidity" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-humidity"}
+Number:Temperature Day06_Hour05_Dew "Dew Point" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-dew"}
+Number:Length Day06_Hour05_Precip "Precipitation" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-precip"}
+Number:Dimensionless Day06_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-precip-prob"}
+String Day06_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-precip-type"}
+Number:Length Day06_Hour05_Snow "Snow" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-snow"}
+Number:Length Day06_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-snow-depth"}
+Number:Speed Day06_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-wind-gust"}
+Number:Speed Day06_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-wind-speed"}
+Number:Angle Day06_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-wind-dir"}
+Number:Pressure Day06_Hour05_Pressure "Pressure" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-pressure"}
+Number:Length Day06_Hour05_Visibility "Visibility" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-visibility"}
+Number:Dimensionless Day06_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-cloud-cover"}
+Number:Intensity Day06_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-solar-radiation"}
+Number Day06_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-solar-energy"}
+Number Day06_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-uv-index"}
+Number Day06_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-severe-risk"}
+String Day06_Hour05_Conditions "Conditions" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-conditions"}
+String Day06_Hour05_Icon "Icon" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-icon"}
+String Day06_Hour05_Stations "Stations" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-stations"}
+String Day06_Hour05_Source "Source" (Total_Weather_Data_Day06_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour05-source"}
+
+// Day06 - Hour06
+Group Total_Weather_Data_Day06_Hour06 "Hour 06" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour06_DateTime "DateTime" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-datetime"}
+DateTime Day06_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-timestamp"}
+Number:Temperature Day06_Hour06_Temperature "Temperature" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-temperature"}
+Number:Temperature Day06_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-feels-like"}
+Number Day06_Hour06_Humidity "Humidity" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-humidity"}
+Number:Temperature Day06_Hour06_Dew "Dew Point" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-dew"}
+Number:Length Day06_Hour06_Precip "Precipitation" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-precip"}
+Number:Dimensionless Day06_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-precip-prob"}
+String Day06_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-precip-type"}
+Number:Length Day06_Hour06_Snow "Snow" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-snow"}
+Number:Length Day06_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-snow-depth"}
+Number:Speed Day06_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-wind-gust"}
+Number:Speed Day06_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-wind-speed"}
+Number:Angle Day06_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-wind-dir"}
+Number:Pressure Day06_Hour06_Pressure "Pressure" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-pressure"}
+Number:Length Day06_Hour06_Visibility "Visibility" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-visibility"}
+Number:Dimensionless Day06_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-cloud-cover"}
+Number:Intensity Day06_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-solar-radiation"}
+Number Day06_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-solar-energy"}
+Number Day06_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-uv-index"}
+Number Day06_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-severe-risk"}
+String Day06_Hour06_Conditions "Conditions" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-conditions"}
+String Day06_Hour06_Icon "Icon" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-icon"}
+String Day06_Hour06_Stations "Stations" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-stations"}
+String Day06_Hour06_Source "Source" (Total_Weather_Data_Day06_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour06-source"}
+
+// Day06 - Hour07
+Group Total_Weather_Data_Day06_Hour07 "Hour 07" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour07_DateTime "DateTime" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-datetime"}
+DateTime Day06_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-timestamp"}
+Number:Temperature Day06_Hour07_Temperature "Temperature" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-temperature"}
+Number:Temperature Day06_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-feels-like"}
+Number Day06_Hour07_Humidity "Humidity" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-humidity"}
+Number:Temperature Day06_Hour07_Dew "Dew Point" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-dew"}
+Number:Length Day06_Hour07_Precip "Precipitation" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-precip"}
+Number:Dimensionless Day06_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-precip-prob"}
+String Day06_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-precip-type"}
+Number:Length Day06_Hour07_Snow "Snow" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-snow"}
+Number:Length Day06_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-snow-depth"}
+Number:Speed Day06_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-wind-gust"}
+Number:Speed Day06_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-wind-speed"}
+Number:Angle Day06_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-wind-dir"}
+Number:Pressure Day06_Hour07_Pressure "Pressure" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-pressure"}
+Number:Length Day06_Hour07_Visibility "Visibility" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-visibility"}
+Number:Dimensionless Day06_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-cloud-cover"}
+Number:Intensity Day06_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-solar-radiation"}
+Number Day06_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-solar-energy"}
+Number Day06_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-uv-index"}
+Number Day06_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-severe-risk"}
+String Day06_Hour07_Conditions "Conditions" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-conditions"}
+String Day06_Hour07_Icon "Icon" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-icon"}
+String Day06_Hour07_Stations "Stations" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-stations"}
+String Day06_Hour07_Source "Source" (Total_Weather_Data_Day06_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour07-source"}
+
+// Day06 - Hour08
+Group Total_Weather_Data_Day06_Hour08 "Hour 08" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour08_DateTime "DateTime" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-datetime"}
+DateTime Day06_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-timestamp"}
+Number:Temperature Day06_Hour08_Temperature "Temperature" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-temperature"}
+Number:Temperature Day06_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-feels-like"}
+Number Day06_Hour08_Humidity "Humidity" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-humidity"}
+Number:Temperature Day06_Hour08_Dew "Dew Point" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-dew"}
+Number:Length Day06_Hour08_Precip "Precipitation" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-precip"}
+Number:Dimensionless Day06_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-precip-prob"}
+String Day06_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-precip-type"}
+Number:Length Day06_Hour08_Snow "Snow" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-snow"}
+Number:Length Day06_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-snow-depth"}
+Number:Speed Day06_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-wind-gust"}
+Number:Speed Day06_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-wind-speed"}
+Number:Angle Day06_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-wind-dir"}
+Number:Pressure Day06_Hour08_Pressure "Pressure" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-pressure"}
+Number:Length Day06_Hour08_Visibility "Visibility" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-visibility"}
+Number:Dimensionless Day06_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-cloud-cover"}
+Number:Intensity Day06_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-solar-radiation"}
+Number Day06_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-solar-energy"}
+Number Day06_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-uv-index"}
+Number Day06_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-severe-risk"}
+String Day06_Hour08_Conditions "Conditions" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-conditions"}
+String Day06_Hour08_Icon "Icon" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-icon"}
+String Day06_Hour08_Stations "Stations" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-stations"}
+String Day06_Hour08_Source "Source" (Total_Weather_Data_Day06_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour08-source"}
+
+// Day06 - Hour09
+Group Total_Weather_Data_Day06_Hour09 "Hour 09" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour09_DateTime "DateTime" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-datetime"}
+DateTime Day06_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-timestamp"}
+Number:Temperature Day06_Hour09_Temperature "Temperature" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-temperature"}
+Number:Temperature Day06_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-feels-like"}
+Number Day06_Hour09_Humidity "Humidity" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-humidity"}
+Number:Temperature Day06_Hour09_Dew "Dew Point" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-dew"}
+Number:Length Day06_Hour09_Precip "Precipitation" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-precip"}
+Number:Dimensionless Day06_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-precip-prob"}
+String Day06_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-precip-type"}
+Number:Length Day06_Hour09_Snow "Snow" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-snow"}
+Number:Length Day06_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-snow-depth"}
+Number:Speed Day06_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-wind-gust"}
+Number:Speed Day06_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-wind-speed"}
+Number:Angle Day06_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-wind-dir"}
+Number:Pressure Day06_Hour09_Pressure "Pressure" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-pressure"}
+Number:Length Day06_Hour09_Visibility "Visibility" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-visibility"}
+Number:Dimensionless Day06_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-cloud-cover"}
+Number:Intensity Day06_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-solar-radiation"}
+Number Day06_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-solar-energy"}
+Number Day06_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-uv-index"}
+Number Day06_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-severe-risk"}
+String Day06_Hour09_Conditions "Conditions" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-conditions"}
+String Day06_Hour09_Icon "Icon" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-icon"}
+String Day06_Hour09_Stations "Stations" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-stations"}
+String Day06_Hour09_Source "Source" (Total_Weather_Data_Day06_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour09-source"}
+
+// Day06 - Hour10
+Group Total_Weather_Data_Day06_Hour10 "Hour 10" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour10_DateTime "DateTime" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-datetime"}
+DateTime Day06_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-timestamp"}
+Number:Temperature Day06_Hour10_Temperature "Temperature" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-temperature"}
+Number:Temperature Day06_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-feels-like"}
+Number Day06_Hour10_Humidity "Humidity" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-humidity"}
+Number:Temperature Day06_Hour10_Dew "Dew Point" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-dew"}
+Number:Length Day06_Hour10_Precip "Precipitation" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-precip"}
+Number:Dimensionless Day06_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-precip-prob"}
+String Day06_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-precip-type"}
+Number:Length Day06_Hour10_Snow "Snow" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-snow"}
+Number:Length Day06_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-snow-depth"}
+Number:Speed Day06_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-wind-gust"}
+Number:Speed Day06_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-wind-speed"}
+Number:Angle Day06_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-wind-dir"}
+Number:Pressure Day06_Hour10_Pressure "Pressure" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-pressure"}
+Number:Length Day06_Hour10_Visibility "Visibility" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-visibility"}
+Number:Dimensionless Day06_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-cloud-cover"}
+Number:Intensity Day06_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-solar-radiation"}
+Number Day06_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-solar-energy"}
+Number Day06_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-uv-index"}
+Number Day06_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-severe-risk"}
+String Day06_Hour10_Conditions "Conditions" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-conditions"}
+String Day06_Hour10_Icon "Icon" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-icon"}
+String Day06_Hour10_Stations "Stations" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-stations"}
+String Day06_Hour10_Source "Source" (Total_Weather_Data_Day06_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour10-source"}
+
+// Day06 - Hour11
+Group Total_Weather_Data_Day06_Hour11 "Hour 11" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour11_DateTime "DateTime" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-datetime"}
+DateTime Day06_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-timestamp"}
+Number:Temperature Day06_Hour11_Temperature "Temperature" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-temperature"}
+Number:Temperature Day06_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-feels-like"}
+Number Day06_Hour11_Humidity "Humidity" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-humidity"}
+Number:Temperature Day06_Hour11_Dew "Dew Point" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-dew"}
+Number:Length Day06_Hour11_Precip "Precipitation" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-precip"}
+Number:Dimensionless Day06_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-precip-prob"}
+String Day06_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-precip-type"}
+Number:Length Day06_Hour11_Snow "Snow" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-snow"}
+Number:Length Day06_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-snow-depth"}
+Number:Speed Day06_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-wind-gust"}
+Number:Speed Day06_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-wind-speed"}
+Number:Angle Day06_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-wind-dir"}
+Number:Pressure Day06_Hour11_Pressure "Pressure" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-pressure"}
+Number:Length Day06_Hour11_Visibility "Visibility" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-visibility"}
+Number:Dimensionless Day06_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-cloud-cover"}
+Number:Intensity Day06_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-solar-radiation"}
+Number Day06_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-solar-energy"}
+Number Day06_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-uv-index"}
+Number Day06_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-severe-risk"}
+String Day06_Hour11_Conditions "Conditions" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-conditions"}
+String Day06_Hour11_Icon "Icon" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-icon"}
+String Day06_Hour11_Stations "Stations" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-stations"}
+String Day06_Hour11_Source "Source" (Total_Weather_Data_Day06_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour11-source"}
+
+// Day06 - Hour12
+Group Total_Weather_Data_Day06_Hour12 "Hour 12" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour12_DateTime "DateTime" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-datetime"}
+DateTime Day06_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-timestamp"}
+Number:Temperature Day06_Hour12_Temperature "Temperature" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-temperature"}
+Number:Temperature Day06_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-feels-like"}
+Number Day06_Hour12_Humidity "Humidity" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-humidity"}
+Number:Temperature Day06_Hour12_Dew "Dew Point" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-dew"}
+Number:Length Day06_Hour12_Precip "Precipitation" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-precip"}
+Number:Dimensionless Day06_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-precip-prob"}
+String Day06_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-precip-type"}
+Number:Length Day06_Hour12_Snow "Snow" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-snow"}
+Number:Length Day06_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-snow-depth"}
+Number:Speed Day06_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-wind-gust"}
+Number:Speed Day06_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-wind-speed"}
+Number:Angle Day06_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-wind-dir"}
+Number:Pressure Day06_Hour12_Pressure "Pressure" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-pressure"}
+Number:Length Day06_Hour12_Visibility "Visibility" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-visibility"}
+Number:Dimensionless Day06_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-cloud-cover"}
+Number:Intensity Day06_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-solar-radiation"}
+Number Day06_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-solar-energy"}
+Number Day06_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-uv-index"}
+Number Day06_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-severe-risk"}
+String Day06_Hour12_Conditions "Conditions" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-conditions"}
+String Day06_Hour12_Icon "Icon" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-icon"}
+String Day06_Hour12_Stations "Stations" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-stations"}
+String Day06_Hour12_Source "Source" (Total_Weather_Data_Day06_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour12-source"}
+
+// Day06 - Hour13
+Group Total_Weather_Data_Day06_Hour13 "Hour 13" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour13_DateTime "DateTime" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-datetime"}
+DateTime Day06_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-timestamp"}
+Number:Temperature Day06_Hour13_Temperature "Temperature" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-temperature"}
+Number:Temperature Day06_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-feels-like"}
+Number Day06_Hour13_Humidity "Humidity" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-humidity"}
+Number:Temperature Day06_Hour13_Dew "Dew Point" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-dew"}
+Number:Length Day06_Hour13_Precip "Precipitation" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-precip"}
+Number:Dimensionless Day06_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-precip-prob"}
+String Day06_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-precip-type"}
+Number:Length Day06_Hour13_Snow "Snow" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-snow"}
+Number:Length Day06_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-snow-depth"}
+Number:Speed Day06_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-wind-gust"}
+Number:Speed Day06_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-wind-speed"}
+Number:Angle Day06_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-wind-dir"}
+Number:Pressure Day06_Hour13_Pressure "Pressure" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-pressure"}
+Number:Length Day06_Hour13_Visibility "Visibility" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-visibility"}
+Number:Dimensionless Day06_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-cloud-cover"}
+Number:Intensity Day06_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-solar-radiation"}
+Number Day06_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-solar-energy"}
+Number Day06_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-uv-index"}
+Number Day06_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-severe-risk"}
+String Day06_Hour13_Conditions "Conditions" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-conditions"}
+String Day06_Hour13_Icon "Icon" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-icon"}
+String Day06_Hour13_Stations "Stations" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-stations"}
+String Day06_Hour13_Source "Source" (Total_Weather_Data_Day06_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour13-source"}
+
+// Day06 - Hour14
+Group Total_Weather_Data_Day06_Hour14 "Hour 14" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour14_DateTime "DateTime" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-datetime"}
+DateTime Day06_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-timestamp"}
+Number:Temperature Day06_Hour14_Temperature "Temperature" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-temperature"}
+Number:Temperature Day06_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-feels-like"}
+Number Day06_Hour14_Humidity "Humidity" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-humidity"}
+Number:Temperature Day06_Hour14_Dew "Dew Point" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-dew"}
+Number:Length Day06_Hour14_Precip "Precipitation" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-precip"}
+Number:Dimensionless Day06_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-precip-prob"}
+String Day06_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-precip-type"}
+Number:Length Day06_Hour14_Snow "Snow" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-snow"}
+Number:Length Day06_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-snow-depth"}
+Number:Speed Day06_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-wind-gust"}
+Number:Speed Day06_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-wind-speed"}
+Number:Angle Day06_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-wind-dir"}
+Number:Pressure Day06_Hour14_Pressure "Pressure" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-pressure"}
+Number:Length Day06_Hour14_Visibility "Visibility" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-visibility"}
+Number:Dimensionless Day06_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-cloud-cover"}
+Number:Intensity Day06_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-solar-radiation"}
+Number Day06_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-solar-energy"}
+Number Day06_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-uv-index"}
+Number Day06_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-severe-risk"}
+String Day06_Hour14_Conditions "Conditions" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-conditions"}
+String Day06_Hour14_Icon "Icon" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-icon"}
+String Day06_Hour14_Stations "Stations" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-stations"}
+String Day06_Hour14_Source "Source" (Total_Weather_Data_Day06_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour14-source"}
+
+// Day06 - Hour15
+Group Total_Weather_Data_Day06_Hour15 "Hour 15" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour15_DateTime "DateTime" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-datetime"}
+DateTime Day06_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-timestamp"}
+Number:Temperature Day06_Hour15_Temperature "Temperature" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-temperature"}
+Number:Temperature Day06_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-feels-like"}
+Number Day06_Hour15_Humidity "Humidity" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-humidity"}
+Number:Temperature Day06_Hour15_Dew "Dew Point" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-dew"}
+Number:Length Day06_Hour15_Precip "Precipitation" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-precip"}
+Number:Dimensionless Day06_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-precip-prob"}
+String Day06_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-precip-type"}
+Number:Length Day06_Hour15_Snow "Snow" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-snow"}
+Number:Length Day06_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-snow-depth"}
+Number:Speed Day06_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-wind-gust"}
+Number:Speed Day06_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-wind-speed"}
+Number:Angle Day06_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-wind-dir"}
+Number:Pressure Day06_Hour15_Pressure "Pressure" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-pressure"}
+Number:Length Day06_Hour15_Visibility "Visibility" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-visibility"}
+Number:Dimensionless Day06_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-cloud-cover"}
+Number:Intensity Day06_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-solar-radiation"}
+Number Day06_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-solar-energy"}
+Number Day06_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-uv-index"}
+Number Day06_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-severe-risk"}
+String Day06_Hour15_Conditions "Conditions" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-conditions"}
+String Day06_Hour15_Icon "Icon" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-icon"}
+String Day06_Hour15_Stations "Stations" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-stations"}
+String Day06_Hour15_Source "Source" (Total_Weather_Data_Day06_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour15-source"}
+
+// Day06 - Hour16
+Group Total_Weather_Data_Day06_Hour16 "Hour 16" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour16_DateTime "DateTime" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-datetime"}
+DateTime Day06_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-timestamp"}
+Number:Temperature Day06_Hour16_Temperature "Temperature" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-temperature"}
+Number:Temperature Day06_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-feels-like"}
+Number Day06_Hour16_Humidity "Humidity" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-humidity"}
+Number:Temperature Day06_Hour16_Dew "Dew Point" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-dew"}
+Number:Length Day06_Hour16_Precip "Precipitation" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-precip"}
+Number:Dimensionless Day06_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-precip-prob"}
+String Day06_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-precip-type"}
+Number:Length Day06_Hour16_Snow "Snow" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-snow"}
+Number:Length Day06_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-snow-depth"}
+Number:Speed Day06_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-wind-gust"}
+Number:Speed Day06_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-wind-speed"}
+Number:Angle Day06_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-wind-dir"}
+Number:Pressure Day06_Hour16_Pressure "Pressure" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-pressure"}
+Number:Length Day06_Hour16_Visibility "Visibility" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-visibility"}
+Number:Dimensionless Day06_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-cloud-cover"}
+Number:Intensity Day06_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-solar-radiation"}
+Number Day06_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-solar-energy"}
+Number Day06_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-uv-index"}
+Number Day06_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-severe-risk"}
+String Day06_Hour16_Conditions "Conditions" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-conditions"}
+String Day06_Hour16_Icon "Icon" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-icon"}
+String Day06_Hour16_Stations "Stations" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-stations"}
+String Day06_Hour16_Source "Source" (Total_Weather_Data_Day06_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour16-source"}
+
+// Day06 - Hour17
+Group Total_Weather_Data_Day06_Hour17 "Hour 17" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour17_DateTime "DateTime" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-datetime"}
+DateTime Day06_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-timestamp"}
+Number:Temperature Day06_Hour17_Temperature "Temperature" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-temperature"}
+Number:Temperature Day06_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-feels-like"}
+Number Day06_Hour17_Humidity "Humidity" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-humidity"}
+Number:Temperature Day06_Hour17_Dew "Dew Point" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-dew"}
+Number:Length Day06_Hour17_Precip "Precipitation" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-precip"}
+Number:Dimensionless Day06_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-precip-prob"}
+String Day06_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-precip-type"}
+Number:Length Day06_Hour17_Snow "Snow" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-snow"}
+Number:Length Day06_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-snow-depth"}
+Number:Speed Day06_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-wind-gust"}
+Number:Speed Day06_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-wind-speed"}
+Number:Angle Day06_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-wind-dir"}
+Number:Pressure Day06_Hour17_Pressure "Pressure" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-pressure"}
+Number:Length Day06_Hour17_Visibility "Visibility" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-visibility"}
+Number:Dimensionless Day06_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-cloud-cover"}
+Number:Intensity Day06_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-solar-radiation"}
+Number Day06_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-solar-energy"}
+Number Day06_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-uv-index"}
+Number Day06_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-severe-risk"}
+String Day06_Hour17_Conditions "Conditions" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-conditions"}
+String Day06_Hour17_Icon "Icon" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-icon"}
+String Day06_Hour17_Stations "Stations" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-stations"}
+String Day06_Hour17_Source "Source" (Total_Weather_Data_Day06_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour17-source"}
+
+// Day06 - Hour18
+Group Total_Weather_Data_Day06_Hour18 "Hour 18" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour18_DateTime "DateTime" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-datetime"}
+DateTime Day06_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-timestamp"}
+Number:Temperature Day06_Hour18_Temperature "Temperature" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-temperature"}
+Number:Temperature Day06_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-feels-like"}
+Number Day06_Hour18_Humidity "Humidity" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-humidity"}
+Number:Temperature Day06_Hour18_Dew "Dew Point" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-dew"}
+Number:Length Day06_Hour18_Precip "Precipitation" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-precip"}
+Number:Dimensionless Day06_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-precip-prob"}
+String Day06_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-precip-type"}
+Number:Length Day06_Hour18_Snow "Snow" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-snow"}
+Number:Length Day06_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-snow-depth"}
+Number:Speed Day06_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-wind-gust"}
+Number:Speed Day06_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-wind-speed"}
+Number:Angle Day06_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-wind-dir"}
+Number:Pressure Day06_Hour18_Pressure "Pressure" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-pressure"}
+Number:Length Day06_Hour18_Visibility "Visibility" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-visibility"}
+Number:Dimensionless Day06_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-cloud-cover"}
+Number:Intensity Day06_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-solar-radiation"}
+Number Day06_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-solar-energy"}
+Number Day06_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-uv-index"}
+Number Day06_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-severe-risk"}
+String Day06_Hour18_Conditions "Conditions" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-conditions"}
+String Day06_Hour18_Icon "Icon" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-icon"}
+String Day06_Hour18_Stations "Stations" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-stations"}
+String Day06_Hour18_Source "Source" (Total_Weather_Data_Day06_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour18-source"}
+
+// Day06 - Hour19
+Group Total_Weather_Data_Day06_Hour19 "Hour 19" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour19_DateTime "DateTime" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-datetime"}
+DateTime Day06_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-timestamp"}
+Number:Temperature Day06_Hour19_Temperature "Temperature" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-temperature"}
+Number:Temperature Day06_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-feels-like"}
+Number Day06_Hour19_Humidity "Humidity" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-humidity"}
+Number:Temperature Day06_Hour19_Dew "Dew Point" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-dew"}
+Number:Length Day06_Hour19_Precip "Precipitation" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-precip"}
+Number:Dimensionless Day06_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-precip-prob"}
+String Day06_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-precip-type"}
+Number:Length Day06_Hour19_Snow "Snow" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-snow"}
+Number:Length Day06_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-snow-depth"}
+Number:Speed Day06_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-wind-gust"}
+Number:Speed Day06_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-wind-speed"}
+Number:Angle Day06_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-wind-dir"}
+Number:Pressure Day06_Hour19_Pressure "Pressure" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-pressure"}
+Number:Length Day06_Hour19_Visibility "Visibility" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-visibility"}
+Number:Dimensionless Day06_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-cloud-cover"}
+Number:Intensity Day06_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-solar-radiation"}
+Number Day06_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-solar-energy"}
+Number Day06_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-uv-index"}
+Number Day06_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-severe-risk"}
+String Day06_Hour19_Conditions "Conditions" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-conditions"}
+String Day06_Hour19_Icon "Icon" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-icon"}
+String Day06_Hour19_Stations "Stations" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-stations"}
+String Day06_Hour19_Source "Source" (Total_Weather_Data_Day06_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour19-source"}
+
+// Day06 - Hour20
+Group Total_Weather_Data_Day06_Hour20 "Hour 20" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour20_DateTime "DateTime" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-datetime"}
+DateTime Day06_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-timestamp"}
+Number:Temperature Day06_Hour20_Temperature "Temperature" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-temperature"}
+Number:Temperature Day06_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-feels-like"}
+Number Day06_Hour20_Humidity "Humidity" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-humidity"}
+Number:Temperature Day06_Hour20_Dew "Dew Point" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-dew"}
+Number:Length Day06_Hour20_Precip "Precipitation" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-precip"}
+Number:Dimensionless Day06_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-precip-prob"}
+String Day06_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-precip-type"}
+Number:Length Day06_Hour20_Snow "Snow" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-snow"}
+Number:Length Day06_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-snow-depth"}
+Number:Speed Day06_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-wind-gust"}
+Number:Speed Day06_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-wind-speed"}
+Number:Angle Day06_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-wind-dir"}
+Number:Pressure Day06_Hour20_Pressure "Pressure" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-pressure"}
+Number:Length Day06_Hour20_Visibility "Visibility" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-visibility"}
+Number:Dimensionless Day06_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-cloud-cover"}
+Number:Intensity Day06_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-solar-radiation"}
+Number Day06_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-solar-energy"}
+Number Day06_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-uv-index"}
+Number Day06_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-severe-risk"}
+String Day06_Hour20_Conditions "Conditions" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-conditions"}
+String Day06_Hour20_Icon "Icon" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-icon"}
+String Day06_Hour20_Stations "Stations" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-stations"}
+String Day06_Hour20_Source "Source" (Total_Weather_Data_Day06_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour20-source"}
+
+// Day06 - Hour21
+Group Total_Weather_Data_Day06_Hour21 "Hour 21" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour21_DateTime "DateTime" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-datetime"}
+DateTime Day06_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-timestamp"}
+Number:Temperature Day06_Hour21_Temperature "Temperature" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-temperature"}
+Number:Temperature Day06_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-feels-like"}
+Number Day06_Hour21_Humidity "Humidity" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-humidity"}
+Number:Temperature Day06_Hour21_Dew "Dew Point" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-dew"}
+Number:Length Day06_Hour21_Precip "Precipitation" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-precip"}
+Number:Dimensionless Day06_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-precip-prob"}
+String Day06_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-precip-type"}
+Number:Length Day06_Hour21_Snow "Snow" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-snow"}
+Number:Length Day06_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-snow-depth"}
+Number:Speed Day06_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-wind-gust"}
+Number:Speed Day06_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-wind-speed"}
+Number:Angle Day06_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-wind-dir"}
+Number:Pressure Day06_Hour21_Pressure "Pressure" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-pressure"}
+Number:Length Day06_Hour21_Visibility "Visibility" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-visibility"}
+Number:Dimensionless Day06_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-cloud-cover"}
+Number:Intensity Day06_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-solar-radiation"}
+Number Day06_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-solar-energy"}
+Number Day06_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-uv-index"}
+Number Day06_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-severe-risk"}
+String Day06_Hour21_Conditions "Conditions" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-conditions"}
+String Day06_Hour21_Icon "Icon" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-icon"}
+String Day06_Hour21_Stations "Stations" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-stations"}
+String Day06_Hour21_Source "Source" (Total_Weather_Data_Day06_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour21-source"}
+
+// Day06 - Hour22
+Group Total_Weather_Data_Day06_Hour22 "Hour 22" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour22_DateTime "DateTime" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-datetime"}
+DateTime Day06_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-timestamp"}
+Number:Temperature Day06_Hour22_Temperature "Temperature" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-temperature"}
+Number:Temperature Day06_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-feels-like"}
+Number Day06_Hour22_Humidity "Humidity" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-humidity"}
+Number:Temperature Day06_Hour22_Dew "Dew Point" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-dew"}
+Number:Length Day06_Hour22_Precip "Precipitation" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-precip"}
+Number:Dimensionless Day06_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-precip-prob"}
+String Day06_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-precip-type"}
+Number:Length Day06_Hour22_Snow "Snow" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-snow"}
+Number:Length Day06_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-snow-depth"}
+Number:Speed Day06_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-wind-gust"}
+Number:Speed Day06_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-wind-speed"}
+Number:Angle Day06_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-wind-dir"}
+Number:Pressure Day06_Hour22_Pressure "Pressure" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-pressure"}
+Number:Length Day06_Hour22_Visibility "Visibility" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-visibility"}
+Number:Dimensionless Day06_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-cloud-cover"}
+Number:Intensity Day06_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-solar-radiation"}
+Number Day06_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-solar-energy"}
+Number Day06_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-uv-index"}
+Number Day06_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-severe-risk"}
+String Day06_Hour22_Conditions "Conditions" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-conditions"}
+String Day06_Hour22_Icon "Icon" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-icon"}
+String Day06_Hour22_Stations "Stations" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-stations"}
+String Day06_Hour22_Source "Source" (Total_Weather_Data_Day06_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour22-source"}
+
+// Day06 - Hour23
+Group Total_Weather_Data_Day06_Hour23 "Hour 23" (Total_Weather_Data_Day06) [ "Equipment" ] 
+String Day06_Hour23_DateTime "DateTime" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-datetime"}
+DateTime Day06_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-timestamp"}
+Number:Temperature Day06_Hour23_Temperature "Temperature" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-temperature"}
+Number:Temperature Day06_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-feels-like"}
+Number Day06_Hour23_Humidity "Humidity" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-humidity"}
+Number:Temperature Day06_Hour23_Dew "Dew Point" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-dew"}
+Number:Length Day06_Hour23_Precip "Precipitation" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-precip"}
+Number:Dimensionless Day06_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-precip-prob"}
+String Day06_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-precip-type"}
+Number:Length Day06_Hour23_Snow "Snow" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-snow"}
+Number:Length Day06_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-snow-depth"}
+Number:Speed Day06_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-wind-gust"}
+Number:Speed Day06_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-wind-speed"}
+Number:Angle Day06_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-wind-dir"}
+Number:Pressure Day06_Hour23_Pressure "Pressure" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-pressure"}
+Number:Length Day06_Hour23_Visibility "Visibility" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-visibility"}
+Number:Dimensionless Day06_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-cloud-cover"}
+Number:Intensity Day06_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-solar-radiation"}
+Number Day06_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-solar-energy"}
+Number Day06_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-uv-index"}
+Number Day06_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-severe-risk"}
+String Day06_Hour23_Conditions "Conditions" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-conditions"}
+String Day06_Hour23_Icon "Icon" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-icon"}
+String Day06_Hour23_Stations "Stations" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-stations"}
+String Day06_Hour23_Source "Source" (Total_Weather_Data_Day06_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day06#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_07.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_07.items
@@ -1,39 +1,712 @@
 // Day07
 Group Total_Weather_Data_Day07 "Day T+07" (Total_Weather_Data) [ "Equipment" ] 
-String Day07_DateTime "Time" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day07_Timestamp "Timestamp" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day07_Temperature "Temperature" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day07_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day07_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day07_FeelsLike "Feels Like" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day07_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day07_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day07_Dew "Dew Point" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day07_Humidity "Humidity" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day07_Precip "Precipitation" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day07_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day07_Precip_Type "Precipitation Type" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day07_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day07_Snow "Snow" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day07_Snow_Depth "Snow Depth" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day07_Wind_Gust "Wind Gust" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day07_Wind_Speed "Wind Speed" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day07_Wind_Dir "Wind Direction" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day07_Pressure "Pressure" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day07_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day07_Visibility "Visibility" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day07_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day07_Solar_Energy "Solar Energy" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day07_UV_Index "UV Index" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day07_Sunrise "Sunrise" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day07_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day07_Sunset "Sunset" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day07_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day07_Moon_Phase "Moon Phase" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day07_Conditions "Conditions" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day07_Description "Description" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day07_Icon "Icon" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day07_Stations "Stations" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day07_Source "Source" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day07_Severe_Risk "Severe Risk" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day07_DateTime "Time" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#datetime" }
+DateTime Day07_Timestamp "Timestamp" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#timestamp" }
+Number:Temperature Day07_Temperature "Temperature" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#temperature" }
+Number:Temperature Day07_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#temperature-min" }
+Number:Temperature Day07_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#temperature-max" }
+Number:Temperature Day07_FeelsLike "Feels Like" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#feels-like" }
+Number:Temperature Day07_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#feels-like-min" }
+Number:Temperature Day07_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#feels-like-max" }
+Number:Temperature Day07_Dew "Dew Point" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#dew" }
+Number Day07_Humidity "Humidity" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#humidity" }
+Number:Length Day07_Precip "Precipitation" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#precip" }
+Number Day07_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#precip-prob" }
+String Day07_Precip_Type "Precipitation Type" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#precip-type" }
+Number Day07_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#precip-cover" }
+Number:Length Day07_Snow "Snow" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#snow" }
+Number:Length Day07_Snow_Depth "Snow Depth" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#snow-depth" }
+Number:Speed Day07_Wind_Gust "Wind Gust" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#wind-gust" }
+Number:Speed Day07_Wind_Speed "Wind Speed" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#wind-speed" }
+Number:Angle Day07_Wind_Dir "Wind Direction" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#wind-dir" }
+Number:Pressure Day07_Pressure "Pressure" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#pressure" }
+Number Day07_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#cloud-cover" }
+Number:Length Day07_Visibility "Visibility" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#visibility" }
+Number:Intensity Day07_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#solar-radiation" }
+Number Day07_Solar_Energy "Solar Energy" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#solar-energy" }
+Number Day07_UV_Index "UV Index" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#uv-index" }
+String Day07_Sunrise "Sunrise" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#sunrise" }
+DateTime Day07_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#sunrise-epoch" }
+String Day07_Sunset "Sunset" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#sunset" }
+DateTime Day07_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#sunset-epoch" }
+Number Day07_Moon_Phase "Moon Phase" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#moon-phase" }
+String Day07_Conditions "Conditions" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#conditions" }
+String Day07_Description "Description" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#description" }
+String Day07_Icon "Icon" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#icon" }
+String Day07_Stations "Stations" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#stations" }
+String Day07_Source "Source" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#source" }
+Number Day07_Severe_Risk "Severe Risk" (Total_Weather_Data_Day07)["Point"] { channel="visualcrossing:weather:default_config:day07#severe-risk" }
+
+// Day07 - Hour00
+Group Total_Weather_Data_Day07_Hour00 "Hour 00" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour00_DateTime "DateTime" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-datetime"}
+DateTime Day07_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-timestamp"}
+Number:Temperature Day07_Hour00_Temperature "Temperature" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-temperature"}
+Number:Temperature Day07_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-feels-like"}
+Number Day07_Hour00_Humidity "Humidity" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-humidity"}
+Number:Temperature Day07_Hour00_Dew "Dew Point" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-dew"}
+Number:Length Day07_Hour00_Precip "Precipitation" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-precip"}
+Number:Dimensionless Day07_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-precip-prob"}
+String Day07_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-precip-type"}
+Number:Length Day07_Hour00_Snow "Snow" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-snow"}
+Number:Length Day07_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-snow-depth"}
+Number:Speed Day07_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-wind-gust"}
+Number:Speed Day07_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-wind-speed"}
+Number:Angle Day07_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-wind-dir"}
+Number:Pressure Day07_Hour00_Pressure "Pressure" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-pressure"}
+Number:Length Day07_Hour00_Visibility "Visibility" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-visibility"}
+Number:Dimensionless Day07_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-cloud-cover"}
+Number:Intensity Day07_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-solar-radiation"}
+Number Day07_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-solar-energy"}
+Number Day07_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-uv-index"}
+Number Day07_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-severe-risk"}
+String Day07_Hour00_Conditions "Conditions" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-conditions"}
+String Day07_Hour00_Icon "Icon" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-icon"}
+String Day07_Hour00_Stations "Stations" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-stations"}
+String Day07_Hour00_Source "Source" (Total_Weather_Data_Day07_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour00-source"}
+
+// Day07 - Hour01
+Group Total_Weather_Data_Day07_Hour01 "Hour 01" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour01_DateTime "DateTime" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-datetime"}
+DateTime Day07_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-timestamp"}
+Number:Temperature Day07_Hour01_Temperature "Temperature" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-temperature"}
+Number:Temperature Day07_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-feels-like"}
+Number Day07_Hour01_Humidity "Humidity" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-humidity"}
+Number:Temperature Day07_Hour01_Dew "Dew Point" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-dew"}
+Number:Length Day07_Hour01_Precip "Precipitation" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-precip"}
+Number:Dimensionless Day07_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-precip-prob"}
+String Day07_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-precip-type"}
+Number:Length Day07_Hour01_Snow "Snow" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-snow"}
+Number:Length Day07_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-snow-depth"}
+Number:Speed Day07_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-wind-gust"}
+Number:Speed Day07_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-wind-speed"}
+Number:Angle Day07_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-wind-dir"}
+Number:Pressure Day07_Hour01_Pressure "Pressure" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-pressure"}
+Number:Length Day07_Hour01_Visibility "Visibility" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-visibility"}
+Number:Dimensionless Day07_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-cloud-cover"}
+Number:Intensity Day07_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-solar-radiation"}
+Number Day07_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-solar-energy"}
+Number Day07_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-uv-index"}
+Number Day07_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-severe-risk"}
+String Day07_Hour01_Conditions "Conditions" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-conditions"}
+String Day07_Hour01_Icon "Icon" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-icon"}
+String Day07_Hour01_Stations "Stations" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-stations"}
+String Day07_Hour01_Source "Source" (Total_Weather_Data_Day07_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour01-source"}
+
+// Day07 - Hour02
+Group Total_Weather_Data_Day07_Hour02 "Hour 02" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour02_DateTime "DateTime" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-datetime"}
+DateTime Day07_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-timestamp"}
+Number:Temperature Day07_Hour02_Temperature "Temperature" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-temperature"}
+Number:Temperature Day07_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-feels-like"}
+Number Day07_Hour02_Humidity "Humidity" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-humidity"}
+Number:Temperature Day07_Hour02_Dew "Dew Point" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-dew"}
+Number:Length Day07_Hour02_Precip "Precipitation" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-precip"}
+Number:Dimensionless Day07_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-precip-prob"}
+String Day07_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-precip-type"}
+Number:Length Day07_Hour02_Snow "Snow" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-snow"}
+Number:Length Day07_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-snow-depth"}
+Number:Speed Day07_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-wind-gust"}
+Number:Speed Day07_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-wind-speed"}
+Number:Angle Day07_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-wind-dir"}
+Number:Pressure Day07_Hour02_Pressure "Pressure" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-pressure"}
+Number:Length Day07_Hour02_Visibility "Visibility" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-visibility"}
+Number:Dimensionless Day07_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-cloud-cover"}
+Number:Intensity Day07_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-solar-radiation"}
+Number Day07_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-solar-energy"}
+Number Day07_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-uv-index"}
+Number Day07_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-severe-risk"}
+String Day07_Hour02_Conditions "Conditions" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-conditions"}
+String Day07_Hour02_Icon "Icon" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-icon"}
+String Day07_Hour02_Stations "Stations" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-stations"}
+String Day07_Hour02_Source "Source" (Total_Weather_Data_Day07_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour02-source"}
+
+// Day07 - Hour03
+Group Total_Weather_Data_Day07_Hour03 "Hour 03" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour03_DateTime "DateTime" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-datetime"}
+DateTime Day07_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-timestamp"}
+Number:Temperature Day07_Hour03_Temperature "Temperature" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-temperature"}
+Number:Temperature Day07_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-feels-like"}
+Number Day07_Hour03_Humidity "Humidity" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-humidity"}
+Number:Temperature Day07_Hour03_Dew "Dew Point" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-dew"}
+Number:Length Day07_Hour03_Precip "Precipitation" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-precip"}
+Number:Dimensionless Day07_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-precip-prob"}
+String Day07_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-precip-type"}
+Number:Length Day07_Hour03_Snow "Snow" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-snow"}
+Number:Length Day07_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-snow-depth"}
+Number:Speed Day07_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-wind-gust"}
+Number:Speed Day07_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-wind-speed"}
+Number:Angle Day07_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-wind-dir"}
+Number:Pressure Day07_Hour03_Pressure "Pressure" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-pressure"}
+Number:Length Day07_Hour03_Visibility "Visibility" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-visibility"}
+Number:Dimensionless Day07_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-cloud-cover"}
+Number:Intensity Day07_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-solar-radiation"}
+Number Day07_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-solar-energy"}
+Number Day07_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-uv-index"}
+Number Day07_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-severe-risk"}
+String Day07_Hour03_Conditions "Conditions" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-conditions"}
+String Day07_Hour03_Icon "Icon" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-icon"}
+String Day07_Hour03_Stations "Stations" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-stations"}
+String Day07_Hour03_Source "Source" (Total_Weather_Data_Day07_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour03-source"}
+
+// Day07 - Hour04
+Group Total_Weather_Data_Day07_Hour04 "Hour 04" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour04_DateTime "DateTime" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-datetime"}
+DateTime Day07_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-timestamp"}
+Number:Temperature Day07_Hour04_Temperature "Temperature" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-temperature"}
+Number:Temperature Day07_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-feels-like"}
+Number Day07_Hour04_Humidity "Humidity" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-humidity"}
+Number:Temperature Day07_Hour04_Dew "Dew Point" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-dew"}
+Number:Length Day07_Hour04_Precip "Precipitation" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-precip"}
+Number:Dimensionless Day07_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-precip-prob"}
+String Day07_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-precip-type"}
+Number:Length Day07_Hour04_Snow "Snow" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-snow"}
+Number:Length Day07_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-snow-depth"}
+Number:Speed Day07_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-wind-gust"}
+Number:Speed Day07_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-wind-speed"}
+Number:Angle Day07_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-wind-dir"}
+Number:Pressure Day07_Hour04_Pressure "Pressure" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-pressure"}
+Number:Length Day07_Hour04_Visibility "Visibility" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-visibility"}
+Number:Dimensionless Day07_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-cloud-cover"}
+Number:Intensity Day07_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-solar-radiation"}
+Number Day07_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-solar-energy"}
+Number Day07_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-uv-index"}
+Number Day07_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-severe-risk"}
+String Day07_Hour04_Conditions "Conditions" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-conditions"}
+String Day07_Hour04_Icon "Icon" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-icon"}
+String Day07_Hour04_Stations "Stations" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-stations"}
+String Day07_Hour04_Source "Source" (Total_Weather_Data_Day07_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour04-source"}
+
+// Day07 - Hour05
+Group Total_Weather_Data_Day07_Hour05 "Hour 05" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour05_DateTime "DateTime" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-datetime"}
+DateTime Day07_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-timestamp"}
+Number:Temperature Day07_Hour05_Temperature "Temperature" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-temperature"}
+Number:Temperature Day07_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-feels-like"}
+Number Day07_Hour05_Humidity "Humidity" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-humidity"}
+Number:Temperature Day07_Hour05_Dew "Dew Point" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-dew"}
+Number:Length Day07_Hour05_Precip "Precipitation" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-precip"}
+Number:Dimensionless Day07_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-precip-prob"}
+String Day07_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-precip-type"}
+Number:Length Day07_Hour05_Snow "Snow" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-snow"}
+Number:Length Day07_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-snow-depth"}
+Number:Speed Day07_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-wind-gust"}
+Number:Speed Day07_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-wind-speed"}
+Number:Angle Day07_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-wind-dir"}
+Number:Pressure Day07_Hour05_Pressure "Pressure" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-pressure"}
+Number:Length Day07_Hour05_Visibility "Visibility" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-visibility"}
+Number:Dimensionless Day07_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-cloud-cover"}
+Number:Intensity Day07_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-solar-radiation"}
+Number Day07_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-solar-energy"}
+Number Day07_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-uv-index"}
+Number Day07_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-severe-risk"}
+String Day07_Hour05_Conditions "Conditions" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-conditions"}
+String Day07_Hour05_Icon "Icon" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-icon"}
+String Day07_Hour05_Stations "Stations" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-stations"}
+String Day07_Hour05_Source "Source" (Total_Weather_Data_Day07_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour05-source"}
+
+// Day07 - Hour06
+Group Total_Weather_Data_Day07_Hour06 "Hour 06" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour06_DateTime "DateTime" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-datetime"}
+DateTime Day07_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-timestamp"}
+Number:Temperature Day07_Hour06_Temperature "Temperature" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-temperature"}
+Number:Temperature Day07_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-feels-like"}
+Number Day07_Hour06_Humidity "Humidity" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-humidity"}
+Number:Temperature Day07_Hour06_Dew "Dew Point" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-dew"}
+Number:Length Day07_Hour06_Precip "Precipitation" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-precip"}
+Number:Dimensionless Day07_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-precip-prob"}
+String Day07_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-precip-type"}
+Number:Length Day07_Hour06_Snow "Snow" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-snow"}
+Number:Length Day07_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-snow-depth"}
+Number:Speed Day07_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-wind-gust"}
+Number:Speed Day07_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-wind-speed"}
+Number:Angle Day07_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-wind-dir"}
+Number:Pressure Day07_Hour06_Pressure "Pressure" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-pressure"}
+Number:Length Day07_Hour06_Visibility "Visibility" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-visibility"}
+Number:Dimensionless Day07_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-cloud-cover"}
+Number:Intensity Day07_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-solar-radiation"}
+Number Day07_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-solar-energy"}
+Number Day07_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-uv-index"}
+Number Day07_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-severe-risk"}
+String Day07_Hour06_Conditions "Conditions" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-conditions"}
+String Day07_Hour06_Icon "Icon" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-icon"}
+String Day07_Hour06_Stations "Stations" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-stations"}
+String Day07_Hour06_Source "Source" (Total_Weather_Data_Day07_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour06-source"}
+
+// Day07 - Hour07
+Group Total_Weather_Data_Day07_Hour07 "Hour 07" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour07_DateTime "DateTime" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-datetime"}
+DateTime Day07_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-timestamp"}
+Number:Temperature Day07_Hour07_Temperature "Temperature" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-temperature"}
+Number:Temperature Day07_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-feels-like"}
+Number Day07_Hour07_Humidity "Humidity" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-humidity"}
+Number:Temperature Day07_Hour07_Dew "Dew Point" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-dew"}
+Number:Length Day07_Hour07_Precip "Precipitation" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-precip"}
+Number:Dimensionless Day07_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-precip-prob"}
+String Day07_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-precip-type"}
+Number:Length Day07_Hour07_Snow "Snow" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-snow"}
+Number:Length Day07_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-snow-depth"}
+Number:Speed Day07_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-wind-gust"}
+Number:Speed Day07_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-wind-speed"}
+Number:Angle Day07_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-wind-dir"}
+Number:Pressure Day07_Hour07_Pressure "Pressure" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-pressure"}
+Number:Length Day07_Hour07_Visibility "Visibility" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-visibility"}
+Number:Dimensionless Day07_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-cloud-cover"}
+Number:Intensity Day07_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-solar-radiation"}
+Number Day07_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-solar-energy"}
+Number Day07_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-uv-index"}
+Number Day07_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-severe-risk"}
+String Day07_Hour07_Conditions "Conditions" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-conditions"}
+String Day07_Hour07_Icon "Icon" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-icon"}
+String Day07_Hour07_Stations "Stations" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-stations"}
+String Day07_Hour07_Source "Source" (Total_Weather_Data_Day07_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour07-source"}
+
+// Day07 - Hour08
+Group Total_Weather_Data_Day07_Hour08 "Hour 08" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour08_DateTime "DateTime" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-datetime"}
+DateTime Day07_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-timestamp"}
+Number:Temperature Day07_Hour08_Temperature "Temperature" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-temperature"}
+Number:Temperature Day07_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-feels-like"}
+Number Day07_Hour08_Humidity "Humidity" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-humidity"}
+Number:Temperature Day07_Hour08_Dew "Dew Point" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-dew"}
+Number:Length Day07_Hour08_Precip "Precipitation" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-precip"}
+Number:Dimensionless Day07_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-precip-prob"}
+String Day07_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-precip-type"}
+Number:Length Day07_Hour08_Snow "Snow" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-snow"}
+Number:Length Day07_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-snow-depth"}
+Number:Speed Day07_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-wind-gust"}
+Number:Speed Day07_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-wind-speed"}
+Number:Angle Day07_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-wind-dir"}
+Number:Pressure Day07_Hour08_Pressure "Pressure" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-pressure"}
+Number:Length Day07_Hour08_Visibility "Visibility" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-visibility"}
+Number:Dimensionless Day07_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-cloud-cover"}
+Number:Intensity Day07_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-solar-radiation"}
+Number Day07_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-solar-energy"}
+Number Day07_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-uv-index"}
+Number Day07_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-severe-risk"}
+String Day07_Hour08_Conditions "Conditions" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-conditions"}
+String Day07_Hour08_Icon "Icon" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-icon"}
+String Day07_Hour08_Stations "Stations" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-stations"}
+String Day07_Hour08_Source "Source" (Total_Weather_Data_Day07_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour08-source"}
+
+// Day07 - Hour09
+Group Total_Weather_Data_Day07_Hour09 "Hour 09" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour09_DateTime "DateTime" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-datetime"}
+DateTime Day07_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-timestamp"}
+Number:Temperature Day07_Hour09_Temperature "Temperature" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-temperature"}
+Number:Temperature Day07_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-feels-like"}
+Number Day07_Hour09_Humidity "Humidity" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-humidity"}
+Number:Temperature Day07_Hour09_Dew "Dew Point" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-dew"}
+Number:Length Day07_Hour09_Precip "Precipitation" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-precip"}
+Number:Dimensionless Day07_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-precip-prob"}
+String Day07_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-precip-type"}
+Number:Length Day07_Hour09_Snow "Snow" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-snow"}
+Number:Length Day07_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-snow-depth"}
+Number:Speed Day07_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-wind-gust"}
+Number:Speed Day07_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-wind-speed"}
+Number:Angle Day07_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-wind-dir"}
+Number:Pressure Day07_Hour09_Pressure "Pressure" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-pressure"}
+Number:Length Day07_Hour09_Visibility "Visibility" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-visibility"}
+Number:Dimensionless Day07_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-cloud-cover"}
+Number:Intensity Day07_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-solar-radiation"}
+Number Day07_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-solar-energy"}
+Number Day07_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-uv-index"}
+Number Day07_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-severe-risk"}
+String Day07_Hour09_Conditions "Conditions" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-conditions"}
+String Day07_Hour09_Icon "Icon" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-icon"}
+String Day07_Hour09_Stations "Stations" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-stations"}
+String Day07_Hour09_Source "Source" (Total_Weather_Data_Day07_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour09-source"}
+
+// Day07 - Hour10
+Group Total_Weather_Data_Day07_Hour10 "Hour 10" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour10_DateTime "DateTime" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-datetime"}
+DateTime Day07_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-timestamp"}
+Number:Temperature Day07_Hour10_Temperature "Temperature" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-temperature"}
+Number:Temperature Day07_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-feels-like"}
+Number Day07_Hour10_Humidity "Humidity" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-humidity"}
+Number:Temperature Day07_Hour10_Dew "Dew Point" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-dew"}
+Number:Length Day07_Hour10_Precip "Precipitation" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-precip"}
+Number:Dimensionless Day07_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-precip-prob"}
+String Day07_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-precip-type"}
+Number:Length Day07_Hour10_Snow "Snow" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-snow"}
+Number:Length Day07_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-snow-depth"}
+Number:Speed Day07_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-wind-gust"}
+Number:Speed Day07_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-wind-speed"}
+Number:Angle Day07_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-wind-dir"}
+Number:Pressure Day07_Hour10_Pressure "Pressure" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-pressure"}
+Number:Length Day07_Hour10_Visibility "Visibility" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-visibility"}
+Number:Dimensionless Day07_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-cloud-cover"}
+Number:Intensity Day07_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-solar-radiation"}
+Number Day07_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-solar-energy"}
+Number Day07_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-uv-index"}
+Number Day07_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-severe-risk"}
+String Day07_Hour10_Conditions "Conditions" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-conditions"}
+String Day07_Hour10_Icon "Icon" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-icon"}
+String Day07_Hour10_Stations "Stations" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-stations"}
+String Day07_Hour10_Source "Source" (Total_Weather_Data_Day07_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour10-source"}
+
+// Day07 - Hour11
+Group Total_Weather_Data_Day07_Hour11 "Hour 11" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour11_DateTime "DateTime" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-datetime"}
+DateTime Day07_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-timestamp"}
+Number:Temperature Day07_Hour11_Temperature "Temperature" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-temperature"}
+Number:Temperature Day07_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-feels-like"}
+Number Day07_Hour11_Humidity "Humidity" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-humidity"}
+Number:Temperature Day07_Hour11_Dew "Dew Point" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-dew"}
+Number:Length Day07_Hour11_Precip "Precipitation" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-precip"}
+Number:Dimensionless Day07_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-precip-prob"}
+String Day07_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-precip-type"}
+Number:Length Day07_Hour11_Snow "Snow" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-snow"}
+Number:Length Day07_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-snow-depth"}
+Number:Speed Day07_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-wind-gust"}
+Number:Speed Day07_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-wind-speed"}
+Number:Angle Day07_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-wind-dir"}
+Number:Pressure Day07_Hour11_Pressure "Pressure" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-pressure"}
+Number:Length Day07_Hour11_Visibility "Visibility" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-visibility"}
+Number:Dimensionless Day07_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-cloud-cover"}
+Number:Intensity Day07_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-solar-radiation"}
+Number Day07_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-solar-energy"}
+Number Day07_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-uv-index"}
+Number Day07_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-severe-risk"}
+String Day07_Hour11_Conditions "Conditions" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-conditions"}
+String Day07_Hour11_Icon "Icon" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-icon"}
+String Day07_Hour11_Stations "Stations" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-stations"}
+String Day07_Hour11_Source "Source" (Total_Weather_Data_Day07_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour11-source"}
+
+// Day07 - Hour12
+Group Total_Weather_Data_Day07_Hour12 "Hour 12" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour12_DateTime "DateTime" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-datetime"}
+DateTime Day07_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-timestamp"}
+Number:Temperature Day07_Hour12_Temperature "Temperature" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-temperature"}
+Number:Temperature Day07_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-feels-like"}
+Number Day07_Hour12_Humidity "Humidity" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-humidity"}
+Number:Temperature Day07_Hour12_Dew "Dew Point" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-dew"}
+Number:Length Day07_Hour12_Precip "Precipitation" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-precip"}
+Number:Dimensionless Day07_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-precip-prob"}
+String Day07_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-precip-type"}
+Number:Length Day07_Hour12_Snow "Snow" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-snow"}
+Number:Length Day07_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-snow-depth"}
+Number:Speed Day07_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-wind-gust"}
+Number:Speed Day07_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-wind-speed"}
+Number:Angle Day07_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-wind-dir"}
+Number:Pressure Day07_Hour12_Pressure "Pressure" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-pressure"}
+Number:Length Day07_Hour12_Visibility "Visibility" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-visibility"}
+Number:Dimensionless Day07_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-cloud-cover"}
+Number:Intensity Day07_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-solar-radiation"}
+Number Day07_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-solar-energy"}
+Number Day07_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-uv-index"}
+Number Day07_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-severe-risk"}
+String Day07_Hour12_Conditions "Conditions" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-conditions"}
+String Day07_Hour12_Icon "Icon" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-icon"}
+String Day07_Hour12_Stations "Stations" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-stations"}
+String Day07_Hour12_Source "Source" (Total_Weather_Data_Day07_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour12-source"}
+
+// Day07 - Hour13
+Group Total_Weather_Data_Day07_Hour13 "Hour 13" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour13_DateTime "DateTime" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-datetime"}
+DateTime Day07_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-timestamp"}
+Number:Temperature Day07_Hour13_Temperature "Temperature" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-temperature"}
+Number:Temperature Day07_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-feels-like"}
+Number Day07_Hour13_Humidity "Humidity" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-humidity"}
+Number:Temperature Day07_Hour13_Dew "Dew Point" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-dew"}
+Number:Length Day07_Hour13_Precip "Precipitation" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-precip"}
+Number:Dimensionless Day07_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-precip-prob"}
+String Day07_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-precip-type"}
+Number:Length Day07_Hour13_Snow "Snow" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-snow"}
+Number:Length Day07_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-snow-depth"}
+Number:Speed Day07_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-wind-gust"}
+Number:Speed Day07_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-wind-speed"}
+Number:Angle Day07_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-wind-dir"}
+Number:Pressure Day07_Hour13_Pressure "Pressure" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-pressure"}
+Number:Length Day07_Hour13_Visibility "Visibility" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-visibility"}
+Number:Dimensionless Day07_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-cloud-cover"}
+Number:Intensity Day07_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-solar-radiation"}
+Number Day07_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-solar-energy"}
+Number Day07_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-uv-index"}
+Number Day07_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-severe-risk"}
+String Day07_Hour13_Conditions "Conditions" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-conditions"}
+String Day07_Hour13_Icon "Icon" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-icon"}
+String Day07_Hour13_Stations "Stations" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-stations"}
+String Day07_Hour13_Source "Source" (Total_Weather_Data_Day07_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour13-source"}
+
+// Day07 - Hour14
+Group Total_Weather_Data_Day07_Hour14 "Hour 14" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour14_DateTime "DateTime" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-datetime"}
+DateTime Day07_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-timestamp"}
+Number:Temperature Day07_Hour14_Temperature "Temperature" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-temperature"}
+Number:Temperature Day07_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-feels-like"}
+Number Day07_Hour14_Humidity "Humidity" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-humidity"}
+Number:Temperature Day07_Hour14_Dew "Dew Point" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-dew"}
+Number:Length Day07_Hour14_Precip "Precipitation" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-precip"}
+Number:Dimensionless Day07_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-precip-prob"}
+String Day07_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-precip-type"}
+Number:Length Day07_Hour14_Snow "Snow" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-snow"}
+Number:Length Day07_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-snow-depth"}
+Number:Speed Day07_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-wind-gust"}
+Number:Speed Day07_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-wind-speed"}
+Number:Angle Day07_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-wind-dir"}
+Number:Pressure Day07_Hour14_Pressure "Pressure" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-pressure"}
+Number:Length Day07_Hour14_Visibility "Visibility" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-visibility"}
+Number:Dimensionless Day07_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-cloud-cover"}
+Number:Intensity Day07_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-solar-radiation"}
+Number Day07_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-solar-energy"}
+Number Day07_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-uv-index"}
+Number Day07_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-severe-risk"}
+String Day07_Hour14_Conditions "Conditions" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-conditions"}
+String Day07_Hour14_Icon "Icon" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-icon"}
+String Day07_Hour14_Stations "Stations" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-stations"}
+String Day07_Hour14_Source "Source" (Total_Weather_Data_Day07_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour14-source"}
+
+// Day07 - Hour15
+Group Total_Weather_Data_Day07_Hour15 "Hour 15" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour15_DateTime "DateTime" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-datetime"}
+DateTime Day07_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-timestamp"}
+Number:Temperature Day07_Hour15_Temperature "Temperature" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-temperature"}
+Number:Temperature Day07_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-feels-like"}
+Number Day07_Hour15_Humidity "Humidity" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-humidity"}
+Number:Temperature Day07_Hour15_Dew "Dew Point" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-dew"}
+Number:Length Day07_Hour15_Precip "Precipitation" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-precip"}
+Number:Dimensionless Day07_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-precip-prob"}
+String Day07_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-precip-type"}
+Number:Length Day07_Hour15_Snow "Snow" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-snow"}
+Number:Length Day07_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-snow-depth"}
+Number:Speed Day07_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-wind-gust"}
+Number:Speed Day07_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-wind-speed"}
+Number:Angle Day07_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-wind-dir"}
+Number:Pressure Day07_Hour15_Pressure "Pressure" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-pressure"}
+Number:Length Day07_Hour15_Visibility "Visibility" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-visibility"}
+Number:Dimensionless Day07_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-cloud-cover"}
+Number:Intensity Day07_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-solar-radiation"}
+Number Day07_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-solar-energy"}
+Number Day07_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-uv-index"}
+Number Day07_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-severe-risk"}
+String Day07_Hour15_Conditions "Conditions" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-conditions"}
+String Day07_Hour15_Icon "Icon" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-icon"}
+String Day07_Hour15_Stations "Stations" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-stations"}
+String Day07_Hour15_Source "Source" (Total_Weather_Data_Day07_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour15-source"}
+
+// Day07 - Hour16
+Group Total_Weather_Data_Day07_Hour16 "Hour 16" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour16_DateTime "DateTime" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-datetime"}
+DateTime Day07_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-timestamp"}
+Number:Temperature Day07_Hour16_Temperature "Temperature" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-temperature"}
+Number:Temperature Day07_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-feels-like"}
+Number Day07_Hour16_Humidity "Humidity" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-humidity"}
+Number:Temperature Day07_Hour16_Dew "Dew Point" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-dew"}
+Number:Length Day07_Hour16_Precip "Precipitation" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-precip"}
+Number:Dimensionless Day07_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-precip-prob"}
+String Day07_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-precip-type"}
+Number:Length Day07_Hour16_Snow "Snow" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-snow"}
+Number:Length Day07_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-snow-depth"}
+Number:Speed Day07_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-wind-gust"}
+Number:Speed Day07_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-wind-speed"}
+Number:Angle Day07_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-wind-dir"}
+Number:Pressure Day07_Hour16_Pressure "Pressure" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-pressure"}
+Number:Length Day07_Hour16_Visibility "Visibility" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-visibility"}
+Number:Dimensionless Day07_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-cloud-cover"}
+Number:Intensity Day07_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-solar-radiation"}
+Number Day07_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-solar-energy"}
+Number Day07_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-uv-index"}
+Number Day07_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-severe-risk"}
+String Day07_Hour16_Conditions "Conditions" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-conditions"}
+String Day07_Hour16_Icon "Icon" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-icon"}
+String Day07_Hour16_Stations "Stations" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-stations"}
+String Day07_Hour16_Source "Source" (Total_Weather_Data_Day07_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour16-source"}
+
+// Day07 - Hour17
+Group Total_Weather_Data_Day07_Hour17 "Hour 17" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour17_DateTime "DateTime" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-datetime"}
+DateTime Day07_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-timestamp"}
+Number:Temperature Day07_Hour17_Temperature "Temperature" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-temperature"}
+Number:Temperature Day07_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-feels-like"}
+Number Day07_Hour17_Humidity "Humidity" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-humidity"}
+Number:Temperature Day07_Hour17_Dew "Dew Point" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-dew"}
+Number:Length Day07_Hour17_Precip "Precipitation" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-precip"}
+Number:Dimensionless Day07_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-precip-prob"}
+String Day07_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-precip-type"}
+Number:Length Day07_Hour17_Snow "Snow" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-snow"}
+Number:Length Day07_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-snow-depth"}
+Number:Speed Day07_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-wind-gust"}
+Number:Speed Day07_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-wind-speed"}
+Number:Angle Day07_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-wind-dir"}
+Number:Pressure Day07_Hour17_Pressure "Pressure" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-pressure"}
+Number:Length Day07_Hour17_Visibility "Visibility" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-visibility"}
+Number:Dimensionless Day07_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-cloud-cover"}
+Number:Intensity Day07_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-solar-radiation"}
+Number Day07_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-solar-energy"}
+Number Day07_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-uv-index"}
+Number Day07_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-severe-risk"}
+String Day07_Hour17_Conditions "Conditions" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-conditions"}
+String Day07_Hour17_Icon "Icon" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-icon"}
+String Day07_Hour17_Stations "Stations" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-stations"}
+String Day07_Hour17_Source "Source" (Total_Weather_Data_Day07_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour17-source"}
+
+// Day07 - Hour18
+Group Total_Weather_Data_Day07_Hour18 "Hour 18" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour18_DateTime "DateTime" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-datetime"}
+DateTime Day07_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-timestamp"}
+Number:Temperature Day07_Hour18_Temperature "Temperature" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-temperature"}
+Number:Temperature Day07_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-feels-like"}
+Number Day07_Hour18_Humidity "Humidity" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-humidity"}
+Number:Temperature Day07_Hour18_Dew "Dew Point" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-dew"}
+Number:Length Day07_Hour18_Precip "Precipitation" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-precip"}
+Number:Dimensionless Day07_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-precip-prob"}
+String Day07_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-precip-type"}
+Number:Length Day07_Hour18_Snow "Snow" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-snow"}
+Number:Length Day07_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-snow-depth"}
+Number:Speed Day07_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-wind-gust"}
+Number:Speed Day07_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-wind-speed"}
+Number:Angle Day07_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-wind-dir"}
+Number:Pressure Day07_Hour18_Pressure "Pressure" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-pressure"}
+Number:Length Day07_Hour18_Visibility "Visibility" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-visibility"}
+Number:Dimensionless Day07_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-cloud-cover"}
+Number:Intensity Day07_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-solar-radiation"}
+Number Day07_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-solar-energy"}
+Number Day07_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-uv-index"}
+Number Day07_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-severe-risk"}
+String Day07_Hour18_Conditions "Conditions" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-conditions"}
+String Day07_Hour18_Icon "Icon" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-icon"}
+String Day07_Hour18_Stations "Stations" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-stations"}
+String Day07_Hour18_Source "Source" (Total_Weather_Data_Day07_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour18-source"}
+
+// Day07 - Hour19
+Group Total_Weather_Data_Day07_Hour19 "Hour 19" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour19_DateTime "DateTime" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-datetime"}
+DateTime Day07_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-timestamp"}
+Number:Temperature Day07_Hour19_Temperature "Temperature" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-temperature"}
+Number:Temperature Day07_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-feels-like"}
+Number Day07_Hour19_Humidity "Humidity" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-humidity"}
+Number:Temperature Day07_Hour19_Dew "Dew Point" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-dew"}
+Number:Length Day07_Hour19_Precip "Precipitation" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-precip"}
+Number:Dimensionless Day07_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-precip-prob"}
+String Day07_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-precip-type"}
+Number:Length Day07_Hour19_Snow "Snow" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-snow"}
+Number:Length Day07_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-snow-depth"}
+Number:Speed Day07_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-wind-gust"}
+Number:Speed Day07_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-wind-speed"}
+Number:Angle Day07_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-wind-dir"}
+Number:Pressure Day07_Hour19_Pressure "Pressure" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-pressure"}
+Number:Length Day07_Hour19_Visibility "Visibility" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-visibility"}
+Number:Dimensionless Day07_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-cloud-cover"}
+Number:Intensity Day07_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-solar-radiation"}
+Number Day07_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-solar-energy"}
+Number Day07_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-uv-index"}
+Number Day07_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-severe-risk"}
+String Day07_Hour19_Conditions "Conditions" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-conditions"}
+String Day07_Hour19_Icon "Icon" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-icon"}
+String Day07_Hour19_Stations "Stations" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-stations"}
+String Day07_Hour19_Source "Source" (Total_Weather_Data_Day07_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour19-source"}
+
+// Day07 - Hour20
+Group Total_Weather_Data_Day07_Hour20 "Hour 20" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour20_DateTime "DateTime" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-datetime"}
+DateTime Day07_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-timestamp"}
+Number:Temperature Day07_Hour20_Temperature "Temperature" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-temperature"}
+Number:Temperature Day07_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-feels-like"}
+Number Day07_Hour20_Humidity "Humidity" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-humidity"}
+Number:Temperature Day07_Hour20_Dew "Dew Point" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-dew"}
+Number:Length Day07_Hour20_Precip "Precipitation" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-precip"}
+Number:Dimensionless Day07_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-precip-prob"}
+String Day07_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-precip-type"}
+Number:Length Day07_Hour20_Snow "Snow" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-snow"}
+Number:Length Day07_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-snow-depth"}
+Number:Speed Day07_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-wind-gust"}
+Number:Speed Day07_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-wind-speed"}
+Number:Angle Day07_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-wind-dir"}
+Number:Pressure Day07_Hour20_Pressure "Pressure" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-pressure"}
+Number:Length Day07_Hour20_Visibility "Visibility" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-visibility"}
+Number:Dimensionless Day07_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-cloud-cover"}
+Number:Intensity Day07_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-solar-radiation"}
+Number Day07_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-solar-energy"}
+Number Day07_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-uv-index"}
+Number Day07_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-severe-risk"}
+String Day07_Hour20_Conditions "Conditions" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-conditions"}
+String Day07_Hour20_Icon "Icon" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-icon"}
+String Day07_Hour20_Stations "Stations" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-stations"}
+String Day07_Hour20_Source "Source" (Total_Weather_Data_Day07_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour20-source"}
+
+// Day07 - Hour21
+Group Total_Weather_Data_Day07_Hour21 "Hour 21" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour21_DateTime "DateTime" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-datetime"}
+DateTime Day07_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-timestamp"}
+Number:Temperature Day07_Hour21_Temperature "Temperature" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-temperature"}
+Number:Temperature Day07_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-feels-like"}
+Number Day07_Hour21_Humidity "Humidity" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-humidity"}
+Number:Temperature Day07_Hour21_Dew "Dew Point" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-dew"}
+Number:Length Day07_Hour21_Precip "Precipitation" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-precip"}
+Number:Dimensionless Day07_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-precip-prob"}
+String Day07_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-precip-type"}
+Number:Length Day07_Hour21_Snow "Snow" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-snow"}
+Number:Length Day07_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-snow-depth"}
+Number:Speed Day07_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-wind-gust"}
+Number:Speed Day07_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-wind-speed"}
+Number:Angle Day07_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-wind-dir"}
+Number:Pressure Day07_Hour21_Pressure "Pressure" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-pressure"}
+Number:Length Day07_Hour21_Visibility "Visibility" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-visibility"}
+Number:Dimensionless Day07_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-cloud-cover"}
+Number:Intensity Day07_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-solar-radiation"}
+Number Day07_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-solar-energy"}
+Number Day07_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-uv-index"}
+Number Day07_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-severe-risk"}
+String Day07_Hour21_Conditions "Conditions" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-conditions"}
+String Day07_Hour21_Icon "Icon" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-icon"}
+String Day07_Hour21_Stations "Stations" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-stations"}
+String Day07_Hour21_Source "Source" (Total_Weather_Data_Day07_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour21-source"}
+
+// Day07 - Hour22
+Group Total_Weather_Data_Day07_Hour22 "Hour 22" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour22_DateTime "DateTime" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-datetime"}
+DateTime Day07_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-timestamp"}
+Number:Temperature Day07_Hour22_Temperature "Temperature" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-temperature"}
+Number:Temperature Day07_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-feels-like"}
+Number Day07_Hour22_Humidity "Humidity" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-humidity"}
+Number:Temperature Day07_Hour22_Dew "Dew Point" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-dew"}
+Number:Length Day07_Hour22_Precip "Precipitation" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-precip"}
+Number:Dimensionless Day07_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-precip-prob"}
+String Day07_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-precip-type"}
+Number:Length Day07_Hour22_Snow "Snow" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-snow"}
+Number:Length Day07_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-snow-depth"}
+Number:Speed Day07_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-wind-gust"}
+Number:Speed Day07_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-wind-speed"}
+Number:Angle Day07_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-wind-dir"}
+Number:Pressure Day07_Hour22_Pressure "Pressure" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-pressure"}
+Number:Length Day07_Hour22_Visibility "Visibility" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-visibility"}
+Number:Dimensionless Day07_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-cloud-cover"}
+Number:Intensity Day07_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-solar-radiation"}
+Number Day07_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-solar-energy"}
+Number Day07_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-uv-index"}
+Number Day07_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-severe-risk"}
+String Day07_Hour22_Conditions "Conditions" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-conditions"}
+String Day07_Hour22_Icon "Icon" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-icon"}
+String Day07_Hour22_Stations "Stations" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-stations"}
+String Day07_Hour22_Source "Source" (Total_Weather_Data_Day07_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour22-source"}
+
+// Day07 - Hour23
+Group Total_Weather_Data_Day07_Hour23 "Hour 23" (Total_Weather_Data_Day07) [ "Equipment" ] 
+String Day07_Hour23_DateTime "DateTime" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-datetime"}
+DateTime Day07_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-timestamp"}
+Number:Temperature Day07_Hour23_Temperature "Temperature" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-temperature"}
+Number:Temperature Day07_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-feels-like"}
+Number Day07_Hour23_Humidity "Humidity" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-humidity"}
+Number:Temperature Day07_Hour23_Dew "Dew Point" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-dew"}
+Number:Length Day07_Hour23_Precip "Precipitation" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-precip"}
+Number:Dimensionless Day07_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-precip-prob"}
+String Day07_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-precip-type"}
+Number:Length Day07_Hour23_Snow "Snow" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-snow"}
+Number:Length Day07_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-snow-depth"}
+Number:Speed Day07_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-wind-gust"}
+Number:Speed Day07_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-wind-speed"}
+Number:Angle Day07_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-wind-dir"}
+Number:Pressure Day07_Hour23_Pressure "Pressure" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-pressure"}
+Number:Length Day07_Hour23_Visibility "Visibility" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-visibility"}
+Number:Dimensionless Day07_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-cloud-cover"}
+Number:Intensity Day07_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-solar-radiation"}
+Number Day07_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-solar-energy"}
+Number Day07_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-uv-index"}
+Number Day07_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-severe-risk"}
+String Day07_Hour23_Conditions "Conditions" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-conditions"}
+String Day07_Hour23_Icon "Icon" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-icon"}
+String Day07_Hour23_Stations "Stations" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-stations"}
+String Day07_Hour23_Source "Source" (Total_Weather_Data_Day07_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day07#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_08.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_08.items
@@ -1,39 +1,712 @@
 // Day08
 Group Total_Weather_Data_Day08 "Day T+08" (Total_Weather_Data) [ "Equipment" ] 
-String Day08_DateTime "Time" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day08_Timestamp "Timestamp" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day08_Temperature "Temperature" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day08_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day08_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day08_FeelsLike "Feels Like" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day08_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day08_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day08_Dew "Dew Point" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day08_Humidity "Humidity" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day08_Precip "Precipitation" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day08_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day08_Precip_Type "Precipitation Type" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day08_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day08_Snow "Snow" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day08_Snow_Depth "Snow Depth" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day08_Wind_Gust "Wind Gust" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day08_Wind_Speed "Wind Speed" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day08_Wind_Dir "Wind Direction" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day08_Pressure "Pressure" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day08_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day08_Visibility "Visibility" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day08_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day08_Solar_Energy "Solar Energy" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day08_UV_Index "UV Index" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day08_Sunrise "Sunrise" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day08_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day08_Sunset "Sunset" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day08_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day08_Moon_Phase "Moon Phase" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day08_Conditions "Conditions" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day08_Description "Description" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day08_Icon "Icon" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day08_Stations "Stations" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day08_Source "Source" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day08_Severe_Risk "Severe Risk" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day08_DateTime "Time" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#datetime" }
+DateTime Day08_Timestamp "Timestamp" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#timestamp" }
+Number:Temperature Day08_Temperature "Temperature" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#temperature" }
+Number:Temperature Day08_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#temperature-min" }
+Number:Temperature Day08_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#temperature-max" }
+Number:Temperature Day08_FeelsLike "Feels Like" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#feels-like" }
+Number:Temperature Day08_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#feels-like-min" }
+Number:Temperature Day08_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#feels-like-max" }
+Number:Temperature Day08_Dew "Dew Point" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#dew" }
+Number Day08_Humidity "Humidity" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#humidity" }
+Number:Length Day08_Precip "Precipitation" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#precip" }
+Number Day08_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#precip-prob" }
+String Day08_Precip_Type "Precipitation Type" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#precip-type" }
+Number Day08_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#precip-cover" }
+Number:Length Day08_Snow "Snow" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#snow" }
+Number:Length Day08_Snow_Depth "Snow Depth" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#snow-depth" }
+Number:Speed Day08_Wind_Gust "Wind Gust" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#wind-gust" }
+Number:Speed Day08_Wind_Speed "Wind Speed" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#wind-speed" }
+Number:Angle Day08_Wind_Dir "Wind Direction" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#wind-dir" }
+Number:Pressure Day08_Pressure "Pressure" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#pressure" }
+Number Day08_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#cloud-cover" }
+Number:Length Day08_Visibility "Visibility" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#visibility" }
+Number:Intensity Day08_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#solar-radiation" }
+Number Day08_Solar_Energy "Solar Energy" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#solar-energy" }
+Number Day08_UV_Index "UV Index" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#uv-index" }
+String Day08_Sunrise "Sunrise" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#sunrise" }
+DateTime Day08_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#sunrise-epoch" }
+String Day08_Sunset "Sunset" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#sunset" }
+DateTime Day08_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#sunset-epoch" }
+Number Day08_Moon_Phase "Moon Phase" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#moon-phase" }
+String Day08_Conditions "Conditions" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#conditions" }
+String Day08_Description "Description" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#description" }
+String Day08_Icon "Icon" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#icon" }
+String Day08_Stations "Stations" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#stations" }
+String Day08_Source "Source" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#source" }
+Number Day08_Severe_Risk "Severe Risk" (Total_Weather_Data_Day08)["Point"] { channel="visualcrossing:weather:default_config:day08#severe-risk" }
+
+// Day08 - Hour00
+Group Total_Weather_Data_Day08_Hour00 "Hour 00" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour00_DateTime "DateTime" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-datetime"}
+DateTime Day08_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-timestamp"}
+Number:Temperature Day08_Hour00_Temperature "Temperature" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-temperature"}
+Number:Temperature Day08_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-feels-like"}
+Number Day08_Hour00_Humidity "Humidity" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-humidity"}
+Number:Temperature Day08_Hour00_Dew "Dew Point" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-dew"}
+Number:Length Day08_Hour00_Precip "Precipitation" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-precip"}
+Number:Dimensionless Day08_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-precip-prob"}
+String Day08_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-precip-type"}
+Number:Length Day08_Hour00_Snow "Snow" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-snow"}
+Number:Length Day08_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-snow-depth"}
+Number:Speed Day08_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-wind-gust"}
+Number:Speed Day08_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-wind-speed"}
+Number:Angle Day08_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-wind-dir"}
+Number:Pressure Day08_Hour00_Pressure "Pressure" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-pressure"}
+Number:Length Day08_Hour00_Visibility "Visibility" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-visibility"}
+Number:Dimensionless Day08_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-cloud-cover"}
+Number:Intensity Day08_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-solar-radiation"}
+Number Day08_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-solar-energy"}
+Number Day08_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-uv-index"}
+Number Day08_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-severe-risk"}
+String Day08_Hour00_Conditions "Conditions" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-conditions"}
+String Day08_Hour00_Icon "Icon" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-icon"}
+String Day08_Hour00_Stations "Stations" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-stations"}
+String Day08_Hour00_Source "Source" (Total_Weather_Data_Day08_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour00-source"}
+
+// Day08 - Hour01
+Group Total_Weather_Data_Day08_Hour01 "Hour 01" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour01_DateTime "DateTime" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-datetime"}
+DateTime Day08_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-timestamp"}
+Number:Temperature Day08_Hour01_Temperature "Temperature" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-temperature"}
+Number:Temperature Day08_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-feels-like"}
+Number Day08_Hour01_Humidity "Humidity" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-humidity"}
+Number:Temperature Day08_Hour01_Dew "Dew Point" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-dew"}
+Number:Length Day08_Hour01_Precip "Precipitation" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-precip"}
+Number:Dimensionless Day08_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-precip-prob"}
+String Day08_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-precip-type"}
+Number:Length Day08_Hour01_Snow "Snow" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-snow"}
+Number:Length Day08_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-snow-depth"}
+Number:Speed Day08_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-wind-gust"}
+Number:Speed Day08_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-wind-speed"}
+Number:Angle Day08_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-wind-dir"}
+Number:Pressure Day08_Hour01_Pressure "Pressure" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-pressure"}
+Number:Length Day08_Hour01_Visibility "Visibility" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-visibility"}
+Number:Dimensionless Day08_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-cloud-cover"}
+Number:Intensity Day08_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-solar-radiation"}
+Number Day08_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-solar-energy"}
+Number Day08_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-uv-index"}
+Number Day08_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-severe-risk"}
+String Day08_Hour01_Conditions "Conditions" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-conditions"}
+String Day08_Hour01_Icon "Icon" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-icon"}
+String Day08_Hour01_Stations "Stations" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-stations"}
+String Day08_Hour01_Source "Source" (Total_Weather_Data_Day08_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour01-source"}
+
+// Day08 - Hour02
+Group Total_Weather_Data_Day08_Hour02 "Hour 02" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour02_DateTime "DateTime" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-datetime"}
+DateTime Day08_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-timestamp"}
+Number:Temperature Day08_Hour02_Temperature "Temperature" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-temperature"}
+Number:Temperature Day08_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-feels-like"}
+Number Day08_Hour02_Humidity "Humidity" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-humidity"}
+Number:Temperature Day08_Hour02_Dew "Dew Point" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-dew"}
+Number:Length Day08_Hour02_Precip "Precipitation" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-precip"}
+Number:Dimensionless Day08_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-precip-prob"}
+String Day08_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-precip-type"}
+Number:Length Day08_Hour02_Snow "Snow" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-snow"}
+Number:Length Day08_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-snow-depth"}
+Number:Speed Day08_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-wind-gust"}
+Number:Speed Day08_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-wind-speed"}
+Number:Angle Day08_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-wind-dir"}
+Number:Pressure Day08_Hour02_Pressure "Pressure" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-pressure"}
+Number:Length Day08_Hour02_Visibility "Visibility" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-visibility"}
+Number:Dimensionless Day08_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-cloud-cover"}
+Number:Intensity Day08_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-solar-radiation"}
+Number Day08_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-solar-energy"}
+Number Day08_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-uv-index"}
+Number Day08_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-severe-risk"}
+String Day08_Hour02_Conditions "Conditions" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-conditions"}
+String Day08_Hour02_Icon "Icon" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-icon"}
+String Day08_Hour02_Stations "Stations" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-stations"}
+String Day08_Hour02_Source "Source" (Total_Weather_Data_Day08_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour02-source"}
+
+// Day08 - Hour03
+Group Total_Weather_Data_Day08_Hour03 "Hour 03" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour03_DateTime "DateTime" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-datetime"}
+DateTime Day08_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-timestamp"}
+Number:Temperature Day08_Hour03_Temperature "Temperature" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-temperature"}
+Number:Temperature Day08_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-feels-like"}
+Number Day08_Hour03_Humidity "Humidity" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-humidity"}
+Number:Temperature Day08_Hour03_Dew "Dew Point" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-dew"}
+Number:Length Day08_Hour03_Precip "Precipitation" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-precip"}
+Number:Dimensionless Day08_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-precip-prob"}
+String Day08_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-precip-type"}
+Number:Length Day08_Hour03_Snow "Snow" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-snow"}
+Number:Length Day08_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-snow-depth"}
+Number:Speed Day08_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-wind-gust"}
+Number:Speed Day08_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-wind-speed"}
+Number:Angle Day08_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-wind-dir"}
+Number:Pressure Day08_Hour03_Pressure "Pressure" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-pressure"}
+Number:Length Day08_Hour03_Visibility "Visibility" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-visibility"}
+Number:Dimensionless Day08_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-cloud-cover"}
+Number:Intensity Day08_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-solar-radiation"}
+Number Day08_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-solar-energy"}
+Number Day08_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-uv-index"}
+Number Day08_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-severe-risk"}
+String Day08_Hour03_Conditions "Conditions" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-conditions"}
+String Day08_Hour03_Icon "Icon" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-icon"}
+String Day08_Hour03_Stations "Stations" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-stations"}
+String Day08_Hour03_Source "Source" (Total_Weather_Data_Day08_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour03-source"}
+
+// Day08 - Hour04
+Group Total_Weather_Data_Day08_Hour04 "Hour 04" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour04_DateTime "DateTime" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-datetime"}
+DateTime Day08_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-timestamp"}
+Number:Temperature Day08_Hour04_Temperature "Temperature" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-temperature"}
+Number:Temperature Day08_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-feels-like"}
+Number Day08_Hour04_Humidity "Humidity" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-humidity"}
+Number:Temperature Day08_Hour04_Dew "Dew Point" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-dew"}
+Number:Length Day08_Hour04_Precip "Precipitation" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-precip"}
+Number:Dimensionless Day08_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-precip-prob"}
+String Day08_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-precip-type"}
+Number:Length Day08_Hour04_Snow "Snow" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-snow"}
+Number:Length Day08_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-snow-depth"}
+Number:Speed Day08_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-wind-gust"}
+Number:Speed Day08_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-wind-speed"}
+Number:Angle Day08_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-wind-dir"}
+Number:Pressure Day08_Hour04_Pressure "Pressure" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-pressure"}
+Number:Length Day08_Hour04_Visibility "Visibility" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-visibility"}
+Number:Dimensionless Day08_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-cloud-cover"}
+Number:Intensity Day08_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-solar-radiation"}
+Number Day08_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-solar-energy"}
+Number Day08_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-uv-index"}
+Number Day08_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-severe-risk"}
+String Day08_Hour04_Conditions "Conditions" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-conditions"}
+String Day08_Hour04_Icon "Icon" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-icon"}
+String Day08_Hour04_Stations "Stations" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-stations"}
+String Day08_Hour04_Source "Source" (Total_Weather_Data_Day08_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour04-source"}
+
+// Day08 - Hour05
+Group Total_Weather_Data_Day08_Hour05 "Hour 05" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour05_DateTime "DateTime" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-datetime"}
+DateTime Day08_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-timestamp"}
+Number:Temperature Day08_Hour05_Temperature "Temperature" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-temperature"}
+Number:Temperature Day08_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-feels-like"}
+Number Day08_Hour05_Humidity "Humidity" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-humidity"}
+Number:Temperature Day08_Hour05_Dew "Dew Point" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-dew"}
+Number:Length Day08_Hour05_Precip "Precipitation" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-precip"}
+Number:Dimensionless Day08_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-precip-prob"}
+String Day08_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-precip-type"}
+Number:Length Day08_Hour05_Snow "Snow" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-snow"}
+Number:Length Day08_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-snow-depth"}
+Number:Speed Day08_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-wind-gust"}
+Number:Speed Day08_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-wind-speed"}
+Number:Angle Day08_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-wind-dir"}
+Number:Pressure Day08_Hour05_Pressure "Pressure" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-pressure"}
+Number:Length Day08_Hour05_Visibility "Visibility" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-visibility"}
+Number:Dimensionless Day08_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-cloud-cover"}
+Number:Intensity Day08_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-solar-radiation"}
+Number Day08_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-solar-energy"}
+Number Day08_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-uv-index"}
+Number Day08_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-severe-risk"}
+String Day08_Hour05_Conditions "Conditions" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-conditions"}
+String Day08_Hour05_Icon "Icon" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-icon"}
+String Day08_Hour05_Stations "Stations" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-stations"}
+String Day08_Hour05_Source "Source" (Total_Weather_Data_Day08_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour05-source"}
+
+// Day08 - Hour06
+Group Total_Weather_Data_Day08_Hour06 "Hour 06" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour06_DateTime "DateTime" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-datetime"}
+DateTime Day08_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-timestamp"}
+Number:Temperature Day08_Hour06_Temperature "Temperature" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-temperature"}
+Number:Temperature Day08_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-feels-like"}
+Number Day08_Hour06_Humidity "Humidity" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-humidity"}
+Number:Temperature Day08_Hour06_Dew "Dew Point" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-dew"}
+Number:Length Day08_Hour06_Precip "Precipitation" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-precip"}
+Number:Dimensionless Day08_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-precip-prob"}
+String Day08_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-precip-type"}
+Number:Length Day08_Hour06_Snow "Snow" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-snow"}
+Number:Length Day08_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-snow-depth"}
+Number:Speed Day08_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-wind-gust"}
+Number:Speed Day08_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-wind-speed"}
+Number:Angle Day08_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-wind-dir"}
+Number:Pressure Day08_Hour06_Pressure "Pressure" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-pressure"}
+Number:Length Day08_Hour06_Visibility "Visibility" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-visibility"}
+Number:Dimensionless Day08_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-cloud-cover"}
+Number:Intensity Day08_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-solar-radiation"}
+Number Day08_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-solar-energy"}
+Number Day08_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-uv-index"}
+Number Day08_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-severe-risk"}
+String Day08_Hour06_Conditions "Conditions" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-conditions"}
+String Day08_Hour06_Icon "Icon" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-icon"}
+String Day08_Hour06_Stations "Stations" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-stations"}
+String Day08_Hour06_Source "Source" (Total_Weather_Data_Day08_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour06-source"}
+
+// Day08 - Hour07
+Group Total_Weather_Data_Day08_Hour07 "Hour 07" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour07_DateTime "DateTime" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-datetime"}
+DateTime Day08_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-timestamp"}
+Number:Temperature Day08_Hour07_Temperature "Temperature" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-temperature"}
+Number:Temperature Day08_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-feels-like"}
+Number Day08_Hour07_Humidity "Humidity" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-humidity"}
+Number:Temperature Day08_Hour07_Dew "Dew Point" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-dew"}
+Number:Length Day08_Hour07_Precip "Precipitation" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-precip"}
+Number:Dimensionless Day08_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-precip-prob"}
+String Day08_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-precip-type"}
+Number:Length Day08_Hour07_Snow "Snow" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-snow"}
+Number:Length Day08_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-snow-depth"}
+Number:Speed Day08_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-wind-gust"}
+Number:Speed Day08_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-wind-speed"}
+Number:Angle Day08_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-wind-dir"}
+Number:Pressure Day08_Hour07_Pressure "Pressure" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-pressure"}
+Number:Length Day08_Hour07_Visibility "Visibility" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-visibility"}
+Number:Dimensionless Day08_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-cloud-cover"}
+Number:Intensity Day08_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-solar-radiation"}
+Number Day08_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-solar-energy"}
+Number Day08_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-uv-index"}
+Number Day08_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-severe-risk"}
+String Day08_Hour07_Conditions "Conditions" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-conditions"}
+String Day08_Hour07_Icon "Icon" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-icon"}
+String Day08_Hour07_Stations "Stations" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-stations"}
+String Day08_Hour07_Source "Source" (Total_Weather_Data_Day08_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour07-source"}
+
+// Day08 - Hour08
+Group Total_Weather_Data_Day08_Hour08 "Hour 08" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour08_DateTime "DateTime" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-datetime"}
+DateTime Day08_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-timestamp"}
+Number:Temperature Day08_Hour08_Temperature "Temperature" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-temperature"}
+Number:Temperature Day08_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-feels-like"}
+Number Day08_Hour08_Humidity "Humidity" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-humidity"}
+Number:Temperature Day08_Hour08_Dew "Dew Point" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-dew"}
+Number:Length Day08_Hour08_Precip "Precipitation" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-precip"}
+Number:Dimensionless Day08_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-precip-prob"}
+String Day08_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-precip-type"}
+Number:Length Day08_Hour08_Snow "Snow" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-snow"}
+Number:Length Day08_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-snow-depth"}
+Number:Speed Day08_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-wind-gust"}
+Number:Speed Day08_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-wind-speed"}
+Number:Angle Day08_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-wind-dir"}
+Number:Pressure Day08_Hour08_Pressure "Pressure" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-pressure"}
+Number:Length Day08_Hour08_Visibility "Visibility" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-visibility"}
+Number:Dimensionless Day08_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-cloud-cover"}
+Number:Intensity Day08_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-solar-radiation"}
+Number Day08_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-solar-energy"}
+Number Day08_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-uv-index"}
+Number Day08_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-severe-risk"}
+String Day08_Hour08_Conditions "Conditions" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-conditions"}
+String Day08_Hour08_Icon "Icon" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-icon"}
+String Day08_Hour08_Stations "Stations" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-stations"}
+String Day08_Hour08_Source "Source" (Total_Weather_Data_Day08_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour08-source"}
+
+// Day08 - Hour09
+Group Total_Weather_Data_Day08_Hour09 "Hour 09" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour09_DateTime "DateTime" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-datetime"}
+DateTime Day08_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-timestamp"}
+Number:Temperature Day08_Hour09_Temperature "Temperature" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-temperature"}
+Number:Temperature Day08_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-feels-like"}
+Number Day08_Hour09_Humidity "Humidity" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-humidity"}
+Number:Temperature Day08_Hour09_Dew "Dew Point" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-dew"}
+Number:Length Day08_Hour09_Precip "Precipitation" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-precip"}
+Number:Dimensionless Day08_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-precip-prob"}
+String Day08_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-precip-type"}
+Number:Length Day08_Hour09_Snow "Snow" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-snow"}
+Number:Length Day08_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-snow-depth"}
+Number:Speed Day08_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-wind-gust"}
+Number:Speed Day08_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-wind-speed"}
+Number:Angle Day08_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-wind-dir"}
+Number:Pressure Day08_Hour09_Pressure "Pressure" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-pressure"}
+Number:Length Day08_Hour09_Visibility "Visibility" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-visibility"}
+Number:Dimensionless Day08_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-cloud-cover"}
+Number:Intensity Day08_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-solar-radiation"}
+Number Day08_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-solar-energy"}
+Number Day08_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-uv-index"}
+Number Day08_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-severe-risk"}
+String Day08_Hour09_Conditions "Conditions" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-conditions"}
+String Day08_Hour09_Icon "Icon" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-icon"}
+String Day08_Hour09_Stations "Stations" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-stations"}
+String Day08_Hour09_Source "Source" (Total_Weather_Data_Day08_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour09-source"}
+
+// Day08 - Hour10
+Group Total_Weather_Data_Day08_Hour10 "Hour 10" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour10_DateTime "DateTime" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-datetime"}
+DateTime Day08_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-timestamp"}
+Number:Temperature Day08_Hour10_Temperature "Temperature" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-temperature"}
+Number:Temperature Day08_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-feels-like"}
+Number Day08_Hour10_Humidity "Humidity" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-humidity"}
+Number:Temperature Day08_Hour10_Dew "Dew Point" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-dew"}
+Number:Length Day08_Hour10_Precip "Precipitation" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-precip"}
+Number:Dimensionless Day08_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-precip-prob"}
+String Day08_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-precip-type"}
+Number:Length Day08_Hour10_Snow "Snow" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-snow"}
+Number:Length Day08_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-snow-depth"}
+Number:Speed Day08_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-wind-gust"}
+Number:Speed Day08_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-wind-speed"}
+Number:Angle Day08_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-wind-dir"}
+Number:Pressure Day08_Hour10_Pressure "Pressure" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-pressure"}
+Number:Length Day08_Hour10_Visibility "Visibility" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-visibility"}
+Number:Dimensionless Day08_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-cloud-cover"}
+Number:Intensity Day08_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-solar-radiation"}
+Number Day08_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-solar-energy"}
+Number Day08_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-uv-index"}
+Number Day08_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-severe-risk"}
+String Day08_Hour10_Conditions "Conditions" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-conditions"}
+String Day08_Hour10_Icon "Icon" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-icon"}
+String Day08_Hour10_Stations "Stations" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-stations"}
+String Day08_Hour10_Source "Source" (Total_Weather_Data_Day08_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour10-source"}
+
+// Day08 - Hour11
+Group Total_Weather_Data_Day08_Hour11 "Hour 11" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour11_DateTime "DateTime" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-datetime"}
+DateTime Day08_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-timestamp"}
+Number:Temperature Day08_Hour11_Temperature "Temperature" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-temperature"}
+Number:Temperature Day08_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-feels-like"}
+Number Day08_Hour11_Humidity "Humidity" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-humidity"}
+Number:Temperature Day08_Hour11_Dew "Dew Point" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-dew"}
+Number:Length Day08_Hour11_Precip "Precipitation" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-precip"}
+Number:Dimensionless Day08_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-precip-prob"}
+String Day08_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-precip-type"}
+Number:Length Day08_Hour11_Snow "Snow" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-snow"}
+Number:Length Day08_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-snow-depth"}
+Number:Speed Day08_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-wind-gust"}
+Number:Speed Day08_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-wind-speed"}
+Number:Angle Day08_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-wind-dir"}
+Number:Pressure Day08_Hour11_Pressure "Pressure" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-pressure"}
+Number:Length Day08_Hour11_Visibility "Visibility" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-visibility"}
+Number:Dimensionless Day08_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-cloud-cover"}
+Number:Intensity Day08_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-solar-radiation"}
+Number Day08_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-solar-energy"}
+Number Day08_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-uv-index"}
+Number Day08_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-severe-risk"}
+String Day08_Hour11_Conditions "Conditions" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-conditions"}
+String Day08_Hour11_Icon "Icon" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-icon"}
+String Day08_Hour11_Stations "Stations" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-stations"}
+String Day08_Hour11_Source "Source" (Total_Weather_Data_Day08_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour11-source"}
+
+// Day08 - Hour12
+Group Total_Weather_Data_Day08_Hour12 "Hour 12" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour12_DateTime "DateTime" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-datetime"}
+DateTime Day08_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-timestamp"}
+Number:Temperature Day08_Hour12_Temperature "Temperature" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-temperature"}
+Number:Temperature Day08_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-feels-like"}
+Number Day08_Hour12_Humidity "Humidity" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-humidity"}
+Number:Temperature Day08_Hour12_Dew "Dew Point" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-dew"}
+Number:Length Day08_Hour12_Precip "Precipitation" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-precip"}
+Number:Dimensionless Day08_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-precip-prob"}
+String Day08_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-precip-type"}
+Number:Length Day08_Hour12_Snow "Snow" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-snow"}
+Number:Length Day08_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-snow-depth"}
+Number:Speed Day08_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-wind-gust"}
+Number:Speed Day08_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-wind-speed"}
+Number:Angle Day08_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-wind-dir"}
+Number:Pressure Day08_Hour12_Pressure "Pressure" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-pressure"}
+Number:Length Day08_Hour12_Visibility "Visibility" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-visibility"}
+Number:Dimensionless Day08_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-cloud-cover"}
+Number:Intensity Day08_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-solar-radiation"}
+Number Day08_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-solar-energy"}
+Number Day08_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-uv-index"}
+Number Day08_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-severe-risk"}
+String Day08_Hour12_Conditions "Conditions" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-conditions"}
+String Day08_Hour12_Icon "Icon" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-icon"}
+String Day08_Hour12_Stations "Stations" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-stations"}
+String Day08_Hour12_Source "Source" (Total_Weather_Data_Day08_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour12-source"}
+
+// Day08 - Hour13
+Group Total_Weather_Data_Day08_Hour13 "Hour 13" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour13_DateTime "DateTime" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-datetime"}
+DateTime Day08_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-timestamp"}
+Number:Temperature Day08_Hour13_Temperature "Temperature" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-temperature"}
+Number:Temperature Day08_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-feels-like"}
+Number Day08_Hour13_Humidity "Humidity" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-humidity"}
+Number:Temperature Day08_Hour13_Dew "Dew Point" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-dew"}
+Number:Length Day08_Hour13_Precip "Precipitation" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-precip"}
+Number:Dimensionless Day08_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-precip-prob"}
+String Day08_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-precip-type"}
+Number:Length Day08_Hour13_Snow "Snow" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-snow"}
+Number:Length Day08_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-snow-depth"}
+Number:Speed Day08_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-wind-gust"}
+Number:Speed Day08_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-wind-speed"}
+Number:Angle Day08_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-wind-dir"}
+Number:Pressure Day08_Hour13_Pressure "Pressure" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-pressure"}
+Number:Length Day08_Hour13_Visibility "Visibility" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-visibility"}
+Number:Dimensionless Day08_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-cloud-cover"}
+Number:Intensity Day08_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-solar-radiation"}
+Number Day08_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-solar-energy"}
+Number Day08_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-uv-index"}
+Number Day08_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-severe-risk"}
+String Day08_Hour13_Conditions "Conditions" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-conditions"}
+String Day08_Hour13_Icon "Icon" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-icon"}
+String Day08_Hour13_Stations "Stations" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-stations"}
+String Day08_Hour13_Source "Source" (Total_Weather_Data_Day08_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour13-source"}
+
+// Day08 - Hour14
+Group Total_Weather_Data_Day08_Hour14 "Hour 14" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour14_DateTime "DateTime" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-datetime"}
+DateTime Day08_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-timestamp"}
+Number:Temperature Day08_Hour14_Temperature "Temperature" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-temperature"}
+Number:Temperature Day08_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-feels-like"}
+Number Day08_Hour14_Humidity "Humidity" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-humidity"}
+Number:Temperature Day08_Hour14_Dew "Dew Point" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-dew"}
+Number:Length Day08_Hour14_Precip "Precipitation" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-precip"}
+Number:Dimensionless Day08_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-precip-prob"}
+String Day08_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-precip-type"}
+Number:Length Day08_Hour14_Snow "Snow" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-snow"}
+Number:Length Day08_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-snow-depth"}
+Number:Speed Day08_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-wind-gust"}
+Number:Speed Day08_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-wind-speed"}
+Number:Angle Day08_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-wind-dir"}
+Number:Pressure Day08_Hour14_Pressure "Pressure" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-pressure"}
+Number:Length Day08_Hour14_Visibility "Visibility" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-visibility"}
+Number:Dimensionless Day08_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-cloud-cover"}
+Number:Intensity Day08_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-solar-radiation"}
+Number Day08_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-solar-energy"}
+Number Day08_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-uv-index"}
+Number Day08_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-severe-risk"}
+String Day08_Hour14_Conditions "Conditions" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-conditions"}
+String Day08_Hour14_Icon "Icon" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-icon"}
+String Day08_Hour14_Stations "Stations" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-stations"}
+String Day08_Hour14_Source "Source" (Total_Weather_Data_Day08_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour14-source"}
+
+// Day08 - Hour15
+Group Total_Weather_Data_Day08_Hour15 "Hour 15" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour15_DateTime "DateTime" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-datetime"}
+DateTime Day08_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-timestamp"}
+Number:Temperature Day08_Hour15_Temperature "Temperature" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-temperature"}
+Number:Temperature Day08_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-feels-like"}
+Number Day08_Hour15_Humidity "Humidity" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-humidity"}
+Number:Temperature Day08_Hour15_Dew "Dew Point" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-dew"}
+Number:Length Day08_Hour15_Precip "Precipitation" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-precip"}
+Number:Dimensionless Day08_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-precip-prob"}
+String Day08_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-precip-type"}
+Number:Length Day08_Hour15_Snow "Snow" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-snow"}
+Number:Length Day08_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-snow-depth"}
+Number:Speed Day08_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-wind-gust"}
+Number:Speed Day08_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-wind-speed"}
+Number:Angle Day08_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-wind-dir"}
+Number:Pressure Day08_Hour15_Pressure "Pressure" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-pressure"}
+Number:Length Day08_Hour15_Visibility "Visibility" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-visibility"}
+Number:Dimensionless Day08_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-cloud-cover"}
+Number:Intensity Day08_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-solar-radiation"}
+Number Day08_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-solar-energy"}
+Number Day08_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-uv-index"}
+Number Day08_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-severe-risk"}
+String Day08_Hour15_Conditions "Conditions" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-conditions"}
+String Day08_Hour15_Icon "Icon" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-icon"}
+String Day08_Hour15_Stations "Stations" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-stations"}
+String Day08_Hour15_Source "Source" (Total_Weather_Data_Day08_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour15-source"}
+
+// Day08 - Hour16
+Group Total_Weather_Data_Day08_Hour16 "Hour 16" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour16_DateTime "DateTime" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-datetime"}
+DateTime Day08_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-timestamp"}
+Number:Temperature Day08_Hour16_Temperature "Temperature" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-temperature"}
+Number:Temperature Day08_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-feels-like"}
+Number Day08_Hour16_Humidity "Humidity" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-humidity"}
+Number:Temperature Day08_Hour16_Dew "Dew Point" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-dew"}
+Number:Length Day08_Hour16_Precip "Precipitation" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-precip"}
+Number:Dimensionless Day08_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-precip-prob"}
+String Day08_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-precip-type"}
+Number:Length Day08_Hour16_Snow "Snow" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-snow"}
+Number:Length Day08_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-snow-depth"}
+Number:Speed Day08_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-wind-gust"}
+Number:Speed Day08_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-wind-speed"}
+Number:Angle Day08_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-wind-dir"}
+Number:Pressure Day08_Hour16_Pressure "Pressure" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-pressure"}
+Number:Length Day08_Hour16_Visibility "Visibility" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-visibility"}
+Number:Dimensionless Day08_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-cloud-cover"}
+Number:Intensity Day08_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-solar-radiation"}
+Number Day08_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-solar-energy"}
+Number Day08_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-uv-index"}
+Number Day08_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-severe-risk"}
+String Day08_Hour16_Conditions "Conditions" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-conditions"}
+String Day08_Hour16_Icon "Icon" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-icon"}
+String Day08_Hour16_Stations "Stations" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-stations"}
+String Day08_Hour16_Source "Source" (Total_Weather_Data_Day08_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour16-source"}
+
+// Day08 - Hour17
+Group Total_Weather_Data_Day08_Hour17 "Hour 17" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour17_DateTime "DateTime" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-datetime"}
+DateTime Day08_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-timestamp"}
+Number:Temperature Day08_Hour17_Temperature "Temperature" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-temperature"}
+Number:Temperature Day08_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-feels-like"}
+Number Day08_Hour17_Humidity "Humidity" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-humidity"}
+Number:Temperature Day08_Hour17_Dew "Dew Point" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-dew"}
+Number:Length Day08_Hour17_Precip "Precipitation" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-precip"}
+Number:Dimensionless Day08_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-precip-prob"}
+String Day08_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-precip-type"}
+Number:Length Day08_Hour17_Snow "Snow" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-snow"}
+Number:Length Day08_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-snow-depth"}
+Number:Speed Day08_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-wind-gust"}
+Number:Speed Day08_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-wind-speed"}
+Number:Angle Day08_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-wind-dir"}
+Number:Pressure Day08_Hour17_Pressure "Pressure" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-pressure"}
+Number:Length Day08_Hour17_Visibility "Visibility" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-visibility"}
+Number:Dimensionless Day08_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-cloud-cover"}
+Number:Intensity Day08_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-solar-radiation"}
+Number Day08_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-solar-energy"}
+Number Day08_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-uv-index"}
+Number Day08_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-severe-risk"}
+String Day08_Hour17_Conditions "Conditions" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-conditions"}
+String Day08_Hour17_Icon "Icon" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-icon"}
+String Day08_Hour17_Stations "Stations" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-stations"}
+String Day08_Hour17_Source "Source" (Total_Weather_Data_Day08_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour17-source"}
+
+// Day08 - Hour18
+Group Total_Weather_Data_Day08_Hour18 "Hour 18" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour18_DateTime "DateTime" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-datetime"}
+DateTime Day08_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-timestamp"}
+Number:Temperature Day08_Hour18_Temperature "Temperature" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-temperature"}
+Number:Temperature Day08_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-feels-like"}
+Number Day08_Hour18_Humidity "Humidity" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-humidity"}
+Number:Temperature Day08_Hour18_Dew "Dew Point" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-dew"}
+Number:Length Day08_Hour18_Precip "Precipitation" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-precip"}
+Number:Dimensionless Day08_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-precip-prob"}
+String Day08_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-precip-type"}
+Number:Length Day08_Hour18_Snow "Snow" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-snow"}
+Number:Length Day08_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-snow-depth"}
+Number:Speed Day08_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-wind-gust"}
+Number:Speed Day08_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-wind-speed"}
+Number:Angle Day08_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-wind-dir"}
+Number:Pressure Day08_Hour18_Pressure "Pressure" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-pressure"}
+Number:Length Day08_Hour18_Visibility "Visibility" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-visibility"}
+Number:Dimensionless Day08_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-cloud-cover"}
+Number:Intensity Day08_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-solar-radiation"}
+Number Day08_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-solar-energy"}
+Number Day08_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-uv-index"}
+Number Day08_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-severe-risk"}
+String Day08_Hour18_Conditions "Conditions" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-conditions"}
+String Day08_Hour18_Icon "Icon" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-icon"}
+String Day08_Hour18_Stations "Stations" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-stations"}
+String Day08_Hour18_Source "Source" (Total_Weather_Data_Day08_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour18-source"}
+
+// Day08 - Hour19
+Group Total_Weather_Data_Day08_Hour19 "Hour 19" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour19_DateTime "DateTime" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-datetime"}
+DateTime Day08_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-timestamp"}
+Number:Temperature Day08_Hour19_Temperature "Temperature" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-temperature"}
+Number:Temperature Day08_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-feels-like"}
+Number Day08_Hour19_Humidity "Humidity" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-humidity"}
+Number:Temperature Day08_Hour19_Dew "Dew Point" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-dew"}
+Number:Length Day08_Hour19_Precip "Precipitation" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-precip"}
+Number:Dimensionless Day08_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-precip-prob"}
+String Day08_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-precip-type"}
+Number:Length Day08_Hour19_Snow "Snow" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-snow"}
+Number:Length Day08_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-snow-depth"}
+Number:Speed Day08_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-wind-gust"}
+Number:Speed Day08_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-wind-speed"}
+Number:Angle Day08_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-wind-dir"}
+Number:Pressure Day08_Hour19_Pressure "Pressure" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-pressure"}
+Number:Length Day08_Hour19_Visibility "Visibility" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-visibility"}
+Number:Dimensionless Day08_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-cloud-cover"}
+Number:Intensity Day08_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-solar-radiation"}
+Number Day08_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-solar-energy"}
+Number Day08_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-uv-index"}
+Number Day08_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-severe-risk"}
+String Day08_Hour19_Conditions "Conditions" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-conditions"}
+String Day08_Hour19_Icon "Icon" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-icon"}
+String Day08_Hour19_Stations "Stations" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-stations"}
+String Day08_Hour19_Source "Source" (Total_Weather_Data_Day08_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour19-source"}
+
+// Day08 - Hour20
+Group Total_Weather_Data_Day08_Hour20 "Hour 20" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour20_DateTime "DateTime" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-datetime"}
+DateTime Day08_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-timestamp"}
+Number:Temperature Day08_Hour20_Temperature "Temperature" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-temperature"}
+Number:Temperature Day08_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-feels-like"}
+Number Day08_Hour20_Humidity "Humidity" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-humidity"}
+Number:Temperature Day08_Hour20_Dew "Dew Point" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-dew"}
+Number:Length Day08_Hour20_Precip "Precipitation" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-precip"}
+Number:Dimensionless Day08_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-precip-prob"}
+String Day08_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-precip-type"}
+Number:Length Day08_Hour20_Snow "Snow" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-snow"}
+Number:Length Day08_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-snow-depth"}
+Number:Speed Day08_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-wind-gust"}
+Number:Speed Day08_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-wind-speed"}
+Number:Angle Day08_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-wind-dir"}
+Number:Pressure Day08_Hour20_Pressure "Pressure" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-pressure"}
+Number:Length Day08_Hour20_Visibility "Visibility" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-visibility"}
+Number:Dimensionless Day08_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-cloud-cover"}
+Number:Intensity Day08_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-solar-radiation"}
+Number Day08_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-solar-energy"}
+Number Day08_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-uv-index"}
+Number Day08_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-severe-risk"}
+String Day08_Hour20_Conditions "Conditions" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-conditions"}
+String Day08_Hour20_Icon "Icon" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-icon"}
+String Day08_Hour20_Stations "Stations" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-stations"}
+String Day08_Hour20_Source "Source" (Total_Weather_Data_Day08_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour20-source"}
+
+// Day08 - Hour21
+Group Total_Weather_Data_Day08_Hour21 "Hour 21" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour21_DateTime "DateTime" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-datetime"}
+DateTime Day08_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-timestamp"}
+Number:Temperature Day08_Hour21_Temperature "Temperature" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-temperature"}
+Number:Temperature Day08_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-feels-like"}
+Number Day08_Hour21_Humidity "Humidity" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-humidity"}
+Number:Temperature Day08_Hour21_Dew "Dew Point" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-dew"}
+Number:Length Day08_Hour21_Precip "Precipitation" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-precip"}
+Number:Dimensionless Day08_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-precip-prob"}
+String Day08_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-precip-type"}
+Number:Length Day08_Hour21_Snow "Snow" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-snow"}
+Number:Length Day08_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-snow-depth"}
+Number:Speed Day08_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-wind-gust"}
+Number:Speed Day08_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-wind-speed"}
+Number:Angle Day08_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-wind-dir"}
+Number:Pressure Day08_Hour21_Pressure "Pressure" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-pressure"}
+Number:Length Day08_Hour21_Visibility "Visibility" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-visibility"}
+Number:Dimensionless Day08_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-cloud-cover"}
+Number:Intensity Day08_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-solar-radiation"}
+Number Day08_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-solar-energy"}
+Number Day08_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-uv-index"}
+Number Day08_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-severe-risk"}
+String Day08_Hour21_Conditions "Conditions" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-conditions"}
+String Day08_Hour21_Icon "Icon" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-icon"}
+String Day08_Hour21_Stations "Stations" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-stations"}
+String Day08_Hour21_Source "Source" (Total_Weather_Data_Day08_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour21-source"}
+
+// Day08 - Hour22
+Group Total_Weather_Data_Day08_Hour22 "Hour 22" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour22_DateTime "DateTime" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-datetime"}
+DateTime Day08_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-timestamp"}
+Number:Temperature Day08_Hour22_Temperature "Temperature" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-temperature"}
+Number:Temperature Day08_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-feels-like"}
+Number Day08_Hour22_Humidity "Humidity" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-humidity"}
+Number:Temperature Day08_Hour22_Dew "Dew Point" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-dew"}
+Number:Length Day08_Hour22_Precip "Precipitation" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-precip"}
+Number:Dimensionless Day08_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-precip-prob"}
+String Day08_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-precip-type"}
+Number:Length Day08_Hour22_Snow "Snow" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-snow"}
+Number:Length Day08_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-snow-depth"}
+Number:Speed Day08_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-wind-gust"}
+Number:Speed Day08_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-wind-speed"}
+Number:Angle Day08_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-wind-dir"}
+Number:Pressure Day08_Hour22_Pressure "Pressure" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-pressure"}
+Number:Length Day08_Hour22_Visibility "Visibility" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-visibility"}
+Number:Dimensionless Day08_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-cloud-cover"}
+Number:Intensity Day08_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-solar-radiation"}
+Number Day08_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-solar-energy"}
+Number Day08_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-uv-index"}
+Number Day08_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-severe-risk"}
+String Day08_Hour22_Conditions "Conditions" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-conditions"}
+String Day08_Hour22_Icon "Icon" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-icon"}
+String Day08_Hour22_Stations "Stations" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-stations"}
+String Day08_Hour22_Source "Source" (Total_Weather_Data_Day08_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour22-source"}
+
+// Day08 - Hour23
+Group Total_Weather_Data_Day08_Hour23 "Hour 23" (Total_Weather_Data_Day08) [ "Equipment" ] 
+String Day08_Hour23_DateTime "DateTime" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-datetime"}
+DateTime Day08_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-timestamp"}
+Number:Temperature Day08_Hour23_Temperature "Temperature" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-temperature"}
+Number:Temperature Day08_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-feels-like"}
+Number Day08_Hour23_Humidity "Humidity" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-humidity"}
+Number:Temperature Day08_Hour23_Dew "Dew Point" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-dew"}
+Number:Length Day08_Hour23_Precip "Precipitation" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-precip"}
+Number:Dimensionless Day08_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-precip-prob"}
+String Day08_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-precip-type"}
+Number:Length Day08_Hour23_Snow "Snow" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-snow"}
+Number:Length Day08_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-snow-depth"}
+Number:Speed Day08_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-wind-gust"}
+Number:Speed Day08_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-wind-speed"}
+Number:Angle Day08_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-wind-dir"}
+Number:Pressure Day08_Hour23_Pressure "Pressure" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-pressure"}
+Number:Length Day08_Hour23_Visibility "Visibility" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-visibility"}
+Number:Dimensionless Day08_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-cloud-cover"}
+Number:Intensity Day08_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-solar-radiation"}
+Number Day08_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-solar-energy"}
+Number Day08_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-uv-index"}
+Number Day08_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-severe-risk"}
+String Day08_Hour23_Conditions "Conditions" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-conditions"}
+String Day08_Hour23_Icon "Icon" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-icon"}
+String Day08_Hour23_Stations "Stations" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-stations"}
+String Day08_Hour23_Source "Source" (Total_Weather_Data_Day08_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day08#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_09.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_09.items
@@ -1,39 +1,712 @@
 // Day09
 Group Total_Weather_Data_Day09 "Day T+09" (Total_Weather_Data) [ "Equipment" ] 
-String Day09_DateTime "Time" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day09_Timestamp "Timestamp" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day09_Temperature "Temperature" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day09_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day09_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day09_FeelsLike "Feels Like" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day09_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day09_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day09_Dew "Dew Point" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day09_Humidity "Humidity" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day09_Precip "Precipitation" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day09_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day09_Precip_Type "Precipitation Type" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day09_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day09_Snow "Snow" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day09_Snow_Depth "Snow Depth" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day09_Wind_Gust "Wind Gust" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day09_Wind_Speed "Wind Speed" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day09_Wind_Dir "Wind Direction" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day09_Pressure "Pressure" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day09_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day09_Visibility "Visibility" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day09_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day09_Solar_Energy "Solar Energy" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day09_UV_Index "UV Index" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day09_Sunrise "Sunrise" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day09_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day09_Sunset "Sunset" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day09_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day09_Moon_Phase "Moon Phase" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day09_Conditions "Conditions" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day09_Description "Description" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day09_Icon "Icon" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day09_Stations "Stations" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day09_Source "Source" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day09_Severe_Risk "Severe Risk" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day09_DateTime "Time" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#datetime" }
+DateTime Day09_Timestamp "Timestamp" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#timestamp" }
+Number:Temperature Day09_Temperature "Temperature" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#temperature" }
+Number:Temperature Day09_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#temperature-min" }
+Number:Temperature Day09_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#temperature-max" }
+Number:Temperature Day09_FeelsLike "Feels Like" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#feels-like" }
+Number:Temperature Day09_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#feels-like-min" }
+Number:Temperature Day09_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#feels-like-max" }
+Number:Temperature Day09_Dew "Dew Point" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#dew" }
+Number Day09_Humidity "Humidity" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#humidity" }
+Number:Length Day09_Precip "Precipitation" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#precip" }
+Number Day09_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#precip-prob" }
+String Day09_Precip_Type "Precipitation Type" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#precip-type" }
+Number Day09_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#precip-cover" }
+Number:Length Day09_Snow "Snow" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#snow" }
+Number:Length Day09_Snow_Depth "Snow Depth" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#snow-depth" }
+Number:Speed Day09_Wind_Gust "Wind Gust" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#wind-gust" }
+Number:Speed Day09_Wind_Speed "Wind Speed" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#wind-speed" }
+Number:Angle Day09_Wind_Dir "Wind Direction" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#wind-dir" }
+Number:Pressure Day09_Pressure "Pressure" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#pressure" }
+Number Day09_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#cloud-cover" }
+Number:Length Day09_Visibility "Visibility" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#visibility" }
+Number:Intensity Day09_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#solar-radiation" }
+Number Day09_Solar_Energy "Solar Energy" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#solar-energy" }
+Number Day09_UV_Index "UV Index" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#uv-index" }
+String Day09_Sunrise "Sunrise" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#sunrise" }
+DateTime Day09_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#sunrise-epoch" }
+String Day09_Sunset "Sunset" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#sunset" }
+DateTime Day09_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#sunset-epoch" }
+Number Day09_Moon_Phase "Moon Phase" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#moon-phase" }
+String Day09_Conditions "Conditions" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#conditions" }
+String Day09_Description "Description" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#description" }
+String Day09_Icon "Icon" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#icon" }
+String Day09_Stations "Stations" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#stations" }
+String Day09_Source "Source" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#source" }
+Number Day09_Severe_Risk "Severe Risk" (Total_Weather_Data_Day09)["Point"] { channel="visualcrossing:weather:default_config:day09#severe-risk" }
+
+// Day09 - Hour00
+Group Total_Weather_Data_Day09_Hour00 "Hour 00" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour00_DateTime "DateTime" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-datetime"}
+DateTime Day09_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-timestamp"}
+Number:Temperature Day09_Hour00_Temperature "Temperature" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-temperature"}
+Number:Temperature Day09_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-feels-like"}
+Number Day09_Hour00_Humidity "Humidity" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-humidity"}
+Number:Temperature Day09_Hour00_Dew "Dew Point" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-dew"}
+Number:Length Day09_Hour00_Precip "Precipitation" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-precip"}
+Number:Dimensionless Day09_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-precip-prob"}
+String Day09_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-precip-type"}
+Number:Length Day09_Hour00_Snow "Snow" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-snow"}
+Number:Length Day09_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-snow-depth"}
+Number:Speed Day09_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-wind-gust"}
+Number:Speed Day09_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-wind-speed"}
+Number:Angle Day09_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-wind-dir"}
+Number:Pressure Day09_Hour00_Pressure "Pressure" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-pressure"}
+Number:Length Day09_Hour00_Visibility "Visibility" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-visibility"}
+Number:Dimensionless Day09_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-cloud-cover"}
+Number:Intensity Day09_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-solar-radiation"}
+Number Day09_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-solar-energy"}
+Number Day09_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-uv-index"}
+Number Day09_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-severe-risk"}
+String Day09_Hour00_Conditions "Conditions" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-conditions"}
+String Day09_Hour00_Icon "Icon" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-icon"}
+String Day09_Hour00_Stations "Stations" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-stations"}
+String Day09_Hour00_Source "Source" (Total_Weather_Data_Day09_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour00-source"}
+
+// Day09 - Hour01
+Group Total_Weather_Data_Day09_Hour01 "Hour 01" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour01_DateTime "DateTime" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-datetime"}
+DateTime Day09_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-timestamp"}
+Number:Temperature Day09_Hour01_Temperature "Temperature" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-temperature"}
+Number:Temperature Day09_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-feels-like"}
+Number Day09_Hour01_Humidity "Humidity" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-humidity"}
+Number:Temperature Day09_Hour01_Dew "Dew Point" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-dew"}
+Number:Length Day09_Hour01_Precip "Precipitation" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-precip"}
+Number:Dimensionless Day09_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-precip-prob"}
+String Day09_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-precip-type"}
+Number:Length Day09_Hour01_Snow "Snow" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-snow"}
+Number:Length Day09_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-snow-depth"}
+Number:Speed Day09_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-wind-gust"}
+Number:Speed Day09_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-wind-speed"}
+Number:Angle Day09_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-wind-dir"}
+Number:Pressure Day09_Hour01_Pressure "Pressure" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-pressure"}
+Number:Length Day09_Hour01_Visibility "Visibility" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-visibility"}
+Number:Dimensionless Day09_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-cloud-cover"}
+Number:Intensity Day09_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-solar-radiation"}
+Number Day09_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-solar-energy"}
+Number Day09_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-uv-index"}
+Number Day09_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-severe-risk"}
+String Day09_Hour01_Conditions "Conditions" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-conditions"}
+String Day09_Hour01_Icon "Icon" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-icon"}
+String Day09_Hour01_Stations "Stations" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-stations"}
+String Day09_Hour01_Source "Source" (Total_Weather_Data_Day09_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour01-source"}
+
+// Day09 - Hour02
+Group Total_Weather_Data_Day09_Hour02 "Hour 02" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour02_DateTime "DateTime" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-datetime"}
+DateTime Day09_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-timestamp"}
+Number:Temperature Day09_Hour02_Temperature "Temperature" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-temperature"}
+Number:Temperature Day09_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-feels-like"}
+Number Day09_Hour02_Humidity "Humidity" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-humidity"}
+Number:Temperature Day09_Hour02_Dew "Dew Point" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-dew"}
+Number:Length Day09_Hour02_Precip "Precipitation" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-precip"}
+Number:Dimensionless Day09_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-precip-prob"}
+String Day09_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-precip-type"}
+Number:Length Day09_Hour02_Snow "Snow" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-snow"}
+Number:Length Day09_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-snow-depth"}
+Number:Speed Day09_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-wind-gust"}
+Number:Speed Day09_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-wind-speed"}
+Number:Angle Day09_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-wind-dir"}
+Number:Pressure Day09_Hour02_Pressure "Pressure" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-pressure"}
+Number:Length Day09_Hour02_Visibility "Visibility" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-visibility"}
+Number:Dimensionless Day09_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-cloud-cover"}
+Number:Intensity Day09_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-solar-radiation"}
+Number Day09_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-solar-energy"}
+Number Day09_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-uv-index"}
+Number Day09_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-severe-risk"}
+String Day09_Hour02_Conditions "Conditions" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-conditions"}
+String Day09_Hour02_Icon "Icon" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-icon"}
+String Day09_Hour02_Stations "Stations" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-stations"}
+String Day09_Hour02_Source "Source" (Total_Weather_Data_Day09_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour02-source"}
+
+// Day09 - Hour03
+Group Total_Weather_Data_Day09_Hour03 "Hour 03" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour03_DateTime "DateTime" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-datetime"}
+DateTime Day09_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-timestamp"}
+Number:Temperature Day09_Hour03_Temperature "Temperature" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-temperature"}
+Number:Temperature Day09_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-feels-like"}
+Number Day09_Hour03_Humidity "Humidity" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-humidity"}
+Number:Temperature Day09_Hour03_Dew "Dew Point" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-dew"}
+Number:Length Day09_Hour03_Precip "Precipitation" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-precip"}
+Number:Dimensionless Day09_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-precip-prob"}
+String Day09_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-precip-type"}
+Number:Length Day09_Hour03_Snow "Snow" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-snow"}
+Number:Length Day09_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-snow-depth"}
+Number:Speed Day09_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-wind-gust"}
+Number:Speed Day09_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-wind-speed"}
+Number:Angle Day09_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-wind-dir"}
+Number:Pressure Day09_Hour03_Pressure "Pressure" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-pressure"}
+Number:Length Day09_Hour03_Visibility "Visibility" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-visibility"}
+Number:Dimensionless Day09_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-cloud-cover"}
+Number:Intensity Day09_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-solar-radiation"}
+Number Day09_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-solar-energy"}
+Number Day09_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-uv-index"}
+Number Day09_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-severe-risk"}
+String Day09_Hour03_Conditions "Conditions" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-conditions"}
+String Day09_Hour03_Icon "Icon" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-icon"}
+String Day09_Hour03_Stations "Stations" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-stations"}
+String Day09_Hour03_Source "Source" (Total_Weather_Data_Day09_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour03-source"}
+
+// Day09 - Hour04
+Group Total_Weather_Data_Day09_Hour04 "Hour 04" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour04_DateTime "DateTime" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-datetime"}
+DateTime Day09_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-timestamp"}
+Number:Temperature Day09_Hour04_Temperature "Temperature" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-temperature"}
+Number:Temperature Day09_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-feels-like"}
+Number Day09_Hour04_Humidity "Humidity" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-humidity"}
+Number:Temperature Day09_Hour04_Dew "Dew Point" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-dew"}
+Number:Length Day09_Hour04_Precip "Precipitation" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-precip"}
+Number:Dimensionless Day09_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-precip-prob"}
+String Day09_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-precip-type"}
+Number:Length Day09_Hour04_Snow "Snow" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-snow"}
+Number:Length Day09_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-snow-depth"}
+Number:Speed Day09_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-wind-gust"}
+Number:Speed Day09_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-wind-speed"}
+Number:Angle Day09_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-wind-dir"}
+Number:Pressure Day09_Hour04_Pressure "Pressure" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-pressure"}
+Number:Length Day09_Hour04_Visibility "Visibility" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-visibility"}
+Number:Dimensionless Day09_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-cloud-cover"}
+Number:Intensity Day09_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-solar-radiation"}
+Number Day09_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-solar-energy"}
+Number Day09_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-uv-index"}
+Number Day09_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-severe-risk"}
+String Day09_Hour04_Conditions "Conditions" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-conditions"}
+String Day09_Hour04_Icon "Icon" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-icon"}
+String Day09_Hour04_Stations "Stations" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-stations"}
+String Day09_Hour04_Source "Source" (Total_Weather_Data_Day09_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour04-source"}
+
+// Day09 - Hour05
+Group Total_Weather_Data_Day09_Hour05 "Hour 05" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour05_DateTime "DateTime" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-datetime"}
+DateTime Day09_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-timestamp"}
+Number:Temperature Day09_Hour05_Temperature "Temperature" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-temperature"}
+Number:Temperature Day09_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-feels-like"}
+Number Day09_Hour05_Humidity "Humidity" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-humidity"}
+Number:Temperature Day09_Hour05_Dew "Dew Point" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-dew"}
+Number:Length Day09_Hour05_Precip "Precipitation" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-precip"}
+Number:Dimensionless Day09_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-precip-prob"}
+String Day09_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-precip-type"}
+Number:Length Day09_Hour05_Snow "Snow" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-snow"}
+Number:Length Day09_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-snow-depth"}
+Number:Speed Day09_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-wind-gust"}
+Number:Speed Day09_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-wind-speed"}
+Number:Angle Day09_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-wind-dir"}
+Number:Pressure Day09_Hour05_Pressure "Pressure" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-pressure"}
+Number:Length Day09_Hour05_Visibility "Visibility" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-visibility"}
+Number:Dimensionless Day09_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-cloud-cover"}
+Number:Intensity Day09_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-solar-radiation"}
+Number Day09_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-solar-energy"}
+Number Day09_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-uv-index"}
+Number Day09_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-severe-risk"}
+String Day09_Hour05_Conditions "Conditions" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-conditions"}
+String Day09_Hour05_Icon "Icon" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-icon"}
+String Day09_Hour05_Stations "Stations" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-stations"}
+String Day09_Hour05_Source "Source" (Total_Weather_Data_Day09_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour05-source"}
+
+// Day09 - Hour06
+Group Total_Weather_Data_Day09_Hour06 "Hour 06" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour06_DateTime "DateTime" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-datetime"}
+DateTime Day09_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-timestamp"}
+Number:Temperature Day09_Hour06_Temperature "Temperature" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-temperature"}
+Number:Temperature Day09_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-feels-like"}
+Number Day09_Hour06_Humidity "Humidity" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-humidity"}
+Number:Temperature Day09_Hour06_Dew "Dew Point" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-dew"}
+Number:Length Day09_Hour06_Precip "Precipitation" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-precip"}
+Number:Dimensionless Day09_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-precip-prob"}
+String Day09_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-precip-type"}
+Number:Length Day09_Hour06_Snow "Snow" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-snow"}
+Number:Length Day09_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-snow-depth"}
+Number:Speed Day09_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-wind-gust"}
+Number:Speed Day09_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-wind-speed"}
+Number:Angle Day09_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-wind-dir"}
+Number:Pressure Day09_Hour06_Pressure "Pressure" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-pressure"}
+Number:Length Day09_Hour06_Visibility "Visibility" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-visibility"}
+Number:Dimensionless Day09_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-cloud-cover"}
+Number:Intensity Day09_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-solar-radiation"}
+Number Day09_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-solar-energy"}
+Number Day09_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-uv-index"}
+Number Day09_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-severe-risk"}
+String Day09_Hour06_Conditions "Conditions" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-conditions"}
+String Day09_Hour06_Icon "Icon" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-icon"}
+String Day09_Hour06_Stations "Stations" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-stations"}
+String Day09_Hour06_Source "Source" (Total_Weather_Data_Day09_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour06-source"}
+
+// Day09 - Hour07
+Group Total_Weather_Data_Day09_Hour07 "Hour 07" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour07_DateTime "DateTime" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-datetime"}
+DateTime Day09_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-timestamp"}
+Number:Temperature Day09_Hour07_Temperature "Temperature" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-temperature"}
+Number:Temperature Day09_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-feels-like"}
+Number Day09_Hour07_Humidity "Humidity" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-humidity"}
+Number:Temperature Day09_Hour07_Dew "Dew Point" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-dew"}
+Number:Length Day09_Hour07_Precip "Precipitation" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-precip"}
+Number:Dimensionless Day09_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-precip-prob"}
+String Day09_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-precip-type"}
+Number:Length Day09_Hour07_Snow "Snow" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-snow"}
+Number:Length Day09_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-snow-depth"}
+Number:Speed Day09_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-wind-gust"}
+Number:Speed Day09_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-wind-speed"}
+Number:Angle Day09_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-wind-dir"}
+Number:Pressure Day09_Hour07_Pressure "Pressure" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-pressure"}
+Number:Length Day09_Hour07_Visibility "Visibility" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-visibility"}
+Number:Dimensionless Day09_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-cloud-cover"}
+Number:Intensity Day09_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-solar-radiation"}
+Number Day09_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-solar-energy"}
+Number Day09_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-uv-index"}
+Number Day09_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-severe-risk"}
+String Day09_Hour07_Conditions "Conditions" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-conditions"}
+String Day09_Hour07_Icon "Icon" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-icon"}
+String Day09_Hour07_Stations "Stations" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-stations"}
+String Day09_Hour07_Source "Source" (Total_Weather_Data_Day09_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour07-source"}
+
+// Day09 - Hour08
+Group Total_Weather_Data_Day09_Hour08 "Hour 08" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour08_DateTime "DateTime" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-datetime"}
+DateTime Day09_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-timestamp"}
+Number:Temperature Day09_Hour08_Temperature "Temperature" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-temperature"}
+Number:Temperature Day09_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-feels-like"}
+Number Day09_Hour08_Humidity "Humidity" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-humidity"}
+Number:Temperature Day09_Hour08_Dew "Dew Point" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-dew"}
+Number:Length Day09_Hour08_Precip "Precipitation" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-precip"}
+Number:Dimensionless Day09_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-precip-prob"}
+String Day09_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-precip-type"}
+Number:Length Day09_Hour08_Snow "Snow" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-snow"}
+Number:Length Day09_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-snow-depth"}
+Number:Speed Day09_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-wind-gust"}
+Number:Speed Day09_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-wind-speed"}
+Number:Angle Day09_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-wind-dir"}
+Number:Pressure Day09_Hour08_Pressure "Pressure" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-pressure"}
+Number:Length Day09_Hour08_Visibility "Visibility" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-visibility"}
+Number:Dimensionless Day09_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-cloud-cover"}
+Number:Intensity Day09_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-solar-radiation"}
+Number Day09_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-solar-energy"}
+Number Day09_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-uv-index"}
+Number Day09_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-severe-risk"}
+String Day09_Hour08_Conditions "Conditions" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-conditions"}
+String Day09_Hour08_Icon "Icon" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-icon"}
+String Day09_Hour08_Stations "Stations" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-stations"}
+String Day09_Hour08_Source "Source" (Total_Weather_Data_Day09_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour08-source"}
+
+// Day09 - Hour09
+Group Total_Weather_Data_Day09_Hour09 "Hour 09" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour09_DateTime "DateTime" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-datetime"}
+DateTime Day09_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-timestamp"}
+Number:Temperature Day09_Hour09_Temperature "Temperature" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-temperature"}
+Number:Temperature Day09_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-feels-like"}
+Number Day09_Hour09_Humidity "Humidity" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-humidity"}
+Number:Temperature Day09_Hour09_Dew "Dew Point" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-dew"}
+Number:Length Day09_Hour09_Precip "Precipitation" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-precip"}
+Number:Dimensionless Day09_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-precip-prob"}
+String Day09_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-precip-type"}
+Number:Length Day09_Hour09_Snow "Snow" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-snow"}
+Number:Length Day09_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-snow-depth"}
+Number:Speed Day09_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-wind-gust"}
+Number:Speed Day09_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-wind-speed"}
+Number:Angle Day09_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-wind-dir"}
+Number:Pressure Day09_Hour09_Pressure "Pressure" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-pressure"}
+Number:Length Day09_Hour09_Visibility "Visibility" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-visibility"}
+Number:Dimensionless Day09_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-cloud-cover"}
+Number:Intensity Day09_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-solar-radiation"}
+Number Day09_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-solar-energy"}
+Number Day09_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-uv-index"}
+Number Day09_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-severe-risk"}
+String Day09_Hour09_Conditions "Conditions" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-conditions"}
+String Day09_Hour09_Icon "Icon" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-icon"}
+String Day09_Hour09_Stations "Stations" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-stations"}
+String Day09_Hour09_Source "Source" (Total_Weather_Data_Day09_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour09-source"}
+
+// Day09 - Hour10
+Group Total_Weather_Data_Day09_Hour10 "Hour 10" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour10_DateTime "DateTime" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-datetime"}
+DateTime Day09_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-timestamp"}
+Number:Temperature Day09_Hour10_Temperature "Temperature" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-temperature"}
+Number:Temperature Day09_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-feels-like"}
+Number Day09_Hour10_Humidity "Humidity" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-humidity"}
+Number:Temperature Day09_Hour10_Dew "Dew Point" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-dew"}
+Number:Length Day09_Hour10_Precip "Precipitation" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-precip"}
+Number:Dimensionless Day09_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-precip-prob"}
+String Day09_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-precip-type"}
+Number:Length Day09_Hour10_Snow "Snow" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-snow"}
+Number:Length Day09_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-snow-depth"}
+Number:Speed Day09_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-wind-gust"}
+Number:Speed Day09_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-wind-speed"}
+Number:Angle Day09_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-wind-dir"}
+Number:Pressure Day09_Hour10_Pressure "Pressure" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-pressure"}
+Number:Length Day09_Hour10_Visibility "Visibility" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-visibility"}
+Number:Dimensionless Day09_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-cloud-cover"}
+Number:Intensity Day09_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-solar-radiation"}
+Number Day09_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-solar-energy"}
+Number Day09_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-uv-index"}
+Number Day09_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-severe-risk"}
+String Day09_Hour10_Conditions "Conditions" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-conditions"}
+String Day09_Hour10_Icon "Icon" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-icon"}
+String Day09_Hour10_Stations "Stations" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-stations"}
+String Day09_Hour10_Source "Source" (Total_Weather_Data_Day09_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour10-source"}
+
+// Day09 - Hour11
+Group Total_Weather_Data_Day09_Hour11 "Hour 11" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour11_DateTime "DateTime" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-datetime"}
+DateTime Day09_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-timestamp"}
+Number:Temperature Day09_Hour11_Temperature "Temperature" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-temperature"}
+Number:Temperature Day09_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-feels-like"}
+Number Day09_Hour11_Humidity "Humidity" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-humidity"}
+Number:Temperature Day09_Hour11_Dew "Dew Point" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-dew"}
+Number:Length Day09_Hour11_Precip "Precipitation" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-precip"}
+Number:Dimensionless Day09_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-precip-prob"}
+String Day09_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-precip-type"}
+Number:Length Day09_Hour11_Snow "Snow" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-snow"}
+Number:Length Day09_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-snow-depth"}
+Number:Speed Day09_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-wind-gust"}
+Number:Speed Day09_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-wind-speed"}
+Number:Angle Day09_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-wind-dir"}
+Number:Pressure Day09_Hour11_Pressure "Pressure" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-pressure"}
+Number:Length Day09_Hour11_Visibility "Visibility" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-visibility"}
+Number:Dimensionless Day09_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-cloud-cover"}
+Number:Intensity Day09_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-solar-radiation"}
+Number Day09_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-solar-energy"}
+Number Day09_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-uv-index"}
+Number Day09_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-severe-risk"}
+String Day09_Hour11_Conditions "Conditions" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-conditions"}
+String Day09_Hour11_Icon "Icon" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-icon"}
+String Day09_Hour11_Stations "Stations" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-stations"}
+String Day09_Hour11_Source "Source" (Total_Weather_Data_Day09_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour11-source"}
+
+// Day09 - Hour12
+Group Total_Weather_Data_Day09_Hour12 "Hour 12" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour12_DateTime "DateTime" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-datetime"}
+DateTime Day09_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-timestamp"}
+Number:Temperature Day09_Hour12_Temperature "Temperature" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-temperature"}
+Number:Temperature Day09_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-feels-like"}
+Number Day09_Hour12_Humidity "Humidity" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-humidity"}
+Number:Temperature Day09_Hour12_Dew "Dew Point" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-dew"}
+Number:Length Day09_Hour12_Precip "Precipitation" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-precip"}
+Number:Dimensionless Day09_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-precip-prob"}
+String Day09_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-precip-type"}
+Number:Length Day09_Hour12_Snow "Snow" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-snow"}
+Number:Length Day09_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-snow-depth"}
+Number:Speed Day09_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-wind-gust"}
+Number:Speed Day09_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-wind-speed"}
+Number:Angle Day09_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-wind-dir"}
+Number:Pressure Day09_Hour12_Pressure "Pressure" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-pressure"}
+Number:Length Day09_Hour12_Visibility "Visibility" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-visibility"}
+Number:Dimensionless Day09_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-cloud-cover"}
+Number:Intensity Day09_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-solar-radiation"}
+Number Day09_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-solar-energy"}
+Number Day09_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-uv-index"}
+Number Day09_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-severe-risk"}
+String Day09_Hour12_Conditions "Conditions" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-conditions"}
+String Day09_Hour12_Icon "Icon" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-icon"}
+String Day09_Hour12_Stations "Stations" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-stations"}
+String Day09_Hour12_Source "Source" (Total_Weather_Data_Day09_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour12-source"}
+
+// Day09 - Hour13
+Group Total_Weather_Data_Day09_Hour13 "Hour 13" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour13_DateTime "DateTime" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-datetime"}
+DateTime Day09_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-timestamp"}
+Number:Temperature Day09_Hour13_Temperature "Temperature" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-temperature"}
+Number:Temperature Day09_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-feels-like"}
+Number Day09_Hour13_Humidity "Humidity" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-humidity"}
+Number:Temperature Day09_Hour13_Dew "Dew Point" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-dew"}
+Number:Length Day09_Hour13_Precip "Precipitation" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-precip"}
+Number:Dimensionless Day09_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-precip-prob"}
+String Day09_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-precip-type"}
+Number:Length Day09_Hour13_Snow "Snow" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-snow"}
+Number:Length Day09_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-snow-depth"}
+Number:Speed Day09_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-wind-gust"}
+Number:Speed Day09_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-wind-speed"}
+Number:Angle Day09_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-wind-dir"}
+Number:Pressure Day09_Hour13_Pressure "Pressure" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-pressure"}
+Number:Length Day09_Hour13_Visibility "Visibility" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-visibility"}
+Number:Dimensionless Day09_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-cloud-cover"}
+Number:Intensity Day09_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-solar-radiation"}
+Number Day09_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-solar-energy"}
+Number Day09_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-uv-index"}
+Number Day09_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-severe-risk"}
+String Day09_Hour13_Conditions "Conditions" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-conditions"}
+String Day09_Hour13_Icon "Icon" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-icon"}
+String Day09_Hour13_Stations "Stations" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-stations"}
+String Day09_Hour13_Source "Source" (Total_Weather_Data_Day09_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour13-source"}
+
+// Day09 - Hour14
+Group Total_Weather_Data_Day09_Hour14 "Hour 14" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour14_DateTime "DateTime" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-datetime"}
+DateTime Day09_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-timestamp"}
+Number:Temperature Day09_Hour14_Temperature "Temperature" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-temperature"}
+Number:Temperature Day09_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-feels-like"}
+Number Day09_Hour14_Humidity "Humidity" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-humidity"}
+Number:Temperature Day09_Hour14_Dew "Dew Point" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-dew"}
+Number:Length Day09_Hour14_Precip "Precipitation" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-precip"}
+Number:Dimensionless Day09_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-precip-prob"}
+String Day09_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-precip-type"}
+Number:Length Day09_Hour14_Snow "Snow" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-snow"}
+Number:Length Day09_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-snow-depth"}
+Number:Speed Day09_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-wind-gust"}
+Number:Speed Day09_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-wind-speed"}
+Number:Angle Day09_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-wind-dir"}
+Number:Pressure Day09_Hour14_Pressure "Pressure" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-pressure"}
+Number:Length Day09_Hour14_Visibility "Visibility" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-visibility"}
+Number:Dimensionless Day09_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-cloud-cover"}
+Number:Intensity Day09_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-solar-radiation"}
+Number Day09_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-solar-energy"}
+Number Day09_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-uv-index"}
+Number Day09_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-severe-risk"}
+String Day09_Hour14_Conditions "Conditions" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-conditions"}
+String Day09_Hour14_Icon "Icon" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-icon"}
+String Day09_Hour14_Stations "Stations" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-stations"}
+String Day09_Hour14_Source "Source" (Total_Weather_Data_Day09_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour14-source"}
+
+// Day09 - Hour15
+Group Total_Weather_Data_Day09_Hour15 "Hour 15" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour15_DateTime "DateTime" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-datetime"}
+DateTime Day09_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-timestamp"}
+Number:Temperature Day09_Hour15_Temperature "Temperature" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-temperature"}
+Number:Temperature Day09_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-feels-like"}
+Number Day09_Hour15_Humidity "Humidity" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-humidity"}
+Number:Temperature Day09_Hour15_Dew "Dew Point" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-dew"}
+Number:Length Day09_Hour15_Precip "Precipitation" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-precip"}
+Number:Dimensionless Day09_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-precip-prob"}
+String Day09_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-precip-type"}
+Number:Length Day09_Hour15_Snow "Snow" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-snow"}
+Number:Length Day09_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-snow-depth"}
+Number:Speed Day09_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-wind-gust"}
+Number:Speed Day09_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-wind-speed"}
+Number:Angle Day09_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-wind-dir"}
+Number:Pressure Day09_Hour15_Pressure "Pressure" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-pressure"}
+Number:Length Day09_Hour15_Visibility "Visibility" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-visibility"}
+Number:Dimensionless Day09_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-cloud-cover"}
+Number:Intensity Day09_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-solar-radiation"}
+Number Day09_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-solar-energy"}
+Number Day09_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-uv-index"}
+Number Day09_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-severe-risk"}
+String Day09_Hour15_Conditions "Conditions" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-conditions"}
+String Day09_Hour15_Icon "Icon" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-icon"}
+String Day09_Hour15_Stations "Stations" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-stations"}
+String Day09_Hour15_Source "Source" (Total_Weather_Data_Day09_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour15-source"}
+
+// Day09 - Hour16
+Group Total_Weather_Data_Day09_Hour16 "Hour 16" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour16_DateTime "DateTime" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-datetime"}
+DateTime Day09_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-timestamp"}
+Number:Temperature Day09_Hour16_Temperature "Temperature" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-temperature"}
+Number:Temperature Day09_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-feels-like"}
+Number Day09_Hour16_Humidity "Humidity" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-humidity"}
+Number:Temperature Day09_Hour16_Dew "Dew Point" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-dew"}
+Number:Length Day09_Hour16_Precip "Precipitation" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-precip"}
+Number:Dimensionless Day09_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-precip-prob"}
+String Day09_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-precip-type"}
+Number:Length Day09_Hour16_Snow "Snow" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-snow"}
+Number:Length Day09_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-snow-depth"}
+Number:Speed Day09_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-wind-gust"}
+Number:Speed Day09_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-wind-speed"}
+Number:Angle Day09_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-wind-dir"}
+Number:Pressure Day09_Hour16_Pressure "Pressure" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-pressure"}
+Number:Length Day09_Hour16_Visibility "Visibility" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-visibility"}
+Number:Dimensionless Day09_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-cloud-cover"}
+Number:Intensity Day09_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-solar-radiation"}
+Number Day09_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-solar-energy"}
+Number Day09_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-uv-index"}
+Number Day09_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-severe-risk"}
+String Day09_Hour16_Conditions "Conditions" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-conditions"}
+String Day09_Hour16_Icon "Icon" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-icon"}
+String Day09_Hour16_Stations "Stations" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-stations"}
+String Day09_Hour16_Source "Source" (Total_Weather_Data_Day09_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour16-source"}
+
+// Day09 - Hour17
+Group Total_Weather_Data_Day09_Hour17 "Hour 17" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour17_DateTime "DateTime" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-datetime"}
+DateTime Day09_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-timestamp"}
+Number:Temperature Day09_Hour17_Temperature "Temperature" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-temperature"}
+Number:Temperature Day09_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-feels-like"}
+Number Day09_Hour17_Humidity "Humidity" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-humidity"}
+Number:Temperature Day09_Hour17_Dew "Dew Point" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-dew"}
+Number:Length Day09_Hour17_Precip "Precipitation" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-precip"}
+Number:Dimensionless Day09_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-precip-prob"}
+String Day09_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-precip-type"}
+Number:Length Day09_Hour17_Snow "Snow" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-snow"}
+Number:Length Day09_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-snow-depth"}
+Number:Speed Day09_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-wind-gust"}
+Number:Speed Day09_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-wind-speed"}
+Number:Angle Day09_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-wind-dir"}
+Number:Pressure Day09_Hour17_Pressure "Pressure" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-pressure"}
+Number:Length Day09_Hour17_Visibility "Visibility" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-visibility"}
+Number:Dimensionless Day09_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-cloud-cover"}
+Number:Intensity Day09_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-solar-radiation"}
+Number Day09_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-solar-energy"}
+Number Day09_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-uv-index"}
+Number Day09_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-severe-risk"}
+String Day09_Hour17_Conditions "Conditions" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-conditions"}
+String Day09_Hour17_Icon "Icon" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-icon"}
+String Day09_Hour17_Stations "Stations" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-stations"}
+String Day09_Hour17_Source "Source" (Total_Weather_Data_Day09_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour17-source"}
+
+// Day09 - Hour18
+Group Total_Weather_Data_Day09_Hour18 "Hour 18" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour18_DateTime "DateTime" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-datetime"}
+DateTime Day09_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-timestamp"}
+Number:Temperature Day09_Hour18_Temperature "Temperature" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-temperature"}
+Number:Temperature Day09_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-feels-like"}
+Number Day09_Hour18_Humidity "Humidity" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-humidity"}
+Number:Temperature Day09_Hour18_Dew "Dew Point" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-dew"}
+Number:Length Day09_Hour18_Precip "Precipitation" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-precip"}
+Number:Dimensionless Day09_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-precip-prob"}
+String Day09_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-precip-type"}
+Number:Length Day09_Hour18_Snow "Snow" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-snow"}
+Number:Length Day09_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-snow-depth"}
+Number:Speed Day09_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-wind-gust"}
+Number:Speed Day09_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-wind-speed"}
+Number:Angle Day09_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-wind-dir"}
+Number:Pressure Day09_Hour18_Pressure "Pressure" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-pressure"}
+Number:Length Day09_Hour18_Visibility "Visibility" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-visibility"}
+Number:Dimensionless Day09_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-cloud-cover"}
+Number:Intensity Day09_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-solar-radiation"}
+Number Day09_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-solar-energy"}
+Number Day09_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-uv-index"}
+Number Day09_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-severe-risk"}
+String Day09_Hour18_Conditions "Conditions" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-conditions"}
+String Day09_Hour18_Icon "Icon" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-icon"}
+String Day09_Hour18_Stations "Stations" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-stations"}
+String Day09_Hour18_Source "Source" (Total_Weather_Data_Day09_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour18-source"}
+
+// Day09 - Hour19
+Group Total_Weather_Data_Day09_Hour19 "Hour 19" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour19_DateTime "DateTime" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-datetime"}
+DateTime Day09_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-timestamp"}
+Number:Temperature Day09_Hour19_Temperature "Temperature" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-temperature"}
+Number:Temperature Day09_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-feels-like"}
+Number Day09_Hour19_Humidity "Humidity" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-humidity"}
+Number:Temperature Day09_Hour19_Dew "Dew Point" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-dew"}
+Number:Length Day09_Hour19_Precip "Precipitation" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-precip"}
+Number:Dimensionless Day09_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-precip-prob"}
+String Day09_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-precip-type"}
+Number:Length Day09_Hour19_Snow "Snow" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-snow"}
+Number:Length Day09_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-snow-depth"}
+Number:Speed Day09_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-wind-gust"}
+Number:Speed Day09_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-wind-speed"}
+Number:Angle Day09_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-wind-dir"}
+Number:Pressure Day09_Hour19_Pressure "Pressure" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-pressure"}
+Number:Length Day09_Hour19_Visibility "Visibility" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-visibility"}
+Number:Dimensionless Day09_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-cloud-cover"}
+Number:Intensity Day09_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-solar-radiation"}
+Number Day09_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-solar-energy"}
+Number Day09_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-uv-index"}
+Number Day09_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-severe-risk"}
+String Day09_Hour19_Conditions "Conditions" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-conditions"}
+String Day09_Hour19_Icon "Icon" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-icon"}
+String Day09_Hour19_Stations "Stations" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-stations"}
+String Day09_Hour19_Source "Source" (Total_Weather_Data_Day09_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour19-source"}
+
+// Day09 - Hour20
+Group Total_Weather_Data_Day09_Hour20 "Hour 20" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour20_DateTime "DateTime" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-datetime"}
+DateTime Day09_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-timestamp"}
+Number:Temperature Day09_Hour20_Temperature "Temperature" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-temperature"}
+Number:Temperature Day09_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-feels-like"}
+Number Day09_Hour20_Humidity "Humidity" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-humidity"}
+Number:Temperature Day09_Hour20_Dew "Dew Point" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-dew"}
+Number:Length Day09_Hour20_Precip "Precipitation" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-precip"}
+Number:Dimensionless Day09_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-precip-prob"}
+String Day09_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-precip-type"}
+Number:Length Day09_Hour20_Snow "Snow" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-snow"}
+Number:Length Day09_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-snow-depth"}
+Number:Speed Day09_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-wind-gust"}
+Number:Speed Day09_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-wind-speed"}
+Number:Angle Day09_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-wind-dir"}
+Number:Pressure Day09_Hour20_Pressure "Pressure" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-pressure"}
+Number:Length Day09_Hour20_Visibility "Visibility" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-visibility"}
+Number:Dimensionless Day09_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-cloud-cover"}
+Number:Intensity Day09_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-solar-radiation"}
+Number Day09_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-solar-energy"}
+Number Day09_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-uv-index"}
+Number Day09_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-severe-risk"}
+String Day09_Hour20_Conditions "Conditions" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-conditions"}
+String Day09_Hour20_Icon "Icon" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-icon"}
+String Day09_Hour20_Stations "Stations" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-stations"}
+String Day09_Hour20_Source "Source" (Total_Weather_Data_Day09_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour20-source"}
+
+// Day09 - Hour21
+Group Total_Weather_Data_Day09_Hour21 "Hour 21" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour21_DateTime "DateTime" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-datetime"}
+DateTime Day09_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-timestamp"}
+Number:Temperature Day09_Hour21_Temperature "Temperature" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-temperature"}
+Number:Temperature Day09_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-feels-like"}
+Number Day09_Hour21_Humidity "Humidity" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-humidity"}
+Number:Temperature Day09_Hour21_Dew "Dew Point" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-dew"}
+Number:Length Day09_Hour21_Precip "Precipitation" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-precip"}
+Number:Dimensionless Day09_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-precip-prob"}
+String Day09_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-precip-type"}
+Number:Length Day09_Hour21_Snow "Snow" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-snow"}
+Number:Length Day09_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-snow-depth"}
+Number:Speed Day09_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-wind-gust"}
+Number:Speed Day09_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-wind-speed"}
+Number:Angle Day09_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-wind-dir"}
+Number:Pressure Day09_Hour21_Pressure "Pressure" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-pressure"}
+Number:Length Day09_Hour21_Visibility "Visibility" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-visibility"}
+Number:Dimensionless Day09_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-cloud-cover"}
+Number:Intensity Day09_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-solar-radiation"}
+Number Day09_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-solar-energy"}
+Number Day09_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-uv-index"}
+Number Day09_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-severe-risk"}
+String Day09_Hour21_Conditions "Conditions" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-conditions"}
+String Day09_Hour21_Icon "Icon" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-icon"}
+String Day09_Hour21_Stations "Stations" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-stations"}
+String Day09_Hour21_Source "Source" (Total_Weather_Data_Day09_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour21-source"}
+
+// Day09 - Hour22
+Group Total_Weather_Data_Day09_Hour22 "Hour 22" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour22_DateTime "DateTime" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-datetime"}
+DateTime Day09_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-timestamp"}
+Number:Temperature Day09_Hour22_Temperature "Temperature" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-temperature"}
+Number:Temperature Day09_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-feels-like"}
+Number Day09_Hour22_Humidity "Humidity" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-humidity"}
+Number:Temperature Day09_Hour22_Dew "Dew Point" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-dew"}
+Number:Length Day09_Hour22_Precip "Precipitation" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-precip"}
+Number:Dimensionless Day09_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-precip-prob"}
+String Day09_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-precip-type"}
+Number:Length Day09_Hour22_Snow "Snow" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-snow"}
+Number:Length Day09_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-snow-depth"}
+Number:Speed Day09_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-wind-gust"}
+Number:Speed Day09_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-wind-speed"}
+Number:Angle Day09_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-wind-dir"}
+Number:Pressure Day09_Hour22_Pressure "Pressure" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-pressure"}
+Number:Length Day09_Hour22_Visibility "Visibility" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-visibility"}
+Number:Dimensionless Day09_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-cloud-cover"}
+Number:Intensity Day09_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-solar-radiation"}
+Number Day09_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-solar-energy"}
+Number Day09_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-uv-index"}
+Number Day09_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-severe-risk"}
+String Day09_Hour22_Conditions "Conditions" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-conditions"}
+String Day09_Hour22_Icon "Icon" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-icon"}
+String Day09_Hour22_Stations "Stations" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-stations"}
+String Day09_Hour22_Source "Source" (Total_Weather_Data_Day09_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour22-source"}
+
+// Day09 - Hour23
+Group Total_Weather_Data_Day09_Hour23 "Hour 23" (Total_Weather_Data_Day09) [ "Equipment" ] 
+String Day09_Hour23_DateTime "DateTime" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-datetime"}
+DateTime Day09_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-timestamp"}
+Number:Temperature Day09_Hour23_Temperature "Temperature" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-temperature"}
+Number:Temperature Day09_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-feels-like"}
+Number Day09_Hour23_Humidity "Humidity" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-humidity"}
+Number:Temperature Day09_Hour23_Dew "Dew Point" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-dew"}
+Number:Length Day09_Hour23_Precip "Precipitation" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-precip"}
+Number:Dimensionless Day09_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-precip-prob"}
+String Day09_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-precip-type"}
+Number:Length Day09_Hour23_Snow "Snow" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-snow"}
+Number:Length Day09_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-snow-depth"}
+Number:Speed Day09_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-wind-gust"}
+Number:Speed Day09_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-wind-speed"}
+Number:Angle Day09_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-wind-dir"}
+Number:Pressure Day09_Hour23_Pressure "Pressure" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-pressure"}
+Number:Length Day09_Hour23_Visibility "Visibility" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-visibility"}
+Number:Dimensionless Day09_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-cloud-cover"}
+Number:Intensity Day09_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-solar-radiation"}
+Number Day09_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-solar-energy"}
+Number Day09_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-uv-index"}
+Number Day09_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-severe-risk"}
+String Day09_Hour23_Conditions "Conditions" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-conditions"}
+String Day09_Hour23_Icon "Icon" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-icon"}
+String Day09_Hour23_Stations "Stations" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-stations"}
+String Day09_Hour23_Source "Source" (Total_Weather_Data_Day09_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day09#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_10.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_10.items
@@ -1,39 +1,712 @@
 // Day10
 Group Total_Weather_Data_Day10 "Day T+10" (Total_Weather_Data) [ "Equipment" ] 
-String Day10_DateTime "Time" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day10_Timestamp "Timestamp" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day10_Temperature "Temperature" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day10_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day10_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day10_FeelsLike "Feels Like" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day10_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day10_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day10_Dew "Dew Point" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day10_Humidity "Humidity" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day10_Precip "Precipitation" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day10_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day10_Precip_Type "Precipitation Type" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day10_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day10_Snow "Snow" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day10_Snow_Depth "Snow Depth" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day10_Wind_Gust "Wind Gust" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day10_Wind_Speed "Wind Speed" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day10_Wind_Dir "Wind Direction" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day10_Pressure "Pressure" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day10_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day10_Visibility "Visibility" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day10_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day10_Solar_Energy "Solar Energy" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day10_UV_Index "UV Index" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day10_Sunrise "Sunrise" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day10_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day10_Sunset "Sunset" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day10_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day10_Moon_Phase "Moon Phase" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day10_Conditions "Conditions" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day10_Description "Description" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day10_Icon "Icon" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day10_Stations "Stations" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day10_Source "Source" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day10_Severe_Risk "Severe Risk" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day10_DateTime "Time" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#datetime" }
+DateTime Day10_Timestamp "Timestamp" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#timestamp" }
+Number:Temperature Day10_Temperature "Temperature" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#temperature" }
+Number:Temperature Day10_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#temperature-min" }
+Number:Temperature Day10_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#temperature-max" }
+Number:Temperature Day10_FeelsLike "Feels Like" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#feels-like" }
+Number:Temperature Day10_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#feels-like-min" }
+Number:Temperature Day10_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#feels-like-max" }
+Number:Temperature Day10_Dew "Dew Point" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#dew" }
+Number Day10_Humidity "Humidity" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#humidity" }
+Number:Length Day10_Precip "Precipitation" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#precip" }
+Number Day10_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#precip-prob" }
+String Day10_Precip_Type "Precipitation Type" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#precip-type" }
+Number Day10_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#precip-cover" }
+Number:Length Day10_Snow "Snow" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#snow" }
+Number:Length Day10_Snow_Depth "Snow Depth" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#snow-depth" }
+Number:Speed Day10_Wind_Gust "Wind Gust" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#wind-gust" }
+Number:Speed Day10_Wind_Speed "Wind Speed" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#wind-speed" }
+Number:Angle Day10_Wind_Dir "Wind Direction" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#wind-dir" }
+Number:Pressure Day10_Pressure "Pressure" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#pressure" }
+Number Day10_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#cloud-cover" }
+Number:Length Day10_Visibility "Visibility" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#visibility" }
+Number:Intensity Day10_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#solar-radiation" }
+Number Day10_Solar_Energy "Solar Energy" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#solar-energy" }
+Number Day10_UV_Index "UV Index" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#uv-index" }
+String Day10_Sunrise "Sunrise" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#sunrise" }
+DateTime Day10_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#sunrise-epoch" }
+String Day10_Sunset "Sunset" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#sunset" }
+DateTime Day10_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#sunset-epoch" }
+Number Day10_Moon_Phase "Moon Phase" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#moon-phase" }
+String Day10_Conditions "Conditions" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#conditions" }
+String Day10_Description "Description" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#description" }
+String Day10_Icon "Icon" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#icon" }
+String Day10_Stations "Stations" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#stations" }
+String Day10_Source "Source" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#source" }
+Number Day10_Severe_Risk "Severe Risk" (Total_Weather_Data_Day10)["Point"] { channel="visualcrossing:weather:default_config:day10#severe-risk" }
+
+// Day10 - Hour00
+Group Total_Weather_Data_Day10_Hour00 "Hour 00" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour00_DateTime "DateTime" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-datetime"}
+DateTime Day10_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-timestamp"}
+Number:Temperature Day10_Hour00_Temperature "Temperature" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-temperature"}
+Number:Temperature Day10_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-feels-like"}
+Number Day10_Hour00_Humidity "Humidity" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-humidity"}
+Number:Temperature Day10_Hour00_Dew "Dew Point" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-dew"}
+Number:Length Day10_Hour00_Precip "Precipitation" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-precip"}
+Number:Dimensionless Day10_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-precip-prob"}
+String Day10_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-precip-type"}
+Number:Length Day10_Hour00_Snow "Snow" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-snow"}
+Number:Length Day10_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-snow-depth"}
+Number:Speed Day10_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-wind-gust"}
+Number:Speed Day10_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-wind-speed"}
+Number:Angle Day10_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-wind-dir"}
+Number:Pressure Day10_Hour00_Pressure "Pressure" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-pressure"}
+Number:Length Day10_Hour00_Visibility "Visibility" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-visibility"}
+Number:Dimensionless Day10_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-cloud-cover"}
+Number:Intensity Day10_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-solar-radiation"}
+Number Day10_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-solar-energy"}
+Number Day10_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-uv-index"}
+Number Day10_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-severe-risk"}
+String Day10_Hour00_Conditions "Conditions" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-conditions"}
+String Day10_Hour00_Icon "Icon" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-icon"}
+String Day10_Hour00_Stations "Stations" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-stations"}
+String Day10_Hour00_Source "Source" (Total_Weather_Data_Day10_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour00-source"}
+
+// Day10 - Hour01
+Group Total_Weather_Data_Day10_Hour01 "Hour 01" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour01_DateTime "DateTime" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-datetime"}
+DateTime Day10_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-timestamp"}
+Number:Temperature Day10_Hour01_Temperature "Temperature" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-temperature"}
+Number:Temperature Day10_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-feels-like"}
+Number Day10_Hour01_Humidity "Humidity" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-humidity"}
+Number:Temperature Day10_Hour01_Dew "Dew Point" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-dew"}
+Number:Length Day10_Hour01_Precip "Precipitation" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-precip"}
+Number:Dimensionless Day10_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-precip-prob"}
+String Day10_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-precip-type"}
+Number:Length Day10_Hour01_Snow "Snow" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-snow"}
+Number:Length Day10_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-snow-depth"}
+Number:Speed Day10_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-wind-gust"}
+Number:Speed Day10_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-wind-speed"}
+Number:Angle Day10_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-wind-dir"}
+Number:Pressure Day10_Hour01_Pressure "Pressure" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-pressure"}
+Number:Length Day10_Hour01_Visibility "Visibility" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-visibility"}
+Number:Dimensionless Day10_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-cloud-cover"}
+Number:Intensity Day10_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-solar-radiation"}
+Number Day10_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-solar-energy"}
+Number Day10_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-uv-index"}
+Number Day10_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-severe-risk"}
+String Day10_Hour01_Conditions "Conditions" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-conditions"}
+String Day10_Hour01_Icon "Icon" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-icon"}
+String Day10_Hour01_Stations "Stations" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-stations"}
+String Day10_Hour01_Source "Source" (Total_Weather_Data_Day10_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour01-source"}
+
+// Day10 - Hour02
+Group Total_Weather_Data_Day10_Hour02 "Hour 02" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour02_DateTime "DateTime" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-datetime"}
+DateTime Day10_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-timestamp"}
+Number:Temperature Day10_Hour02_Temperature "Temperature" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-temperature"}
+Number:Temperature Day10_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-feels-like"}
+Number Day10_Hour02_Humidity "Humidity" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-humidity"}
+Number:Temperature Day10_Hour02_Dew "Dew Point" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-dew"}
+Number:Length Day10_Hour02_Precip "Precipitation" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-precip"}
+Number:Dimensionless Day10_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-precip-prob"}
+String Day10_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-precip-type"}
+Number:Length Day10_Hour02_Snow "Snow" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-snow"}
+Number:Length Day10_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-snow-depth"}
+Number:Speed Day10_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-wind-gust"}
+Number:Speed Day10_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-wind-speed"}
+Number:Angle Day10_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-wind-dir"}
+Number:Pressure Day10_Hour02_Pressure "Pressure" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-pressure"}
+Number:Length Day10_Hour02_Visibility "Visibility" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-visibility"}
+Number:Dimensionless Day10_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-cloud-cover"}
+Number:Intensity Day10_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-solar-radiation"}
+Number Day10_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-solar-energy"}
+Number Day10_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-uv-index"}
+Number Day10_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-severe-risk"}
+String Day10_Hour02_Conditions "Conditions" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-conditions"}
+String Day10_Hour02_Icon "Icon" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-icon"}
+String Day10_Hour02_Stations "Stations" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-stations"}
+String Day10_Hour02_Source "Source" (Total_Weather_Data_Day10_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour02-source"}
+
+// Day10 - Hour03
+Group Total_Weather_Data_Day10_Hour03 "Hour 03" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour03_DateTime "DateTime" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-datetime"}
+DateTime Day10_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-timestamp"}
+Number:Temperature Day10_Hour03_Temperature "Temperature" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-temperature"}
+Number:Temperature Day10_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-feels-like"}
+Number Day10_Hour03_Humidity "Humidity" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-humidity"}
+Number:Temperature Day10_Hour03_Dew "Dew Point" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-dew"}
+Number:Length Day10_Hour03_Precip "Precipitation" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-precip"}
+Number:Dimensionless Day10_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-precip-prob"}
+String Day10_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-precip-type"}
+Number:Length Day10_Hour03_Snow "Snow" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-snow"}
+Number:Length Day10_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-snow-depth"}
+Number:Speed Day10_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-wind-gust"}
+Number:Speed Day10_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-wind-speed"}
+Number:Angle Day10_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-wind-dir"}
+Number:Pressure Day10_Hour03_Pressure "Pressure" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-pressure"}
+Number:Length Day10_Hour03_Visibility "Visibility" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-visibility"}
+Number:Dimensionless Day10_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-cloud-cover"}
+Number:Intensity Day10_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-solar-radiation"}
+Number Day10_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-solar-energy"}
+Number Day10_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-uv-index"}
+Number Day10_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-severe-risk"}
+String Day10_Hour03_Conditions "Conditions" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-conditions"}
+String Day10_Hour03_Icon "Icon" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-icon"}
+String Day10_Hour03_Stations "Stations" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-stations"}
+String Day10_Hour03_Source "Source" (Total_Weather_Data_Day10_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour03-source"}
+
+// Day10 - Hour04
+Group Total_Weather_Data_Day10_Hour04 "Hour 04" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour04_DateTime "DateTime" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-datetime"}
+DateTime Day10_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-timestamp"}
+Number:Temperature Day10_Hour04_Temperature "Temperature" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-temperature"}
+Number:Temperature Day10_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-feels-like"}
+Number Day10_Hour04_Humidity "Humidity" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-humidity"}
+Number:Temperature Day10_Hour04_Dew "Dew Point" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-dew"}
+Number:Length Day10_Hour04_Precip "Precipitation" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-precip"}
+Number:Dimensionless Day10_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-precip-prob"}
+String Day10_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-precip-type"}
+Number:Length Day10_Hour04_Snow "Snow" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-snow"}
+Number:Length Day10_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-snow-depth"}
+Number:Speed Day10_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-wind-gust"}
+Number:Speed Day10_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-wind-speed"}
+Number:Angle Day10_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-wind-dir"}
+Number:Pressure Day10_Hour04_Pressure "Pressure" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-pressure"}
+Number:Length Day10_Hour04_Visibility "Visibility" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-visibility"}
+Number:Dimensionless Day10_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-cloud-cover"}
+Number:Intensity Day10_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-solar-radiation"}
+Number Day10_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-solar-energy"}
+Number Day10_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-uv-index"}
+Number Day10_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-severe-risk"}
+String Day10_Hour04_Conditions "Conditions" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-conditions"}
+String Day10_Hour04_Icon "Icon" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-icon"}
+String Day10_Hour04_Stations "Stations" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-stations"}
+String Day10_Hour04_Source "Source" (Total_Weather_Data_Day10_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour04-source"}
+
+// Day10 - Hour05
+Group Total_Weather_Data_Day10_Hour05 "Hour 05" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour05_DateTime "DateTime" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-datetime"}
+DateTime Day10_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-timestamp"}
+Number:Temperature Day10_Hour05_Temperature "Temperature" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-temperature"}
+Number:Temperature Day10_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-feels-like"}
+Number Day10_Hour05_Humidity "Humidity" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-humidity"}
+Number:Temperature Day10_Hour05_Dew "Dew Point" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-dew"}
+Number:Length Day10_Hour05_Precip "Precipitation" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-precip"}
+Number:Dimensionless Day10_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-precip-prob"}
+String Day10_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-precip-type"}
+Number:Length Day10_Hour05_Snow "Snow" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-snow"}
+Number:Length Day10_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-snow-depth"}
+Number:Speed Day10_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-wind-gust"}
+Number:Speed Day10_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-wind-speed"}
+Number:Angle Day10_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-wind-dir"}
+Number:Pressure Day10_Hour05_Pressure "Pressure" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-pressure"}
+Number:Length Day10_Hour05_Visibility "Visibility" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-visibility"}
+Number:Dimensionless Day10_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-cloud-cover"}
+Number:Intensity Day10_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-solar-radiation"}
+Number Day10_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-solar-energy"}
+Number Day10_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-uv-index"}
+Number Day10_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-severe-risk"}
+String Day10_Hour05_Conditions "Conditions" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-conditions"}
+String Day10_Hour05_Icon "Icon" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-icon"}
+String Day10_Hour05_Stations "Stations" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-stations"}
+String Day10_Hour05_Source "Source" (Total_Weather_Data_Day10_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour05-source"}
+
+// Day10 - Hour06
+Group Total_Weather_Data_Day10_Hour06 "Hour 06" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour06_DateTime "DateTime" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-datetime"}
+DateTime Day10_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-timestamp"}
+Number:Temperature Day10_Hour06_Temperature "Temperature" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-temperature"}
+Number:Temperature Day10_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-feels-like"}
+Number Day10_Hour06_Humidity "Humidity" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-humidity"}
+Number:Temperature Day10_Hour06_Dew "Dew Point" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-dew"}
+Number:Length Day10_Hour06_Precip "Precipitation" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-precip"}
+Number:Dimensionless Day10_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-precip-prob"}
+String Day10_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-precip-type"}
+Number:Length Day10_Hour06_Snow "Snow" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-snow"}
+Number:Length Day10_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-snow-depth"}
+Number:Speed Day10_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-wind-gust"}
+Number:Speed Day10_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-wind-speed"}
+Number:Angle Day10_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-wind-dir"}
+Number:Pressure Day10_Hour06_Pressure "Pressure" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-pressure"}
+Number:Length Day10_Hour06_Visibility "Visibility" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-visibility"}
+Number:Dimensionless Day10_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-cloud-cover"}
+Number:Intensity Day10_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-solar-radiation"}
+Number Day10_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-solar-energy"}
+Number Day10_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-uv-index"}
+Number Day10_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-severe-risk"}
+String Day10_Hour06_Conditions "Conditions" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-conditions"}
+String Day10_Hour06_Icon "Icon" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-icon"}
+String Day10_Hour06_Stations "Stations" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-stations"}
+String Day10_Hour06_Source "Source" (Total_Weather_Data_Day10_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour06-source"}
+
+// Day10 - Hour07
+Group Total_Weather_Data_Day10_Hour07 "Hour 07" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour07_DateTime "DateTime" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-datetime"}
+DateTime Day10_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-timestamp"}
+Number:Temperature Day10_Hour07_Temperature "Temperature" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-temperature"}
+Number:Temperature Day10_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-feels-like"}
+Number Day10_Hour07_Humidity "Humidity" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-humidity"}
+Number:Temperature Day10_Hour07_Dew "Dew Point" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-dew"}
+Number:Length Day10_Hour07_Precip "Precipitation" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-precip"}
+Number:Dimensionless Day10_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-precip-prob"}
+String Day10_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-precip-type"}
+Number:Length Day10_Hour07_Snow "Snow" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-snow"}
+Number:Length Day10_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-snow-depth"}
+Number:Speed Day10_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-wind-gust"}
+Number:Speed Day10_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-wind-speed"}
+Number:Angle Day10_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-wind-dir"}
+Number:Pressure Day10_Hour07_Pressure "Pressure" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-pressure"}
+Number:Length Day10_Hour07_Visibility "Visibility" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-visibility"}
+Number:Dimensionless Day10_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-cloud-cover"}
+Number:Intensity Day10_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-solar-radiation"}
+Number Day10_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-solar-energy"}
+Number Day10_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-uv-index"}
+Number Day10_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-severe-risk"}
+String Day10_Hour07_Conditions "Conditions" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-conditions"}
+String Day10_Hour07_Icon "Icon" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-icon"}
+String Day10_Hour07_Stations "Stations" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-stations"}
+String Day10_Hour07_Source "Source" (Total_Weather_Data_Day10_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour07-source"}
+
+// Day10 - Hour08
+Group Total_Weather_Data_Day10_Hour08 "Hour 08" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour08_DateTime "DateTime" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-datetime"}
+DateTime Day10_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-timestamp"}
+Number:Temperature Day10_Hour08_Temperature "Temperature" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-temperature"}
+Number:Temperature Day10_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-feels-like"}
+Number Day10_Hour08_Humidity "Humidity" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-humidity"}
+Number:Temperature Day10_Hour08_Dew "Dew Point" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-dew"}
+Number:Length Day10_Hour08_Precip "Precipitation" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-precip"}
+Number:Dimensionless Day10_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-precip-prob"}
+String Day10_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-precip-type"}
+Number:Length Day10_Hour08_Snow "Snow" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-snow"}
+Number:Length Day10_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-snow-depth"}
+Number:Speed Day10_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-wind-gust"}
+Number:Speed Day10_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-wind-speed"}
+Number:Angle Day10_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-wind-dir"}
+Number:Pressure Day10_Hour08_Pressure "Pressure" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-pressure"}
+Number:Length Day10_Hour08_Visibility "Visibility" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-visibility"}
+Number:Dimensionless Day10_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-cloud-cover"}
+Number:Intensity Day10_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-solar-radiation"}
+Number Day10_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-solar-energy"}
+Number Day10_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-uv-index"}
+Number Day10_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-severe-risk"}
+String Day10_Hour08_Conditions "Conditions" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-conditions"}
+String Day10_Hour08_Icon "Icon" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-icon"}
+String Day10_Hour08_Stations "Stations" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-stations"}
+String Day10_Hour08_Source "Source" (Total_Weather_Data_Day10_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour08-source"}
+
+// Day10 - Hour09
+Group Total_Weather_Data_Day10_Hour09 "Hour 09" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour09_DateTime "DateTime" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-datetime"}
+DateTime Day10_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-timestamp"}
+Number:Temperature Day10_Hour09_Temperature "Temperature" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-temperature"}
+Number:Temperature Day10_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-feels-like"}
+Number Day10_Hour09_Humidity "Humidity" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-humidity"}
+Number:Temperature Day10_Hour09_Dew "Dew Point" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-dew"}
+Number:Length Day10_Hour09_Precip "Precipitation" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-precip"}
+Number:Dimensionless Day10_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-precip-prob"}
+String Day10_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-precip-type"}
+Number:Length Day10_Hour09_Snow "Snow" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-snow"}
+Number:Length Day10_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-snow-depth"}
+Number:Speed Day10_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-wind-gust"}
+Number:Speed Day10_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-wind-speed"}
+Number:Angle Day10_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-wind-dir"}
+Number:Pressure Day10_Hour09_Pressure "Pressure" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-pressure"}
+Number:Length Day10_Hour09_Visibility "Visibility" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-visibility"}
+Number:Dimensionless Day10_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-cloud-cover"}
+Number:Intensity Day10_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-solar-radiation"}
+Number Day10_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-solar-energy"}
+Number Day10_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-uv-index"}
+Number Day10_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-severe-risk"}
+String Day10_Hour09_Conditions "Conditions" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-conditions"}
+String Day10_Hour09_Icon "Icon" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-icon"}
+String Day10_Hour09_Stations "Stations" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-stations"}
+String Day10_Hour09_Source "Source" (Total_Weather_Data_Day10_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour09-source"}
+
+// Day10 - Hour10
+Group Total_Weather_Data_Day10_Hour10 "Hour 10" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour10_DateTime "DateTime" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-datetime"}
+DateTime Day10_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-timestamp"}
+Number:Temperature Day10_Hour10_Temperature "Temperature" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-temperature"}
+Number:Temperature Day10_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-feels-like"}
+Number Day10_Hour10_Humidity "Humidity" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-humidity"}
+Number:Temperature Day10_Hour10_Dew "Dew Point" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-dew"}
+Number:Length Day10_Hour10_Precip "Precipitation" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-precip"}
+Number:Dimensionless Day10_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-precip-prob"}
+String Day10_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-precip-type"}
+Number:Length Day10_Hour10_Snow "Snow" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-snow"}
+Number:Length Day10_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-snow-depth"}
+Number:Speed Day10_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-wind-gust"}
+Number:Speed Day10_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-wind-speed"}
+Number:Angle Day10_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-wind-dir"}
+Number:Pressure Day10_Hour10_Pressure "Pressure" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-pressure"}
+Number:Length Day10_Hour10_Visibility "Visibility" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-visibility"}
+Number:Dimensionless Day10_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-cloud-cover"}
+Number:Intensity Day10_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-solar-radiation"}
+Number Day10_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-solar-energy"}
+Number Day10_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-uv-index"}
+Number Day10_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-severe-risk"}
+String Day10_Hour10_Conditions "Conditions" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-conditions"}
+String Day10_Hour10_Icon "Icon" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-icon"}
+String Day10_Hour10_Stations "Stations" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-stations"}
+String Day10_Hour10_Source "Source" (Total_Weather_Data_Day10_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour10-source"}
+
+// Day10 - Hour11
+Group Total_Weather_Data_Day10_Hour11 "Hour 11" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour11_DateTime "DateTime" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-datetime"}
+DateTime Day10_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-timestamp"}
+Number:Temperature Day10_Hour11_Temperature "Temperature" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-temperature"}
+Number:Temperature Day10_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-feels-like"}
+Number Day10_Hour11_Humidity "Humidity" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-humidity"}
+Number:Temperature Day10_Hour11_Dew "Dew Point" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-dew"}
+Number:Length Day10_Hour11_Precip "Precipitation" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-precip"}
+Number:Dimensionless Day10_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-precip-prob"}
+String Day10_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-precip-type"}
+Number:Length Day10_Hour11_Snow "Snow" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-snow"}
+Number:Length Day10_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-snow-depth"}
+Number:Speed Day10_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-wind-gust"}
+Number:Speed Day10_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-wind-speed"}
+Number:Angle Day10_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-wind-dir"}
+Number:Pressure Day10_Hour11_Pressure "Pressure" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-pressure"}
+Number:Length Day10_Hour11_Visibility "Visibility" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-visibility"}
+Number:Dimensionless Day10_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-cloud-cover"}
+Number:Intensity Day10_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-solar-radiation"}
+Number Day10_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-solar-energy"}
+Number Day10_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-uv-index"}
+Number Day10_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-severe-risk"}
+String Day10_Hour11_Conditions "Conditions" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-conditions"}
+String Day10_Hour11_Icon "Icon" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-icon"}
+String Day10_Hour11_Stations "Stations" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-stations"}
+String Day10_Hour11_Source "Source" (Total_Weather_Data_Day10_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour11-source"}
+
+// Day10 - Hour12
+Group Total_Weather_Data_Day10_Hour12 "Hour 12" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour12_DateTime "DateTime" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-datetime"}
+DateTime Day10_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-timestamp"}
+Number:Temperature Day10_Hour12_Temperature "Temperature" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-temperature"}
+Number:Temperature Day10_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-feels-like"}
+Number Day10_Hour12_Humidity "Humidity" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-humidity"}
+Number:Temperature Day10_Hour12_Dew "Dew Point" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-dew"}
+Number:Length Day10_Hour12_Precip "Precipitation" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-precip"}
+Number:Dimensionless Day10_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-precip-prob"}
+String Day10_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-precip-type"}
+Number:Length Day10_Hour12_Snow "Snow" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-snow"}
+Number:Length Day10_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-snow-depth"}
+Number:Speed Day10_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-wind-gust"}
+Number:Speed Day10_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-wind-speed"}
+Number:Angle Day10_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-wind-dir"}
+Number:Pressure Day10_Hour12_Pressure "Pressure" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-pressure"}
+Number:Length Day10_Hour12_Visibility "Visibility" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-visibility"}
+Number:Dimensionless Day10_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-cloud-cover"}
+Number:Intensity Day10_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-solar-radiation"}
+Number Day10_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-solar-energy"}
+Number Day10_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-uv-index"}
+Number Day10_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-severe-risk"}
+String Day10_Hour12_Conditions "Conditions" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-conditions"}
+String Day10_Hour12_Icon "Icon" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-icon"}
+String Day10_Hour12_Stations "Stations" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-stations"}
+String Day10_Hour12_Source "Source" (Total_Weather_Data_Day10_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour12-source"}
+
+// Day10 - Hour13
+Group Total_Weather_Data_Day10_Hour13 "Hour 13" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour13_DateTime "DateTime" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-datetime"}
+DateTime Day10_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-timestamp"}
+Number:Temperature Day10_Hour13_Temperature "Temperature" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-temperature"}
+Number:Temperature Day10_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-feels-like"}
+Number Day10_Hour13_Humidity "Humidity" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-humidity"}
+Number:Temperature Day10_Hour13_Dew "Dew Point" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-dew"}
+Number:Length Day10_Hour13_Precip "Precipitation" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-precip"}
+Number:Dimensionless Day10_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-precip-prob"}
+String Day10_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-precip-type"}
+Number:Length Day10_Hour13_Snow "Snow" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-snow"}
+Number:Length Day10_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-snow-depth"}
+Number:Speed Day10_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-wind-gust"}
+Number:Speed Day10_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-wind-speed"}
+Number:Angle Day10_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-wind-dir"}
+Number:Pressure Day10_Hour13_Pressure "Pressure" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-pressure"}
+Number:Length Day10_Hour13_Visibility "Visibility" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-visibility"}
+Number:Dimensionless Day10_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-cloud-cover"}
+Number:Intensity Day10_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-solar-radiation"}
+Number Day10_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-solar-energy"}
+Number Day10_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-uv-index"}
+Number Day10_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-severe-risk"}
+String Day10_Hour13_Conditions "Conditions" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-conditions"}
+String Day10_Hour13_Icon "Icon" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-icon"}
+String Day10_Hour13_Stations "Stations" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-stations"}
+String Day10_Hour13_Source "Source" (Total_Weather_Data_Day10_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour13-source"}
+
+// Day10 - Hour14
+Group Total_Weather_Data_Day10_Hour14 "Hour 14" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour14_DateTime "DateTime" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-datetime"}
+DateTime Day10_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-timestamp"}
+Number:Temperature Day10_Hour14_Temperature "Temperature" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-temperature"}
+Number:Temperature Day10_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-feels-like"}
+Number Day10_Hour14_Humidity "Humidity" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-humidity"}
+Number:Temperature Day10_Hour14_Dew "Dew Point" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-dew"}
+Number:Length Day10_Hour14_Precip "Precipitation" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-precip"}
+Number:Dimensionless Day10_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-precip-prob"}
+String Day10_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-precip-type"}
+Number:Length Day10_Hour14_Snow "Snow" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-snow"}
+Number:Length Day10_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-snow-depth"}
+Number:Speed Day10_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-wind-gust"}
+Number:Speed Day10_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-wind-speed"}
+Number:Angle Day10_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-wind-dir"}
+Number:Pressure Day10_Hour14_Pressure "Pressure" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-pressure"}
+Number:Length Day10_Hour14_Visibility "Visibility" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-visibility"}
+Number:Dimensionless Day10_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-cloud-cover"}
+Number:Intensity Day10_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-solar-radiation"}
+Number Day10_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-solar-energy"}
+Number Day10_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-uv-index"}
+Number Day10_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-severe-risk"}
+String Day10_Hour14_Conditions "Conditions" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-conditions"}
+String Day10_Hour14_Icon "Icon" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-icon"}
+String Day10_Hour14_Stations "Stations" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-stations"}
+String Day10_Hour14_Source "Source" (Total_Weather_Data_Day10_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour14-source"}
+
+// Day10 - Hour15
+Group Total_Weather_Data_Day10_Hour15 "Hour 15" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour15_DateTime "DateTime" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-datetime"}
+DateTime Day10_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-timestamp"}
+Number:Temperature Day10_Hour15_Temperature "Temperature" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-temperature"}
+Number:Temperature Day10_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-feels-like"}
+Number Day10_Hour15_Humidity "Humidity" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-humidity"}
+Number:Temperature Day10_Hour15_Dew "Dew Point" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-dew"}
+Number:Length Day10_Hour15_Precip "Precipitation" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-precip"}
+Number:Dimensionless Day10_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-precip-prob"}
+String Day10_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-precip-type"}
+Number:Length Day10_Hour15_Snow "Snow" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-snow"}
+Number:Length Day10_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-snow-depth"}
+Number:Speed Day10_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-wind-gust"}
+Number:Speed Day10_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-wind-speed"}
+Number:Angle Day10_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-wind-dir"}
+Number:Pressure Day10_Hour15_Pressure "Pressure" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-pressure"}
+Number:Length Day10_Hour15_Visibility "Visibility" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-visibility"}
+Number:Dimensionless Day10_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-cloud-cover"}
+Number:Intensity Day10_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-solar-radiation"}
+Number Day10_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-solar-energy"}
+Number Day10_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-uv-index"}
+Number Day10_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-severe-risk"}
+String Day10_Hour15_Conditions "Conditions" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-conditions"}
+String Day10_Hour15_Icon "Icon" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-icon"}
+String Day10_Hour15_Stations "Stations" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-stations"}
+String Day10_Hour15_Source "Source" (Total_Weather_Data_Day10_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour15-source"}
+
+// Day10 - Hour16
+Group Total_Weather_Data_Day10_Hour16 "Hour 16" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour16_DateTime "DateTime" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-datetime"}
+DateTime Day10_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-timestamp"}
+Number:Temperature Day10_Hour16_Temperature "Temperature" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-temperature"}
+Number:Temperature Day10_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-feels-like"}
+Number Day10_Hour16_Humidity "Humidity" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-humidity"}
+Number:Temperature Day10_Hour16_Dew "Dew Point" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-dew"}
+Number:Length Day10_Hour16_Precip "Precipitation" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-precip"}
+Number:Dimensionless Day10_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-precip-prob"}
+String Day10_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-precip-type"}
+Number:Length Day10_Hour16_Snow "Snow" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-snow"}
+Number:Length Day10_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-snow-depth"}
+Number:Speed Day10_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-wind-gust"}
+Number:Speed Day10_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-wind-speed"}
+Number:Angle Day10_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-wind-dir"}
+Number:Pressure Day10_Hour16_Pressure "Pressure" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-pressure"}
+Number:Length Day10_Hour16_Visibility "Visibility" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-visibility"}
+Number:Dimensionless Day10_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-cloud-cover"}
+Number:Intensity Day10_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-solar-radiation"}
+Number Day10_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-solar-energy"}
+Number Day10_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-uv-index"}
+Number Day10_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-severe-risk"}
+String Day10_Hour16_Conditions "Conditions" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-conditions"}
+String Day10_Hour16_Icon "Icon" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-icon"}
+String Day10_Hour16_Stations "Stations" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-stations"}
+String Day10_Hour16_Source "Source" (Total_Weather_Data_Day10_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour16-source"}
+
+// Day10 - Hour17
+Group Total_Weather_Data_Day10_Hour17 "Hour 17" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour17_DateTime "DateTime" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-datetime"}
+DateTime Day10_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-timestamp"}
+Number:Temperature Day10_Hour17_Temperature "Temperature" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-temperature"}
+Number:Temperature Day10_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-feels-like"}
+Number Day10_Hour17_Humidity "Humidity" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-humidity"}
+Number:Temperature Day10_Hour17_Dew "Dew Point" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-dew"}
+Number:Length Day10_Hour17_Precip "Precipitation" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-precip"}
+Number:Dimensionless Day10_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-precip-prob"}
+String Day10_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-precip-type"}
+Number:Length Day10_Hour17_Snow "Snow" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-snow"}
+Number:Length Day10_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-snow-depth"}
+Number:Speed Day10_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-wind-gust"}
+Number:Speed Day10_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-wind-speed"}
+Number:Angle Day10_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-wind-dir"}
+Number:Pressure Day10_Hour17_Pressure "Pressure" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-pressure"}
+Number:Length Day10_Hour17_Visibility "Visibility" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-visibility"}
+Number:Dimensionless Day10_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-cloud-cover"}
+Number:Intensity Day10_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-solar-radiation"}
+Number Day10_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-solar-energy"}
+Number Day10_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-uv-index"}
+Number Day10_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-severe-risk"}
+String Day10_Hour17_Conditions "Conditions" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-conditions"}
+String Day10_Hour17_Icon "Icon" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-icon"}
+String Day10_Hour17_Stations "Stations" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-stations"}
+String Day10_Hour17_Source "Source" (Total_Weather_Data_Day10_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour17-source"}
+
+// Day10 - Hour18
+Group Total_Weather_Data_Day10_Hour18 "Hour 18" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour18_DateTime "DateTime" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-datetime"}
+DateTime Day10_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-timestamp"}
+Number:Temperature Day10_Hour18_Temperature "Temperature" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-temperature"}
+Number:Temperature Day10_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-feels-like"}
+Number Day10_Hour18_Humidity "Humidity" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-humidity"}
+Number:Temperature Day10_Hour18_Dew "Dew Point" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-dew"}
+Number:Length Day10_Hour18_Precip "Precipitation" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-precip"}
+Number:Dimensionless Day10_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-precip-prob"}
+String Day10_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-precip-type"}
+Number:Length Day10_Hour18_Snow "Snow" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-snow"}
+Number:Length Day10_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-snow-depth"}
+Number:Speed Day10_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-wind-gust"}
+Number:Speed Day10_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-wind-speed"}
+Number:Angle Day10_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-wind-dir"}
+Number:Pressure Day10_Hour18_Pressure "Pressure" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-pressure"}
+Number:Length Day10_Hour18_Visibility "Visibility" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-visibility"}
+Number:Dimensionless Day10_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-cloud-cover"}
+Number:Intensity Day10_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-solar-radiation"}
+Number Day10_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-solar-energy"}
+Number Day10_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-uv-index"}
+Number Day10_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-severe-risk"}
+String Day10_Hour18_Conditions "Conditions" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-conditions"}
+String Day10_Hour18_Icon "Icon" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-icon"}
+String Day10_Hour18_Stations "Stations" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-stations"}
+String Day10_Hour18_Source "Source" (Total_Weather_Data_Day10_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour18-source"}
+
+// Day10 - Hour19
+Group Total_Weather_Data_Day10_Hour19 "Hour 19" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour19_DateTime "DateTime" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-datetime"}
+DateTime Day10_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-timestamp"}
+Number:Temperature Day10_Hour19_Temperature "Temperature" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-temperature"}
+Number:Temperature Day10_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-feels-like"}
+Number Day10_Hour19_Humidity "Humidity" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-humidity"}
+Number:Temperature Day10_Hour19_Dew "Dew Point" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-dew"}
+Number:Length Day10_Hour19_Precip "Precipitation" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-precip"}
+Number:Dimensionless Day10_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-precip-prob"}
+String Day10_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-precip-type"}
+Number:Length Day10_Hour19_Snow "Snow" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-snow"}
+Number:Length Day10_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-snow-depth"}
+Number:Speed Day10_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-wind-gust"}
+Number:Speed Day10_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-wind-speed"}
+Number:Angle Day10_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-wind-dir"}
+Number:Pressure Day10_Hour19_Pressure "Pressure" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-pressure"}
+Number:Length Day10_Hour19_Visibility "Visibility" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-visibility"}
+Number:Dimensionless Day10_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-cloud-cover"}
+Number:Intensity Day10_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-solar-radiation"}
+Number Day10_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-solar-energy"}
+Number Day10_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-uv-index"}
+Number Day10_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-severe-risk"}
+String Day10_Hour19_Conditions "Conditions" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-conditions"}
+String Day10_Hour19_Icon "Icon" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-icon"}
+String Day10_Hour19_Stations "Stations" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-stations"}
+String Day10_Hour19_Source "Source" (Total_Weather_Data_Day10_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour19-source"}
+
+// Day10 - Hour20
+Group Total_Weather_Data_Day10_Hour20 "Hour 20" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour20_DateTime "DateTime" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-datetime"}
+DateTime Day10_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-timestamp"}
+Number:Temperature Day10_Hour20_Temperature "Temperature" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-temperature"}
+Number:Temperature Day10_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-feels-like"}
+Number Day10_Hour20_Humidity "Humidity" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-humidity"}
+Number:Temperature Day10_Hour20_Dew "Dew Point" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-dew"}
+Number:Length Day10_Hour20_Precip "Precipitation" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-precip"}
+Number:Dimensionless Day10_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-precip-prob"}
+String Day10_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-precip-type"}
+Number:Length Day10_Hour20_Snow "Snow" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-snow"}
+Number:Length Day10_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-snow-depth"}
+Number:Speed Day10_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-wind-gust"}
+Number:Speed Day10_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-wind-speed"}
+Number:Angle Day10_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-wind-dir"}
+Number:Pressure Day10_Hour20_Pressure "Pressure" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-pressure"}
+Number:Length Day10_Hour20_Visibility "Visibility" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-visibility"}
+Number:Dimensionless Day10_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-cloud-cover"}
+Number:Intensity Day10_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-solar-radiation"}
+Number Day10_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-solar-energy"}
+Number Day10_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-uv-index"}
+Number Day10_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-severe-risk"}
+String Day10_Hour20_Conditions "Conditions" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-conditions"}
+String Day10_Hour20_Icon "Icon" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-icon"}
+String Day10_Hour20_Stations "Stations" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-stations"}
+String Day10_Hour20_Source "Source" (Total_Weather_Data_Day10_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour20-source"}
+
+// Day10 - Hour21
+Group Total_Weather_Data_Day10_Hour21 "Hour 21" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour21_DateTime "DateTime" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-datetime"}
+DateTime Day10_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-timestamp"}
+Number:Temperature Day10_Hour21_Temperature "Temperature" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-temperature"}
+Number:Temperature Day10_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-feels-like"}
+Number Day10_Hour21_Humidity "Humidity" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-humidity"}
+Number:Temperature Day10_Hour21_Dew "Dew Point" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-dew"}
+Number:Length Day10_Hour21_Precip "Precipitation" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-precip"}
+Number:Dimensionless Day10_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-precip-prob"}
+String Day10_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-precip-type"}
+Number:Length Day10_Hour21_Snow "Snow" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-snow"}
+Number:Length Day10_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-snow-depth"}
+Number:Speed Day10_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-wind-gust"}
+Number:Speed Day10_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-wind-speed"}
+Number:Angle Day10_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-wind-dir"}
+Number:Pressure Day10_Hour21_Pressure "Pressure" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-pressure"}
+Number:Length Day10_Hour21_Visibility "Visibility" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-visibility"}
+Number:Dimensionless Day10_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-cloud-cover"}
+Number:Intensity Day10_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-solar-radiation"}
+Number Day10_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-solar-energy"}
+Number Day10_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-uv-index"}
+Number Day10_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-severe-risk"}
+String Day10_Hour21_Conditions "Conditions" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-conditions"}
+String Day10_Hour21_Icon "Icon" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-icon"}
+String Day10_Hour21_Stations "Stations" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-stations"}
+String Day10_Hour21_Source "Source" (Total_Weather_Data_Day10_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour21-source"}
+
+// Day10 - Hour22
+Group Total_Weather_Data_Day10_Hour22 "Hour 22" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour22_DateTime "DateTime" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-datetime"}
+DateTime Day10_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-timestamp"}
+Number:Temperature Day10_Hour22_Temperature "Temperature" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-temperature"}
+Number:Temperature Day10_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-feels-like"}
+Number Day10_Hour22_Humidity "Humidity" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-humidity"}
+Number:Temperature Day10_Hour22_Dew "Dew Point" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-dew"}
+Number:Length Day10_Hour22_Precip "Precipitation" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-precip"}
+Number:Dimensionless Day10_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-precip-prob"}
+String Day10_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-precip-type"}
+Number:Length Day10_Hour22_Snow "Snow" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-snow"}
+Number:Length Day10_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-snow-depth"}
+Number:Speed Day10_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-wind-gust"}
+Number:Speed Day10_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-wind-speed"}
+Number:Angle Day10_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-wind-dir"}
+Number:Pressure Day10_Hour22_Pressure "Pressure" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-pressure"}
+Number:Length Day10_Hour22_Visibility "Visibility" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-visibility"}
+Number:Dimensionless Day10_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-cloud-cover"}
+Number:Intensity Day10_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-solar-radiation"}
+Number Day10_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-solar-energy"}
+Number Day10_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-uv-index"}
+Number Day10_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-severe-risk"}
+String Day10_Hour22_Conditions "Conditions" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-conditions"}
+String Day10_Hour22_Icon "Icon" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-icon"}
+String Day10_Hour22_Stations "Stations" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-stations"}
+String Day10_Hour22_Source "Source" (Total_Weather_Data_Day10_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour22-source"}
+
+// Day10 - Hour23
+Group Total_Weather_Data_Day10_Hour23 "Hour 23" (Total_Weather_Data_Day10) [ "Equipment" ] 
+String Day10_Hour23_DateTime "DateTime" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-datetime"}
+DateTime Day10_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-timestamp"}
+Number:Temperature Day10_Hour23_Temperature "Temperature" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-temperature"}
+Number:Temperature Day10_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-feels-like"}
+Number Day10_Hour23_Humidity "Humidity" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-humidity"}
+Number:Temperature Day10_Hour23_Dew "Dew Point" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-dew"}
+Number:Length Day10_Hour23_Precip "Precipitation" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-precip"}
+Number:Dimensionless Day10_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-precip-prob"}
+String Day10_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-precip-type"}
+Number:Length Day10_Hour23_Snow "Snow" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-snow"}
+Number:Length Day10_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-snow-depth"}
+Number:Speed Day10_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-wind-gust"}
+Number:Speed Day10_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-wind-speed"}
+Number:Angle Day10_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-wind-dir"}
+Number:Pressure Day10_Hour23_Pressure "Pressure" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-pressure"}
+Number:Length Day10_Hour23_Visibility "Visibility" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-visibility"}
+Number:Dimensionless Day10_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-cloud-cover"}
+Number:Intensity Day10_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-solar-radiation"}
+Number Day10_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-solar-energy"}
+Number Day10_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-uv-index"}
+Number Day10_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-severe-risk"}
+String Day10_Hour23_Conditions "Conditions" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-conditions"}
+String Day10_Hour23_Icon "Icon" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-icon"}
+String Day10_Hour23_Stations "Stations" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-stations"}
+String Day10_Hour23_Source "Source" (Total_Weather_Data_Day10_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day10#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_11.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_11.items
@@ -1,39 +1,712 @@
 // Day11
 Group Total_Weather_Data_Day11 "Day T+11" (Total_Weather_Data) [ "Equipment" ] 
-String Day11_DateTime "Time" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day11_Timestamp "Timestamp" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day11_Temperature "Temperature" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day11_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day11_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day11_FeelsLike "Feels Like" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day11_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day11_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day11_Dew "Dew Point" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day11_Humidity "Humidity" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day11_Precip "Precipitation" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day11_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day11_Precip_Type "Precipitation Type" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day11_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day11_Snow "Snow" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day11_Snow_Depth "Snow Depth" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day11_Wind_Gust "Wind Gust" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day11_Wind_Speed "Wind Speed" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day11_Wind_Dir "Wind Direction" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day11_Pressure "Pressure" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day11_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day11_Visibility "Visibility" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day11_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day11_Solar_Energy "Solar Energy" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day11_UV_Index "UV Index" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day11_Sunrise "Sunrise" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day11_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day11_Sunset "Sunset" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day11_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day11_Moon_Phase "Moon Phase" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day11_Conditions "Conditions" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day11_Description "Description" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day11_Icon "Icon" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day11_Stations "Stations" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day11_Source "Source" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day11_Severe_Risk "Severe Risk" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day11_DateTime "Time" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#datetime" }
+DateTime Day11_Timestamp "Timestamp" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#timestamp" }
+Number:Temperature Day11_Temperature "Temperature" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#temperature" }
+Number:Temperature Day11_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#temperature-min" }
+Number:Temperature Day11_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#temperature-max" }
+Number:Temperature Day11_FeelsLike "Feels Like" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#feels-like" }
+Number:Temperature Day11_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#feels-like-min" }
+Number:Temperature Day11_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#feels-like-max" }
+Number:Temperature Day11_Dew "Dew Point" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#dew" }
+Number Day11_Humidity "Humidity" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#humidity" }
+Number:Length Day11_Precip "Precipitation" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#precip" }
+Number Day11_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#precip-prob" }
+String Day11_Precip_Type "Precipitation Type" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#precip-type" }
+Number Day11_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#precip-cover" }
+Number:Length Day11_Snow "Snow" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#snow" }
+Number:Length Day11_Snow_Depth "Snow Depth" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#snow-depth" }
+Number:Speed Day11_Wind_Gust "Wind Gust" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#wind-gust" }
+Number:Speed Day11_Wind_Speed "Wind Speed" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#wind-speed" }
+Number:Angle Day11_Wind_Dir "Wind Direction" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#wind-dir" }
+Number:Pressure Day11_Pressure "Pressure" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#pressure" }
+Number Day11_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#cloud-cover" }
+Number:Length Day11_Visibility "Visibility" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#visibility" }
+Number:Intensity Day11_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#solar-radiation" }
+Number Day11_Solar_Energy "Solar Energy" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#solar-energy" }
+Number Day11_UV_Index "UV Index" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#uv-index" }
+String Day11_Sunrise "Sunrise" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#sunrise" }
+DateTime Day11_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#sunrise-epoch" }
+String Day11_Sunset "Sunset" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#sunset" }
+DateTime Day11_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#sunset-epoch" }
+Number Day11_Moon_Phase "Moon Phase" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#moon-phase" }
+String Day11_Conditions "Conditions" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#conditions" }
+String Day11_Description "Description" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#description" }
+String Day11_Icon "Icon" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#icon" }
+String Day11_Stations "Stations" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#stations" }
+String Day11_Source "Source" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#source" }
+Number Day11_Severe_Risk "Severe Risk" (Total_Weather_Data_Day11)["Point"] { channel="visualcrossing:weather:default_config:day11#severe-risk" }
+
+// Day11 - Hour00
+Group Total_Weather_Data_Day11_Hour00 "Hour 00" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour00_DateTime "DateTime" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-datetime"}
+DateTime Day11_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-timestamp"}
+Number:Temperature Day11_Hour00_Temperature "Temperature" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-temperature"}
+Number:Temperature Day11_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-feels-like"}
+Number Day11_Hour00_Humidity "Humidity" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-humidity"}
+Number:Temperature Day11_Hour00_Dew "Dew Point" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-dew"}
+Number:Length Day11_Hour00_Precip "Precipitation" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-precip"}
+Number:Dimensionless Day11_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-precip-prob"}
+String Day11_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-precip-type"}
+Number:Length Day11_Hour00_Snow "Snow" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-snow"}
+Number:Length Day11_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-snow-depth"}
+Number:Speed Day11_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-wind-gust"}
+Number:Speed Day11_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-wind-speed"}
+Number:Angle Day11_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-wind-dir"}
+Number:Pressure Day11_Hour00_Pressure "Pressure" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-pressure"}
+Number:Length Day11_Hour00_Visibility "Visibility" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-visibility"}
+Number:Dimensionless Day11_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-cloud-cover"}
+Number:Intensity Day11_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-solar-radiation"}
+Number Day11_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-solar-energy"}
+Number Day11_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-uv-index"}
+Number Day11_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-severe-risk"}
+String Day11_Hour00_Conditions "Conditions" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-conditions"}
+String Day11_Hour00_Icon "Icon" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-icon"}
+String Day11_Hour00_Stations "Stations" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-stations"}
+String Day11_Hour00_Source "Source" (Total_Weather_Data_Day11_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour00-source"}
+
+// Day11 - Hour01
+Group Total_Weather_Data_Day11_Hour01 "Hour 01" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour01_DateTime "DateTime" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-datetime"}
+DateTime Day11_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-timestamp"}
+Number:Temperature Day11_Hour01_Temperature "Temperature" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-temperature"}
+Number:Temperature Day11_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-feels-like"}
+Number Day11_Hour01_Humidity "Humidity" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-humidity"}
+Number:Temperature Day11_Hour01_Dew "Dew Point" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-dew"}
+Number:Length Day11_Hour01_Precip "Precipitation" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-precip"}
+Number:Dimensionless Day11_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-precip-prob"}
+String Day11_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-precip-type"}
+Number:Length Day11_Hour01_Snow "Snow" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-snow"}
+Number:Length Day11_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-snow-depth"}
+Number:Speed Day11_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-wind-gust"}
+Number:Speed Day11_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-wind-speed"}
+Number:Angle Day11_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-wind-dir"}
+Number:Pressure Day11_Hour01_Pressure "Pressure" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-pressure"}
+Number:Length Day11_Hour01_Visibility "Visibility" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-visibility"}
+Number:Dimensionless Day11_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-cloud-cover"}
+Number:Intensity Day11_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-solar-radiation"}
+Number Day11_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-solar-energy"}
+Number Day11_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-uv-index"}
+Number Day11_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-severe-risk"}
+String Day11_Hour01_Conditions "Conditions" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-conditions"}
+String Day11_Hour01_Icon "Icon" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-icon"}
+String Day11_Hour01_Stations "Stations" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-stations"}
+String Day11_Hour01_Source "Source" (Total_Weather_Data_Day11_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour01-source"}
+
+// Day11 - Hour02
+Group Total_Weather_Data_Day11_Hour02 "Hour 02" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour02_DateTime "DateTime" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-datetime"}
+DateTime Day11_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-timestamp"}
+Number:Temperature Day11_Hour02_Temperature "Temperature" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-temperature"}
+Number:Temperature Day11_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-feels-like"}
+Number Day11_Hour02_Humidity "Humidity" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-humidity"}
+Number:Temperature Day11_Hour02_Dew "Dew Point" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-dew"}
+Number:Length Day11_Hour02_Precip "Precipitation" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-precip"}
+Number:Dimensionless Day11_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-precip-prob"}
+String Day11_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-precip-type"}
+Number:Length Day11_Hour02_Snow "Snow" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-snow"}
+Number:Length Day11_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-snow-depth"}
+Number:Speed Day11_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-wind-gust"}
+Number:Speed Day11_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-wind-speed"}
+Number:Angle Day11_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-wind-dir"}
+Number:Pressure Day11_Hour02_Pressure "Pressure" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-pressure"}
+Number:Length Day11_Hour02_Visibility "Visibility" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-visibility"}
+Number:Dimensionless Day11_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-cloud-cover"}
+Number:Intensity Day11_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-solar-radiation"}
+Number Day11_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-solar-energy"}
+Number Day11_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-uv-index"}
+Number Day11_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-severe-risk"}
+String Day11_Hour02_Conditions "Conditions" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-conditions"}
+String Day11_Hour02_Icon "Icon" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-icon"}
+String Day11_Hour02_Stations "Stations" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-stations"}
+String Day11_Hour02_Source "Source" (Total_Weather_Data_Day11_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour02-source"}
+
+// Day11 - Hour03
+Group Total_Weather_Data_Day11_Hour03 "Hour 03" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour03_DateTime "DateTime" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-datetime"}
+DateTime Day11_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-timestamp"}
+Number:Temperature Day11_Hour03_Temperature "Temperature" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-temperature"}
+Number:Temperature Day11_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-feels-like"}
+Number Day11_Hour03_Humidity "Humidity" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-humidity"}
+Number:Temperature Day11_Hour03_Dew "Dew Point" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-dew"}
+Number:Length Day11_Hour03_Precip "Precipitation" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-precip"}
+Number:Dimensionless Day11_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-precip-prob"}
+String Day11_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-precip-type"}
+Number:Length Day11_Hour03_Snow "Snow" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-snow"}
+Number:Length Day11_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-snow-depth"}
+Number:Speed Day11_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-wind-gust"}
+Number:Speed Day11_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-wind-speed"}
+Number:Angle Day11_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-wind-dir"}
+Number:Pressure Day11_Hour03_Pressure "Pressure" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-pressure"}
+Number:Length Day11_Hour03_Visibility "Visibility" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-visibility"}
+Number:Dimensionless Day11_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-cloud-cover"}
+Number:Intensity Day11_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-solar-radiation"}
+Number Day11_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-solar-energy"}
+Number Day11_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-uv-index"}
+Number Day11_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-severe-risk"}
+String Day11_Hour03_Conditions "Conditions" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-conditions"}
+String Day11_Hour03_Icon "Icon" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-icon"}
+String Day11_Hour03_Stations "Stations" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-stations"}
+String Day11_Hour03_Source "Source" (Total_Weather_Data_Day11_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour03-source"}
+
+// Day11 - Hour04
+Group Total_Weather_Data_Day11_Hour04 "Hour 04" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour04_DateTime "DateTime" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-datetime"}
+DateTime Day11_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-timestamp"}
+Number:Temperature Day11_Hour04_Temperature "Temperature" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-temperature"}
+Number:Temperature Day11_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-feels-like"}
+Number Day11_Hour04_Humidity "Humidity" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-humidity"}
+Number:Temperature Day11_Hour04_Dew "Dew Point" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-dew"}
+Number:Length Day11_Hour04_Precip "Precipitation" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-precip"}
+Number:Dimensionless Day11_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-precip-prob"}
+String Day11_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-precip-type"}
+Number:Length Day11_Hour04_Snow "Snow" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-snow"}
+Number:Length Day11_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-snow-depth"}
+Number:Speed Day11_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-wind-gust"}
+Number:Speed Day11_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-wind-speed"}
+Number:Angle Day11_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-wind-dir"}
+Number:Pressure Day11_Hour04_Pressure "Pressure" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-pressure"}
+Number:Length Day11_Hour04_Visibility "Visibility" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-visibility"}
+Number:Dimensionless Day11_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-cloud-cover"}
+Number:Intensity Day11_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-solar-radiation"}
+Number Day11_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-solar-energy"}
+Number Day11_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-uv-index"}
+Number Day11_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-severe-risk"}
+String Day11_Hour04_Conditions "Conditions" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-conditions"}
+String Day11_Hour04_Icon "Icon" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-icon"}
+String Day11_Hour04_Stations "Stations" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-stations"}
+String Day11_Hour04_Source "Source" (Total_Weather_Data_Day11_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour04-source"}
+
+// Day11 - Hour05
+Group Total_Weather_Data_Day11_Hour05 "Hour 05" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour05_DateTime "DateTime" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-datetime"}
+DateTime Day11_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-timestamp"}
+Number:Temperature Day11_Hour05_Temperature "Temperature" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-temperature"}
+Number:Temperature Day11_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-feels-like"}
+Number Day11_Hour05_Humidity "Humidity" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-humidity"}
+Number:Temperature Day11_Hour05_Dew "Dew Point" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-dew"}
+Number:Length Day11_Hour05_Precip "Precipitation" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-precip"}
+Number:Dimensionless Day11_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-precip-prob"}
+String Day11_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-precip-type"}
+Number:Length Day11_Hour05_Snow "Snow" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-snow"}
+Number:Length Day11_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-snow-depth"}
+Number:Speed Day11_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-wind-gust"}
+Number:Speed Day11_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-wind-speed"}
+Number:Angle Day11_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-wind-dir"}
+Number:Pressure Day11_Hour05_Pressure "Pressure" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-pressure"}
+Number:Length Day11_Hour05_Visibility "Visibility" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-visibility"}
+Number:Dimensionless Day11_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-cloud-cover"}
+Number:Intensity Day11_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-solar-radiation"}
+Number Day11_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-solar-energy"}
+Number Day11_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-uv-index"}
+Number Day11_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-severe-risk"}
+String Day11_Hour05_Conditions "Conditions" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-conditions"}
+String Day11_Hour05_Icon "Icon" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-icon"}
+String Day11_Hour05_Stations "Stations" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-stations"}
+String Day11_Hour05_Source "Source" (Total_Weather_Data_Day11_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour05-source"}
+
+// Day11 - Hour06
+Group Total_Weather_Data_Day11_Hour06 "Hour 06" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour06_DateTime "DateTime" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-datetime"}
+DateTime Day11_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-timestamp"}
+Number:Temperature Day11_Hour06_Temperature "Temperature" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-temperature"}
+Number:Temperature Day11_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-feels-like"}
+Number Day11_Hour06_Humidity "Humidity" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-humidity"}
+Number:Temperature Day11_Hour06_Dew "Dew Point" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-dew"}
+Number:Length Day11_Hour06_Precip "Precipitation" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-precip"}
+Number:Dimensionless Day11_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-precip-prob"}
+String Day11_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-precip-type"}
+Number:Length Day11_Hour06_Snow "Snow" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-snow"}
+Number:Length Day11_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-snow-depth"}
+Number:Speed Day11_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-wind-gust"}
+Number:Speed Day11_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-wind-speed"}
+Number:Angle Day11_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-wind-dir"}
+Number:Pressure Day11_Hour06_Pressure "Pressure" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-pressure"}
+Number:Length Day11_Hour06_Visibility "Visibility" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-visibility"}
+Number:Dimensionless Day11_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-cloud-cover"}
+Number:Intensity Day11_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-solar-radiation"}
+Number Day11_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-solar-energy"}
+Number Day11_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-uv-index"}
+Number Day11_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-severe-risk"}
+String Day11_Hour06_Conditions "Conditions" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-conditions"}
+String Day11_Hour06_Icon "Icon" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-icon"}
+String Day11_Hour06_Stations "Stations" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-stations"}
+String Day11_Hour06_Source "Source" (Total_Weather_Data_Day11_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour06-source"}
+
+// Day11 - Hour07
+Group Total_Weather_Data_Day11_Hour07 "Hour 07" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour07_DateTime "DateTime" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-datetime"}
+DateTime Day11_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-timestamp"}
+Number:Temperature Day11_Hour07_Temperature "Temperature" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-temperature"}
+Number:Temperature Day11_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-feels-like"}
+Number Day11_Hour07_Humidity "Humidity" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-humidity"}
+Number:Temperature Day11_Hour07_Dew "Dew Point" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-dew"}
+Number:Length Day11_Hour07_Precip "Precipitation" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-precip"}
+Number:Dimensionless Day11_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-precip-prob"}
+String Day11_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-precip-type"}
+Number:Length Day11_Hour07_Snow "Snow" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-snow"}
+Number:Length Day11_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-snow-depth"}
+Number:Speed Day11_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-wind-gust"}
+Number:Speed Day11_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-wind-speed"}
+Number:Angle Day11_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-wind-dir"}
+Number:Pressure Day11_Hour07_Pressure "Pressure" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-pressure"}
+Number:Length Day11_Hour07_Visibility "Visibility" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-visibility"}
+Number:Dimensionless Day11_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-cloud-cover"}
+Number:Intensity Day11_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-solar-radiation"}
+Number Day11_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-solar-energy"}
+Number Day11_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-uv-index"}
+Number Day11_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-severe-risk"}
+String Day11_Hour07_Conditions "Conditions" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-conditions"}
+String Day11_Hour07_Icon "Icon" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-icon"}
+String Day11_Hour07_Stations "Stations" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-stations"}
+String Day11_Hour07_Source "Source" (Total_Weather_Data_Day11_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour07-source"}
+
+// Day11 - Hour08
+Group Total_Weather_Data_Day11_Hour08 "Hour 08" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour08_DateTime "DateTime" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-datetime"}
+DateTime Day11_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-timestamp"}
+Number:Temperature Day11_Hour08_Temperature "Temperature" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-temperature"}
+Number:Temperature Day11_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-feels-like"}
+Number Day11_Hour08_Humidity "Humidity" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-humidity"}
+Number:Temperature Day11_Hour08_Dew "Dew Point" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-dew"}
+Number:Length Day11_Hour08_Precip "Precipitation" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-precip"}
+Number:Dimensionless Day11_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-precip-prob"}
+String Day11_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-precip-type"}
+Number:Length Day11_Hour08_Snow "Snow" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-snow"}
+Number:Length Day11_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-snow-depth"}
+Number:Speed Day11_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-wind-gust"}
+Number:Speed Day11_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-wind-speed"}
+Number:Angle Day11_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-wind-dir"}
+Number:Pressure Day11_Hour08_Pressure "Pressure" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-pressure"}
+Number:Length Day11_Hour08_Visibility "Visibility" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-visibility"}
+Number:Dimensionless Day11_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-cloud-cover"}
+Number:Intensity Day11_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-solar-radiation"}
+Number Day11_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-solar-energy"}
+Number Day11_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-uv-index"}
+Number Day11_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-severe-risk"}
+String Day11_Hour08_Conditions "Conditions" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-conditions"}
+String Day11_Hour08_Icon "Icon" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-icon"}
+String Day11_Hour08_Stations "Stations" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-stations"}
+String Day11_Hour08_Source "Source" (Total_Weather_Data_Day11_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour08-source"}
+
+// Day11 - Hour09
+Group Total_Weather_Data_Day11_Hour09 "Hour 09" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour09_DateTime "DateTime" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-datetime"}
+DateTime Day11_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-timestamp"}
+Number:Temperature Day11_Hour09_Temperature "Temperature" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-temperature"}
+Number:Temperature Day11_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-feels-like"}
+Number Day11_Hour09_Humidity "Humidity" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-humidity"}
+Number:Temperature Day11_Hour09_Dew "Dew Point" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-dew"}
+Number:Length Day11_Hour09_Precip "Precipitation" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-precip"}
+Number:Dimensionless Day11_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-precip-prob"}
+String Day11_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-precip-type"}
+Number:Length Day11_Hour09_Snow "Snow" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-snow"}
+Number:Length Day11_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-snow-depth"}
+Number:Speed Day11_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-wind-gust"}
+Number:Speed Day11_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-wind-speed"}
+Number:Angle Day11_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-wind-dir"}
+Number:Pressure Day11_Hour09_Pressure "Pressure" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-pressure"}
+Number:Length Day11_Hour09_Visibility "Visibility" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-visibility"}
+Number:Dimensionless Day11_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-cloud-cover"}
+Number:Intensity Day11_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-solar-radiation"}
+Number Day11_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-solar-energy"}
+Number Day11_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-uv-index"}
+Number Day11_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-severe-risk"}
+String Day11_Hour09_Conditions "Conditions" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-conditions"}
+String Day11_Hour09_Icon "Icon" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-icon"}
+String Day11_Hour09_Stations "Stations" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-stations"}
+String Day11_Hour09_Source "Source" (Total_Weather_Data_Day11_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour09-source"}
+
+// Day11 - Hour10
+Group Total_Weather_Data_Day11_Hour10 "Hour 10" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour10_DateTime "DateTime" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-datetime"}
+DateTime Day11_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-timestamp"}
+Number:Temperature Day11_Hour10_Temperature "Temperature" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-temperature"}
+Number:Temperature Day11_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-feels-like"}
+Number Day11_Hour10_Humidity "Humidity" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-humidity"}
+Number:Temperature Day11_Hour10_Dew "Dew Point" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-dew"}
+Number:Length Day11_Hour10_Precip "Precipitation" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-precip"}
+Number:Dimensionless Day11_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-precip-prob"}
+String Day11_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-precip-type"}
+Number:Length Day11_Hour10_Snow "Snow" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-snow"}
+Number:Length Day11_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-snow-depth"}
+Number:Speed Day11_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-wind-gust"}
+Number:Speed Day11_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-wind-speed"}
+Number:Angle Day11_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-wind-dir"}
+Number:Pressure Day11_Hour10_Pressure "Pressure" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-pressure"}
+Number:Length Day11_Hour10_Visibility "Visibility" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-visibility"}
+Number:Dimensionless Day11_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-cloud-cover"}
+Number:Intensity Day11_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-solar-radiation"}
+Number Day11_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-solar-energy"}
+Number Day11_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-uv-index"}
+Number Day11_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-severe-risk"}
+String Day11_Hour10_Conditions "Conditions" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-conditions"}
+String Day11_Hour10_Icon "Icon" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-icon"}
+String Day11_Hour10_Stations "Stations" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-stations"}
+String Day11_Hour10_Source "Source" (Total_Weather_Data_Day11_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour10-source"}
+
+// Day11 - Hour11
+Group Total_Weather_Data_Day11_Hour11 "Hour 11" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour11_DateTime "DateTime" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-datetime"}
+DateTime Day11_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-timestamp"}
+Number:Temperature Day11_Hour11_Temperature "Temperature" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-temperature"}
+Number:Temperature Day11_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-feels-like"}
+Number Day11_Hour11_Humidity "Humidity" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-humidity"}
+Number:Temperature Day11_Hour11_Dew "Dew Point" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-dew"}
+Number:Length Day11_Hour11_Precip "Precipitation" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-precip"}
+Number:Dimensionless Day11_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-precip-prob"}
+String Day11_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-precip-type"}
+Number:Length Day11_Hour11_Snow "Snow" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-snow"}
+Number:Length Day11_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-snow-depth"}
+Number:Speed Day11_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-wind-gust"}
+Number:Speed Day11_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-wind-speed"}
+Number:Angle Day11_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-wind-dir"}
+Number:Pressure Day11_Hour11_Pressure "Pressure" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-pressure"}
+Number:Length Day11_Hour11_Visibility "Visibility" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-visibility"}
+Number:Dimensionless Day11_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-cloud-cover"}
+Number:Intensity Day11_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-solar-radiation"}
+Number Day11_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-solar-energy"}
+Number Day11_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-uv-index"}
+Number Day11_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-severe-risk"}
+String Day11_Hour11_Conditions "Conditions" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-conditions"}
+String Day11_Hour11_Icon "Icon" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-icon"}
+String Day11_Hour11_Stations "Stations" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-stations"}
+String Day11_Hour11_Source "Source" (Total_Weather_Data_Day11_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour11-source"}
+
+// Day11 - Hour12
+Group Total_Weather_Data_Day11_Hour12 "Hour 12" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour12_DateTime "DateTime" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-datetime"}
+DateTime Day11_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-timestamp"}
+Number:Temperature Day11_Hour12_Temperature "Temperature" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-temperature"}
+Number:Temperature Day11_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-feels-like"}
+Number Day11_Hour12_Humidity "Humidity" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-humidity"}
+Number:Temperature Day11_Hour12_Dew "Dew Point" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-dew"}
+Number:Length Day11_Hour12_Precip "Precipitation" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-precip"}
+Number:Dimensionless Day11_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-precip-prob"}
+String Day11_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-precip-type"}
+Number:Length Day11_Hour12_Snow "Snow" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-snow"}
+Number:Length Day11_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-snow-depth"}
+Number:Speed Day11_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-wind-gust"}
+Number:Speed Day11_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-wind-speed"}
+Number:Angle Day11_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-wind-dir"}
+Number:Pressure Day11_Hour12_Pressure "Pressure" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-pressure"}
+Number:Length Day11_Hour12_Visibility "Visibility" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-visibility"}
+Number:Dimensionless Day11_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-cloud-cover"}
+Number:Intensity Day11_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-solar-radiation"}
+Number Day11_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-solar-energy"}
+Number Day11_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-uv-index"}
+Number Day11_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-severe-risk"}
+String Day11_Hour12_Conditions "Conditions" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-conditions"}
+String Day11_Hour12_Icon "Icon" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-icon"}
+String Day11_Hour12_Stations "Stations" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-stations"}
+String Day11_Hour12_Source "Source" (Total_Weather_Data_Day11_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour12-source"}
+
+// Day11 - Hour13
+Group Total_Weather_Data_Day11_Hour13 "Hour 13" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour13_DateTime "DateTime" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-datetime"}
+DateTime Day11_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-timestamp"}
+Number:Temperature Day11_Hour13_Temperature "Temperature" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-temperature"}
+Number:Temperature Day11_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-feels-like"}
+Number Day11_Hour13_Humidity "Humidity" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-humidity"}
+Number:Temperature Day11_Hour13_Dew "Dew Point" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-dew"}
+Number:Length Day11_Hour13_Precip "Precipitation" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-precip"}
+Number:Dimensionless Day11_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-precip-prob"}
+String Day11_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-precip-type"}
+Number:Length Day11_Hour13_Snow "Snow" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-snow"}
+Number:Length Day11_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-snow-depth"}
+Number:Speed Day11_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-wind-gust"}
+Number:Speed Day11_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-wind-speed"}
+Number:Angle Day11_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-wind-dir"}
+Number:Pressure Day11_Hour13_Pressure "Pressure" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-pressure"}
+Number:Length Day11_Hour13_Visibility "Visibility" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-visibility"}
+Number:Dimensionless Day11_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-cloud-cover"}
+Number:Intensity Day11_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-solar-radiation"}
+Number Day11_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-solar-energy"}
+Number Day11_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-uv-index"}
+Number Day11_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-severe-risk"}
+String Day11_Hour13_Conditions "Conditions" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-conditions"}
+String Day11_Hour13_Icon "Icon" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-icon"}
+String Day11_Hour13_Stations "Stations" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-stations"}
+String Day11_Hour13_Source "Source" (Total_Weather_Data_Day11_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour13-source"}
+
+// Day11 - Hour14
+Group Total_Weather_Data_Day11_Hour14 "Hour 14" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour14_DateTime "DateTime" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-datetime"}
+DateTime Day11_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-timestamp"}
+Number:Temperature Day11_Hour14_Temperature "Temperature" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-temperature"}
+Number:Temperature Day11_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-feels-like"}
+Number Day11_Hour14_Humidity "Humidity" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-humidity"}
+Number:Temperature Day11_Hour14_Dew "Dew Point" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-dew"}
+Number:Length Day11_Hour14_Precip "Precipitation" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-precip"}
+Number:Dimensionless Day11_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-precip-prob"}
+String Day11_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-precip-type"}
+Number:Length Day11_Hour14_Snow "Snow" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-snow"}
+Number:Length Day11_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-snow-depth"}
+Number:Speed Day11_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-wind-gust"}
+Number:Speed Day11_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-wind-speed"}
+Number:Angle Day11_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-wind-dir"}
+Number:Pressure Day11_Hour14_Pressure "Pressure" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-pressure"}
+Number:Length Day11_Hour14_Visibility "Visibility" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-visibility"}
+Number:Dimensionless Day11_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-cloud-cover"}
+Number:Intensity Day11_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-solar-radiation"}
+Number Day11_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-solar-energy"}
+Number Day11_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-uv-index"}
+Number Day11_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-severe-risk"}
+String Day11_Hour14_Conditions "Conditions" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-conditions"}
+String Day11_Hour14_Icon "Icon" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-icon"}
+String Day11_Hour14_Stations "Stations" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-stations"}
+String Day11_Hour14_Source "Source" (Total_Weather_Data_Day11_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour14-source"}
+
+// Day11 - Hour15
+Group Total_Weather_Data_Day11_Hour15 "Hour 15" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour15_DateTime "DateTime" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-datetime"}
+DateTime Day11_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-timestamp"}
+Number:Temperature Day11_Hour15_Temperature "Temperature" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-temperature"}
+Number:Temperature Day11_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-feels-like"}
+Number Day11_Hour15_Humidity "Humidity" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-humidity"}
+Number:Temperature Day11_Hour15_Dew "Dew Point" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-dew"}
+Number:Length Day11_Hour15_Precip "Precipitation" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-precip"}
+Number:Dimensionless Day11_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-precip-prob"}
+String Day11_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-precip-type"}
+Number:Length Day11_Hour15_Snow "Snow" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-snow"}
+Number:Length Day11_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-snow-depth"}
+Number:Speed Day11_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-wind-gust"}
+Number:Speed Day11_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-wind-speed"}
+Number:Angle Day11_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-wind-dir"}
+Number:Pressure Day11_Hour15_Pressure "Pressure" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-pressure"}
+Number:Length Day11_Hour15_Visibility "Visibility" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-visibility"}
+Number:Dimensionless Day11_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-cloud-cover"}
+Number:Intensity Day11_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-solar-radiation"}
+Number Day11_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-solar-energy"}
+Number Day11_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-uv-index"}
+Number Day11_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-severe-risk"}
+String Day11_Hour15_Conditions "Conditions" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-conditions"}
+String Day11_Hour15_Icon "Icon" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-icon"}
+String Day11_Hour15_Stations "Stations" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-stations"}
+String Day11_Hour15_Source "Source" (Total_Weather_Data_Day11_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour15-source"}
+
+// Day11 - Hour16
+Group Total_Weather_Data_Day11_Hour16 "Hour 16" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour16_DateTime "DateTime" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-datetime"}
+DateTime Day11_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-timestamp"}
+Number:Temperature Day11_Hour16_Temperature "Temperature" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-temperature"}
+Number:Temperature Day11_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-feels-like"}
+Number Day11_Hour16_Humidity "Humidity" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-humidity"}
+Number:Temperature Day11_Hour16_Dew "Dew Point" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-dew"}
+Number:Length Day11_Hour16_Precip "Precipitation" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-precip"}
+Number:Dimensionless Day11_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-precip-prob"}
+String Day11_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-precip-type"}
+Number:Length Day11_Hour16_Snow "Snow" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-snow"}
+Number:Length Day11_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-snow-depth"}
+Number:Speed Day11_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-wind-gust"}
+Number:Speed Day11_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-wind-speed"}
+Number:Angle Day11_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-wind-dir"}
+Number:Pressure Day11_Hour16_Pressure "Pressure" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-pressure"}
+Number:Length Day11_Hour16_Visibility "Visibility" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-visibility"}
+Number:Dimensionless Day11_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-cloud-cover"}
+Number:Intensity Day11_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-solar-radiation"}
+Number Day11_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-solar-energy"}
+Number Day11_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-uv-index"}
+Number Day11_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-severe-risk"}
+String Day11_Hour16_Conditions "Conditions" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-conditions"}
+String Day11_Hour16_Icon "Icon" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-icon"}
+String Day11_Hour16_Stations "Stations" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-stations"}
+String Day11_Hour16_Source "Source" (Total_Weather_Data_Day11_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour16-source"}
+
+// Day11 - Hour17
+Group Total_Weather_Data_Day11_Hour17 "Hour 17" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour17_DateTime "DateTime" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-datetime"}
+DateTime Day11_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-timestamp"}
+Number:Temperature Day11_Hour17_Temperature "Temperature" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-temperature"}
+Number:Temperature Day11_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-feels-like"}
+Number Day11_Hour17_Humidity "Humidity" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-humidity"}
+Number:Temperature Day11_Hour17_Dew "Dew Point" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-dew"}
+Number:Length Day11_Hour17_Precip "Precipitation" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-precip"}
+Number:Dimensionless Day11_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-precip-prob"}
+String Day11_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-precip-type"}
+Number:Length Day11_Hour17_Snow "Snow" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-snow"}
+Number:Length Day11_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-snow-depth"}
+Number:Speed Day11_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-wind-gust"}
+Number:Speed Day11_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-wind-speed"}
+Number:Angle Day11_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-wind-dir"}
+Number:Pressure Day11_Hour17_Pressure "Pressure" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-pressure"}
+Number:Length Day11_Hour17_Visibility "Visibility" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-visibility"}
+Number:Dimensionless Day11_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-cloud-cover"}
+Number:Intensity Day11_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-solar-radiation"}
+Number Day11_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-solar-energy"}
+Number Day11_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-uv-index"}
+Number Day11_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-severe-risk"}
+String Day11_Hour17_Conditions "Conditions" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-conditions"}
+String Day11_Hour17_Icon "Icon" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-icon"}
+String Day11_Hour17_Stations "Stations" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-stations"}
+String Day11_Hour17_Source "Source" (Total_Weather_Data_Day11_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour17-source"}
+
+// Day11 - Hour18
+Group Total_Weather_Data_Day11_Hour18 "Hour 18" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour18_DateTime "DateTime" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-datetime"}
+DateTime Day11_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-timestamp"}
+Number:Temperature Day11_Hour18_Temperature "Temperature" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-temperature"}
+Number:Temperature Day11_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-feels-like"}
+Number Day11_Hour18_Humidity "Humidity" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-humidity"}
+Number:Temperature Day11_Hour18_Dew "Dew Point" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-dew"}
+Number:Length Day11_Hour18_Precip "Precipitation" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-precip"}
+Number:Dimensionless Day11_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-precip-prob"}
+String Day11_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-precip-type"}
+Number:Length Day11_Hour18_Snow "Snow" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-snow"}
+Number:Length Day11_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-snow-depth"}
+Number:Speed Day11_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-wind-gust"}
+Number:Speed Day11_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-wind-speed"}
+Number:Angle Day11_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-wind-dir"}
+Number:Pressure Day11_Hour18_Pressure "Pressure" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-pressure"}
+Number:Length Day11_Hour18_Visibility "Visibility" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-visibility"}
+Number:Dimensionless Day11_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-cloud-cover"}
+Number:Intensity Day11_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-solar-radiation"}
+Number Day11_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-solar-energy"}
+Number Day11_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-uv-index"}
+Number Day11_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-severe-risk"}
+String Day11_Hour18_Conditions "Conditions" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-conditions"}
+String Day11_Hour18_Icon "Icon" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-icon"}
+String Day11_Hour18_Stations "Stations" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-stations"}
+String Day11_Hour18_Source "Source" (Total_Weather_Data_Day11_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour18-source"}
+
+// Day11 - Hour19
+Group Total_Weather_Data_Day11_Hour19 "Hour 19" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour19_DateTime "DateTime" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-datetime"}
+DateTime Day11_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-timestamp"}
+Number:Temperature Day11_Hour19_Temperature "Temperature" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-temperature"}
+Number:Temperature Day11_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-feels-like"}
+Number Day11_Hour19_Humidity "Humidity" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-humidity"}
+Number:Temperature Day11_Hour19_Dew "Dew Point" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-dew"}
+Number:Length Day11_Hour19_Precip "Precipitation" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-precip"}
+Number:Dimensionless Day11_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-precip-prob"}
+String Day11_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-precip-type"}
+Number:Length Day11_Hour19_Snow "Snow" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-snow"}
+Number:Length Day11_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-snow-depth"}
+Number:Speed Day11_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-wind-gust"}
+Number:Speed Day11_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-wind-speed"}
+Number:Angle Day11_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-wind-dir"}
+Number:Pressure Day11_Hour19_Pressure "Pressure" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-pressure"}
+Number:Length Day11_Hour19_Visibility "Visibility" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-visibility"}
+Number:Dimensionless Day11_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-cloud-cover"}
+Number:Intensity Day11_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-solar-radiation"}
+Number Day11_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-solar-energy"}
+Number Day11_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-uv-index"}
+Number Day11_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-severe-risk"}
+String Day11_Hour19_Conditions "Conditions" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-conditions"}
+String Day11_Hour19_Icon "Icon" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-icon"}
+String Day11_Hour19_Stations "Stations" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-stations"}
+String Day11_Hour19_Source "Source" (Total_Weather_Data_Day11_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour19-source"}
+
+// Day11 - Hour20
+Group Total_Weather_Data_Day11_Hour20 "Hour 20" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour20_DateTime "DateTime" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-datetime"}
+DateTime Day11_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-timestamp"}
+Number:Temperature Day11_Hour20_Temperature "Temperature" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-temperature"}
+Number:Temperature Day11_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-feels-like"}
+Number Day11_Hour20_Humidity "Humidity" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-humidity"}
+Number:Temperature Day11_Hour20_Dew "Dew Point" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-dew"}
+Number:Length Day11_Hour20_Precip "Precipitation" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-precip"}
+Number:Dimensionless Day11_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-precip-prob"}
+String Day11_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-precip-type"}
+Number:Length Day11_Hour20_Snow "Snow" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-snow"}
+Number:Length Day11_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-snow-depth"}
+Number:Speed Day11_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-wind-gust"}
+Number:Speed Day11_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-wind-speed"}
+Number:Angle Day11_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-wind-dir"}
+Number:Pressure Day11_Hour20_Pressure "Pressure" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-pressure"}
+Number:Length Day11_Hour20_Visibility "Visibility" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-visibility"}
+Number:Dimensionless Day11_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-cloud-cover"}
+Number:Intensity Day11_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-solar-radiation"}
+Number Day11_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-solar-energy"}
+Number Day11_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-uv-index"}
+Number Day11_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-severe-risk"}
+String Day11_Hour20_Conditions "Conditions" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-conditions"}
+String Day11_Hour20_Icon "Icon" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-icon"}
+String Day11_Hour20_Stations "Stations" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-stations"}
+String Day11_Hour20_Source "Source" (Total_Weather_Data_Day11_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour20-source"}
+
+// Day11 - Hour21
+Group Total_Weather_Data_Day11_Hour21 "Hour 21" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour21_DateTime "DateTime" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-datetime"}
+DateTime Day11_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-timestamp"}
+Number:Temperature Day11_Hour21_Temperature "Temperature" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-temperature"}
+Number:Temperature Day11_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-feels-like"}
+Number Day11_Hour21_Humidity "Humidity" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-humidity"}
+Number:Temperature Day11_Hour21_Dew "Dew Point" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-dew"}
+Number:Length Day11_Hour21_Precip "Precipitation" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-precip"}
+Number:Dimensionless Day11_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-precip-prob"}
+String Day11_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-precip-type"}
+Number:Length Day11_Hour21_Snow "Snow" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-snow"}
+Number:Length Day11_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-snow-depth"}
+Number:Speed Day11_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-wind-gust"}
+Number:Speed Day11_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-wind-speed"}
+Number:Angle Day11_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-wind-dir"}
+Number:Pressure Day11_Hour21_Pressure "Pressure" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-pressure"}
+Number:Length Day11_Hour21_Visibility "Visibility" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-visibility"}
+Number:Dimensionless Day11_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-cloud-cover"}
+Number:Intensity Day11_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-solar-radiation"}
+Number Day11_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-solar-energy"}
+Number Day11_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-uv-index"}
+Number Day11_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-severe-risk"}
+String Day11_Hour21_Conditions "Conditions" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-conditions"}
+String Day11_Hour21_Icon "Icon" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-icon"}
+String Day11_Hour21_Stations "Stations" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-stations"}
+String Day11_Hour21_Source "Source" (Total_Weather_Data_Day11_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour21-source"}
+
+// Day11 - Hour22
+Group Total_Weather_Data_Day11_Hour22 "Hour 22" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour22_DateTime "DateTime" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-datetime"}
+DateTime Day11_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-timestamp"}
+Number:Temperature Day11_Hour22_Temperature "Temperature" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-temperature"}
+Number:Temperature Day11_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-feels-like"}
+Number Day11_Hour22_Humidity "Humidity" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-humidity"}
+Number:Temperature Day11_Hour22_Dew "Dew Point" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-dew"}
+Number:Length Day11_Hour22_Precip "Precipitation" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-precip"}
+Number:Dimensionless Day11_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-precip-prob"}
+String Day11_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-precip-type"}
+Number:Length Day11_Hour22_Snow "Snow" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-snow"}
+Number:Length Day11_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-snow-depth"}
+Number:Speed Day11_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-wind-gust"}
+Number:Speed Day11_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-wind-speed"}
+Number:Angle Day11_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-wind-dir"}
+Number:Pressure Day11_Hour22_Pressure "Pressure" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-pressure"}
+Number:Length Day11_Hour22_Visibility "Visibility" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-visibility"}
+Number:Dimensionless Day11_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-cloud-cover"}
+Number:Intensity Day11_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-solar-radiation"}
+Number Day11_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-solar-energy"}
+Number Day11_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-uv-index"}
+Number Day11_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-severe-risk"}
+String Day11_Hour22_Conditions "Conditions" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-conditions"}
+String Day11_Hour22_Icon "Icon" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-icon"}
+String Day11_Hour22_Stations "Stations" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-stations"}
+String Day11_Hour22_Source "Source" (Total_Weather_Data_Day11_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour22-source"}
+
+// Day11 - Hour23
+Group Total_Weather_Data_Day11_Hour23 "Hour 23" (Total_Weather_Data_Day11) [ "Equipment" ] 
+String Day11_Hour23_DateTime "DateTime" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-datetime"}
+DateTime Day11_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-timestamp"}
+Number:Temperature Day11_Hour23_Temperature "Temperature" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-temperature"}
+Number:Temperature Day11_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-feels-like"}
+Number Day11_Hour23_Humidity "Humidity" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-humidity"}
+Number:Temperature Day11_Hour23_Dew "Dew Point" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-dew"}
+Number:Length Day11_Hour23_Precip "Precipitation" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-precip"}
+Number:Dimensionless Day11_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-precip-prob"}
+String Day11_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-precip-type"}
+Number:Length Day11_Hour23_Snow "Snow" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-snow"}
+Number:Length Day11_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-snow-depth"}
+Number:Speed Day11_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-wind-gust"}
+Number:Speed Day11_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-wind-speed"}
+Number:Angle Day11_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-wind-dir"}
+Number:Pressure Day11_Hour23_Pressure "Pressure" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-pressure"}
+Number:Length Day11_Hour23_Visibility "Visibility" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-visibility"}
+Number:Dimensionless Day11_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-cloud-cover"}
+Number:Intensity Day11_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-solar-radiation"}
+Number Day11_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-solar-energy"}
+Number Day11_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-uv-index"}
+Number Day11_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-severe-risk"}
+String Day11_Hour23_Conditions "Conditions" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-conditions"}
+String Day11_Hour23_Icon "Icon" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-icon"}
+String Day11_Hour23_Stations "Stations" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-stations"}
+String Day11_Hour23_Source "Source" (Total_Weather_Data_Day11_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day11#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_12.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_12.items
@@ -1,39 +1,712 @@
 // Day12
 Group Total_Weather_Data_Day12 "Day T+12" (Total_Weather_Data) [ "Equipment" ] 
-String Day12_DateTime "Time" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day12_Timestamp "Timestamp" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day12_Temperature "Temperature" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day12_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day12_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day12_FeelsLike "Feels Like" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day12_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day12_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day12_Dew "Dew Point" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day12_Humidity "Humidity" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day12_Precip "Precipitation" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day12_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day12_Precip_Type "Precipitation Type" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day12_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day12_Snow "Snow" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day12_Snow_Depth "Snow Depth" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day12_Wind_Gust "Wind Gust" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day12_Wind_Speed "Wind Speed" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day12_Wind_Dir "Wind Direction" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day12_Pressure "Pressure" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day12_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day12_Visibility "Visibility" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day12_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day12_Solar_Energy "Solar Energy" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day12_UV_Index "UV Index" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day12_Sunrise "Sunrise" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day12_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day12_Sunset "Sunset" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day12_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day12_Moon_Phase "Moon Phase" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day12_Conditions "Conditions" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day12_Description "Description" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day12_Icon "Icon" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day12_Stations "Stations" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day12_Source "Source" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day12_Severe_Risk "Severe Risk" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day12_DateTime "Time" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#datetime" }
+DateTime Day12_Timestamp "Timestamp" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#timestamp" }
+Number:Temperature Day12_Temperature "Temperature" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#temperature" }
+Number:Temperature Day12_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#temperature-min" }
+Number:Temperature Day12_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#temperature-max" }
+Number:Temperature Day12_FeelsLike "Feels Like" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#feels-like" }
+Number:Temperature Day12_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#feels-like-min" }
+Number:Temperature Day12_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#feels-like-max" }
+Number:Temperature Day12_Dew "Dew Point" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#dew" }
+Number Day12_Humidity "Humidity" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#humidity" }
+Number:Length Day12_Precip "Precipitation" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#precip" }
+Number Day12_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#precip-prob" }
+String Day12_Precip_Type "Precipitation Type" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#precip-type" }
+Number Day12_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#precip-cover" }
+Number:Length Day12_Snow "Snow" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#snow" }
+Number:Length Day12_Snow_Depth "Snow Depth" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#snow-depth" }
+Number:Speed Day12_Wind_Gust "Wind Gust" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#wind-gust" }
+Number:Speed Day12_Wind_Speed "Wind Speed" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#wind-speed" }
+Number:Angle Day12_Wind_Dir "Wind Direction" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#wind-dir" }
+Number:Pressure Day12_Pressure "Pressure" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#pressure" }
+Number Day12_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#cloud-cover" }
+Number:Length Day12_Visibility "Visibility" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#visibility" }
+Number:Intensity Day12_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#solar-radiation" }
+Number Day12_Solar_Energy "Solar Energy" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#solar-energy" }
+Number Day12_UV_Index "UV Index" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#uv-index" }
+String Day12_Sunrise "Sunrise" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#sunrise" }
+DateTime Day12_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#sunrise-epoch" }
+String Day12_Sunset "Sunset" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#sunset" }
+DateTime Day12_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#sunset-epoch" }
+Number Day12_Moon_Phase "Moon Phase" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#moon-phase" }
+String Day12_Conditions "Conditions" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#conditions" }
+String Day12_Description "Description" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#description" }
+String Day12_Icon "Icon" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#icon" }
+String Day12_Stations "Stations" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#stations" }
+String Day12_Source "Source" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#source" }
+Number Day12_Severe_Risk "Severe Risk" (Total_Weather_Data_Day12)["Point"] { channel="visualcrossing:weather:default_config:day12#severe-risk" }
+
+// Day12 - Hour00
+Group Total_Weather_Data_Day12_Hour00 "Hour 00" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour00_DateTime "DateTime" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-datetime"}
+DateTime Day12_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-timestamp"}
+Number:Temperature Day12_Hour00_Temperature "Temperature" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-temperature"}
+Number:Temperature Day12_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-feels-like"}
+Number Day12_Hour00_Humidity "Humidity" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-humidity"}
+Number:Temperature Day12_Hour00_Dew "Dew Point" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-dew"}
+Number:Length Day12_Hour00_Precip "Precipitation" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-precip"}
+Number:Dimensionless Day12_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-precip-prob"}
+String Day12_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-precip-type"}
+Number:Length Day12_Hour00_Snow "Snow" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-snow"}
+Number:Length Day12_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-snow-depth"}
+Number:Speed Day12_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-wind-gust"}
+Number:Speed Day12_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-wind-speed"}
+Number:Angle Day12_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-wind-dir"}
+Number:Pressure Day12_Hour00_Pressure "Pressure" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-pressure"}
+Number:Length Day12_Hour00_Visibility "Visibility" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-visibility"}
+Number:Dimensionless Day12_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-cloud-cover"}
+Number:Intensity Day12_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-solar-radiation"}
+Number Day12_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-solar-energy"}
+Number Day12_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-uv-index"}
+Number Day12_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-severe-risk"}
+String Day12_Hour00_Conditions "Conditions" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-conditions"}
+String Day12_Hour00_Icon "Icon" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-icon"}
+String Day12_Hour00_Stations "Stations" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-stations"}
+String Day12_Hour00_Source "Source" (Total_Weather_Data_Day12_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour00-source"}
+
+// Day12 - Hour01
+Group Total_Weather_Data_Day12_Hour01 "Hour 01" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour01_DateTime "DateTime" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-datetime"}
+DateTime Day12_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-timestamp"}
+Number:Temperature Day12_Hour01_Temperature "Temperature" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-temperature"}
+Number:Temperature Day12_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-feels-like"}
+Number Day12_Hour01_Humidity "Humidity" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-humidity"}
+Number:Temperature Day12_Hour01_Dew "Dew Point" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-dew"}
+Number:Length Day12_Hour01_Precip "Precipitation" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-precip"}
+Number:Dimensionless Day12_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-precip-prob"}
+String Day12_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-precip-type"}
+Number:Length Day12_Hour01_Snow "Snow" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-snow"}
+Number:Length Day12_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-snow-depth"}
+Number:Speed Day12_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-wind-gust"}
+Number:Speed Day12_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-wind-speed"}
+Number:Angle Day12_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-wind-dir"}
+Number:Pressure Day12_Hour01_Pressure "Pressure" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-pressure"}
+Number:Length Day12_Hour01_Visibility "Visibility" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-visibility"}
+Number:Dimensionless Day12_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-cloud-cover"}
+Number:Intensity Day12_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-solar-radiation"}
+Number Day12_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-solar-energy"}
+Number Day12_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-uv-index"}
+Number Day12_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-severe-risk"}
+String Day12_Hour01_Conditions "Conditions" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-conditions"}
+String Day12_Hour01_Icon "Icon" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-icon"}
+String Day12_Hour01_Stations "Stations" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-stations"}
+String Day12_Hour01_Source "Source" (Total_Weather_Data_Day12_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour01-source"}
+
+// Day12 - Hour02
+Group Total_Weather_Data_Day12_Hour02 "Hour 02" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour02_DateTime "DateTime" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-datetime"}
+DateTime Day12_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-timestamp"}
+Number:Temperature Day12_Hour02_Temperature "Temperature" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-temperature"}
+Number:Temperature Day12_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-feels-like"}
+Number Day12_Hour02_Humidity "Humidity" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-humidity"}
+Number:Temperature Day12_Hour02_Dew "Dew Point" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-dew"}
+Number:Length Day12_Hour02_Precip "Precipitation" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-precip"}
+Number:Dimensionless Day12_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-precip-prob"}
+String Day12_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-precip-type"}
+Number:Length Day12_Hour02_Snow "Snow" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-snow"}
+Number:Length Day12_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-snow-depth"}
+Number:Speed Day12_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-wind-gust"}
+Number:Speed Day12_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-wind-speed"}
+Number:Angle Day12_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-wind-dir"}
+Number:Pressure Day12_Hour02_Pressure "Pressure" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-pressure"}
+Number:Length Day12_Hour02_Visibility "Visibility" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-visibility"}
+Number:Dimensionless Day12_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-cloud-cover"}
+Number:Intensity Day12_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-solar-radiation"}
+Number Day12_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-solar-energy"}
+Number Day12_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-uv-index"}
+Number Day12_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-severe-risk"}
+String Day12_Hour02_Conditions "Conditions" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-conditions"}
+String Day12_Hour02_Icon "Icon" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-icon"}
+String Day12_Hour02_Stations "Stations" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-stations"}
+String Day12_Hour02_Source "Source" (Total_Weather_Data_Day12_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour02-source"}
+
+// Day12 - Hour03
+Group Total_Weather_Data_Day12_Hour03 "Hour 03" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour03_DateTime "DateTime" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-datetime"}
+DateTime Day12_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-timestamp"}
+Number:Temperature Day12_Hour03_Temperature "Temperature" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-temperature"}
+Number:Temperature Day12_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-feels-like"}
+Number Day12_Hour03_Humidity "Humidity" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-humidity"}
+Number:Temperature Day12_Hour03_Dew "Dew Point" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-dew"}
+Number:Length Day12_Hour03_Precip "Precipitation" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-precip"}
+Number:Dimensionless Day12_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-precip-prob"}
+String Day12_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-precip-type"}
+Number:Length Day12_Hour03_Snow "Snow" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-snow"}
+Number:Length Day12_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-snow-depth"}
+Number:Speed Day12_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-wind-gust"}
+Number:Speed Day12_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-wind-speed"}
+Number:Angle Day12_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-wind-dir"}
+Number:Pressure Day12_Hour03_Pressure "Pressure" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-pressure"}
+Number:Length Day12_Hour03_Visibility "Visibility" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-visibility"}
+Number:Dimensionless Day12_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-cloud-cover"}
+Number:Intensity Day12_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-solar-radiation"}
+Number Day12_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-solar-energy"}
+Number Day12_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-uv-index"}
+Number Day12_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-severe-risk"}
+String Day12_Hour03_Conditions "Conditions" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-conditions"}
+String Day12_Hour03_Icon "Icon" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-icon"}
+String Day12_Hour03_Stations "Stations" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-stations"}
+String Day12_Hour03_Source "Source" (Total_Weather_Data_Day12_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour03-source"}
+
+// Day12 - Hour04
+Group Total_Weather_Data_Day12_Hour04 "Hour 04" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour04_DateTime "DateTime" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-datetime"}
+DateTime Day12_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-timestamp"}
+Number:Temperature Day12_Hour04_Temperature "Temperature" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-temperature"}
+Number:Temperature Day12_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-feels-like"}
+Number Day12_Hour04_Humidity "Humidity" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-humidity"}
+Number:Temperature Day12_Hour04_Dew "Dew Point" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-dew"}
+Number:Length Day12_Hour04_Precip "Precipitation" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-precip"}
+Number:Dimensionless Day12_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-precip-prob"}
+String Day12_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-precip-type"}
+Number:Length Day12_Hour04_Snow "Snow" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-snow"}
+Number:Length Day12_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-snow-depth"}
+Number:Speed Day12_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-wind-gust"}
+Number:Speed Day12_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-wind-speed"}
+Number:Angle Day12_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-wind-dir"}
+Number:Pressure Day12_Hour04_Pressure "Pressure" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-pressure"}
+Number:Length Day12_Hour04_Visibility "Visibility" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-visibility"}
+Number:Dimensionless Day12_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-cloud-cover"}
+Number:Intensity Day12_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-solar-radiation"}
+Number Day12_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-solar-energy"}
+Number Day12_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-uv-index"}
+Number Day12_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-severe-risk"}
+String Day12_Hour04_Conditions "Conditions" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-conditions"}
+String Day12_Hour04_Icon "Icon" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-icon"}
+String Day12_Hour04_Stations "Stations" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-stations"}
+String Day12_Hour04_Source "Source" (Total_Weather_Data_Day12_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour04-source"}
+
+// Day12 - Hour05
+Group Total_Weather_Data_Day12_Hour05 "Hour 05" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour05_DateTime "DateTime" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-datetime"}
+DateTime Day12_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-timestamp"}
+Number:Temperature Day12_Hour05_Temperature "Temperature" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-temperature"}
+Number:Temperature Day12_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-feels-like"}
+Number Day12_Hour05_Humidity "Humidity" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-humidity"}
+Number:Temperature Day12_Hour05_Dew "Dew Point" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-dew"}
+Number:Length Day12_Hour05_Precip "Precipitation" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-precip"}
+Number:Dimensionless Day12_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-precip-prob"}
+String Day12_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-precip-type"}
+Number:Length Day12_Hour05_Snow "Snow" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-snow"}
+Number:Length Day12_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-snow-depth"}
+Number:Speed Day12_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-wind-gust"}
+Number:Speed Day12_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-wind-speed"}
+Number:Angle Day12_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-wind-dir"}
+Number:Pressure Day12_Hour05_Pressure "Pressure" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-pressure"}
+Number:Length Day12_Hour05_Visibility "Visibility" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-visibility"}
+Number:Dimensionless Day12_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-cloud-cover"}
+Number:Intensity Day12_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-solar-radiation"}
+Number Day12_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-solar-energy"}
+Number Day12_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-uv-index"}
+Number Day12_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-severe-risk"}
+String Day12_Hour05_Conditions "Conditions" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-conditions"}
+String Day12_Hour05_Icon "Icon" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-icon"}
+String Day12_Hour05_Stations "Stations" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-stations"}
+String Day12_Hour05_Source "Source" (Total_Weather_Data_Day12_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour05-source"}
+
+// Day12 - Hour06
+Group Total_Weather_Data_Day12_Hour06 "Hour 06" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour06_DateTime "DateTime" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-datetime"}
+DateTime Day12_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-timestamp"}
+Number:Temperature Day12_Hour06_Temperature "Temperature" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-temperature"}
+Number:Temperature Day12_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-feels-like"}
+Number Day12_Hour06_Humidity "Humidity" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-humidity"}
+Number:Temperature Day12_Hour06_Dew "Dew Point" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-dew"}
+Number:Length Day12_Hour06_Precip "Precipitation" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-precip"}
+Number:Dimensionless Day12_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-precip-prob"}
+String Day12_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-precip-type"}
+Number:Length Day12_Hour06_Snow "Snow" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-snow"}
+Number:Length Day12_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-snow-depth"}
+Number:Speed Day12_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-wind-gust"}
+Number:Speed Day12_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-wind-speed"}
+Number:Angle Day12_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-wind-dir"}
+Number:Pressure Day12_Hour06_Pressure "Pressure" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-pressure"}
+Number:Length Day12_Hour06_Visibility "Visibility" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-visibility"}
+Number:Dimensionless Day12_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-cloud-cover"}
+Number:Intensity Day12_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-solar-radiation"}
+Number Day12_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-solar-energy"}
+Number Day12_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-uv-index"}
+Number Day12_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-severe-risk"}
+String Day12_Hour06_Conditions "Conditions" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-conditions"}
+String Day12_Hour06_Icon "Icon" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-icon"}
+String Day12_Hour06_Stations "Stations" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-stations"}
+String Day12_Hour06_Source "Source" (Total_Weather_Data_Day12_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour06-source"}
+
+// Day12 - Hour07
+Group Total_Weather_Data_Day12_Hour07 "Hour 07" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour07_DateTime "DateTime" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-datetime"}
+DateTime Day12_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-timestamp"}
+Number:Temperature Day12_Hour07_Temperature "Temperature" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-temperature"}
+Number:Temperature Day12_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-feels-like"}
+Number Day12_Hour07_Humidity "Humidity" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-humidity"}
+Number:Temperature Day12_Hour07_Dew "Dew Point" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-dew"}
+Number:Length Day12_Hour07_Precip "Precipitation" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-precip"}
+Number:Dimensionless Day12_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-precip-prob"}
+String Day12_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-precip-type"}
+Number:Length Day12_Hour07_Snow "Snow" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-snow"}
+Number:Length Day12_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-snow-depth"}
+Number:Speed Day12_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-wind-gust"}
+Number:Speed Day12_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-wind-speed"}
+Number:Angle Day12_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-wind-dir"}
+Number:Pressure Day12_Hour07_Pressure "Pressure" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-pressure"}
+Number:Length Day12_Hour07_Visibility "Visibility" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-visibility"}
+Number:Dimensionless Day12_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-cloud-cover"}
+Number:Intensity Day12_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-solar-radiation"}
+Number Day12_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-solar-energy"}
+Number Day12_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-uv-index"}
+Number Day12_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-severe-risk"}
+String Day12_Hour07_Conditions "Conditions" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-conditions"}
+String Day12_Hour07_Icon "Icon" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-icon"}
+String Day12_Hour07_Stations "Stations" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-stations"}
+String Day12_Hour07_Source "Source" (Total_Weather_Data_Day12_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour07-source"}
+
+// Day12 - Hour08
+Group Total_Weather_Data_Day12_Hour08 "Hour 08" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour08_DateTime "DateTime" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-datetime"}
+DateTime Day12_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-timestamp"}
+Number:Temperature Day12_Hour08_Temperature "Temperature" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-temperature"}
+Number:Temperature Day12_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-feels-like"}
+Number Day12_Hour08_Humidity "Humidity" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-humidity"}
+Number:Temperature Day12_Hour08_Dew "Dew Point" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-dew"}
+Number:Length Day12_Hour08_Precip "Precipitation" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-precip"}
+Number:Dimensionless Day12_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-precip-prob"}
+String Day12_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-precip-type"}
+Number:Length Day12_Hour08_Snow "Snow" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-snow"}
+Number:Length Day12_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-snow-depth"}
+Number:Speed Day12_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-wind-gust"}
+Number:Speed Day12_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-wind-speed"}
+Number:Angle Day12_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-wind-dir"}
+Number:Pressure Day12_Hour08_Pressure "Pressure" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-pressure"}
+Number:Length Day12_Hour08_Visibility "Visibility" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-visibility"}
+Number:Dimensionless Day12_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-cloud-cover"}
+Number:Intensity Day12_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-solar-radiation"}
+Number Day12_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-solar-energy"}
+Number Day12_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-uv-index"}
+Number Day12_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-severe-risk"}
+String Day12_Hour08_Conditions "Conditions" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-conditions"}
+String Day12_Hour08_Icon "Icon" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-icon"}
+String Day12_Hour08_Stations "Stations" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-stations"}
+String Day12_Hour08_Source "Source" (Total_Weather_Data_Day12_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour08-source"}
+
+// Day12 - Hour09
+Group Total_Weather_Data_Day12_Hour09 "Hour 09" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour09_DateTime "DateTime" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-datetime"}
+DateTime Day12_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-timestamp"}
+Number:Temperature Day12_Hour09_Temperature "Temperature" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-temperature"}
+Number:Temperature Day12_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-feels-like"}
+Number Day12_Hour09_Humidity "Humidity" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-humidity"}
+Number:Temperature Day12_Hour09_Dew "Dew Point" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-dew"}
+Number:Length Day12_Hour09_Precip "Precipitation" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-precip"}
+Number:Dimensionless Day12_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-precip-prob"}
+String Day12_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-precip-type"}
+Number:Length Day12_Hour09_Snow "Snow" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-snow"}
+Number:Length Day12_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-snow-depth"}
+Number:Speed Day12_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-wind-gust"}
+Number:Speed Day12_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-wind-speed"}
+Number:Angle Day12_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-wind-dir"}
+Number:Pressure Day12_Hour09_Pressure "Pressure" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-pressure"}
+Number:Length Day12_Hour09_Visibility "Visibility" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-visibility"}
+Number:Dimensionless Day12_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-cloud-cover"}
+Number:Intensity Day12_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-solar-radiation"}
+Number Day12_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-solar-energy"}
+Number Day12_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-uv-index"}
+Number Day12_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-severe-risk"}
+String Day12_Hour09_Conditions "Conditions" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-conditions"}
+String Day12_Hour09_Icon "Icon" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-icon"}
+String Day12_Hour09_Stations "Stations" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-stations"}
+String Day12_Hour09_Source "Source" (Total_Weather_Data_Day12_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour09-source"}
+
+// Day12 - Hour10
+Group Total_Weather_Data_Day12_Hour10 "Hour 10" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour10_DateTime "DateTime" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-datetime"}
+DateTime Day12_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-timestamp"}
+Number:Temperature Day12_Hour10_Temperature "Temperature" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-temperature"}
+Number:Temperature Day12_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-feels-like"}
+Number Day12_Hour10_Humidity "Humidity" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-humidity"}
+Number:Temperature Day12_Hour10_Dew "Dew Point" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-dew"}
+Number:Length Day12_Hour10_Precip "Precipitation" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-precip"}
+Number:Dimensionless Day12_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-precip-prob"}
+String Day12_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-precip-type"}
+Number:Length Day12_Hour10_Snow "Snow" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-snow"}
+Number:Length Day12_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-snow-depth"}
+Number:Speed Day12_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-wind-gust"}
+Number:Speed Day12_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-wind-speed"}
+Number:Angle Day12_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-wind-dir"}
+Number:Pressure Day12_Hour10_Pressure "Pressure" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-pressure"}
+Number:Length Day12_Hour10_Visibility "Visibility" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-visibility"}
+Number:Dimensionless Day12_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-cloud-cover"}
+Number:Intensity Day12_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-solar-radiation"}
+Number Day12_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-solar-energy"}
+Number Day12_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-uv-index"}
+Number Day12_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-severe-risk"}
+String Day12_Hour10_Conditions "Conditions" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-conditions"}
+String Day12_Hour10_Icon "Icon" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-icon"}
+String Day12_Hour10_Stations "Stations" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-stations"}
+String Day12_Hour10_Source "Source" (Total_Weather_Data_Day12_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour10-source"}
+
+// Day12 - Hour11
+Group Total_Weather_Data_Day12_Hour11 "Hour 11" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour11_DateTime "DateTime" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-datetime"}
+DateTime Day12_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-timestamp"}
+Number:Temperature Day12_Hour11_Temperature "Temperature" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-temperature"}
+Number:Temperature Day12_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-feels-like"}
+Number Day12_Hour11_Humidity "Humidity" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-humidity"}
+Number:Temperature Day12_Hour11_Dew "Dew Point" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-dew"}
+Number:Length Day12_Hour11_Precip "Precipitation" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-precip"}
+Number:Dimensionless Day12_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-precip-prob"}
+String Day12_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-precip-type"}
+Number:Length Day12_Hour11_Snow "Snow" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-snow"}
+Number:Length Day12_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-snow-depth"}
+Number:Speed Day12_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-wind-gust"}
+Number:Speed Day12_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-wind-speed"}
+Number:Angle Day12_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-wind-dir"}
+Number:Pressure Day12_Hour11_Pressure "Pressure" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-pressure"}
+Number:Length Day12_Hour11_Visibility "Visibility" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-visibility"}
+Number:Dimensionless Day12_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-cloud-cover"}
+Number:Intensity Day12_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-solar-radiation"}
+Number Day12_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-solar-energy"}
+Number Day12_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-uv-index"}
+Number Day12_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-severe-risk"}
+String Day12_Hour11_Conditions "Conditions" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-conditions"}
+String Day12_Hour11_Icon "Icon" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-icon"}
+String Day12_Hour11_Stations "Stations" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-stations"}
+String Day12_Hour11_Source "Source" (Total_Weather_Data_Day12_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour11-source"}
+
+// Day12 - Hour12
+Group Total_Weather_Data_Day12_Hour12 "Hour 12" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour12_DateTime "DateTime" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-datetime"}
+DateTime Day12_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-timestamp"}
+Number:Temperature Day12_Hour12_Temperature "Temperature" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-temperature"}
+Number:Temperature Day12_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-feels-like"}
+Number Day12_Hour12_Humidity "Humidity" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-humidity"}
+Number:Temperature Day12_Hour12_Dew "Dew Point" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-dew"}
+Number:Length Day12_Hour12_Precip "Precipitation" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-precip"}
+Number:Dimensionless Day12_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-precip-prob"}
+String Day12_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-precip-type"}
+Number:Length Day12_Hour12_Snow "Snow" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-snow"}
+Number:Length Day12_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-snow-depth"}
+Number:Speed Day12_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-wind-gust"}
+Number:Speed Day12_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-wind-speed"}
+Number:Angle Day12_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-wind-dir"}
+Number:Pressure Day12_Hour12_Pressure "Pressure" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-pressure"}
+Number:Length Day12_Hour12_Visibility "Visibility" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-visibility"}
+Number:Dimensionless Day12_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-cloud-cover"}
+Number:Intensity Day12_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-solar-radiation"}
+Number Day12_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-solar-energy"}
+Number Day12_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-uv-index"}
+Number Day12_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-severe-risk"}
+String Day12_Hour12_Conditions "Conditions" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-conditions"}
+String Day12_Hour12_Icon "Icon" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-icon"}
+String Day12_Hour12_Stations "Stations" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-stations"}
+String Day12_Hour12_Source "Source" (Total_Weather_Data_Day12_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour12-source"}
+
+// Day12 - Hour13
+Group Total_Weather_Data_Day12_Hour13 "Hour 13" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour13_DateTime "DateTime" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-datetime"}
+DateTime Day12_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-timestamp"}
+Number:Temperature Day12_Hour13_Temperature "Temperature" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-temperature"}
+Number:Temperature Day12_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-feels-like"}
+Number Day12_Hour13_Humidity "Humidity" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-humidity"}
+Number:Temperature Day12_Hour13_Dew "Dew Point" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-dew"}
+Number:Length Day12_Hour13_Precip "Precipitation" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-precip"}
+Number:Dimensionless Day12_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-precip-prob"}
+String Day12_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-precip-type"}
+Number:Length Day12_Hour13_Snow "Snow" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-snow"}
+Number:Length Day12_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-snow-depth"}
+Number:Speed Day12_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-wind-gust"}
+Number:Speed Day12_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-wind-speed"}
+Number:Angle Day12_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-wind-dir"}
+Number:Pressure Day12_Hour13_Pressure "Pressure" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-pressure"}
+Number:Length Day12_Hour13_Visibility "Visibility" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-visibility"}
+Number:Dimensionless Day12_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-cloud-cover"}
+Number:Intensity Day12_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-solar-radiation"}
+Number Day12_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-solar-energy"}
+Number Day12_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-uv-index"}
+Number Day12_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-severe-risk"}
+String Day12_Hour13_Conditions "Conditions" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-conditions"}
+String Day12_Hour13_Icon "Icon" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-icon"}
+String Day12_Hour13_Stations "Stations" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-stations"}
+String Day12_Hour13_Source "Source" (Total_Weather_Data_Day12_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour13-source"}
+
+// Day12 - Hour14
+Group Total_Weather_Data_Day12_Hour14 "Hour 14" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour14_DateTime "DateTime" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-datetime"}
+DateTime Day12_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-timestamp"}
+Number:Temperature Day12_Hour14_Temperature "Temperature" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-temperature"}
+Number:Temperature Day12_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-feels-like"}
+Number Day12_Hour14_Humidity "Humidity" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-humidity"}
+Number:Temperature Day12_Hour14_Dew "Dew Point" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-dew"}
+Number:Length Day12_Hour14_Precip "Precipitation" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-precip"}
+Number:Dimensionless Day12_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-precip-prob"}
+String Day12_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-precip-type"}
+Number:Length Day12_Hour14_Snow "Snow" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-snow"}
+Number:Length Day12_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-snow-depth"}
+Number:Speed Day12_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-wind-gust"}
+Number:Speed Day12_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-wind-speed"}
+Number:Angle Day12_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-wind-dir"}
+Number:Pressure Day12_Hour14_Pressure "Pressure" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-pressure"}
+Number:Length Day12_Hour14_Visibility "Visibility" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-visibility"}
+Number:Dimensionless Day12_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-cloud-cover"}
+Number:Intensity Day12_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-solar-radiation"}
+Number Day12_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-solar-energy"}
+Number Day12_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-uv-index"}
+Number Day12_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-severe-risk"}
+String Day12_Hour14_Conditions "Conditions" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-conditions"}
+String Day12_Hour14_Icon "Icon" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-icon"}
+String Day12_Hour14_Stations "Stations" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-stations"}
+String Day12_Hour14_Source "Source" (Total_Weather_Data_Day12_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour14-source"}
+
+// Day12 - Hour15
+Group Total_Weather_Data_Day12_Hour15 "Hour 15" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour15_DateTime "DateTime" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-datetime"}
+DateTime Day12_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-timestamp"}
+Number:Temperature Day12_Hour15_Temperature "Temperature" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-temperature"}
+Number:Temperature Day12_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-feels-like"}
+Number Day12_Hour15_Humidity "Humidity" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-humidity"}
+Number:Temperature Day12_Hour15_Dew "Dew Point" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-dew"}
+Number:Length Day12_Hour15_Precip "Precipitation" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-precip"}
+Number:Dimensionless Day12_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-precip-prob"}
+String Day12_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-precip-type"}
+Number:Length Day12_Hour15_Snow "Snow" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-snow"}
+Number:Length Day12_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-snow-depth"}
+Number:Speed Day12_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-wind-gust"}
+Number:Speed Day12_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-wind-speed"}
+Number:Angle Day12_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-wind-dir"}
+Number:Pressure Day12_Hour15_Pressure "Pressure" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-pressure"}
+Number:Length Day12_Hour15_Visibility "Visibility" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-visibility"}
+Number:Dimensionless Day12_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-cloud-cover"}
+Number:Intensity Day12_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-solar-radiation"}
+Number Day12_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-solar-energy"}
+Number Day12_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-uv-index"}
+Number Day12_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-severe-risk"}
+String Day12_Hour15_Conditions "Conditions" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-conditions"}
+String Day12_Hour15_Icon "Icon" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-icon"}
+String Day12_Hour15_Stations "Stations" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-stations"}
+String Day12_Hour15_Source "Source" (Total_Weather_Data_Day12_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour15-source"}
+
+// Day12 - Hour16
+Group Total_Weather_Data_Day12_Hour16 "Hour 16" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour16_DateTime "DateTime" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-datetime"}
+DateTime Day12_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-timestamp"}
+Number:Temperature Day12_Hour16_Temperature "Temperature" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-temperature"}
+Number:Temperature Day12_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-feels-like"}
+Number Day12_Hour16_Humidity "Humidity" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-humidity"}
+Number:Temperature Day12_Hour16_Dew "Dew Point" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-dew"}
+Number:Length Day12_Hour16_Precip "Precipitation" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-precip"}
+Number:Dimensionless Day12_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-precip-prob"}
+String Day12_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-precip-type"}
+Number:Length Day12_Hour16_Snow "Snow" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-snow"}
+Number:Length Day12_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-snow-depth"}
+Number:Speed Day12_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-wind-gust"}
+Number:Speed Day12_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-wind-speed"}
+Number:Angle Day12_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-wind-dir"}
+Number:Pressure Day12_Hour16_Pressure "Pressure" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-pressure"}
+Number:Length Day12_Hour16_Visibility "Visibility" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-visibility"}
+Number:Dimensionless Day12_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-cloud-cover"}
+Number:Intensity Day12_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-solar-radiation"}
+Number Day12_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-solar-energy"}
+Number Day12_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-uv-index"}
+Number Day12_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-severe-risk"}
+String Day12_Hour16_Conditions "Conditions" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-conditions"}
+String Day12_Hour16_Icon "Icon" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-icon"}
+String Day12_Hour16_Stations "Stations" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-stations"}
+String Day12_Hour16_Source "Source" (Total_Weather_Data_Day12_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour16-source"}
+
+// Day12 - Hour17
+Group Total_Weather_Data_Day12_Hour17 "Hour 17" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour17_DateTime "DateTime" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-datetime"}
+DateTime Day12_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-timestamp"}
+Number:Temperature Day12_Hour17_Temperature "Temperature" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-temperature"}
+Number:Temperature Day12_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-feels-like"}
+Number Day12_Hour17_Humidity "Humidity" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-humidity"}
+Number:Temperature Day12_Hour17_Dew "Dew Point" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-dew"}
+Number:Length Day12_Hour17_Precip "Precipitation" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-precip"}
+Number:Dimensionless Day12_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-precip-prob"}
+String Day12_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-precip-type"}
+Number:Length Day12_Hour17_Snow "Snow" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-snow"}
+Number:Length Day12_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-snow-depth"}
+Number:Speed Day12_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-wind-gust"}
+Number:Speed Day12_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-wind-speed"}
+Number:Angle Day12_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-wind-dir"}
+Number:Pressure Day12_Hour17_Pressure "Pressure" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-pressure"}
+Number:Length Day12_Hour17_Visibility "Visibility" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-visibility"}
+Number:Dimensionless Day12_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-cloud-cover"}
+Number:Intensity Day12_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-solar-radiation"}
+Number Day12_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-solar-energy"}
+Number Day12_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-uv-index"}
+Number Day12_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-severe-risk"}
+String Day12_Hour17_Conditions "Conditions" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-conditions"}
+String Day12_Hour17_Icon "Icon" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-icon"}
+String Day12_Hour17_Stations "Stations" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-stations"}
+String Day12_Hour17_Source "Source" (Total_Weather_Data_Day12_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour17-source"}
+
+// Day12 - Hour18
+Group Total_Weather_Data_Day12_Hour18 "Hour 18" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour18_DateTime "DateTime" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-datetime"}
+DateTime Day12_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-timestamp"}
+Number:Temperature Day12_Hour18_Temperature "Temperature" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-temperature"}
+Number:Temperature Day12_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-feels-like"}
+Number Day12_Hour18_Humidity "Humidity" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-humidity"}
+Number:Temperature Day12_Hour18_Dew "Dew Point" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-dew"}
+Number:Length Day12_Hour18_Precip "Precipitation" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-precip"}
+Number:Dimensionless Day12_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-precip-prob"}
+String Day12_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-precip-type"}
+Number:Length Day12_Hour18_Snow "Snow" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-snow"}
+Number:Length Day12_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-snow-depth"}
+Number:Speed Day12_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-wind-gust"}
+Number:Speed Day12_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-wind-speed"}
+Number:Angle Day12_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-wind-dir"}
+Number:Pressure Day12_Hour18_Pressure "Pressure" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-pressure"}
+Number:Length Day12_Hour18_Visibility "Visibility" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-visibility"}
+Number:Dimensionless Day12_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-cloud-cover"}
+Number:Intensity Day12_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-solar-radiation"}
+Number Day12_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-solar-energy"}
+Number Day12_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-uv-index"}
+Number Day12_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-severe-risk"}
+String Day12_Hour18_Conditions "Conditions" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-conditions"}
+String Day12_Hour18_Icon "Icon" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-icon"}
+String Day12_Hour18_Stations "Stations" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-stations"}
+String Day12_Hour18_Source "Source" (Total_Weather_Data_Day12_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour18-source"}
+
+// Day12 - Hour19
+Group Total_Weather_Data_Day12_Hour19 "Hour 19" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour19_DateTime "DateTime" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-datetime"}
+DateTime Day12_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-timestamp"}
+Number:Temperature Day12_Hour19_Temperature "Temperature" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-temperature"}
+Number:Temperature Day12_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-feels-like"}
+Number Day12_Hour19_Humidity "Humidity" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-humidity"}
+Number:Temperature Day12_Hour19_Dew "Dew Point" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-dew"}
+Number:Length Day12_Hour19_Precip "Precipitation" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-precip"}
+Number:Dimensionless Day12_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-precip-prob"}
+String Day12_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-precip-type"}
+Number:Length Day12_Hour19_Snow "Snow" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-snow"}
+Number:Length Day12_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-snow-depth"}
+Number:Speed Day12_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-wind-gust"}
+Number:Speed Day12_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-wind-speed"}
+Number:Angle Day12_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-wind-dir"}
+Number:Pressure Day12_Hour19_Pressure "Pressure" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-pressure"}
+Number:Length Day12_Hour19_Visibility "Visibility" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-visibility"}
+Number:Dimensionless Day12_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-cloud-cover"}
+Number:Intensity Day12_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-solar-radiation"}
+Number Day12_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-solar-energy"}
+Number Day12_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-uv-index"}
+Number Day12_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-severe-risk"}
+String Day12_Hour19_Conditions "Conditions" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-conditions"}
+String Day12_Hour19_Icon "Icon" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-icon"}
+String Day12_Hour19_Stations "Stations" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-stations"}
+String Day12_Hour19_Source "Source" (Total_Weather_Data_Day12_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour19-source"}
+
+// Day12 - Hour20
+Group Total_Weather_Data_Day12_Hour20 "Hour 20" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour20_DateTime "DateTime" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-datetime"}
+DateTime Day12_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-timestamp"}
+Number:Temperature Day12_Hour20_Temperature "Temperature" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-temperature"}
+Number:Temperature Day12_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-feels-like"}
+Number Day12_Hour20_Humidity "Humidity" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-humidity"}
+Number:Temperature Day12_Hour20_Dew "Dew Point" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-dew"}
+Number:Length Day12_Hour20_Precip "Precipitation" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-precip"}
+Number:Dimensionless Day12_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-precip-prob"}
+String Day12_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-precip-type"}
+Number:Length Day12_Hour20_Snow "Snow" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-snow"}
+Number:Length Day12_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-snow-depth"}
+Number:Speed Day12_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-wind-gust"}
+Number:Speed Day12_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-wind-speed"}
+Number:Angle Day12_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-wind-dir"}
+Number:Pressure Day12_Hour20_Pressure "Pressure" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-pressure"}
+Number:Length Day12_Hour20_Visibility "Visibility" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-visibility"}
+Number:Dimensionless Day12_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-cloud-cover"}
+Number:Intensity Day12_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-solar-radiation"}
+Number Day12_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-solar-energy"}
+Number Day12_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-uv-index"}
+Number Day12_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-severe-risk"}
+String Day12_Hour20_Conditions "Conditions" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-conditions"}
+String Day12_Hour20_Icon "Icon" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-icon"}
+String Day12_Hour20_Stations "Stations" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-stations"}
+String Day12_Hour20_Source "Source" (Total_Weather_Data_Day12_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour20-source"}
+
+// Day12 - Hour21
+Group Total_Weather_Data_Day12_Hour21 "Hour 21" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour21_DateTime "DateTime" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-datetime"}
+DateTime Day12_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-timestamp"}
+Number:Temperature Day12_Hour21_Temperature "Temperature" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-temperature"}
+Number:Temperature Day12_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-feels-like"}
+Number Day12_Hour21_Humidity "Humidity" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-humidity"}
+Number:Temperature Day12_Hour21_Dew "Dew Point" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-dew"}
+Number:Length Day12_Hour21_Precip "Precipitation" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-precip"}
+Number:Dimensionless Day12_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-precip-prob"}
+String Day12_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-precip-type"}
+Number:Length Day12_Hour21_Snow "Snow" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-snow"}
+Number:Length Day12_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-snow-depth"}
+Number:Speed Day12_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-wind-gust"}
+Number:Speed Day12_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-wind-speed"}
+Number:Angle Day12_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-wind-dir"}
+Number:Pressure Day12_Hour21_Pressure "Pressure" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-pressure"}
+Number:Length Day12_Hour21_Visibility "Visibility" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-visibility"}
+Number:Dimensionless Day12_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-cloud-cover"}
+Number:Intensity Day12_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-solar-radiation"}
+Number Day12_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-solar-energy"}
+Number Day12_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-uv-index"}
+Number Day12_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-severe-risk"}
+String Day12_Hour21_Conditions "Conditions" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-conditions"}
+String Day12_Hour21_Icon "Icon" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-icon"}
+String Day12_Hour21_Stations "Stations" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-stations"}
+String Day12_Hour21_Source "Source" (Total_Weather_Data_Day12_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour21-source"}
+
+// Day12 - Hour22
+Group Total_Weather_Data_Day12_Hour22 "Hour 22" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour22_DateTime "DateTime" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-datetime"}
+DateTime Day12_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-timestamp"}
+Number:Temperature Day12_Hour22_Temperature "Temperature" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-temperature"}
+Number:Temperature Day12_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-feels-like"}
+Number Day12_Hour22_Humidity "Humidity" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-humidity"}
+Number:Temperature Day12_Hour22_Dew "Dew Point" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-dew"}
+Number:Length Day12_Hour22_Precip "Precipitation" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-precip"}
+Number:Dimensionless Day12_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-precip-prob"}
+String Day12_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-precip-type"}
+Number:Length Day12_Hour22_Snow "Snow" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-snow"}
+Number:Length Day12_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-snow-depth"}
+Number:Speed Day12_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-wind-gust"}
+Number:Speed Day12_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-wind-speed"}
+Number:Angle Day12_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-wind-dir"}
+Number:Pressure Day12_Hour22_Pressure "Pressure" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-pressure"}
+Number:Length Day12_Hour22_Visibility "Visibility" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-visibility"}
+Number:Dimensionless Day12_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-cloud-cover"}
+Number:Intensity Day12_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-solar-radiation"}
+Number Day12_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-solar-energy"}
+Number Day12_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-uv-index"}
+Number Day12_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-severe-risk"}
+String Day12_Hour22_Conditions "Conditions" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-conditions"}
+String Day12_Hour22_Icon "Icon" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-icon"}
+String Day12_Hour22_Stations "Stations" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-stations"}
+String Day12_Hour22_Source "Source" (Total_Weather_Data_Day12_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour22-source"}
+
+// Day12 - Hour23
+Group Total_Weather_Data_Day12_Hour23 "Hour 23" (Total_Weather_Data_Day12) [ "Equipment" ] 
+String Day12_Hour23_DateTime "DateTime" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-datetime"}
+DateTime Day12_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-timestamp"}
+Number:Temperature Day12_Hour23_Temperature "Temperature" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-temperature"}
+Number:Temperature Day12_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-feels-like"}
+Number Day12_Hour23_Humidity "Humidity" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-humidity"}
+Number:Temperature Day12_Hour23_Dew "Dew Point" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-dew"}
+Number:Length Day12_Hour23_Precip "Precipitation" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-precip"}
+Number:Dimensionless Day12_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-precip-prob"}
+String Day12_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-precip-type"}
+Number:Length Day12_Hour23_Snow "Snow" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-snow"}
+Number:Length Day12_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-snow-depth"}
+Number:Speed Day12_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-wind-gust"}
+Number:Speed Day12_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-wind-speed"}
+Number:Angle Day12_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-wind-dir"}
+Number:Pressure Day12_Hour23_Pressure "Pressure" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-pressure"}
+Number:Length Day12_Hour23_Visibility "Visibility" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-visibility"}
+Number:Dimensionless Day12_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-cloud-cover"}
+Number:Intensity Day12_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-solar-radiation"}
+Number Day12_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-solar-energy"}
+Number Day12_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-uv-index"}
+Number Day12_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-severe-risk"}
+String Day12_Hour23_Conditions "Conditions" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-conditions"}
+String Day12_Hour23_Icon "Icon" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-icon"}
+String Day12_Hour23_Stations "Stations" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-stations"}
+String Day12_Hour23_Source "Source" (Total_Weather_Data_Day12_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day12#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_13.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_13.items
@@ -1,39 +1,712 @@
 // Day13
 Group Total_Weather_Data_Day13 "Day T+13" (Total_Weather_Data) [ "Equipment" ] 
-String Day13_DateTime "Time" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day13_Timestamp "Timestamp" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day13_Temperature "Temperature" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day13_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day13_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day13_FeelsLike "Feels Like" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day13_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day13_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day13_Dew "Dew Point" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day13_Humidity "Humidity" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day13_Precip "Precipitation" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day13_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day13_Precip_Type "Precipitation Type" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day13_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day13_Snow "Snow" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day13_Snow_Depth "Snow Depth" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day13_Wind_Gust "Wind Gust" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day13_Wind_Speed "Wind Speed" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day13_Wind_Dir "Wind Direction" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day13_Pressure "Pressure" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day13_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day13_Visibility "Visibility" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day13_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day13_Solar_Energy "Solar Energy" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day13_UV_Index "UV Index" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day13_Sunrise "Sunrise" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day13_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day13_Sunset "Sunset" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day13_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day13_Moon_Phase "Moon Phase" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day13_Conditions "Conditions" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day13_Description "Description" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day13_Icon "Icon" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day13_Stations "Stations" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day13_Source "Source" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day13_Severe_Risk "Severe Risk" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day13_DateTime "Time" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#datetime" }
+DateTime Day13_Timestamp "Timestamp" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#timestamp" }
+Number:Temperature Day13_Temperature "Temperature" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#temperature" }
+Number:Temperature Day13_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#temperature-min" }
+Number:Temperature Day13_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#temperature-max" }
+Number:Temperature Day13_FeelsLike "Feels Like" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#feels-like" }
+Number:Temperature Day13_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#feels-like-min" }
+Number:Temperature Day13_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#feels-like-max" }
+Number:Temperature Day13_Dew "Dew Point" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#dew" }
+Number Day13_Humidity "Humidity" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#humidity" }
+Number:Length Day13_Precip "Precipitation" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#precip" }
+Number Day13_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#precip-prob" }
+String Day13_Precip_Type "Precipitation Type" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#precip-type" }
+Number Day13_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#precip-cover" }
+Number:Length Day13_Snow "Snow" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#snow" }
+Number:Length Day13_Snow_Depth "Snow Depth" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#snow-depth" }
+Number:Speed Day13_Wind_Gust "Wind Gust" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#wind-gust" }
+Number:Speed Day13_Wind_Speed "Wind Speed" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#wind-speed" }
+Number:Angle Day13_Wind_Dir "Wind Direction" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#wind-dir" }
+Number:Pressure Day13_Pressure "Pressure" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#pressure" }
+Number Day13_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#cloud-cover" }
+Number:Length Day13_Visibility "Visibility" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#visibility" }
+Number:Intensity Day13_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#solar-radiation" }
+Number Day13_Solar_Energy "Solar Energy" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#solar-energy" }
+Number Day13_UV_Index "UV Index" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#uv-index" }
+String Day13_Sunrise "Sunrise" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#sunrise" }
+DateTime Day13_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#sunrise-epoch" }
+String Day13_Sunset "Sunset" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#sunset" }
+DateTime Day13_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#sunset-epoch" }
+Number Day13_Moon_Phase "Moon Phase" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#moon-phase" }
+String Day13_Conditions "Conditions" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#conditions" }
+String Day13_Description "Description" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#description" }
+String Day13_Icon "Icon" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#icon" }
+String Day13_Stations "Stations" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#stations" }
+String Day13_Source "Source" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#source" }
+Number Day13_Severe_Risk "Severe Risk" (Total_Weather_Data_Day13)["Point"] { channel="visualcrossing:weather:default_config:day13#severe-risk" }
+
+// Day13 - Hour00
+Group Total_Weather_Data_Day13_Hour00 "Hour 00" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour00_DateTime "DateTime" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-datetime"}
+DateTime Day13_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-timestamp"}
+Number:Temperature Day13_Hour00_Temperature "Temperature" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-temperature"}
+Number:Temperature Day13_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-feels-like"}
+Number Day13_Hour00_Humidity "Humidity" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-humidity"}
+Number:Temperature Day13_Hour00_Dew "Dew Point" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-dew"}
+Number:Length Day13_Hour00_Precip "Precipitation" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-precip"}
+Number:Dimensionless Day13_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-precip-prob"}
+String Day13_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-precip-type"}
+Number:Length Day13_Hour00_Snow "Snow" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-snow"}
+Number:Length Day13_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-snow-depth"}
+Number:Speed Day13_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-wind-gust"}
+Number:Speed Day13_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-wind-speed"}
+Number:Angle Day13_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-wind-dir"}
+Number:Pressure Day13_Hour00_Pressure "Pressure" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-pressure"}
+Number:Length Day13_Hour00_Visibility "Visibility" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-visibility"}
+Number:Dimensionless Day13_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-cloud-cover"}
+Number:Intensity Day13_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-solar-radiation"}
+Number Day13_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-solar-energy"}
+Number Day13_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-uv-index"}
+Number Day13_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-severe-risk"}
+String Day13_Hour00_Conditions "Conditions" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-conditions"}
+String Day13_Hour00_Icon "Icon" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-icon"}
+String Day13_Hour00_Stations "Stations" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-stations"}
+String Day13_Hour00_Source "Source" (Total_Weather_Data_Day13_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour00-source"}
+
+// Day13 - Hour01
+Group Total_Weather_Data_Day13_Hour01 "Hour 01" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour01_DateTime "DateTime" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-datetime"}
+DateTime Day13_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-timestamp"}
+Number:Temperature Day13_Hour01_Temperature "Temperature" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-temperature"}
+Number:Temperature Day13_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-feels-like"}
+Number Day13_Hour01_Humidity "Humidity" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-humidity"}
+Number:Temperature Day13_Hour01_Dew "Dew Point" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-dew"}
+Number:Length Day13_Hour01_Precip "Precipitation" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-precip"}
+Number:Dimensionless Day13_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-precip-prob"}
+String Day13_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-precip-type"}
+Number:Length Day13_Hour01_Snow "Snow" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-snow"}
+Number:Length Day13_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-snow-depth"}
+Number:Speed Day13_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-wind-gust"}
+Number:Speed Day13_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-wind-speed"}
+Number:Angle Day13_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-wind-dir"}
+Number:Pressure Day13_Hour01_Pressure "Pressure" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-pressure"}
+Number:Length Day13_Hour01_Visibility "Visibility" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-visibility"}
+Number:Dimensionless Day13_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-cloud-cover"}
+Number:Intensity Day13_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-solar-radiation"}
+Number Day13_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-solar-energy"}
+Number Day13_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-uv-index"}
+Number Day13_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-severe-risk"}
+String Day13_Hour01_Conditions "Conditions" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-conditions"}
+String Day13_Hour01_Icon "Icon" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-icon"}
+String Day13_Hour01_Stations "Stations" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-stations"}
+String Day13_Hour01_Source "Source" (Total_Weather_Data_Day13_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour01-source"}
+
+// Day13 - Hour02
+Group Total_Weather_Data_Day13_Hour02 "Hour 02" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour02_DateTime "DateTime" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-datetime"}
+DateTime Day13_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-timestamp"}
+Number:Temperature Day13_Hour02_Temperature "Temperature" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-temperature"}
+Number:Temperature Day13_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-feels-like"}
+Number Day13_Hour02_Humidity "Humidity" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-humidity"}
+Number:Temperature Day13_Hour02_Dew "Dew Point" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-dew"}
+Number:Length Day13_Hour02_Precip "Precipitation" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-precip"}
+Number:Dimensionless Day13_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-precip-prob"}
+String Day13_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-precip-type"}
+Number:Length Day13_Hour02_Snow "Snow" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-snow"}
+Number:Length Day13_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-snow-depth"}
+Number:Speed Day13_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-wind-gust"}
+Number:Speed Day13_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-wind-speed"}
+Number:Angle Day13_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-wind-dir"}
+Number:Pressure Day13_Hour02_Pressure "Pressure" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-pressure"}
+Number:Length Day13_Hour02_Visibility "Visibility" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-visibility"}
+Number:Dimensionless Day13_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-cloud-cover"}
+Number:Intensity Day13_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-solar-radiation"}
+Number Day13_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-solar-energy"}
+Number Day13_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-uv-index"}
+Number Day13_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-severe-risk"}
+String Day13_Hour02_Conditions "Conditions" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-conditions"}
+String Day13_Hour02_Icon "Icon" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-icon"}
+String Day13_Hour02_Stations "Stations" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-stations"}
+String Day13_Hour02_Source "Source" (Total_Weather_Data_Day13_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour02-source"}
+
+// Day13 - Hour03
+Group Total_Weather_Data_Day13_Hour03 "Hour 03" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour03_DateTime "DateTime" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-datetime"}
+DateTime Day13_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-timestamp"}
+Number:Temperature Day13_Hour03_Temperature "Temperature" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-temperature"}
+Number:Temperature Day13_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-feels-like"}
+Number Day13_Hour03_Humidity "Humidity" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-humidity"}
+Number:Temperature Day13_Hour03_Dew "Dew Point" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-dew"}
+Number:Length Day13_Hour03_Precip "Precipitation" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-precip"}
+Number:Dimensionless Day13_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-precip-prob"}
+String Day13_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-precip-type"}
+Number:Length Day13_Hour03_Snow "Snow" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-snow"}
+Number:Length Day13_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-snow-depth"}
+Number:Speed Day13_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-wind-gust"}
+Number:Speed Day13_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-wind-speed"}
+Number:Angle Day13_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-wind-dir"}
+Number:Pressure Day13_Hour03_Pressure "Pressure" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-pressure"}
+Number:Length Day13_Hour03_Visibility "Visibility" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-visibility"}
+Number:Dimensionless Day13_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-cloud-cover"}
+Number:Intensity Day13_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-solar-radiation"}
+Number Day13_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-solar-energy"}
+Number Day13_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-uv-index"}
+Number Day13_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-severe-risk"}
+String Day13_Hour03_Conditions "Conditions" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-conditions"}
+String Day13_Hour03_Icon "Icon" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-icon"}
+String Day13_Hour03_Stations "Stations" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-stations"}
+String Day13_Hour03_Source "Source" (Total_Weather_Data_Day13_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour03-source"}
+
+// Day13 - Hour04
+Group Total_Weather_Data_Day13_Hour04 "Hour 04" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour04_DateTime "DateTime" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-datetime"}
+DateTime Day13_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-timestamp"}
+Number:Temperature Day13_Hour04_Temperature "Temperature" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-temperature"}
+Number:Temperature Day13_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-feels-like"}
+Number Day13_Hour04_Humidity "Humidity" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-humidity"}
+Number:Temperature Day13_Hour04_Dew "Dew Point" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-dew"}
+Number:Length Day13_Hour04_Precip "Precipitation" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-precip"}
+Number:Dimensionless Day13_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-precip-prob"}
+String Day13_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-precip-type"}
+Number:Length Day13_Hour04_Snow "Snow" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-snow"}
+Number:Length Day13_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-snow-depth"}
+Number:Speed Day13_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-wind-gust"}
+Number:Speed Day13_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-wind-speed"}
+Number:Angle Day13_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-wind-dir"}
+Number:Pressure Day13_Hour04_Pressure "Pressure" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-pressure"}
+Number:Length Day13_Hour04_Visibility "Visibility" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-visibility"}
+Number:Dimensionless Day13_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-cloud-cover"}
+Number:Intensity Day13_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-solar-radiation"}
+Number Day13_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-solar-energy"}
+Number Day13_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-uv-index"}
+Number Day13_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-severe-risk"}
+String Day13_Hour04_Conditions "Conditions" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-conditions"}
+String Day13_Hour04_Icon "Icon" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-icon"}
+String Day13_Hour04_Stations "Stations" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-stations"}
+String Day13_Hour04_Source "Source" (Total_Weather_Data_Day13_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour04-source"}
+
+// Day13 - Hour05
+Group Total_Weather_Data_Day13_Hour05 "Hour 05" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour05_DateTime "DateTime" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-datetime"}
+DateTime Day13_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-timestamp"}
+Number:Temperature Day13_Hour05_Temperature "Temperature" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-temperature"}
+Number:Temperature Day13_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-feels-like"}
+Number Day13_Hour05_Humidity "Humidity" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-humidity"}
+Number:Temperature Day13_Hour05_Dew "Dew Point" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-dew"}
+Number:Length Day13_Hour05_Precip "Precipitation" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-precip"}
+Number:Dimensionless Day13_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-precip-prob"}
+String Day13_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-precip-type"}
+Number:Length Day13_Hour05_Snow "Snow" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-snow"}
+Number:Length Day13_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-snow-depth"}
+Number:Speed Day13_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-wind-gust"}
+Number:Speed Day13_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-wind-speed"}
+Number:Angle Day13_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-wind-dir"}
+Number:Pressure Day13_Hour05_Pressure "Pressure" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-pressure"}
+Number:Length Day13_Hour05_Visibility "Visibility" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-visibility"}
+Number:Dimensionless Day13_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-cloud-cover"}
+Number:Intensity Day13_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-solar-radiation"}
+Number Day13_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-solar-energy"}
+Number Day13_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-uv-index"}
+Number Day13_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-severe-risk"}
+String Day13_Hour05_Conditions "Conditions" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-conditions"}
+String Day13_Hour05_Icon "Icon" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-icon"}
+String Day13_Hour05_Stations "Stations" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-stations"}
+String Day13_Hour05_Source "Source" (Total_Weather_Data_Day13_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour05-source"}
+
+// Day13 - Hour06
+Group Total_Weather_Data_Day13_Hour06 "Hour 06" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour06_DateTime "DateTime" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-datetime"}
+DateTime Day13_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-timestamp"}
+Number:Temperature Day13_Hour06_Temperature "Temperature" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-temperature"}
+Number:Temperature Day13_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-feels-like"}
+Number Day13_Hour06_Humidity "Humidity" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-humidity"}
+Number:Temperature Day13_Hour06_Dew "Dew Point" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-dew"}
+Number:Length Day13_Hour06_Precip "Precipitation" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-precip"}
+Number:Dimensionless Day13_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-precip-prob"}
+String Day13_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-precip-type"}
+Number:Length Day13_Hour06_Snow "Snow" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-snow"}
+Number:Length Day13_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-snow-depth"}
+Number:Speed Day13_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-wind-gust"}
+Number:Speed Day13_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-wind-speed"}
+Number:Angle Day13_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-wind-dir"}
+Number:Pressure Day13_Hour06_Pressure "Pressure" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-pressure"}
+Number:Length Day13_Hour06_Visibility "Visibility" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-visibility"}
+Number:Dimensionless Day13_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-cloud-cover"}
+Number:Intensity Day13_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-solar-radiation"}
+Number Day13_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-solar-energy"}
+Number Day13_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-uv-index"}
+Number Day13_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-severe-risk"}
+String Day13_Hour06_Conditions "Conditions" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-conditions"}
+String Day13_Hour06_Icon "Icon" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-icon"}
+String Day13_Hour06_Stations "Stations" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-stations"}
+String Day13_Hour06_Source "Source" (Total_Weather_Data_Day13_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour06-source"}
+
+// Day13 - Hour07
+Group Total_Weather_Data_Day13_Hour07 "Hour 07" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour07_DateTime "DateTime" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-datetime"}
+DateTime Day13_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-timestamp"}
+Number:Temperature Day13_Hour07_Temperature "Temperature" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-temperature"}
+Number:Temperature Day13_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-feels-like"}
+Number Day13_Hour07_Humidity "Humidity" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-humidity"}
+Number:Temperature Day13_Hour07_Dew "Dew Point" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-dew"}
+Number:Length Day13_Hour07_Precip "Precipitation" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-precip"}
+Number:Dimensionless Day13_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-precip-prob"}
+String Day13_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-precip-type"}
+Number:Length Day13_Hour07_Snow "Snow" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-snow"}
+Number:Length Day13_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-snow-depth"}
+Number:Speed Day13_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-wind-gust"}
+Number:Speed Day13_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-wind-speed"}
+Number:Angle Day13_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-wind-dir"}
+Number:Pressure Day13_Hour07_Pressure "Pressure" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-pressure"}
+Number:Length Day13_Hour07_Visibility "Visibility" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-visibility"}
+Number:Dimensionless Day13_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-cloud-cover"}
+Number:Intensity Day13_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-solar-radiation"}
+Number Day13_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-solar-energy"}
+Number Day13_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-uv-index"}
+Number Day13_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-severe-risk"}
+String Day13_Hour07_Conditions "Conditions" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-conditions"}
+String Day13_Hour07_Icon "Icon" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-icon"}
+String Day13_Hour07_Stations "Stations" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-stations"}
+String Day13_Hour07_Source "Source" (Total_Weather_Data_Day13_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour07-source"}
+
+// Day13 - Hour08
+Group Total_Weather_Data_Day13_Hour08 "Hour 08" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour08_DateTime "DateTime" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-datetime"}
+DateTime Day13_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-timestamp"}
+Number:Temperature Day13_Hour08_Temperature "Temperature" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-temperature"}
+Number:Temperature Day13_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-feels-like"}
+Number Day13_Hour08_Humidity "Humidity" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-humidity"}
+Number:Temperature Day13_Hour08_Dew "Dew Point" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-dew"}
+Number:Length Day13_Hour08_Precip "Precipitation" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-precip"}
+Number:Dimensionless Day13_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-precip-prob"}
+String Day13_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-precip-type"}
+Number:Length Day13_Hour08_Snow "Snow" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-snow"}
+Number:Length Day13_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-snow-depth"}
+Number:Speed Day13_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-wind-gust"}
+Number:Speed Day13_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-wind-speed"}
+Number:Angle Day13_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-wind-dir"}
+Number:Pressure Day13_Hour08_Pressure "Pressure" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-pressure"}
+Number:Length Day13_Hour08_Visibility "Visibility" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-visibility"}
+Number:Dimensionless Day13_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-cloud-cover"}
+Number:Intensity Day13_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-solar-radiation"}
+Number Day13_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-solar-energy"}
+Number Day13_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-uv-index"}
+Number Day13_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-severe-risk"}
+String Day13_Hour08_Conditions "Conditions" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-conditions"}
+String Day13_Hour08_Icon "Icon" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-icon"}
+String Day13_Hour08_Stations "Stations" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-stations"}
+String Day13_Hour08_Source "Source" (Total_Weather_Data_Day13_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour08-source"}
+
+// Day13 - Hour09
+Group Total_Weather_Data_Day13_Hour09 "Hour 09" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour09_DateTime "DateTime" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-datetime"}
+DateTime Day13_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-timestamp"}
+Number:Temperature Day13_Hour09_Temperature "Temperature" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-temperature"}
+Number:Temperature Day13_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-feels-like"}
+Number Day13_Hour09_Humidity "Humidity" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-humidity"}
+Number:Temperature Day13_Hour09_Dew "Dew Point" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-dew"}
+Number:Length Day13_Hour09_Precip "Precipitation" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-precip"}
+Number:Dimensionless Day13_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-precip-prob"}
+String Day13_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-precip-type"}
+Number:Length Day13_Hour09_Snow "Snow" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-snow"}
+Number:Length Day13_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-snow-depth"}
+Number:Speed Day13_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-wind-gust"}
+Number:Speed Day13_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-wind-speed"}
+Number:Angle Day13_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-wind-dir"}
+Number:Pressure Day13_Hour09_Pressure "Pressure" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-pressure"}
+Number:Length Day13_Hour09_Visibility "Visibility" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-visibility"}
+Number:Dimensionless Day13_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-cloud-cover"}
+Number:Intensity Day13_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-solar-radiation"}
+Number Day13_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-solar-energy"}
+Number Day13_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-uv-index"}
+Number Day13_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-severe-risk"}
+String Day13_Hour09_Conditions "Conditions" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-conditions"}
+String Day13_Hour09_Icon "Icon" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-icon"}
+String Day13_Hour09_Stations "Stations" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-stations"}
+String Day13_Hour09_Source "Source" (Total_Weather_Data_Day13_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour09-source"}
+
+// Day13 - Hour10
+Group Total_Weather_Data_Day13_Hour10 "Hour 10" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour10_DateTime "DateTime" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-datetime"}
+DateTime Day13_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-timestamp"}
+Number:Temperature Day13_Hour10_Temperature "Temperature" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-temperature"}
+Number:Temperature Day13_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-feels-like"}
+Number Day13_Hour10_Humidity "Humidity" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-humidity"}
+Number:Temperature Day13_Hour10_Dew "Dew Point" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-dew"}
+Number:Length Day13_Hour10_Precip "Precipitation" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-precip"}
+Number:Dimensionless Day13_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-precip-prob"}
+String Day13_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-precip-type"}
+Number:Length Day13_Hour10_Snow "Snow" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-snow"}
+Number:Length Day13_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-snow-depth"}
+Number:Speed Day13_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-wind-gust"}
+Number:Speed Day13_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-wind-speed"}
+Number:Angle Day13_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-wind-dir"}
+Number:Pressure Day13_Hour10_Pressure "Pressure" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-pressure"}
+Number:Length Day13_Hour10_Visibility "Visibility" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-visibility"}
+Number:Dimensionless Day13_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-cloud-cover"}
+Number:Intensity Day13_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-solar-radiation"}
+Number Day13_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-solar-energy"}
+Number Day13_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-uv-index"}
+Number Day13_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-severe-risk"}
+String Day13_Hour10_Conditions "Conditions" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-conditions"}
+String Day13_Hour10_Icon "Icon" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-icon"}
+String Day13_Hour10_Stations "Stations" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-stations"}
+String Day13_Hour10_Source "Source" (Total_Weather_Data_Day13_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour10-source"}
+
+// Day13 - Hour11
+Group Total_Weather_Data_Day13_Hour11 "Hour 11" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour11_DateTime "DateTime" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-datetime"}
+DateTime Day13_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-timestamp"}
+Number:Temperature Day13_Hour11_Temperature "Temperature" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-temperature"}
+Number:Temperature Day13_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-feels-like"}
+Number Day13_Hour11_Humidity "Humidity" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-humidity"}
+Number:Temperature Day13_Hour11_Dew "Dew Point" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-dew"}
+Number:Length Day13_Hour11_Precip "Precipitation" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-precip"}
+Number:Dimensionless Day13_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-precip-prob"}
+String Day13_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-precip-type"}
+Number:Length Day13_Hour11_Snow "Snow" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-snow"}
+Number:Length Day13_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-snow-depth"}
+Number:Speed Day13_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-wind-gust"}
+Number:Speed Day13_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-wind-speed"}
+Number:Angle Day13_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-wind-dir"}
+Number:Pressure Day13_Hour11_Pressure "Pressure" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-pressure"}
+Number:Length Day13_Hour11_Visibility "Visibility" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-visibility"}
+Number:Dimensionless Day13_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-cloud-cover"}
+Number:Intensity Day13_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-solar-radiation"}
+Number Day13_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-solar-energy"}
+Number Day13_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-uv-index"}
+Number Day13_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-severe-risk"}
+String Day13_Hour11_Conditions "Conditions" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-conditions"}
+String Day13_Hour11_Icon "Icon" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-icon"}
+String Day13_Hour11_Stations "Stations" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-stations"}
+String Day13_Hour11_Source "Source" (Total_Weather_Data_Day13_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour11-source"}
+
+// Day13 - Hour12
+Group Total_Weather_Data_Day13_Hour12 "Hour 12" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour12_DateTime "DateTime" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-datetime"}
+DateTime Day13_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-timestamp"}
+Number:Temperature Day13_Hour12_Temperature "Temperature" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-temperature"}
+Number:Temperature Day13_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-feels-like"}
+Number Day13_Hour12_Humidity "Humidity" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-humidity"}
+Number:Temperature Day13_Hour12_Dew "Dew Point" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-dew"}
+Number:Length Day13_Hour12_Precip "Precipitation" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-precip"}
+Number:Dimensionless Day13_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-precip-prob"}
+String Day13_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-precip-type"}
+Number:Length Day13_Hour12_Snow "Snow" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-snow"}
+Number:Length Day13_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-snow-depth"}
+Number:Speed Day13_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-wind-gust"}
+Number:Speed Day13_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-wind-speed"}
+Number:Angle Day13_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-wind-dir"}
+Number:Pressure Day13_Hour12_Pressure "Pressure" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-pressure"}
+Number:Length Day13_Hour12_Visibility "Visibility" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-visibility"}
+Number:Dimensionless Day13_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-cloud-cover"}
+Number:Intensity Day13_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-solar-radiation"}
+Number Day13_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-solar-energy"}
+Number Day13_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-uv-index"}
+Number Day13_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-severe-risk"}
+String Day13_Hour12_Conditions "Conditions" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-conditions"}
+String Day13_Hour12_Icon "Icon" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-icon"}
+String Day13_Hour12_Stations "Stations" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-stations"}
+String Day13_Hour12_Source "Source" (Total_Weather_Data_Day13_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour12-source"}
+
+// Day13 - Hour13
+Group Total_Weather_Data_Day13_Hour13 "Hour 13" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour13_DateTime "DateTime" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-datetime"}
+DateTime Day13_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-timestamp"}
+Number:Temperature Day13_Hour13_Temperature "Temperature" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-temperature"}
+Number:Temperature Day13_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-feels-like"}
+Number Day13_Hour13_Humidity "Humidity" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-humidity"}
+Number:Temperature Day13_Hour13_Dew "Dew Point" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-dew"}
+Number:Length Day13_Hour13_Precip "Precipitation" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-precip"}
+Number:Dimensionless Day13_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-precip-prob"}
+String Day13_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-precip-type"}
+Number:Length Day13_Hour13_Snow "Snow" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-snow"}
+Number:Length Day13_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-snow-depth"}
+Number:Speed Day13_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-wind-gust"}
+Number:Speed Day13_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-wind-speed"}
+Number:Angle Day13_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-wind-dir"}
+Number:Pressure Day13_Hour13_Pressure "Pressure" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-pressure"}
+Number:Length Day13_Hour13_Visibility "Visibility" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-visibility"}
+Number:Dimensionless Day13_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-cloud-cover"}
+Number:Intensity Day13_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-solar-radiation"}
+Number Day13_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-solar-energy"}
+Number Day13_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-uv-index"}
+Number Day13_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-severe-risk"}
+String Day13_Hour13_Conditions "Conditions" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-conditions"}
+String Day13_Hour13_Icon "Icon" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-icon"}
+String Day13_Hour13_Stations "Stations" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-stations"}
+String Day13_Hour13_Source "Source" (Total_Weather_Data_Day13_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour13-source"}
+
+// Day13 - Hour14
+Group Total_Weather_Data_Day13_Hour14 "Hour 14" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour14_DateTime "DateTime" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-datetime"}
+DateTime Day13_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-timestamp"}
+Number:Temperature Day13_Hour14_Temperature "Temperature" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-temperature"}
+Number:Temperature Day13_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-feels-like"}
+Number Day13_Hour14_Humidity "Humidity" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-humidity"}
+Number:Temperature Day13_Hour14_Dew "Dew Point" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-dew"}
+Number:Length Day13_Hour14_Precip "Precipitation" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-precip"}
+Number:Dimensionless Day13_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-precip-prob"}
+String Day13_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-precip-type"}
+Number:Length Day13_Hour14_Snow "Snow" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-snow"}
+Number:Length Day13_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-snow-depth"}
+Number:Speed Day13_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-wind-gust"}
+Number:Speed Day13_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-wind-speed"}
+Number:Angle Day13_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-wind-dir"}
+Number:Pressure Day13_Hour14_Pressure "Pressure" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-pressure"}
+Number:Length Day13_Hour14_Visibility "Visibility" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-visibility"}
+Number:Dimensionless Day13_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-cloud-cover"}
+Number:Intensity Day13_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-solar-radiation"}
+Number Day13_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-solar-energy"}
+Number Day13_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-uv-index"}
+Number Day13_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-severe-risk"}
+String Day13_Hour14_Conditions "Conditions" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-conditions"}
+String Day13_Hour14_Icon "Icon" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-icon"}
+String Day13_Hour14_Stations "Stations" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-stations"}
+String Day13_Hour14_Source "Source" (Total_Weather_Data_Day13_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour14-source"}
+
+// Day13 - Hour15
+Group Total_Weather_Data_Day13_Hour15 "Hour 15" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour15_DateTime "DateTime" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-datetime"}
+DateTime Day13_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-timestamp"}
+Number:Temperature Day13_Hour15_Temperature "Temperature" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-temperature"}
+Number:Temperature Day13_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-feels-like"}
+Number Day13_Hour15_Humidity "Humidity" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-humidity"}
+Number:Temperature Day13_Hour15_Dew "Dew Point" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-dew"}
+Number:Length Day13_Hour15_Precip "Precipitation" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-precip"}
+Number:Dimensionless Day13_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-precip-prob"}
+String Day13_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-precip-type"}
+Number:Length Day13_Hour15_Snow "Snow" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-snow"}
+Number:Length Day13_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-snow-depth"}
+Number:Speed Day13_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-wind-gust"}
+Number:Speed Day13_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-wind-speed"}
+Number:Angle Day13_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-wind-dir"}
+Number:Pressure Day13_Hour15_Pressure "Pressure" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-pressure"}
+Number:Length Day13_Hour15_Visibility "Visibility" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-visibility"}
+Number:Dimensionless Day13_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-cloud-cover"}
+Number:Intensity Day13_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-solar-radiation"}
+Number Day13_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-solar-energy"}
+Number Day13_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-uv-index"}
+Number Day13_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-severe-risk"}
+String Day13_Hour15_Conditions "Conditions" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-conditions"}
+String Day13_Hour15_Icon "Icon" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-icon"}
+String Day13_Hour15_Stations "Stations" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-stations"}
+String Day13_Hour15_Source "Source" (Total_Weather_Data_Day13_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour15-source"}
+
+// Day13 - Hour16
+Group Total_Weather_Data_Day13_Hour16 "Hour 16" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour16_DateTime "DateTime" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-datetime"}
+DateTime Day13_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-timestamp"}
+Number:Temperature Day13_Hour16_Temperature "Temperature" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-temperature"}
+Number:Temperature Day13_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-feels-like"}
+Number Day13_Hour16_Humidity "Humidity" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-humidity"}
+Number:Temperature Day13_Hour16_Dew "Dew Point" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-dew"}
+Number:Length Day13_Hour16_Precip "Precipitation" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-precip"}
+Number:Dimensionless Day13_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-precip-prob"}
+String Day13_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-precip-type"}
+Number:Length Day13_Hour16_Snow "Snow" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-snow"}
+Number:Length Day13_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-snow-depth"}
+Number:Speed Day13_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-wind-gust"}
+Number:Speed Day13_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-wind-speed"}
+Number:Angle Day13_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-wind-dir"}
+Number:Pressure Day13_Hour16_Pressure "Pressure" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-pressure"}
+Number:Length Day13_Hour16_Visibility "Visibility" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-visibility"}
+Number:Dimensionless Day13_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-cloud-cover"}
+Number:Intensity Day13_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-solar-radiation"}
+Number Day13_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-solar-energy"}
+Number Day13_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-uv-index"}
+Number Day13_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-severe-risk"}
+String Day13_Hour16_Conditions "Conditions" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-conditions"}
+String Day13_Hour16_Icon "Icon" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-icon"}
+String Day13_Hour16_Stations "Stations" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-stations"}
+String Day13_Hour16_Source "Source" (Total_Weather_Data_Day13_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour16-source"}
+
+// Day13 - Hour17
+Group Total_Weather_Data_Day13_Hour17 "Hour 17" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour17_DateTime "DateTime" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-datetime"}
+DateTime Day13_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-timestamp"}
+Number:Temperature Day13_Hour17_Temperature "Temperature" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-temperature"}
+Number:Temperature Day13_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-feels-like"}
+Number Day13_Hour17_Humidity "Humidity" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-humidity"}
+Number:Temperature Day13_Hour17_Dew "Dew Point" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-dew"}
+Number:Length Day13_Hour17_Precip "Precipitation" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-precip"}
+Number:Dimensionless Day13_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-precip-prob"}
+String Day13_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-precip-type"}
+Number:Length Day13_Hour17_Snow "Snow" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-snow"}
+Number:Length Day13_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-snow-depth"}
+Number:Speed Day13_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-wind-gust"}
+Number:Speed Day13_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-wind-speed"}
+Number:Angle Day13_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-wind-dir"}
+Number:Pressure Day13_Hour17_Pressure "Pressure" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-pressure"}
+Number:Length Day13_Hour17_Visibility "Visibility" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-visibility"}
+Number:Dimensionless Day13_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-cloud-cover"}
+Number:Intensity Day13_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-solar-radiation"}
+Number Day13_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-solar-energy"}
+Number Day13_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-uv-index"}
+Number Day13_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-severe-risk"}
+String Day13_Hour17_Conditions "Conditions" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-conditions"}
+String Day13_Hour17_Icon "Icon" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-icon"}
+String Day13_Hour17_Stations "Stations" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-stations"}
+String Day13_Hour17_Source "Source" (Total_Weather_Data_Day13_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour17-source"}
+
+// Day13 - Hour18
+Group Total_Weather_Data_Day13_Hour18 "Hour 18" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour18_DateTime "DateTime" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-datetime"}
+DateTime Day13_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-timestamp"}
+Number:Temperature Day13_Hour18_Temperature "Temperature" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-temperature"}
+Number:Temperature Day13_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-feels-like"}
+Number Day13_Hour18_Humidity "Humidity" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-humidity"}
+Number:Temperature Day13_Hour18_Dew "Dew Point" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-dew"}
+Number:Length Day13_Hour18_Precip "Precipitation" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-precip"}
+Number:Dimensionless Day13_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-precip-prob"}
+String Day13_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-precip-type"}
+Number:Length Day13_Hour18_Snow "Snow" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-snow"}
+Number:Length Day13_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-snow-depth"}
+Number:Speed Day13_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-wind-gust"}
+Number:Speed Day13_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-wind-speed"}
+Number:Angle Day13_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-wind-dir"}
+Number:Pressure Day13_Hour18_Pressure "Pressure" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-pressure"}
+Number:Length Day13_Hour18_Visibility "Visibility" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-visibility"}
+Number:Dimensionless Day13_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-cloud-cover"}
+Number:Intensity Day13_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-solar-radiation"}
+Number Day13_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-solar-energy"}
+Number Day13_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-uv-index"}
+Number Day13_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-severe-risk"}
+String Day13_Hour18_Conditions "Conditions" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-conditions"}
+String Day13_Hour18_Icon "Icon" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-icon"}
+String Day13_Hour18_Stations "Stations" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-stations"}
+String Day13_Hour18_Source "Source" (Total_Weather_Data_Day13_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour18-source"}
+
+// Day13 - Hour19
+Group Total_Weather_Data_Day13_Hour19 "Hour 19" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour19_DateTime "DateTime" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-datetime"}
+DateTime Day13_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-timestamp"}
+Number:Temperature Day13_Hour19_Temperature "Temperature" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-temperature"}
+Number:Temperature Day13_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-feels-like"}
+Number Day13_Hour19_Humidity "Humidity" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-humidity"}
+Number:Temperature Day13_Hour19_Dew "Dew Point" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-dew"}
+Number:Length Day13_Hour19_Precip "Precipitation" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-precip"}
+Number:Dimensionless Day13_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-precip-prob"}
+String Day13_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-precip-type"}
+Number:Length Day13_Hour19_Snow "Snow" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-snow"}
+Number:Length Day13_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-snow-depth"}
+Number:Speed Day13_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-wind-gust"}
+Number:Speed Day13_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-wind-speed"}
+Number:Angle Day13_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-wind-dir"}
+Number:Pressure Day13_Hour19_Pressure "Pressure" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-pressure"}
+Number:Length Day13_Hour19_Visibility "Visibility" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-visibility"}
+Number:Dimensionless Day13_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-cloud-cover"}
+Number:Intensity Day13_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-solar-radiation"}
+Number Day13_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-solar-energy"}
+Number Day13_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-uv-index"}
+Number Day13_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-severe-risk"}
+String Day13_Hour19_Conditions "Conditions" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-conditions"}
+String Day13_Hour19_Icon "Icon" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-icon"}
+String Day13_Hour19_Stations "Stations" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-stations"}
+String Day13_Hour19_Source "Source" (Total_Weather_Data_Day13_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour19-source"}
+
+// Day13 - Hour20
+Group Total_Weather_Data_Day13_Hour20 "Hour 20" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour20_DateTime "DateTime" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-datetime"}
+DateTime Day13_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-timestamp"}
+Number:Temperature Day13_Hour20_Temperature "Temperature" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-temperature"}
+Number:Temperature Day13_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-feels-like"}
+Number Day13_Hour20_Humidity "Humidity" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-humidity"}
+Number:Temperature Day13_Hour20_Dew "Dew Point" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-dew"}
+Number:Length Day13_Hour20_Precip "Precipitation" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-precip"}
+Number:Dimensionless Day13_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-precip-prob"}
+String Day13_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-precip-type"}
+Number:Length Day13_Hour20_Snow "Snow" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-snow"}
+Number:Length Day13_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-snow-depth"}
+Number:Speed Day13_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-wind-gust"}
+Number:Speed Day13_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-wind-speed"}
+Number:Angle Day13_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-wind-dir"}
+Number:Pressure Day13_Hour20_Pressure "Pressure" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-pressure"}
+Number:Length Day13_Hour20_Visibility "Visibility" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-visibility"}
+Number:Dimensionless Day13_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-cloud-cover"}
+Number:Intensity Day13_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-solar-radiation"}
+Number Day13_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-solar-energy"}
+Number Day13_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-uv-index"}
+Number Day13_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-severe-risk"}
+String Day13_Hour20_Conditions "Conditions" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-conditions"}
+String Day13_Hour20_Icon "Icon" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-icon"}
+String Day13_Hour20_Stations "Stations" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-stations"}
+String Day13_Hour20_Source "Source" (Total_Weather_Data_Day13_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour20-source"}
+
+// Day13 - Hour21
+Group Total_Weather_Data_Day13_Hour21 "Hour 21" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour21_DateTime "DateTime" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-datetime"}
+DateTime Day13_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-timestamp"}
+Number:Temperature Day13_Hour21_Temperature "Temperature" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-temperature"}
+Number:Temperature Day13_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-feels-like"}
+Number Day13_Hour21_Humidity "Humidity" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-humidity"}
+Number:Temperature Day13_Hour21_Dew "Dew Point" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-dew"}
+Number:Length Day13_Hour21_Precip "Precipitation" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-precip"}
+Number:Dimensionless Day13_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-precip-prob"}
+String Day13_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-precip-type"}
+Number:Length Day13_Hour21_Snow "Snow" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-snow"}
+Number:Length Day13_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-snow-depth"}
+Number:Speed Day13_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-wind-gust"}
+Number:Speed Day13_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-wind-speed"}
+Number:Angle Day13_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-wind-dir"}
+Number:Pressure Day13_Hour21_Pressure "Pressure" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-pressure"}
+Number:Length Day13_Hour21_Visibility "Visibility" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-visibility"}
+Number:Dimensionless Day13_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-cloud-cover"}
+Number:Intensity Day13_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-solar-radiation"}
+Number Day13_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-solar-energy"}
+Number Day13_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-uv-index"}
+Number Day13_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-severe-risk"}
+String Day13_Hour21_Conditions "Conditions" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-conditions"}
+String Day13_Hour21_Icon "Icon" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-icon"}
+String Day13_Hour21_Stations "Stations" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-stations"}
+String Day13_Hour21_Source "Source" (Total_Weather_Data_Day13_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour21-source"}
+
+// Day13 - Hour22
+Group Total_Weather_Data_Day13_Hour22 "Hour 22" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour22_DateTime "DateTime" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-datetime"}
+DateTime Day13_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-timestamp"}
+Number:Temperature Day13_Hour22_Temperature "Temperature" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-temperature"}
+Number:Temperature Day13_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-feels-like"}
+Number Day13_Hour22_Humidity "Humidity" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-humidity"}
+Number:Temperature Day13_Hour22_Dew "Dew Point" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-dew"}
+Number:Length Day13_Hour22_Precip "Precipitation" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-precip"}
+Number:Dimensionless Day13_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-precip-prob"}
+String Day13_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-precip-type"}
+Number:Length Day13_Hour22_Snow "Snow" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-snow"}
+Number:Length Day13_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-snow-depth"}
+Number:Speed Day13_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-wind-gust"}
+Number:Speed Day13_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-wind-speed"}
+Number:Angle Day13_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-wind-dir"}
+Number:Pressure Day13_Hour22_Pressure "Pressure" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-pressure"}
+Number:Length Day13_Hour22_Visibility "Visibility" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-visibility"}
+Number:Dimensionless Day13_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-cloud-cover"}
+Number:Intensity Day13_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-solar-radiation"}
+Number Day13_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-solar-energy"}
+Number Day13_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-uv-index"}
+Number Day13_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-severe-risk"}
+String Day13_Hour22_Conditions "Conditions" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-conditions"}
+String Day13_Hour22_Icon "Icon" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-icon"}
+String Day13_Hour22_Stations "Stations" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-stations"}
+String Day13_Hour22_Source "Source" (Total_Weather_Data_Day13_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour22-source"}
+
+// Day13 - Hour23
+Group Total_Weather_Data_Day13_Hour23 "Hour 23" (Total_Weather_Data_Day13) [ "Equipment" ] 
+String Day13_Hour23_DateTime "DateTime" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-datetime"}
+DateTime Day13_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-timestamp"}
+Number:Temperature Day13_Hour23_Temperature "Temperature" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-temperature"}
+Number:Temperature Day13_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-feels-like"}
+Number Day13_Hour23_Humidity "Humidity" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-humidity"}
+Number:Temperature Day13_Hour23_Dew "Dew Point" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-dew"}
+Number:Length Day13_Hour23_Precip "Precipitation" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-precip"}
+Number:Dimensionless Day13_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-precip-prob"}
+String Day13_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-precip-type"}
+Number:Length Day13_Hour23_Snow "Snow" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-snow"}
+Number:Length Day13_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-snow-depth"}
+Number:Speed Day13_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-wind-gust"}
+Number:Speed Day13_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-wind-speed"}
+Number:Angle Day13_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-wind-dir"}
+Number:Pressure Day13_Hour23_Pressure "Pressure" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-pressure"}
+Number:Length Day13_Hour23_Visibility "Visibility" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-visibility"}
+Number:Dimensionless Day13_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-cloud-cover"}
+Number:Intensity Day13_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-solar-radiation"}
+Number Day13_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-solar-energy"}
+Number Day13_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-uv-index"}
+Number Day13_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-severe-risk"}
+String Day13_Hour23_Conditions "Conditions" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-conditions"}
+String Day13_Hour23_Icon "Icon" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-icon"}
+String Day13_Hour23_Stations "Stations" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-stations"}
+String Day13_Hour23_Source "Source" (Total_Weather_Data_Day13_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day13#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_14.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_14.items
@@ -1,39 +1,712 @@
 // Day14
 Group Total_Weather_Data_Day14 "Day T+14" (Total_Weather_Data) [ "Equipment" ] 
-String Day14_DateTime "Time" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day14_Timestamp "Timestamp" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day14_Temperature "Temperature" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day14_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day14_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day14_FeelsLike "Feels Like" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day14_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day14_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day14_Dew "Dew Point" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day14_Humidity "Humidity" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day14_Precip "Precipitation" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day14_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day14_Precip_Type "Precipitation Type" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day14_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day14_Snow "Snow" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day14_Snow_Depth "Snow Depth" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day14_Wind_Gust "Wind Gust" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day14_Wind_Speed "Wind Speed" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day14_Wind_Dir "Wind Direction" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day14_Pressure "Pressure" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day14_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day14_Visibility "Visibility" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day14_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day14_Solar_Energy "Solar Energy" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day14_UV_Index "UV Index" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day14_Sunrise "Sunrise" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day14_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day14_Sunset "Sunset" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day14_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day14_Moon_Phase "Moon Phase" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day14_Conditions "Conditions" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day14_Description "Description" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day14_Icon "Icon" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day14_Stations "Stations" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day14_Source "Source" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day14_Severe_Risk "Severe Risk" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day14_DateTime "Time" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#datetime" }
+DateTime Day14_Timestamp "Timestamp" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#timestamp" }
+Number:Temperature Day14_Temperature "Temperature" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#temperature" }
+Number:Temperature Day14_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#temperature-min" }
+Number:Temperature Day14_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#temperature-max" }
+Number:Temperature Day14_FeelsLike "Feels Like" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#feels-like" }
+Number:Temperature Day14_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#feels-like-min" }
+Number:Temperature Day14_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#feels-like-max" }
+Number:Temperature Day14_Dew "Dew Point" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#dew" }
+Number Day14_Humidity "Humidity" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#humidity" }
+Number:Length Day14_Precip "Precipitation" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#precip" }
+Number Day14_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#precip-prob" }
+String Day14_Precip_Type "Precipitation Type" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#precip-type" }
+Number Day14_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#precip-cover" }
+Number:Length Day14_Snow "Snow" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#snow" }
+Number:Length Day14_Snow_Depth "Snow Depth" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#snow-depth" }
+Number:Speed Day14_Wind_Gust "Wind Gust" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#wind-gust" }
+Number:Speed Day14_Wind_Speed "Wind Speed" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#wind-speed" }
+Number:Angle Day14_Wind_Dir "Wind Direction" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#wind-dir" }
+Number:Pressure Day14_Pressure "Pressure" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#pressure" }
+Number Day14_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#cloud-cover" }
+Number:Length Day14_Visibility "Visibility" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#visibility" }
+Number:Intensity Day14_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#solar-radiation" }
+Number Day14_Solar_Energy "Solar Energy" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#solar-energy" }
+Number Day14_UV_Index "UV Index" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#uv-index" }
+String Day14_Sunrise "Sunrise" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#sunrise" }
+DateTime Day14_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#sunrise-epoch" }
+String Day14_Sunset "Sunset" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#sunset" }
+DateTime Day14_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#sunset-epoch" }
+Number Day14_Moon_Phase "Moon Phase" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#moon-phase" }
+String Day14_Conditions "Conditions" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#conditions" }
+String Day14_Description "Description" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#description" }
+String Day14_Icon "Icon" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#icon" }
+String Day14_Stations "Stations" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#stations" }
+String Day14_Source "Source" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#source" }
+Number Day14_Severe_Risk "Severe Risk" (Total_Weather_Data_Day14)["Point"] { channel="visualcrossing:weather:default_config:day14#severe-risk" }
+
+// Day14 - Hour00
+Group Total_Weather_Data_Day14_Hour00 "Hour 00" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour00_DateTime "DateTime" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-datetime"}
+DateTime Day14_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-timestamp"}
+Number:Temperature Day14_Hour00_Temperature "Temperature" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-temperature"}
+Number:Temperature Day14_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-feels-like"}
+Number Day14_Hour00_Humidity "Humidity" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-humidity"}
+Number:Temperature Day14_Hour00_Dew "Dew Point" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-dew"}
+Number:Length Day14_Hour00_Precip "Precipitation" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-precip"}
+Number:Dimensionless Day14_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-precip-prob"}
+String Day14_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-precip-type"}
+Number:Length Day14_Hour00_Snow "Snow" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-snow"}
+Number:Length Day14_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-snow-depth"}
+Number:Speed Day14_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-wind-gust"}
+Number:Speed Day14_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-wind-speed"}
+Number:Angle Day14_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-wind-dir"}
+Number:Pressure Day14_Hour00_Pressure "Pressure" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-pressure"}
+Number:Length Day14_Hour00_Visibility "Visibility" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-visibility"}
+Number:Dimensionless Day14_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-cloud-cover"}
+Number:Intensity Day14_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-solar-radiation"}
+Number Day14_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-solar-energy"}
+Number Day14_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-uv-index"}
+Number Day14_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-severe-risk"}
+String Day14_Hour00_Conditions "Conditions" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-conditions"}
+String Day14_Hour00_Icon "Icon" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-icon"}
+String Day14_Hour00_Stations "Stations" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-stations"}
+String Day14_Hour00_Source "Source" (Total_Weather_Data_Day14_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour00-source"}
+
+// Day14 - Hour01
+Group Total_Weather_Data_Day14_Hour01 "Hour 01" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour01_DateTime "DateTime" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-datetime"}
+DateTime Day14_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-timestamp"}
+Number:Temperature Day14_Hour01_Temperature "Temperature" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-temperature"}
+Number:Temperature Day14_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-feels-like"}
+Number Day14_Hour01_Humidity "Humidity" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-humidity"}
+Number:Temperature Day14_Hour01_Dew "Dew Point" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-dew"}
+Number:Length Day14_Hour01_Precip "Precipitation" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-precip"}
+Number:Dimensionless Day14_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-precip-prob"}
+String Day14_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-precip-type"}
+Number:Length Day14_Hour01_Snow "Snow" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-snow"}
+Number:Length Day14_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-snow-depth"}
+Number:Speed Day14_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-wind-gust"}
+Number:Speed Day14_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-wind-speed"}
+Number:Angle Day14_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-wind-dir"}
+Number:Pressure Day14_Hour01_Pressure "Pressure" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-pressure"}
+Number:Length Day14_Hour01_Visibility "Visibility" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-visibility"}
+Number:Dimensionless Day14_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-cloud-cover"}
+Number:Intensity Day14_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-solar-radiation"}
+Number Day14_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-solar-energy"}
+Number Day14_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-uv-index"}
+Number Day14_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-severe-risk"}
+String Day14_Hour01_Conditions "Conditions" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-conditions"}
+String Day14_Hour01_Icon "Icon" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-icon"}
+String Day14_Hour01_Stations "Stations" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-stations"}
+String Day14_Hour01_Source "Source" (Total_Weather_Data_Day14_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour01-source"}
+
+// Day14 - Hour02
+Group Total_Weather_Data_Day14_Hour02 "Hour 02" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour02_DateTime "DateTime" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-datetime"}
+DateTime Day14_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-timestamp"}
+Number:Temperature Day14_Hour02_Temperature "Temperature" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-temperature"}
+Number:Temperature Day14_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-feels-like"}
+Number Day14_Hour02_Humidity "Humidity" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-humidity"}
+Number:Temperature Day14_Hour02_Dew "Dew Point" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-dew"}
+Number:Length Day14_Hour02_Precip "Precipitation" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-precip"}
+Number:Dimensionless Day14_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-precip-prob"}
+String Day14_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-precip-type"}
+Number:Length Day14_Hour02_Snow "Snow" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-snow"}
+Number:Length Day14_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-snow-depth"}
+Number:Speed Day14_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-wind-gust"}
+Number:Speed Day14_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-wind-speed"}
+Number:Angle Day14_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-wind-dir"}
+Number:Pressure Day14_Hour02_Pressure "Pressure" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-pressure"}
+Number:Length Day14_Hour02_Visibility "Visibility" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-visibility"}
+Number:Dimensionless Day14_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-cloud-cover"}
+Number:Intensity Day14_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-solar-radiation"}
+Number Day14_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-solar-energy"}
+Number Day14_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-uv-index"}
+Number Day14_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-severe-risk"}
+String Day14_Hour02_Conditions "Conditions" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-conditions"}
+String Day14_Hour02_Icon "Icon" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-icon"}
+String Day14_Hour02_Stations "Stations" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-stations"}
+String Day14_Hour02_Source "Source" (Total_Weather_Data_Day14_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour02-source"}
+
+// Day14 - Hour03
+Group Total_Weather_Data_Day14_Hour03 "Hour 03" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour03_DateTime "DateTime" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-datetime"}
+DateTime Day14_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-timestamp"}
+Number:Temperature Day14_Hour03_Temperature "Temperature" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-temperature"}
+Number:Temperature Day14_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-feels-like"}
+Number Day14_Hour03_Humidity "Humidity" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-humidity"}
+Number:Temperature Day14_Hour03_Dew "Dew Point" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-dew"}
+Number:Length Day14_Hour03_Precip "Precipitation" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-precip"}
+Number:Dimensionless Day14_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-precip-prob"}
+String Day14_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-precip-type"}
+Number:Length Day14_Hour03_Snow "Snow" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-snow"}
+Number:Length Day14_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-snow-depth"}
+Number:Speed Day14_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-wind-gust"}
+Number:Speed Day14_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-wind-speed"}
+Number:Angle Day14_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-wind-dir"}
+Number:Pressure Day14_Hour03_Pressure "Pressure" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-pressure"}
+Number:Length Day14_Hour03_Visibility "Visibility" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-visibility"}
+Number:Dimensionless Day14_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-cloud-cover"}
+Number:Intensity Day14_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-solar-radiation"}
+Number Day14_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-solar-energy"}
+Number Day14_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-uv-index"}
+Number Day14_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-severe-risk"}
+String Day14_Hour03_Conditions "Conditions" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-conditions"}
+String Day14_Hour03_Icon "Icon" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-icon"}
+String Day14_Hour03_Stations "Stations" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-stations"}
+String Day14_Hour03_Source "Source" (Total_Weather_Data_Day14_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour03-source"}
+
+// Day14 - Hour04
+Group Total_Weather_Data_Day14_Hour04 "Hour 04" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour04_DateTime "DateTime" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-datetime"}
+DateTime Day14_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-timestamp"}
+Number:Temperature Day14_Hour04_Temperature "Temperature" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-temperature"}
+Number:Temperature Day14_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-feels-like"}
+Number Day14_Hour04_Humidity "Humidity" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-humidity"}
+Number:Temperature Day14_Hour04_Dew "Dew Point" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-dew"}
+Number:Length Day14_Hour04_Precip "Precipitation" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-precip"}
+Number:Dimensionless Day14_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-precip-prob"}
+String Day14_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-precip-type"}
+Number:Length Day14_Hour04_Snow "Snow" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-snow"}
+Number:Length Day14_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-snow-depth"}
+Number:Speed Day14_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-wind-gust"}
+Number:Speed Day14_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-wind-speed"}
+Number:Angle Day14_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-wind-dir"}
+Number:Pressure Day14_Hour04_Pressure "Pressure" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-pressure"}
+Number:Length Day14_Hour04_Visibility "Visibility" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-visibility"}
+Number:Dimensionless Day14_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-cloud-cover"}
+Number:Intensity Day14_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-solar-radiation"}
+Number Day14_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-solar-energy"}
+Number Day14_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-uv-index"}
+Number Day14_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-severe-risk"}
+String Day14_Hour04_Conditions "Conditions" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-conditions"}
+String Day14_Hour04_Icon "Icon" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-icon"}
+String Day14_Hour04_Stations "Stations" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-stations"}
+String Day14_Hour04_Source "Source" (Total_Weather_Data_Day14_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour04-source"}
+
+// Day14 - Hour05
+Group Total_Weather_Data_Day14_Hour05 "Hour 05" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour05_DateTime "DateTime" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-datetime"}
+DateTime Day14_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-timestamp"}
+Number:Temperature Day14_Hour05_Temperature "Temperature" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-temperature"}
+Number:Temperature Day14_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-feels-like"}
+Number Day14_Hour05_Humidity "Humidity" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-humidity"}
+Number:Temperature Day14_Hour05_Dew "Dew Point" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-dew"}
+Number:Length Day14_Hour05_Precip "Precipitation" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-precip"}
+Number:Dimensionless Day14_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-precip-prob"}
+String Day14_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-precip-type"}
+Number:Length Day14_Hour05_Snow "Snow" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-snow"}
+Number:Length Day14_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-snow-depth"}
+Number:Speed Day14_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-wind-gust"}
+Number:Speed Day14_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-wind-speed"}
+Number:Angle Day14_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-wind-dir"}
+Number:Pressure Day14_Hour05_Pressure "Pressure" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-pressure"}
+Number:Length Day14_Hour05_Visibility "Visibility" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-visibility"}
+Number:Dimensionless Day14_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-cloud-cover"}
+Number:Intensity Day14_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-solar-radiation"}
+Number Day14_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-solar-energy"}
+Number Day14_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-uv-index"}
+Number Day14_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-severe-risk"}
+String Day14_Hour05_Conditions "Conditions" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-conditions"}
+String Day14_Hour05_Icon "Icon" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-icon"}
+String Day14_Hour05_Stations "Stations" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-stations"}
+String Day14_Hour05_Source "Source" (Total_Weather_Data_Day14_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour05-source"}
+
+// Day14 - Hour06
+Group Total_Weather_Data_Day14_Hour06 "Hour 06" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour06_DateTime "DateTime" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-datetime"}
+DateTime Day14_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-timestamp"}
+Number:Temperature Day14_Hour06_Temperature "Temperature" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-temperature"}
+Number:Temperature Day14_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-feels-like"}
+Number Day14_Hour06_Humidity "Humidity" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-humidity"}
+Number:Temperature Day14_Hour06_Dew "Dew Point" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-dew"}
+Number:Length Day14_Hour06_Precip "Precipitation" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-precip"}
+Number:Dimensionless Day14_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-precip-prob"}
+String Day14_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-precip-type"}
+Number:Length Day14_Hour06_Snow "Snow" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-snow"}
+Number:Length Day14_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-snow-depth"}
+Number:Speed Day14_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-wind-gust"}
+Number:Speed Day14_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-wind-speed"}
+Number:Angle Day14_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-wind-dir"}
+Number:Pressure Day14_Hour06_Pressure "Pressure" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-pressure"}
+Number:Length Day14_Hour06_Visibility "Visibility" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-visibility"}
+Number:Dimensionless Day14_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-cloud-cover"}
+Number:Intensity Day14_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-solar-radiation"}
+Number Day14_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-solar-energy"}
+Number Day14_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-uv-index"}
+Number Day14_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-severe-risk"}
+String Day14_Hour06_Conditions "Conditions" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-conditions"}
+String Day14_Hour06_Icon "Icon" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-icon"}
+String Day14_Hour06_Stations "Stations" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-stations"}
+String Day14_Hour06_Source "Source" (Total_Weather_Data_Day14_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour06-source"}
+
+// Day14 - Hour07
+Group Total_Weather_Data_Day14_Hour07 "Hour 07" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour07_DateTime "DateTime" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-datetime"}
+DateTime Day14_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-timestamp"}
+Number:Temperature Day14_Hour07_Temperature "Temperature" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-temperature"}
+Number:Temperature Day14_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-feels-like"}
+Number Day14_Hour07_Humidity "Humidity" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-humidity"}
+Number:Temperature Day14_Hour07_Dew "Dew Point" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-dew"}
+Number:Length Day14_Hour07_Precip "Precipitation" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-precip"}
+Number:Dimensionless Day14_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-precip-prob"}
+String Day14_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-precip-type"}
+Number:Length Day14_Hour07_Snow "Snow" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-snow"}
+Number:Length Day14_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-snow-depth"}
+Number:Speed Day14_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-wind-gust"}
+Number:Speed Day14_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-wind-speed"}
+Number:Angle Day14_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-wind-dir"}
+Number:Pressure Day14_Hour07_Pressure "Pressure" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-pressure"}
+Number:Length Day14_Hour07_Visibility "Visibility" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-visibility"}
+Number:Dimensionless Day14_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-cloud-cover"}
+Number:Intensity Day14_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-solar-radiation"}
+Number Day14_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-solar-energy"}
+Number Day14_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-uv-index"}
+Number Day14_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-severe-risk"}
+String Day14_Hour07_Conditions "Conditions" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-conditions"}
+String Day14_Hour07_Icon "Icon" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-icon"}
+String Day14_Hour07_Stations "Stations" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-stations"}
+String Day14_Hour07_Source "Source" (Total_Weather_Data_Day14_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour07-source"}
+
+// Day14 - Hour08
+Group Total_Weather_Data_Day14_Hour08 "Hour 08" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour08_DateTime "DateTime" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-datetime"}
+DateTime Day14_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-timestamp"}
+Number:Temperature Day14_Hour08_Temperature "Temperature" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-temperature"}
+Number:Temperature Day14_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-feels-like"}
+Number Day14_Hour08_Humidity "Humidity" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-humidity"}
+Number:Temperature Day14_Hour08_Dew "Dew Point" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-dew"}
+Number:Length Day14_Hour08_Precip "Precipitation" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-precip"}
+Number:Dimensionless Day14_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-precip-prob"}
+String Day14_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-precip-type"}
+Number:Length Day14_Hour08_Snow "Snow" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-snow"}
+Number:Length Day14_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-snow-depth"}
+Number:Speed Day14_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-wind-gust"}
+Number:Speed Day14_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-wind-speed"}
+Number:Angle Day14_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-wind-dir"}
+Number:Pressure Day14_Hour08_Pressure "Pressure" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-pressure"}
+Number:Length Day14_Hour08_Visibility "Visibility" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-visibility"}
+Number:Dimensionless Day14_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-cloud-cover"}
+Number:Intensity Day14_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-solar-radiation"}
+Number Day14_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-solar-energy"}
+Number Day14_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-uv-index"}
+Number Day14_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-severe-risk"}
+String Day14_Hour08_Conditions "Conditions" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-conditions"}
+String Day14_Hour08_Icon "Icon" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-icon"}
+String Day14_Hour08_Stations "Stations" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-stations"}
+String Day14_Hour08_Source "Source" (Total_Weather_Data_Day14_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour08-source"}
+
+// Day14 - Hour09
+Group Total_Weather_Data_Day14_Hour09 "Hour 09" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour09_DateTime "DateTime" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-datetime"}
+DateTime Day14_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-timestamp"}
+Number:Temperature Day14_Hour09_Temperature "Temperature" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-temperature"}
+Number:Temperature Day14_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-feels-like"}
+Number Day14_Hour09_Humidity "Humidity" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-humidity"}
+Number:Temperature Day14_Hour09_Dew "Dew Point" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-dew"}
+Number:Length Day14_Hour09_Precip "Precipitation" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-precip"}
+Number:Dimensionless Day14_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-precip-prob"}
+String Day14_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-precip-type"}
+Number:Length Day14_Hour09_Snow "Snow" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-snow"}
+Number:Length Day14_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-snow-depth"}
+Number:Speed Day14_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-wind-gust"}
+Number:Speed Day14_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-wind-speed"}
+Number:Angle Day14_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-wind-dir"}
+Number:Pressure Day14_Hour09_Pressure "Pressure" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-pressure"}
+Number:Length Day14_Hour09_Visibility "Visibility" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-visibility"}
+Number:Dimensionless Day14_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-cloud-cover"}
+Number:Intensity Day14_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-solar-radiation"}
+Number Day14_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-solar-energy"}
+Number Day14_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-uv-index"}
+Number Day14_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-severe-risk"}
+String Day14_Hour09_Conditions "Conditions" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-conditions"}
+String Day14_Hour09_Icon "Icon" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-icon"}
+String Day14_Hour09_Stations "Stations" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-stations"}
+String Day14_Hour09_Source "Source" (Total_Weather_Data_Day14_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour09-source"}
+
+// Day14 - Hour10
+Group Total_Weather_Data_Day14_Hour10 "Hour 10" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour10_DateTime "DateTime" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-datetime"}
+DateTime Day14_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-timestamp"}
+Number:Temperature Day14_Hour10_Temperature "Temperature" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-temperature"}
+Number:Temperature Day14_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-feels-like"}
+Number Day14_Hour10_Humidity "Humidity" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-humidity"}
+Number:Temperature Day14_Hour10_Dew "Dew Point" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-dew"}
+Number:Length Day14_Hour10_Precip "Precipitation" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-precip"}
+Number:Dimensionless Day14_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-precip-prob"}
+String Day14_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-precip-type"}
+Number:Length Day14_Hour10_Snow "Snow" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-snow"}
+Number:Length Day14_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-snow-depth"}
+Number:Speed Day14_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-wind-gust"}
+Number:Speed Day14_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-wind-speed"}
+Number:Angle Day14_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-wind-dir"}
+Number:Pressure Day14_Hour10_Pressure "Pressure" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-pressure"}
+Number:Length Day14_Hour10_Visibility "Visibility" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-visibility"}
+Number:Dimensionless Day14_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-cloud-cover"}
+Number:Intensity Day14_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-solar-radiation"}
+Number Day14_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-solar-energy"}
+Number Day14_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-uv-index"}
+Number Day14_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-severe-risk"}
+String Day14_Hour10_Conditions "Conditions" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-conditions"}
+String Day14_Hour10_Icon "Icon" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-icon"}
+String Day14_Hour10_Stations "Stations" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-stations"}
+String Day14_Hour10_Source "Source" (Total_Weather_Data_Day14_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour10-source"}
+
+// Day14 - Hour11
+Group Total_Weather_Data_Day14_Hour11 "Hour 11" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour11_DateTime "DateTime" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-datetime"}
+DateTime Day14_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-timestamp"}
+Number:Temperature Day14_Hour11_Temperature "Temperature" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-temperature"}
+Number:Temperature Day14_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-feels-like"}
+Number Day14_Hour11_Humidity "Humidity" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-humidity"}
+Number:Temperature Day14_Hour11_Dew "Dew Point" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-dew"}
+Number:Length Day14_Hour11_Precip "Precipitation" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-precip"}
+Number:Dimensionless Day14_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-precip-prob"}
+String Day14_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-precip-type"}
+Number:Length Day14_Hour11_Snow "Snow" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-snow"}
+Number:Length Day14_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-snow-depth"}
+Number:Speed Day14_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-wind-gust"}
+Number:Speed Day14_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-wind-speed"}
+Number:Angle Day14_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-wind-dir"}
+Number:Pressure Day14_Hour11_Pressure "Pressure" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-pressure"}
+Number:Length Day14_Hour11_Visibility "Visibility" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-visibility"}
+Number:Dimensionless Day14_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-cloud-cover"}
+Number:Intensity Day14_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-solar-radiation"}
+Number Day14_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-solar-energy"}
+Number Day14_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-uv-index"}
+Number Day14_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-severe-risk"}
+String Day14_Hour11_Conditions "Conditions" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-conditions"}
+String Day14_Hour11_Icon "Icon" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-icon"}
+String Day14_Hour11_Stations "Stations" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-stations"}
+String Day14_Hour11_Source "Source" (Total_Weather_Data_Day14_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour11-source"}
+
+// Day14 - Hour12
+Group Total_Weather_Data_Day14_Hour12 "Hour 12" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour12_DateTime "DateTime" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-datetime"}
+DateTime Day14_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-timestamp"}
+Number:Temperature Day14_Hour12_Temperature "Temperature" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-temperature"}
+Number:Temperature Day14_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-feels-like"}
+Number Day14_Hour12_Humidity "Humidity" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-humidity"}
+Number:Temperature Day14_Hour12_Dew "Dew Point" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-dew"}
+Number:Length Day14_Hour12_Precip "Precipitation" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-precip"}
+Number:Dimensionless Day14_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-precip-prob"}
+String Day14_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-precip-type"}
+Number:Length Day14_Hour12_Snow "Snow" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-snow"}
+Number:Length Day14_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-snow-depth"}
+Number:Speed Day14_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-wind-gust"}
+Number:Speed Day14_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-wind-speed"}
+Number:Angle Day14_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-wind-dir"}
+Number:Pressure Day14_Hour12_Pressure "Pressure" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-pressure"}
+Number:Length Day14_Hour12_Visibility "Visibility" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-visibility"}
+Number:Dimensionless Day14_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-cloud-cover"}
+Number:Intensity Day14_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-solar-radiation"}
+Number Day14_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-solar-energy"}
+Number Day14_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-uv-index"}
+Number Day14_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-severe-risk"}
+String Day14_Hour12_Conditions "Conditions" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-conditions"}
+String Day14_Hour12_Icon "Icon" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-icon"}
+String Day14_Hour12_Stations "Stations" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-stations"}
+String Day14_Hour12_Source "Source" (Total_Weather_Data_Day14_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour12-source"}
+
+// Day14 - Hour13
+Group Total_Weather_Data_Day14_Hour13 "Hour 13" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour13_DateTime "DateTime" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-datetime"}
+DateTime Day14_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-timestamp"}
+Number:Temperature Day14_Hour13_Temperature "Temperature" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-temperature"}
+Number:Temperature Day14_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-feels-like"}
+Number Day14_Hour13_Humidity "Humidity" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-humidity"}
+Number:Temperature Day14_Hour13_Dew "Dew Point" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-dew"}
+Number:Length Day14_Hour13_Precip "Precipitation" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-precip"}
+Number:Dimensionless Day14_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-precip-prob"}
+String Day14_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-precip-type"}
+Number:Length Day14_Hour13_Snow "Snow" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-snow"}
+Number:Length Day14_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-snow-depth"}
+Number:Speed Day14_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-wind-gust"}
+Number:Speed Day14_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-wind-speed"}
+Number:Angle Day14_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-wind-dir"}
+Number:Pressure Day14_Hour13_Pressure "Pressure" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-pressure"}
+Number:Length Day14_Hour13_Visibility "Visibility" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-visibility"}
+Number:Dimensionless Day14_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-cloud-cover"}
+Number:Intensity Day14_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-solar-radiation"}
+Number Day14_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-solar-energy"}
+Number Day14_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-uv-index"}
+Number Day14_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-severe-risk"}
+String Day14_Hour13_Conditions "Conditions" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-conditions"}
+String Day14_Hour13_Icon "Icon" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-icon"}
+String Day14_Hour13_Stations "Stations" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-stations"}
+String Day14_Hour13_Source "Source" (Total_Weather_Data_Day14_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour13-source"}
+
+// Day14 - Hour14
+Group Total_Weather_Data_Day14_Hour14 "Hour 14" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour14_DateTime "DateTime" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-datetime"}
+DateTime Day14_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-timestamp"}
+Number:Temperature Day14_Hour14_Temperature "Temperature" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-temperature"}
+Number:Temperature Day14_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-feels-like"}
+Number Day14_Hour14_Humidity "Humidity" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-humidity"}
+Number:Temperature Day14_Hour14_Dew "Dew Point" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-dew"}
+Number:Length Day14_Hour14_Precip "Precipitation" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-precip"}
+Number:Dimensionless Day14_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-precip-prob"}
+String Day14_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-precip-type"}
+Number:Length Day14_Hour14_Snow "Snow" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-snow"}
+Number:Length Day14_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-snow-depth"}
+Number:Speed Day14_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-wind-gust"}
+Number:Speed Day14_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-wind-speed"}
+Number:Angle Day14_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-wind-dir"}
+Number:Pressure Day14_Hour14_Pressure "Pressure" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-pressure"}
+Number:Length Day14_Hour14_Visibility "Visibility" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-visibility"}
+Number:Dimensionless Day14_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-cloud-cover"}
+Number:Intensity Day14_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-solar-radiation"}
+Number Day14_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-solar-energy"}
+Number Day14_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-uv-index"}
+Number Day14_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-severe-risk"}
+String Day14_Hour14_Conditions "Conditions" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-conditions"}
+String Day14_Hour14_Icon "Icon" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-icon"}
+String Day14_Hour14_Stations "Stations" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-stations"}
+String Day14_Hour14_Source "Source" (Total_Weather_Data_Day14_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour14-source"}
+
+// Day14 - Hour15
+Group Total_Weather_Data_Day14_Hour15 "Hour 15" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour15_DateTime "DateTime" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-datetime"}
+DateTime Day14_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-timestamp"}
+Number:Temperature Day14_Hour15_Temperature "Temperature" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-temperature"}
+Number:Temperature Day14_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-feels-like"}
+Number Day14_Hour15_Humidity "Humidity" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-humidity"}
+Number:Temperature Day14_Hour15_Dew "Dew Point" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-dew"}
+Number:Length Day14_Hour15_Precip "Precipitation" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-precip"}
+Number:Dimensionless Day14_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-precip-prob"}
+String Day14_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-precip-type"}
+Number:Length Day14_Hour15_Snow "Snow" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-snow"}
+Number:Length Day14_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-snow-depth"}
+Number:Speed Day14_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-wind-gust"}
+Number:Speed Day14_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-wind-speed"}
+Number:Angle Day14_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-wind-dir"}
+Number:Pressure Day14_Hour15_Pressure "Pressure" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-pressure"}
+Number:Length Day14_Hour15_Visibility "Visibility" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-visibility"}
+Number:Dimensionless Day14_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-cloud-cover"}
+Number:Intensity Day14_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-solar-radiation"}
+Number Day14_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-solar-energy"}
+Number Day14_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-uv-index"}
+Number Day14_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-severe-risk"}
+String Day14_Hour15_Conditions "Conditions" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-conditions"}
+String Day14_Hour15_Icon "Icon" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-icon"}
+String Day14_Hour15_Stations "Stations" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-stations"}
+String Day14_Hour15_Source "Source" (Total_Weather_Data_Day14_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour15-source"}
+
+// Day14 - Hour16
+Group Total_Weather_Data_Day14_Hour16 "Hour 16" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour16_DateTime "DateTime" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-datetime"}
+DateTime Day14_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-timestamp"}
+Number:Temperature Day14_Hour16_Temperature "Temperature" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-temperature"}
+Number:Temperature Day14_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-feels-like"}
+Number Day14_Hour16_Humidity "Humidity" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-humidity"}
+Number:Temperature Day14_Hour16_Dew "Dew Point" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-dew"}
+Number:Length Day14_Hour16_Precip "Precipitation" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-precip"}
+Number:Dimensionless Day14_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-precip-prob"}
+String Day14_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-precip-type"}
+Number:Length Day14_Hour16_Snow "Snow" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-snow"}
+Number:Length Day14_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-snow-depth"}
+Number:Speed Day14_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-wind-gust"}
+Number:Speed Day14_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-wind-speed"}
+Number:Angle Day14_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-wind-dir"}
+Number:Pressure Day14_Hour16_Pressure "Pressure" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-pressure"}
+Number:Length Day14_Hour16_Visibility "Visibility" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-visibility"}
+Number:Dimensionless Day14_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-cloud-cover"}
+Number:Intensity Day14_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-solar-radiation"}
+Number Day14_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-solar-energy"}
+Number Day14_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-uv-index"}
+Number Day14_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-severe-risk"}
+String Day14_Hour16_Conditions "Conditions" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-conditions"}
+String Day14_Hour16_Icon "Icon" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-icon"}
+String Day14_Hour16_Stations "Stations" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-stations"}
+String Day14_Hour16_Source "Source" (Total_Weather_Data_Day14_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour16-source"}
+
+// Day14 - Hour17
+Group Total_Weather_Data_Day14_Hour17 "Hour 17" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour17_DateTime "DateTime" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-datetime"}
+DateTime Day14_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-timestamp"}
+Number:Temperature Day14_Hour17_Temperature "Temperature" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-temperature"}
+Number:Temperature Day14_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-feels-like"}
+Number Day14_Hour17_Humidity "Humidity" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-humidity"}
+Number:Temperature Day14_Hour17_Dew "Dew Point" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-dew"}
+Number:Length Day14_Hour17_Precip "Precipitation" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-precip"}
+Number:Dimensionless Day14_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-precip-prob"}
+String Day14_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-precip-type"}
+Number:Length Day14_Hour17_Snow "Snow" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-snow"}
+Number:Length Day14_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-snow-depth"}
+Number:Speed Day14_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-wind-gust"}
+Number:Speed Day14_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-wind-speed"}
+Number:Angle Day14_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-wind-dir"}
+Number:Pressure Day14_Hour17_Pressure "Pressure" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-pressure"}
+Number:Length Day14_Hour17_Visibility "Visibility" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-visibility"}
+Number:Dimensionless Day14_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-cloud-cover"}
+Number:Intensity Day14_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-solar-radiation"}
+Number Day14_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-solar-energy"}
+Number Day14_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-uv-index"}
+Number Day14_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-severe-risk"}
+String Day14_Hour17_Conditions "Conditions" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-conditions"}
+String Day14_Hour17_Icon "Icon" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-icon"}
+String Day14_Hour17_Stations "Stations" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-stations"}
+String Day14_Hour17_Source "Source" (Total_Weather_Data_Day14_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour17-source"}
+
+// Day14 - Hour18
+Group Total_Weather_Data_Day14_Hour18 "Hour 18" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour18_DateTime "DateTime" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-datetime"}
+DateTime Day14_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-timestamp"}
+Number:Temperature Day14_Hour18_Temperature "Temperature" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-temperature"}
+Number:Temperature Day14_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-feels-like"}
+Number Day14_Hour18_Humidity "Humidity" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-humidity"}
+Number:Temperature Day14_Hour18_Dew "Dew Point" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-dew"}
+Number:Length Day14_Hour18_Precip "Precipitation" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-precip"}
+Number:Dimensionless Day14_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-precip-prob"}
+String Day14_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-precip-type"}
+Number:Length Day14_Hour18_Snow "Snow" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-snow"}
+Number:Length Day14_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-snow-depth"}
+Number:Speed Day14_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-wind-gust"}
+Number:Speed Day14_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-wind-speed"}
+Number:Angle Day14_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-wind-dir"}
+Number:Pressure Day14_Hour18_Pressure "Pressure" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-pressure"}
+Number:Length Day14_Hour18_Visibility "Visibility" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-visibility"}
+Number:Dimensionless Day14_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-cloud-cover"}
+Number:Intensity Day14_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-solar-radiation"}
+Number Day14_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-solar-energy"}
+Number Day14_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-uv-index"}
+Number Day14_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-severe-risk"}
+String Day14_Hour18_Conditions "Conditions" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-conditions"}
+String Day14_Hour18_Icon "Icon" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-icon"}
+String Day14_Hour18_Stations "Stations" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-stations"}
+String Day14_Hour18_Source "Source" (Total_Weather_Data_Day14_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour18-source"}
+
+// Day14 - Hour19
+Group Total_Weather_Data_Day14_Hour19 "Hour 19" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour19_DateTime "DateTime" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-datetime"}
+DateTime Day14_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-timestamp"}
+Number:Temperature Day14_Hour19_Temperature "Temperature" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-temperature"}
+Number:Temperature Day14_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-feels-like"}
+Number Day14_Hour19_Humidity "Humidity" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-humidity"}
+Number:Temperature Day14_Hour19_Dew "Dew Point" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-dew"}
+Number:Length Day14_Hour19_Precip "Precipitation" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-precip"}
+Number:Dimensionless Day14_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-precip-prob"}
+String Day14_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-precip-type"}
+Number:Length Day14_Hour19_Snow "Snow" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-snow"}
+Number:Length Day14_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-snow-depth"}
+Number:Speed Day14_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-wind-gust"}
+Number:Speed Day14_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-wind-speed"}
+Number:Angle Day14_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-wind-dir"}
+Number:Pressure Day14_Hour19_Pressure "Pressure" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-pressure"}
+Number:Length Day14_Hour19_Visibility "Visibility" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-visibility"}
+Number:Dimensionless Day14_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-cloud-cover"}
+Number:Intensity Day14_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-solar-radiation"}
+Number Day14_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-solar-energy"}
+Number Day14_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-uv-index"}
+Number Day14_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-severe-risk"}
+String Day14_Hour19_Conditions "Conditions" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-conditions"}
+String Day14_Hour19_Icon "Icon" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-icon"}
+String Day14_Hour19_Stations "Stations" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-stations"}
+String Day14_Hour19_Source "Source" (Total_Weather_Data_Day14_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour19-source"}
+
+// Day14 - Hour20
+Group Total_Weather_Data_Day14_Hour20 "Hour 20" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour20_DateTime "DateTime" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-datetime"}
+DateTime Day14_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-timestamp"}
+Number:Temperature Day14_Hour20_Temperature "Temperature" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-temperature"}
+Number:Temperature Day14_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-feels-like"}
+Number Day14_Hour20_Humidity "Humidity" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-humidity"}
+Number:Temperature Day14_Hour20_Dew "Dew Point" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-dew"}
+Number:Length Day14_Hour20_Precip "Precipitation" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-precip"}
+Number:Dimensionless Day14_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-precip-prob"}
+String Day14_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-precip-type"}
+Number:Length Day14_Hour20_Snow "Snow" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-snow"}
+Number:Length Day14_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-snow-depth"}
+Number:Speed Day14_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-wind-gust"}
+Number:Speed Day14_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-wind-speed"}
+Number:Angle Day14_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-wind-dir"}
+Number:Pressure Day14_Hour20_Pressure "Pressure" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-pressure"}
+Number:Length Day14_Hour20_Visibility "Visibility" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-visibility"}
+Number:Dimensionless Day14_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-cloud-cover"}
+Number:Intensity Day14_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-solar-radiation"}
+Number Day14_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-solar-energy"}
+Number Day14_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-uv-index"}
+Number Day14_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-severe-risk"}
+String Day14_Hour20_Conditions "Conditions" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-conditions"}
+String Day14_Hour20_Icon "Icon" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-icon"}
+String Day14_Hour20_Stations "Stations" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-stations"}
+String Day14_Hour20_Source "Source" (Total_Weather_Data_Day14_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour20-source"}
+
+// Day14 - Hour21
+Group Total_Weather_Data_Day14_Hour21 "Hour 21" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour21_DateTime "DateTime" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-datetime"}
+DateTime Day14_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-timestamp"}
+Number:Temperature Day14_Hour21_Temperature "Temperature" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-temperature"}
+Number:Temperature Day14_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-feels-like"}
+Number Day14_Hour21_Humidity "Humidity" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-humidity"}
+Number:Temperature Day14_Hour21_Dew "Dew Point" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-dew"}
+Number:Length Day14_Hour21_Precip "Precipitation" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-precip"}
+Number:Dimensionless Day14_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-precip-prob"}
+String Day14_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-precip-type"}
+Number:Length Day14_Hour21_Snow "Snow" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-snow"}
+Number:Length Day14_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-snow-depth"}
+Number:Speed Day14_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-wind-gust"}
+Number:Speed Day14_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-wind-speed"}
+Number:Angle Day14_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-wind-dir"}
+Number:Pressure Day14_Hour21_Pressure "Pressure" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-pressure"}
+Number:Length Day14_Hour21_Visibility "Visibility" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-visibility"}
+Number:Dimensionless Day14_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-cloud-cover"}
+Number:Intensity Day14_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-solar-radiation"}
+Number Day14_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-solar-energy"}
+Number Day14_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-uv-index"}
+Number Day14_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-severe-risk"}
+String Day14_Hour21_Conditions "Conditions" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-conditions"}
+String Day14_Hour21_Icon "Icon" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-icon"}
+String Day14_Hour21_Stations "Stations" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-stations"}
+String Day14_Hour21_Source "Source" (Total_Weather_Data_Day14_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour21-source"}
+
+// Day14 - Hour22
+Group Total_Weather_Data_Day14_Hour22 "Hour 22" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour22_DateTime "DateTime" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-datetime"}
+DateTime Day14_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-timestamp"}
+Number:Temperature Day14_Hour22_Temperature "Temperature" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-temperature"}
+Number:Temperature Day14_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-feels-like"}
+Number Day14_Hour22_Humidity "Humidity" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-humidity"}
+Number:Temperature Day14_Hour22_Dew "Dew Point" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-dew"}
+Number:Length Day14_Hour22_Precip "Precipitation" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-precip"}
+Number:Dimensionless Day14_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-precip-prob"}
+String Day14_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-precip-type"}
+Number:Length Day14_Hour22_Snow "Snow" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-snow"}
+Number:Length Day14_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-snow-depth"}
+Number:Speed Day14_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-wind-gust"}
+Number:Speed Day14_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-wind-speed"}
+Number:Angle Day14_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-wind-dir"}
+Number:Pressure Day14_Hour22_Pressure "Pressure" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-pressure"}
+Number:Length Day14_Hour22_Visibility "Visibility" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-visibility"}
+Number:Dimensionless Day14_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-cloud-cover"}
+Number:Intensity Day14_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-solar-radiation"}
+Number Day14_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-solar-energy"}
+Number Day14_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-uv-index"}
+Number Day14_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-severe-risk"}
+String Day14_Hour22_Conditions "Conditions" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-conditions"}
+String Day14_Hour22_Icon "Icon" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-icon"}
+String Day14_Hour22_Stations "Stations" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-stations"}
+String Day14_Hour22_Source "Source" (Total_Weather_Data_Day14_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour22-source"}
+
+// Day14 - Hour23
+Group Total_Weather_Data_Day14_Hour23 "Hour 23" (Total_Weather_Data_Day14) [ "Equipment" ] 
+String Day14_Hour23_DateTime "DateTime" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-datetime"}
+DateTime Day14_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-timestamp"}
+Number:Temperature Day14_Hour23_Temperature "Temperature" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-temperature"}
+Number:Temperature Day14_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-feels-like"}
+Number Day14_Hour23_Humidity "Humidity" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-humidity"}
+Number:Temperature Day14_Hour23_Dew "Dew Point" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-dew"}
+Number:Length Day14_Hour23_Precip "Precipitation" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-precip"}
+Number:Dimensionless Day14_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-precip-prob"}
+String Day14_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-precip-type"}
+Number:Length Day14_Hour23_Snow "Snow" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-snow"}
+Number:Length Day14_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-snow-depth"}
+Number:Speed Day14_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-wind-gust"}
+Number:Speed Day14_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-wind-speed"}
+Number:Angle Day14_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-wind-dir"}
+Number:Pressure Day14_Hour23_Pressure "Pressure" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-pressure"}
+Number:Length Day14_Hour23_Visibility "Visibility" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-visibility"}
+Number:Dimensionless Day14_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-cloud-cover"}
+Number:Intensity Day14_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-solar-radiation"}
+Number Day14_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-solar-energy"}
+Number Day14_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-uv-index"}
+Number Day14_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-severe-risk"}
+String Day14_Hour23_Conditions "Conditions" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-conditions"}
+String Day14_Hour23_Icon "Icon" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-icon"}
+String Day14_Hour23_Stations "Stations" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-stations"}
+String Day14_Hour23_Source "Source" (Total_Weather_Data_Day14_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day14#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/docs/Day_15.items
+++ b/bundles/org.openhab.binding.visualcrossing/docs/Day_15.items
@@ -1,39 +1,712 @@
 // Day15
 Group Total_Weather_Data_Day15 "Day T+15" (Total_Weather_Data) [ "Equipment" ] 
-String Day15_DateTime "Time" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#datetime" }
-DateTime Day15_Timestamp "Timestamp" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#timestamp" }
-Number:Temperature Day15_Temperature "Temperature" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature" }
-Number:Temperature Day15_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-min" }
-Number:Temperature Day15_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#temperature-max" }
-Number:Temperature Day15_FeelsLike "Feels Like" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like" }
-Number:Temperature Day15_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-min" }
-Number:Temperature Day15_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#feels-like-max" }
-Number:Temperature Day15_Dew "Dew Point" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#dew" }
-Number Day15_Humidity "Humidity" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#humidity" }
-Number:Length Day15_Precip "Precipitation" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#precip" }
-Number Day15_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-prob" }
-String Day15_Precip_Type "Precipitation Type" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-type" }
-Number Day15_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#precip-cover" }
-Number:Length Day15_Snow "Snow" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#snow" }
-Number:Length Day15_Snow_Depth "Snow Depth" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#snow-depth" }
-Number:Speed Day15_Wind_Gust "Wind Gust" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-gust" }
-Number:Speed Day15_Wind_Speed "Wind Speed" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-speed" }
-Number:Angle Day15_Wind_Dir "Wind Direction" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#wind-dir" }
-Number:Pressure Day15_Pressure "Pressure" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#pressure" }
-Number Day15_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#cloud-cover" }
-Number:Length Day15_Visibility "Visibility" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#visibility" }
-Number:Intensity Day15_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-radiation" }
-Number Day15_Solar_Energy "Solar Energy" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#solar-energy" }
-Number Day15_UV_Index "UV Index" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#uv-index" }
-String Day15_Sunrise "Sunrise" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise" }
-DateTime Day15_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#sunrise-epoch" }
-String Day15_Sunset "Sunset" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset" }
-DateTime Day15_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#sunset-epoch" }
-Number Day15_Moon_Phase "Moon Phase" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#moon-phase" }
-String Day15_Conditions "Conditions" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#conditions" }
-String Day15_Description "Description" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#description" }
-String Day15_Icon "Icon" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#icon" }
-String Day15_Stations "Stations" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#stations" }
-String Day15_Source "Source" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#source" }
-Number Day15_Severe_Risk "Severe Risk" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day01#severe-risk" }
+String Day15_DateTime "Time" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#datetime" }
+DateTime Day15_Timestamp "Timestamp" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#timestamp" }
+Number:Temperature Day15_Temperature "Temperature" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#temperature" }
+Number:Temperature Day15_Temperature_Min "Minimum Temperature" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#temperature-min" }
+Number:Temperature Day15_Temperature_Max "Maximum Temperature" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#temperature-max" }
+Number:Temperature Day15_FeelsLike "Feels Like" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#feels-like" }
+Number:Temperature Day15_FeelsLike_Min "Feels Like (min)" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#feels-like-min" }
+Number:Temperature Day15_FeelsLike_Max "Feels Like (max)" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#feels-like-max" }
+Number:Temperature Day15_Dew "Dew Point" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#dew" }
+Number Day15_Humidity "Humidity" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#humidity" }
+Number:Length Day15_Precip "Precipitation" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#precip" }
+Number Day15_Precip_Prob "Precipitation Probability" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#precip-prob" }
+String Day15_Precip_Type "Precipitation Type" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#precip-type" }
+Number Day15_Precip_Cover "Precipitation Cover" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#precip-cover" }
+Number:Length Day15_Snow "Snow" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#snow" }
+Number:Length Day15_Snow_Depth "Snow Depth" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#snow-depth" }
+Number:Speed Day15_Wind_Gust "Wind Gust" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#wind-gust" }
+Number:Speed Day15_Wind_Speed "Wind Speed" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#wind-speed" }
+Number:Angle Day15_Wind_Dir "Wind Direction" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#wind-dir" }
+Number:Pressure Day15_Pressure "Pressure" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#pressure" }
+Number Day15_Cloud_Cover "Cloud Cover" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#cloud-cover" }
+Number:Length Day15_Visibility "Visibility" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#visibility" }
+Number:Intensity Day15_Solar_Radiation "Solar Radiation" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#solar-radiation" }
+Number Day15_Solar_Energy "Solar Energy" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#solar-energy" }
+Number Day15_UV_Index "UV Index" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#uv-index" }
+String Day15_Sunrise "Sunrise" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#sunrise" }
+DateTime Day15_Sunrise_Epoch "Sunrise Epoch" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#sunrise-epoch" }
+String Day15_Sunset "Sunset" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#sunset" }
+DateTime Day15_Sunset_Epoch "Sunset Epoch" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#sunset-epoch" }
+Number Day15_Moon_Phase "Moon Phase" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#moon-phase" }
+String Day15_Conditions "Conditions" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#conditions" }
+String Day15_Description "Description" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#description" }
+String Day15_Icon "Icon" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#icon" }
+String Day15_Stations "Stations" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#stations" }
+String Day15_Source "Source" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#source" }
+Number Day15_Severe_Risk "Severe Risk" (Total_Weather_Data_Day15)["Point"] { channel="visualcrossing:weather:default_config:day15#severe-risk" }
+
+// Day15 - Hour00
+Group Total_Weather_Data_Day15_Hour00 "Hour 00" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour00_DateTime "DateTime" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-datetime"}
+DateTime Day15_Hour00_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-timestamp"}
+Number:Temperature Day15_Hour00_Temperature "Temperature" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-temperature"}
+Number:Temperature Day15_Hour00_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-feels-like"}
+Number Day15_Hour00_Humidity "Humidity" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-humidity"}
+Number:Temperature Day15_Hour00_Dew "Dew Point" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-dew"}
+Number:Length Day15_Hour00_Precip "Precipitation" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-precip"}
+Number:Dimensionless Day15_Hour00_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-precip-prob"}
+String Day15_Hour00_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-precip-type"}
+Number:Length Day15_Hour00_Snow "Snow" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-snow"}
+Number:Length Day15_Hour00_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-snow-depth"}
+Number:Speed Day15_Hour00_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-wind-gust"}
+Number:Speed Day15_Hour00_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-wind-speed"}
+Number:Angle Day15_Hour00_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-wind-dir"}
+Number:Pressure Day15_Hour00_Pressure "Pressure" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-pressure"}
+Number:Length Day15_Hour00_Visibility "Visibility" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-visibility"}
+Number:Dimensionless Day15_Hour00_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-cloud-cover"}
+Number:Intensity Day15_Hour00_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-solar-radiation"}
+Number Day15_Hour00_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-solar-energy"}
+Number Day15_Hour00_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-uv-index"}
+Number Day15_Hour00_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-severe-risk"}
+String Day15_Hour00_Conditions "Conditions" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-conditions"}
+String Day15_Hour00_Icon "Icon" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-icon"}
+String Day15_Hour00_Stations "Stations" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-stations"}
+String Day15_Hour00_Source "Source" (Total_Weather_Data_Day15_Hour00) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour00-source"}
+
+// Day15 - Hour01
+Group Total_Weather_Data_Day15_Hour01 "Hour 01" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour01_DateTime "DateTime" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-datetime"}
+DateTime Day15_Hour01_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-timestamp"}
+Number:Temperature Day15_Hour01_Temperature "Temperature" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-temperature"}
+Number:Temperature Day15_Hour01_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-feels-like"}
+Number Day15_Hour01_Humidity "Humidity" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-humidity"}
+Number:Temperature Day15_Hour01_Dew "Dew Point" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-dew"}
+Number:Length Day15_Hour01_Precip "Precipitation" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-precip"}
+Number:Dimensionless Day15_Hour01_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-precip-prob"}
+String Day15_Hour01_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-precip-type"}
+Number:Length Day15_Hour01_Snow "Snow" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-snow"}
+Number:Length Day15_Hour01_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-snow-depth"}
+Number:Speed Day15_Hour01_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-wind-gust"}
+Number:Speed Day15_Hour01_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-wind-speed"}
+Number:Angle Day15_Hour01_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-wind-dir"}
+Number:Pressure Day15_Hour01_Pressure "Pressure" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-pressure"}
+Number:Length Day15_Hour01_Visibility "Visibility" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-visibility"}
+Number:Dimensionless Day15_Hour01_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-cloud-cover"}
+Number:Intensity Day15_Hour01_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-solar-radiation"}
+Number Day15_Hour01_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-solar-energy"}
+Number Day15_Hour01_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-uv-index"}
+Number Day15_Hour01_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-severe-risk"}
+String Day15_Hour01_Conditions "Conditions" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-conditions"}
+String Day15_Hour01_Icon "Icon" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-icon"}
+String Day15_Hour01_Stations "Stations" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-stations"}
+String Day15_Hour01_Source "Source" (Total_Weather_Data_Day15_Hour01) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour01-source"}
+
+// Day15 - Hour02
+Group Total_Weather_Data_Day15_Hour02 "Hour 02" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour02_DateTime "DateTime" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-datetime"}
+DateTime Day15_Hour02_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-timestamp"}
+Number:Temperature Day15_Hour02_Temperature "Temperature" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-temperature"}
+Number:Temperature Day15_Hour02_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-feels-like"}
+Number Day15_Hour02_Humidity "Humidity" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-humidity"}
+Number:Temperature Day15_Hour02_Dew "Dew Point" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-dew"}
+Number:Length Day15_Hour02_Precip "Precipitation" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-precip"}
+Number:Dimensionless Day15_Hour02_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-precip-prob"}
+String Day15_Hour02_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-precip-type"}
+Number:Length Day15_Hour02_Snow "Snow" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-snow"}
+Number:Length Day15_Hour02_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-snow-depth"}
+Number:Speed Day15_Hour02_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-wind-gust"}
+Number:Speed Day15_Hour02_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-wind-speed"}
+Number:Angle Day15_Hour02_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-wind-dir"}
+Number:Pressure Day15_Hour02_Pressure "Pressure" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-pressure"}
+Number:Length Day15_Hour02_Visibility "Visibility" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-visibility"}
+Number:Dimensionless Day15_Hour02_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-cloud-cover"}
+Number:Intensity Day15_Hour02_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-solar-radiation"}
+Number Day15_Hour02_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-solar-energy"}
+Number Day15_Hour02_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-uv-index"}
+Number Day15_Hour02_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-severe-risk"}
+String Day15_Hour02_Conditions "Conditions" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-conditions"}
+String Day15_Hour02_Icon "Icon" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-icon"}
+String Day15_Hour02_Stations "Stations" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-stations"}
+String Day15_Hour02_Source "Source" (Total_Weather_Data_Day15_Hour02) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour02-source"}
+
+// Day15 - Hour03
+Group Total_Weather_Data_Day15_Hour03 "Hour 03" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour03_DateTime "DateTime" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-datetime"}
+DateTime Day15_Hour03_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-timestamp"}
+Number:Temperature Day15_Hour03_Temperature "Temperature" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-temperature"}
+Number:Temperature Day15_Hour03_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-feels-like"}
+Number Day15_Hour03_Humidity "Humidity" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-humidity"}
+Number:Temperature Day15_Hour03_Dew "Dew Point" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-dew"}
+Number:Length Day15_Hour03_Precip "Precipitation" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-precip"}
+Number:Dimensionless Day15_Hour03_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-precip-prob"}
+String Day15_Hour03_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-precip-type"}
+Number:Length Day15_Hour03_Snow "Snow" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-snow"}
+Number:Length Day15_Hour03_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-snow-depth"}
+Number:Speed Day15_Hour03_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-wind-gust"}
+Number:Speed Day15_Hour03_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-wind-speed"}
+Number:Angle Day15_Hour03_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-wind-dir"}
+Number:Pressure Day15_Hour03_Pressure "Pressure" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-pressure"}
+Number:Length Day15_Hour03_Visibility "Visibility" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-visibility"}
+Number:Dimensionless Day15_Hour03_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-cloud-cover"}
+Number:Intensity Day15_Hour03_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-solar-radiation"}
+Number Day15_Hour03_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-solar-energy"}
+Number Day15_Hour03_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-uv-index"}
+Number Day15_Hour03_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-severe-risk"}
+String Day15_Hour03_Conditions "Conditions" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-conditions"}
+String Day15_Hour03_Icon "Icon" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-icon"}
+String Day15_Hour03_Stations "Stations" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-stations"}
+String Day15_Hour03_Source "Source" (Total_Weather_Data_Day15_Hour03) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour03-source"}
+
+// Day15 - Hour04
+Group Total_Weather_Data_Day15_Hour04 "Hour 04" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour04_DateTime "DateTime" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-datetime"}
+DateTime Day15_Hour04_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-timestamp"}
+Number:Temperature Day15_Hour04_Temperature "Temperature" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-temperature"}
+Number:Temperature Day15_Hour04_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-feels-like"}
+Number Day15_Hour04_Humidity "Humidity" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-humidity"}
+Number:Temperature Day15_Hour04_Dew "Dew Point" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-dew"}
+Number:Length Day15_Hour04_Precip "Precipitation" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-precip"}
+Number:Dimensionless Day15_Hour04_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-precip-prob"}
+String Day15_Hour04_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-precip-type"}
+Number:Length Day15_Hour04_Snow "Snow" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-snow"}
+Number:Length Day15_Hour04_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-snow-depth"}
+Number:Speed Day15_Hour04_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-wind-gust"}
+Number:Speed Day15_Hour04_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-wind-speed"}
+Number:Angle Day15_Hour04_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-wind-dir"}
+Number:Pressure Day15_Hour04_Pressure "Pressure" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-pressure"}
+Number:Length Day15_Hour04_Visibility "Visibility" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-visibility"}
+Number:Dimensionless Day15_Hour04_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-cloud-cover"}
+Number:Intensity Day15_Hour04_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-solar-radiation"}
+Number Day15_Hour04_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-solar-energy"}
+Number Day15_Hour04_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-uv-index"}
+Number Day15_Hour04_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-severe-risk"}
+String Day15_Hour04_Conditions "Conditions" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-conditions"}
+String Day15_Hour04_Icon "Icon" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-icon"}
+String Day15_Hour04_Stations "Stations" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-stations"}
+String Day15_Hour04_Source "Source" (Total_Weather_Data_Day15_Hour04) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour04-source"}
+
+// Day15 - Hour05
+Group Total_Weather_Data_Day15_Hour05 "Hour 05" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour05_DateTime "DateTime" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-datetime"}
+DateTime Day15_Hour05_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-timestamp"}
+Number:Temperature Day15_Hour05_Temperature "Temperature" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-temperature"}
+Number:Temperature Day15_Hour05_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-feels-like"}
+Number Day15_Hour05_Humidity "Humidity" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-humidity"}
+Number:Temperature Day15_Hour05_Dew "Dew Point" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-dew"}
+Number:Length Day15_Hour05_Precip "Precipitation" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-precip"}
+Number:Dimensionless Day15_Hour05_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-precip-prob"}
+String Day15_Hour05_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-precip-type"}
+Number:Length Day15_Hour05_Snow "Snow" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-snow"}
+Number:Length Day15_Hour05_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-snow-depth"}
+Number:Speed Day15_Hour05_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-wind-gust"}
+Number:Speed Day15_Hour05_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-wind-speed"}
+Number:Angle Day15_Hour05_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-wind-dir"}
+Number:Pressure Day15_Hour05_Pressure "Pressure" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-pressure"}
+Number:Length Day15_Hour05_Visibility "Visibility" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-visibility"}
+Number:Dimensionless Day15_Hour05_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-cloud-cover"}
+Number:Intensity Day15_Hour05_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-solar-radiation"}
+Number Day15_Hour05_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-solar-energy"}
+Number Day15_Hour05_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-uv-index"}
+Number Day15_Hour05_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-severe-risk"}
+String Day15_Hour05_Conditions "Conditions" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-conditions"}
+String Day15_Hour05_Icon "Icon" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-icon"}
+String Day15_Hour05_Stations "Stations" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-stations"}
+String Day15_Hour05_Source "Source" (Total_Weather_Data_Day15_Hour05) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour05-source"}
+
+// Day15 - Hour06
+Group Total_Weather_Data_Day15_Hour06 "Hour 06" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour06_DateTime "DateTime" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-datetime"}
+DateTime Day15_Hour06_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-timestamp"}
+Number:Temperature Day15_Hour06_Temperature "Temperature" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-temperature"}
+Number:Temperature Day15_Hour06_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-feels-like"}
+Number Day15_Hour06_Humidity "Humidity" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-humidity"}
+Number:Temperature Day15_Hour06_Dew "Dew Point" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-dew"}
+Number:Length Day15_Hour06_Precip "Precipitation" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-precip"}
+Number:Dimensionless Day15_Hour06_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-precip-prob"}
+String Day15_Hour06_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-precip-type"}
+Number:Length Day15_Hour06_Snow "Snow" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-snow"}
+Number:Length Day15_Hour06_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-snow-depth"}
+Number:Speed Day15_Hour06_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-wind-gust"}
+Number:Speed Day15_Hour06_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-wind-speed"}
+Number:Angle Day15_Hour06_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-wind-dir"}
+Number:Pressure Day15_Hour06_Pressure "Pressure" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-pressure"}
+Number:Length Day15_Hour06_Visibility "Visibility" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-visibility"}
+Number:Dimensionless Day15_Hour06_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-cloud-cover"}
+Number:Intensity Day15_Hour06_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-solar-radiation"}
+Number Day15_Hour06_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-solar-energy"}
+Number Day15_Hour06_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-uv-index"}
+Number Day15_Hour06_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-severe-risk"}
+String Day15_Hour06_Conditions "Conditions" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-conditions"}
+String Day15_Hour06_Icon "Icon" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-icon"}
+String Day15_Hour06_Stations "Stations" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-stations"}
+String Day15_Hour06_Source "Source" (Total_Weather_Data_Day15_Hour06) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour06-source"}
+
+// Day15 - Hour07
+Group Total_Weather_Data_Day15_Hour07 "Hour 07" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour07_DateTime "DateTime" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-datetime"}
+DateTime Day15_Hour07_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-timestamp"}
+Number:Temperature Day15_Hour07_Temperature "Temperature" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-temperature"}
+Number:Temperature Day15_Hour07_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-feels-like"}
+Number Day15_Hour07_Humidity "Humidity" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-humidity"}
+Number:Temperature Day15_Hour07_Dew "Dew Point" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-dew"}
+Number:Length Day15_Hour07_Precip "Precipitation" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-precip"}
+Number:Dimensionless Day15_Hour07_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-precip-prob"}
+String Day15_Hour07_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-precip-type"}
+Number:Length Day15_Hour07_Snow "Snow" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-snow"}
+Number:Length Day15_Hour07_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-snow-depth"}
+Number:Speed Day15_Hour07_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-wind-gust"}
+Number:Speed Day15_Hour07_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-wind-speed"}
+Number:Angle Day15_Hour07_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-wind-dir"}
+Number:Pressure Day15_Hour07_Pressure "Pressure" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-pressure"}
+Number:Length Day15_Hour07_Visibility "Visibility" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-visibility"}
+Number:Dimensionless Day15_Hour07_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-cloud-cover"}
+Number:Intensity Day15_Hour07_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-solar-radiation"}
+Number Day15_Hour07_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-solar-energy"}
+Number Day15_Hour07_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-uv-index"}
+Number Day15_Hour07_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-severe-risk"}
+String Day15_Hour07_Conditions "Conditions" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-conditions"}
+String Day15_Hour07_Icon "Icon" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-icon"}
+String Day15_Hour07_Stations "Stations" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-stations"}
+String Day15_Hour07_Source "Source" (Total_Weather_Data_Day15_Hour07) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour07-source"}
+
+// Day15 - Hour08
+Group Total_Weather_Data_Day15_Hour08 "Hour 08" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour08_DateTime "DateTime" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-datetime"}
+DateTime Day15_Hour08_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-timestamp"}
+Number:Temperature Day15_Hour08_Temperature "Temperature" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-temperature"}
+Number:Temperature Day15_Hour08_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-feels-like"}
+Number Day15_Hour08_Humidity "Humidity" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-humidity"}
+Number:Temperature Day15_Hour08_Dew "Dew Point" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-dew"}
+Number:Length Day15_Hour08_Precip "Precipitation" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-precip"}
+Number:Dimensionless Day15_Hour08_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-precip-prob"}
+String Day15_Hour08_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-precip-type"}
+Number:Length Day15_Hour08_Snow "Snow" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-snow"}
+Number:Length Day15_Hour08_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-snow-depth"}
+Number:Speed Day15_Hour08_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-wind-gust"}
+Number:Speed Day15_Hour08_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-wind-speed"}
+Number:Angle Day15_Hour08_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-wind-dir"}
+Number:Pressure Day15_Hour08_Pressure "Pressure" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-pressure"}
+Number:Length Day15_Hour08_Visibility "Visibility" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-visibility"}
+Number:Dimensionless Day15_Hour08_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-cloud-cover"}
+Number:Intensity Day15_Hour08_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-solar-radiation"}
+Number Day15_Hour08_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-solar-energy"}
+Number Day15_Hour08_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-uv-index"}
+Number Day15_Hour08_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-severe-risk"}
+String Day15_Hour08_Conditions "Conditions" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-conditions"}
+String Day15_Hour08_Icon "Icon" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-icon"}
+String Day15_Hour08_Stations "Stations" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-stations"}
+String Day15_Hour08_Source "Source" (Total_Weather_Data_Day15_Hour08) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour08-source"}
+
+// Day15 - Hour09
+Group Total_Weather_Data_Day15_Hour09 "Hour 09" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour09_DateTime "DateTime" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-datetime"}
+DateTime Day15_Hour09_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-timestamp"}
+Number:Temperature Day15_Hour09_Temperature "Temperature" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-temperature"}
+Number:Temperature Day15_Hour09_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-feels-like"}
+Number Day15_Hour09_Humidity "Humidity" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-humidity"}
+Number:Temperature Day15_Hour09_Dew "Dew Point" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-dew"}
+Number:Length Day15_Hour09_Precip "Precipitation" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-precip"}
+Number:Dimensionless Day15_Hour09_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-precip-prob"}
+String Day15_Hour09_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-precip-type"}
+Number:Length Day15_Hour09_Snow "Snow" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-snow"}
+Number:Length Day15_Hour09_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-snow-depth"}
+Number:Speed Day15_Hour09_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-wind-gust"}
+Number:Speed Day15_Hour09_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-wind-speed"}
+Number:Angle Day15_Hour09_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-wind-dir"}
+Number:Pressure Day15_Hour09_Pressure "Pressure" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-pressure"}
+Number:Length Day15_Hour09_Visibility "Visibility" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-visibility"}
+Number:Dimensionless Day15_Hour09_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-cloud-cover"}
+Number:Intensity Day15_Hour09_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-solar-radiation"}
+Number Day15_Hour09_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-solar-energy"}
+Number Day15_Hour09_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-uv-index"}
+Number Day15_Hour09_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-severe-risk"}
+String Day15_Hour09_Conditions "Conditions" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-conditions"}
+String Day15_Hour09_Icon "Icon" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-icon"}
+String Day15_Hour09_Stations "Stations" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-stations"}
+String Day15_Hour09_Source "Source" (Total_Weather_Data_Day15_Hour09) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour09-source"}
+
+// Day15 - Hour10
+Group Total_Weather_Data_Day15_Hour10 "Hour 10" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour10_DateTime "DateTime" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-datetime"}
+DateTime Day15_Hour10_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-timestamp"}
+Number:Temperature Day15_Hour10_Temperature "Temperature" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-temperature"}
+Number:Temperature Day15_Hour10_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-feels-like"}
+Number Day15_Hour10_Humidity "Humidity" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-humidity"}
+Number:Temperature Day15_Hour10_Dew "Dew Point" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-dew"}
+Number:Length Day15_Hour10_Precip "Precipitation" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-precip"}
+Number:Dimensionless Day15_Hour10_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-precip-prob"}
+String Day15_Hour10_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-precip-type"}
+Number:Length Day15_Hour10_Snow "Snow" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-snow"}
+Number:Length Day15_Hour10_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-snow-depth"}
+Number:Speed Day15_Hour10_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-wind-gust"}
+Number:Speed Day15_Hour10_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-wind-speed"}
+Number:Angle Day15_Hour10_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-wind-dir"}
+Number:Pressure Day15_Hour10_Pressure "Pressure" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-pressure"}
+Number:Length Day15_Hour10_Visibility "Visibility" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-visibility"}
+Number:Dimensionless Day15_Hour10_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-cloud-cover"}
+Number:Intensity Day15_Hour10_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-solar-radiation"}
+Number Day15_Hour10_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-solar-energy"}
+Number Day15_Hour10_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-uv-index"}
+Number Day15_Hour10_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-severe-risk"}
+String Day15_Hour10_Conditions "Conditions" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-conditions"}
+String Day15_Hour10_Icon "Icon" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-icon"}
+String Day15_Hour10_Stations "Stations" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-stations"}
+String Day15_Hour10_Source "Source" (Total_Weather_Data_Day15_Hour10) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour10-source"}
+
+// Day15 - Hour11
+Group Total_Weather_Data_Day15_Hour11 "Hour 11" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour11_DateTime "DateTime" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-datetime"}
+DateTime Day15_Hour11_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-timestamp"}
+Number:Temperature Day15_Hour11_Temperature "Temperature" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-temperature"}
+Number:Temperature Day15_Hour11_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-feels-like"}
+Number Day15_Hour11_Humidity "Humidity" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-humidity"}
+Number:Temperature Day15_Hour11_Dew "Dew Point" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-dew"}
+Number:Length Day15_Hour11_Precip "Precipitation" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-precip"}
+Number:Dimensionless Day15_Hour11_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-precip-prob"}
+String Day15_Hour11_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-precip-type"}
+Number:Length Day15_Hour11_Snow "Snow" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-snow"}
+Number:Length Day15_Hour11_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-snow-depth"}
+Number:Speed Day15_Hour11_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-wind-gust"}
+Number:Speed Day15_Hour11_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-wind-speed"}
+Number:Angle Day15_Hour11_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-wind-dir"}
+Number:Pressure Day15_Hour11_Pressure "Pressure" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-pressure"}
+Number:Length Day15_Hour11_Visibility "Visibility" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-visibility"}
+Number:Dimensionless Day15_Hour11_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-cloud-cover"}
+Number:Intensity Day15_Hour11_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-solar-radiation"}
+Number Day15_Hour11_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-solar-energy"}
+Number Day15_Hour11_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-uv-index"}
+Number Day15_Hour11_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-severe-risk"}
+String Day15_Hour11_Conditions "Conditions" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-conditions"}
+String Day15_Hour11_Icon "Icon" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-icon"}
+String Day15_Hour11_Stations "Stations" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-stations"}
+String Day15_Hour11_Source "Source" (Total_Weather_Data_Day15_Hour11) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour11-source"}
+
+// Day15 - Hour12
+Group Total_Weather_Data_Day15_Hour12 "Hour 12" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour12_DateTime "DateTime" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-datetime"}
+DateTime Day15_Hour12_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-timestamp"}
+Number:Temperature Day15_Hour12_Temperature "Temperature" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-temperature"}
+Number:Temperature Day15_Hour12_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-feels-like"}
+Number Day15_Hour12_Humidity "Humidity" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-humidity"}
+Number:Temperature Day15_Hour12_Dew "Dew Point" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-dew"}
+Number:Length Day15_Hour12_Precip "Precipitation" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-precip"}
+Number:Dimensionless Day15_Hour12_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-precip-prob"}
+String Day15_Hour12_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-precip-type"}
+Number:Length Day15_Hour12_Snow "Snow" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-snow"}
+Number:Length Day15_Hour12_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-snow-depth"}
+Number:Speed Day15_Hour12_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-wind-gust"}
+Number:Speed Day15_Hour12_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-wind-speed"}
+Number:Angle Day15_Hour12_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-wind-dir"}
+Number:Pressure Day15_Hour12_Pressure "Pressure" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-pressure"}
+Number:Length Day15_Hour12_Visibility "Visibility" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-visibility"}
+Number:Dimensionless Day15_Hour12_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-cloud-cover"}
+Number:Intensity Day15_Hour12_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-solar-radiation"}
+Number Day15_Hour12_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-solar-energy"}
+Number Day15_Hour12_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-uv-index"}
+Number Day15_Hour12_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-severe-risk"}
+String Day15_Hour12_Conditions "Conditions" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-conditions"}
+String Day15_Hour12_Icon "Icon" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-icon"}
+String Day15_Hour12_Stations "Stations" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-stations"}
+String Day15_Hour12_Source "Source" (Total_Weather_Data_Day15_Hour12) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour12-source"}
+
+// Day15 - Hour13
+Group Total_Weather_Data_Day15_Hour13 "Hour 13" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour13_DateTime "DateTime" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-datetime"}
+DateTime Day15_Hour13_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-timestamp"}
+Number:Temperature Day15_Hour13_Temperature "Temperature" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-temperature"}
+Number:Temperature Day15_Hour13_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-feels-like"}
+Number Day15_Hour13_Humidity "Humidity" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-humidity"}
+Number:Temperature Day15_Hour13_Dew "Dew Point" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-dew"}
+Number:Length Day15_Hour13_Precip "Precipitation" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-precip"}
+Number:Dimensionless Day15_Hour13_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-precip-prob"}
+String Day15_Hour13_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-precip-type"}
+Number:Length Day15_Hour13_Snow "Snow" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-snow"}
+Number:Length Day15_Hour13_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-snow-depth"}
+Number:Speed Day15_Hour13_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-wind-gust"}
+Number:Speed Day15_Hour13_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-wind-speed"}
+Number:Angle Day15_Hour13_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-wind-dir"}
+Number:Pressure Day15_Hour13_Pressure "Pressure" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-pressure"}
+Number:Length Day15_Hour13_Visibility "Visibility" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-visibility"}
+Number:Dimensionless Day15_Hour13_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-cloud-cover"}
+Number:Intensity Day15_Hour13_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-solar-radiation"}
+Number Day15_Hour13_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-solar-energy"}
+Number Day15_Hour13_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-uv-index"}
+Number Day15_Hour13_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-severe-risk"}
+String Day15_Hour13_Conditions "Conditions" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-conditions"}
+String Day15_Hour13_Icon "Icon" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-icon"}
+String Day15_Hour13_Stations "Stations" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-stations"}
+String Day15_Hour13_Source "Source" (Total_Weather_Data_Day15_Hour13) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour13-source"}
+
+// Day15 - Hour14
+Group Total_Weather_Data_Day15_Hour14 "Hour 14" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour14_DateTime "DateTime" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-datetime"}
+DateTime Day15_Hour14_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-timestamp"}
+Number:Temperature Day15_Hour14_Temperature "Temperature" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-temperature"}
+Number:Temperature Day15_Hour14_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-feels-like"}
+Number Day15_Hour14_Humidity "Humidity" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-humidity"}
+Number:Temperature Day15_Hour14_Dew "Dew Point" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-dew"}
+Number:Length Day15_Hour14_Precip "Precipitation" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-precip"}
+Number:Dimensionless Day15_Hour14_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-precip-prob"}
+String Day15_Hour14_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-precip-type"}
+Number:Length Day15_Hour14_Snow "Snow" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-snow"}
+Number:Length Day15_Hour14_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-snow-depth"}
+Number:Speed Day15_Hour14_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-wind-gust"}
+Number:Speed Day15_Hour14_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-wind-speed"}
+Number:Angle Day15_Hour14_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-wind-dir"}
+Number:Pressure Day15_Hour14_Pressure "Pressure" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-pressure"}
+Number:Length Day15_Hour14_Visibility "Visibility" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-visibility"}
+Number:Dimensionless Day15_Hour14_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-cloud-cover"}
+Number:Intensity Day15_Hour14_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-solar-radiation"}
+Number Day15_Hour14_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-solar-energy"}
+Number Day15_Hour14_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-uv-index"}
+Number Day15_Hour14_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-severe-risk"}
+String Day15_Hour14_Conditions "Conditions" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-conditions"}
+String Day15_Hour14_Icon "Icon" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-icon"}
+String Day15_Hour14_Stations "Stations" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-stations"}
+String Day15_Hour14_Source "Source" (Total_Weather_Data_Day15_Hour14) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour14-source"}
+
+// Day15 - Hour15
+Group Total_Weather_Data_Day15_Hour15 "Hour 15" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour15_DateTime "DateTime" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-datetime"}
+DateTime Day15_Hour15_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-timestamp"}
+Number:Temperature Day15_Hour15_Temperature "Temperature" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-temperature"}
+Number:Temperature Day15_Hour15_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-feels-like"}
+Number Day15_Hour15_Humidity "Humidity" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-humidity"}
+Number:Temperature Day15_Hour15_Dew "Dew Point" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-dew"}
+Number:Length Day15_Hour15_Precip "Precipitation" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-precip"}
+Number:Dimensionless Day15_Hour15_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-precip-prob"}
+String Day15_Hour15_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-precip-type"}
+Number:Length Day15_Hour15_Snow "Snow" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-snow"}
+Number:Length Day15_Hour15_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-snow-depth"}
+Number:Speed Day15_Hour15_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-wind-gust"}
+Number:Speed Day15_Hour15_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-wind-speed"}
+Number:Angle Day15_Hour15_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-wind-dir"}
+Number:Pressure Day15_Hour15_Pressure "Pressure" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-pressure"}
+Number:Length Day15_Hour15_Visibility "Visibility" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-visibility"}
+Number:Dimensionless Day15_Hour15_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-cloud-cover"}
+Number:Intensity Day15_Hour15_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-solar-radiation"}
+Number Day15_Hour15_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-solar-energy"}
+Number Day15_Hour15_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-uv-index"}
+Number Day15_Hour15_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-severe-risk"}
+String Day15_Hour15_Conditions "Conditions" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-conditions"}
+String Day15_Hour15_Icon "Icon" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-icon"}
+String Day15_Hour15_Stations "Stations" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-stations"}
+String Day15_Hour15_Source "Source" (Total_Weather_Data_Day15_Hour15) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour15-source"}
+
+// Day15 - Hour16
+Group Total_Weather_Data_Day15_Hour16 "Hour 16" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour16_DateTime "DateTime" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-datetime"}
+DateTime Day15_Hour16_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-timestamp"}
+Number:Temperature Day15_Hour16_Temperature "Temperature" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-temperature"}
+Number:Temperature Day15_Hour16_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-feels-like"}
+Number Day15_Hour16_Humidity "Humidity" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-humidity"}
+Number:Temperature Day15_Hour16_Dew "Dew Point" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-dew"}
+Number:Length Day15_Hour16_Precip "Precipitation" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-precip"}
+Number:Dimensionless Day15_Hour16_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-precip-prob"}
+String Day15_Hour16_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-precip-type"}
+Number:Length Day15_Hour16_Snow "Snow" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-snow"}
+Number:Length Day15_Hour16_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-snow-depth"}
+Number:Speed Day15_Hour16_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-wind-gust"}
+Number:Speed Day15_Hour16_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-wind-speed"}
+Number:Angle Day15_Hour16_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-wind-dir"}
+Number:Pressure Day15_Hour16_Pressure "Pressure" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-pressure"}
+Number:Length Day15_Hour16_Visibility "Visibility" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-visibility"}
+Number:Dimensionless Day15_Hour16_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-cloud-cover"}
+Number:Intensity Day15_Hour16_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-solar-radiation"}
+Number Day15_Hour16_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-solar-energy"}
+Number Day15_Hour16_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-uv-index"}
+Number Day15_Hour16_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-severe-risk"}
+String Day15_Hour16_Conditions "Conditions" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-conditions"}
+String Day15_Hour16_Icon "Icon" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-icon"}
+String Day15_Hour16_Stations "Stations" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-stations"}
+String Day15_Hour16_Source "Source" (Total_Weather_Data_Day15_Hour16) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour16-source"}
+
+// Day15 - Hour17
+Group Total_Weather_Data_Day15_Hour17 "Hour 17" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour17_DateTime "DateTime" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-datetime"}
+DateTime Day15_Hour17_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-timestamp"}
+Number:Temperature Day15_Hour17_Temperature "Temperature" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-temperature"}
+Number:Temperature Day15_Hour17_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-feels-like"}
+Number Day15_Hour17_Humidity "Humidity" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-humidity"}
+Number:Temperature Day15_Hour17_Dew "Dew Point" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-dew"}
+Number:Length Day15_Hour17_Precip "Precipitation" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-precip"}
+Number:Dimensionless Day15_Hour17_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-precip-prob"}
+String Day15_Hour17_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-precip-type"}
+Number:Length Day15_Hour17_Snow "Snow" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-snow"}
+Number:Length Day15_Hour17_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-snow-depth"}
+Number:Speed Day15_Hour17_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-wind-gust"}
+Number:Speed Day15_Hour17_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-wind-speed"}
+Number:Angle Day15_Hour17_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-wind-dir"}
+Number:Pressure Day15_Hour17_Pressure "Pressure" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-pressure"}
+Number:Length Day15_Hour17_Visibility "Visibility" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-visibility"}
+Number:Dimensionless Day15_Hour17_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-cloud-cover"}
+Number:Intensity Day15_Hour17_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-solar-radiation"}
+Number Day15_Hour17_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-solar-energy"}
+Number Day15_Hour17_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-uv-index"}
+Number Day15_Hour17_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-severe-risk"}
+String Day15_Hour17_Conditions "Conditions" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-conditions"}
+String Day15_Hour17_Icon "Icon" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-icon"}
+String Day15_Hour17_Stations "Stations" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-stations"}
+String Day15_Hour17_Source "Source" (Total_Weather_Data_Day15_Hour17) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour17-source"}
+
+// Day15 - Hour18
+Group Total_Weather_Data_Day15_Hour18 "Hour 18" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour18_DateTime "DateTime" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-datetime"}
+DateTime Day15_Hour18_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-timestamp"}
+Number:Temperature Day15_Hour18_Temperature "Temperature" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-temperature"}
+Number:Temperature Day15_Hour18_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-feels-like"}
+Number Day15_Hour18_Humidity "Humidity" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-humidity"}
+Number:Temperature Day15_Hour18_Dew "Dew Point" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-dew"}
+Number:Length Day15_Hour18_Precip "Precipitation" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-precip"}
+Number:Dimensionless Day15_Hour18_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-precip-prob"}
+String Day15_Hour18_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-precip-type"}
+Number:Length Day15_Hour18_Snow "Snow" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-snow"}
+Number:Length Day15_Hour18_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-snow-depth"}
+Number:Speed Day15_Hour18_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-wind-gust"}
+Number:Speed Day15_Hour18_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-wind-speed"}
+Number:Angle Day15_Hour18_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-wind-dir"}
+Number:Pressure Day15_Hour18_Pressure "Pressure" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-pressure"}
+Number:Length Day15_Hour18_Visibility "Visibility" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-visibility"}
+Number:Dimensionless Day15_Hour18_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-cloud-cover"}
+Number:Intensity Day15_Hour18_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-solar-radiation"}
+Number Day15_Hour18_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-solar-energy"}
+Number Day15_Hour18_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-uv-index"}
+Number Day15_Hour18_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-severe-risk"}
+String Day15_Hour18_Conditions "Conditions" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-conditions"}
+String Day15_Hour18_Icon "Icon" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-icon"}
+String Day15_Hour18_Stations "Stations" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-stations"}
+String Day15_Hour18_Source "Source" (Total_Weather_Data_Day15_Hour18) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour18-source"}
+
+// Day15 - Hour19
+Group Total_Weather_Data_Day15_Hour19 "Hour 19" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour19_DateTime "DateTime" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-datetime"}
+DateTime Day15_Hour19_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-timestamp"}
+Number:Temperature Day15_Hour19_Temperature "Temperature" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-temperature"}
+Number:Temperature Day15_Hour19_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-feels-like"}
+Number Day15_Hour19_Humidity "Humidity" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-humidity"}
+Number:Temperature Day15_Hour19_Dew "Dew Point" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-dew"}
+Number:Length Day15_Hour19_Precip "Precipitation" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-precip"}
+Number:Dimensionless Day15_Hour19_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-precip-prob"}
+String Day15_Hour19_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-precip-type"}
+Number:Length Day15_Hour19_Snow "Snow" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-snow"}
+Number:Length Day15_Hour19_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-snow-depth"}
+Number:Speed Day15_Hour19_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-wind-gust"}
+Number:Speed Day15_Hour19_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-wind-speed"}
+Number:Angle Day15_Hour19_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-wind-dir"}
+Number:Pressure Day15_Hour19_Pressure "Pressure" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-pressure"}
+Number:Length Day15_Hour19_Visibility "Visibility" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-visibility"}
+Number:Dimensionless Day15_Hour19_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-cloud-cover"}
+Number:Intensity Day15_Hour19_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-solar-radiation"}
+Number Day15_Hour19_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-solar-energy"}
+Number Day15_Hour19_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-uv-index"}
+Number Day15_Hour19_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-severe-risk"}
+String Day15_Hour19_Conditions "Conditions" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-conditions"}
+String Day15_Hour19_Icon "Icon" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-icon"}
+String Day15_Hour19_Stations "Stations" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-stations"}
+String Day15_Hour19_Source "Source" (Total_Weather_Data_Day15_Hour19) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour19-source"}
+
+// Day15 - Hour20
+Group Total_Weather_Data_Day15_Hour20 "Hour 20" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour20_DateTime "DateTime" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-datetime"}
+DateTime Day15_Hour20_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-timestamp"}
+Number:Temperature Day15_Hour20_Temperature "Temperature" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-temperature"}
+Number:Temperature Day15_Hour20_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-feels-like"}
+Number Day15_Hour20_Humidity "Humidity" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-humidity"}
+Number:Temperature Day15_Hour20_Dew "Dew Point" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-dew"}
+Number:Length Day15_Hour20_Precip "Precipitation" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-precip"}
+Number:Dimensionless Day15_Hour20_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-precip-prob"}
+String Day15_Hour20_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-precip-type"}
+Number:Length Day15_Hour20_Snow "Snow" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-snow"}
+Number:Length Day15_Hour20_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-snow-depth"}
+Number:Speed Day15_Hour20_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-wind-gust"}
+Number:Speed Day15_Hour20_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-wind-speed"}
+Number:Angle Day15_Hour20_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-wind-dir"}
+Number:Pressure Day15_Hour20_Pressure "Pressure" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-pressure"}
+Number:Length Day15_Hour20_Visibility "Visibility" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-visibility"}
+Number:Dimensionless Day15_Hour20_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-cloud-cover"}
+Number:Intensity Day15_Hour20_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-solar-radiation"}
+Number Day15_Hour20_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-solar-energy"}
+Number Day15_Hour20_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-uv-index"}
+Number Day15_Hour20_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-severe-risk"}
+String Day15_Hour20_Conditions "Conditions" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-conditions"}
+String Day15_Hour20_Icon "Icon" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-icon"}
+String Day15_Hour20_Stations "Stations" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-stations"}
+String Day15_Hour20_Source "Source" (Total_Weather_Data_Day15_Hour20) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour20-source"}
+
+// Day15 - Hour21
+Group Total_Weather_Data_Day15_Hour21 "Hour 21" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour21_DateTime "DateTime" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-datetime"}
+DateTime Day15_Hour21_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-timestamp"}
+Number:Temperature Day15_Hour21_Temperature "Temperature" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-temperature"}
+Number:Temperature Day15_Hour21_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-feels-like"}
+Number Day15_Hour21_Humidity "Humidity" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-humidity"}
+Number:Temperature Day15_Hour21_Dew "Dew Point" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-dew"}
+Number:Length Day15_Hour21_Precip "Precipitation" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-precip"}
+Number:Dimensionless Day15_Hour21_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-precip-prob"}
+String Day15_Hour21_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-precip-type"}
+Number:Length Day15_Hour21_Snow "Snow" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-snow"}
+Number:Length Day15_Hour21_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-snow-depth"}
+Number:Speed Day15_Hour21_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-wind-gust"}
+Number:Speed Day15_Hour21_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-wind-speed"}
+Number:Angle Day15_Hour21_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-wind-dir"}
+Number:Pressure Day15_Hour21_Pressure "Pressure" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-pressure"}
+Number:Length Day15_Hour21_Visibility "Visibility" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-visibility"}
+Number:Dimensionless Day15_Hour21_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-cloud-cover"}
+Number:Intensity Day15_Hour21_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-solar-radiation"}
+Number Day15_Hour21_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-solar-energy"}
+Number Day15_Hour21_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-uv-index"}
+Number Day15_Hour21_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-severe-risk"}
+String Day15_Hour21_Conditions "Conditions" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-conditions"}
+String Day15_Hour21_Icon "Icon" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-icon"}
+String Day15_Hour21_Stations "Stations" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-stations"}
+String Day15_Hour21_Source "Source" (Total_Weather_Data_Day15_Hour21) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour21-source"}
+
+// Day15 - Hour22
+Group Total_Weather_Data_Day15_Hour22 "Hour 22" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour22_DateTime "DateTime" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-datetime"}
+DateTime Day15_Hour22_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-timestamp"}
+Number:Temperature Day15_Hour22_Temperature "Temperature" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-temperature"}
+Number:Temperature Day15_Hour22_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-feels-like"}
+Number Day15_Hour22_Humidity "Humidity" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-humidity"}
+Number:Temperature Day15_Hour22_Dew "Dew Point" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-dew"}
+Number:Length Day15_Hour22_Precip "Precipitation" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-precip"}
+Number:Dimensionless Day15_Hour22_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-precip-prob"}
+String Day15_Hour22_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-precip-type"}
+Number:Length Day15_Hour22_Snow "Snow" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-snow"}
+Number:Length Day15_Hour22_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-snow-depth"}
+Number:Speed Day15_Hour22_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-wind-gust"}
+Number:Speed Day15_Hour22_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-wind-speed"}
+Number:Angle Day15_Hour22_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-wind-dir"}
+Number:Pressure Day15_Hour22_Pressure "Pressure" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-pressure"}
+Number:Length Day15_Hour22_Visibility "Visibility" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-visibility"}
+Number:Dimensionless Day15_Hour22_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-cloud-cover"}
+Number:Intensity Day15_Hour22_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-solar-radiation"}
+Number Day15_Hour22_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-solar-energy"}
+Number Day15_Hour22_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-uv-index"}
+Number Day15_Hour22_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-severe-risk"}
+String Day15_Hour22_Conditions "Conditions" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-conditions"}
+String Day15_Hour22_Icon "Icon" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-icon"}
+String Day15_Hour22_Stations "Stations" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-stations"}
+String Day15_Hour22_Source "Source" (Total_Weather_Data_Day15_Hour22) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour22-source"}
+
+// Day15 - Hour23
+Group Total_Weather_Data_Day15_Hour23 "Hour 23" (Total_Weather_Data_Day15) [ "Equipment" ] 
+String Day15_Hour23_DateTime "DateTime" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-datetime"}
+DateTime Day15_Hour23_Timestamp "Timestamp" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-timestamp"}
+Number:Temperature Day15_Hour23_Temperature "Temperature" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-temperature"}
+Number:Temperature Day15_Hour23_FeelsLike "Feels Like" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-feels-like"}
+Number Day15_Hour23_Humidity "Humidity" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-humidity"}
+Number:Temperature Day15_Hour23_Dew "Dew Point" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-dew"}
+Number:Length Day15_Hour23_Precip "Precipitation" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-precip"}
+Number:Dimensionless Day15_Hour23_PrecipProb "Precipitation Probability" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-precip-prob"}
+String Day15_Hour23_PrecipType "Precipitation Type" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-precip-type"}
+Number:Length Day15_Hour23_Snow "Snow" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-snow"}
+Number:Length Day15_Hour23_SnowDepth "Snow Depth" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-snow-depth"}
+Number:Speed Day15_Hour23_WindGust "Wind Gust" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-wind-gust"}
+Number:Speed Day15_Hour23_WindSpeed "Wind Speed" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-wind-speed"}
+Number:Angle Day15_Hour23_WindDir "Wind Direction" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-wind-dir"}
+Number:Pressure Day15_Hour23_Pressure "Pressure" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-pressure"}
+Number:Length Day15_Hour23_Visibility "Visibility" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-visibility"}
+Number:Dimensionless Day15_Hour23_CloudCover "Cloud Cover" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-cloud-cover"}
+Number:Intensity Day15_Hour23_SolarRadiation "Solar Radiation" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-solar-radiation"}
+Number Day15_Hour23_SolarEnergy "Solar Energy" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-solar-energy"}
+Number Day15_Hour23_UVIndex "UV Index" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-uv-index"}
+Number Day15_Hour23_SevereRisk "Severe Risk" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-severe-risk"}
+String Day15_Hour23_Conditions "Conditions" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-conditions"}
+String Day15_Hour23_Icon "Icon" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-icon"}
+String Day15_Hour23_Stations "Stations" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-stations"}
+String Day15_Hour23_Source "Source" (Total_Weather_Data_Day15_Hour23) ["Point"] { channel="visualcrossing:weather:default_config:day15#hour23-source"}
+
 

--- a/bundles/org.openhab.binding.visualcrossing/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.visualcrossing/src/main/resources/OH-INF/thing/channel-types.xml
@@ -1845,7 +1845,7 @@
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="precip-cover-channel">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Precip Cover</label>
 		<description>The proportion of hours where there was non-zero precipitation</description>
 		<state readOnly="true" min="0" max="100" pattern="%.0f %%"/>

--- a/bundles/org.openhab.binding.visualcrossing/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.visualcrossing/src/main/resources/OH-INF/thing/channel-types.xml
@@ -1830,10 +1830,10 @@
 		<state readOnly="true" pattern="%.2f %unit%"/>
 	</channel-type>
 	<channel-type id="precip-prob-channel">
-		<item-type unitHint="%">Number:Dimensionless</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Precip Prob</label>
 		<description>The likelihood of measurable precipitation ranging from 0% to 100%</description>
-		<state readOnly="true" min="0" max="100" pattern="%.0f %unit%"/>
+		<state readOnly="true" min="0" max="100" pattern="%.0f %%"/>
 	</channel-type>
 	<channel-type id="precip-type-channel">
 		<item-type>String</item-type>
@@ -1845,10 +1845,10 @@
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="precip-cover-channel">
-		<item-type unitHint="%">Number</item-type>
+		<item-type>Number</item-type>
 		<label>Precip Cover</label>
 		<description>The proportion of hours where there was non-zero precipitation</description>
-		<state readOnly="true" min="0" max="100" pattern="%.0f %unit%"/>
+		<state readOnly="true" min="0" max="100" pattern="%.0f %%"/>
 	</channel-type>
 	<channel-type id="snow-channel">
 		<item-type>Number:Length</item-type>
@@ -1870,11 +1870,11 @@
 		<state readOnly="true" pattern="%.2f %unit%"/>
 	</channel-type>
 	<channel-type id="cloud-cover-channel">
-		<item-type unitHint="%">Number:Dimensionless</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Cloud Cover</label>
 		<description>How much of the sky is covered in cloud ranging from 0–100%</description>
 		<category>Sun_Clouds</category>
-		<state readOnly="true" min="0" max="100" pattern="%.0f %unit%"/>
+		<state readOnly="true" min="0" max="100" pattern="%.0f %%"/>
 	</channel-type>
 	<channel-type id="solar-radiation-channel">
 		<item-type>Number:Intensity</item-type>
@@ -1961,7 +1961,7 @@
 		<state readOnly="true" min="0" max="1" pattern="%.1f"/>
 	</channel-type>
 	<channel-type id="severe-risk-channel">
-		<item-type unitHint="%">Number:Dimensionless</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Severe Risk</label>
 		<description>
 			A value between 0 and 100 representing the risk of convective storms (e.g. thunderstorms, hail and
@@ -1969,7 +1969,7 @@
 			potential energy (CAPE) and convective inhibition (CIN), predicted rain and wind. Typically, a severe risk value less
 			than 30 indicates a low risk, between 30 and 70 a moderate risk and above 70 a high risk.
 		</description>
-		<state readOnly="true" min="0" max="100" pattern="%.0f %unit%"/>
+		<state readOnly="true" min="0" max="100" pattern="%.0f %%"/>
 	</channel-type>
 	<!-- ❌ Channels ❌ -->
 </thing:thing-descriptions>


### PR DESCRIPTION
@lsiepel I found 1 bug 😬 and 1 missing doc

1. I cannot add `uihint` with % channel `Caused by: java.lang.IllegalArgumentException: A unit hint must not be set if the item type is not a number with dimension!`
2. At `Day_xx.items` files I was missing hours. `only_days.items` contains days without hours and `Day_xx.items` should contains 0-23 hours (for easy copying)