### PR TITLE
[transform.jinja] Properly use jinjava OSGi

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/pom.xml
@@ -40,5 +40,16 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.hubspot.jinjava</groupId>
+      <artifactId>jinjava</artifactId>
+      <version>2.7.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.re2j</groupId>
+      <artifactId>re2j</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.transform.jinja/pom.xml
+++ b/bundles/org.openhab.transform.jinja/pom.xml
@@ -14,23 +14,16 @@
 
   <name>openHAB Add-ons :: Bundles :: Transformation Service :: Jinja</name>
 
-  <properties>
-    <bnd.importpackage>
-      javax.annotation.*;resolution:=optional,com.googlecode.ipv6.*;resolution:=optional,ch.obermuhlner.math.big.*;resolution:=optional,com.google.common.*;resolution:=optional,com.fasterxml.jackson.*;resolution:=optional,org.jsoup.*;resolution:=optional,org.apache.commons.*;resolution:=optional,org.apache.commons.net.*;resolution:=optional
-    </bnd.importpackage>
-    <dep.noembedding>jackson-annotations,jackson-databind,jackson-core,jackson-dataformat-yaml,commons-lang3,commons-net</dep.noembedding>
-  </properties>
-
   <dependencies>
     <dependency>
-      <groupId>org.openhab.osgiify</groupId>
-      <artifactId>com.hubspot.jinjava.jinjava</artifactId>
+      <groupId>com.hubspot.jinjava</groupId>
+      <artifactId>jinjava</artifactId>
       <version>2.7.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.openhab.osgiify</groupId>
-      <artifactId>com.google.re2j.re2j</artifactId>
+      <groupId>com.google.re2j</groupId>
+      <artifactId>re2j</artifactId>
       <version>1.2</version>
       <scope>compile</scope>
     </dependency>
@@ -68,7 +61,7 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <version>1.15.3</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -5,7 +5,9 @@
 	<feature name="openhab-transformation-jinja" description="Jinja Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.2_0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
+		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
 		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.jinja/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
Follow-up to #17356 
Depends on https://github.com/openhab/openhab-osgiify/pull/49

The former version did use the OSGiified bundle, but did still embed it. This properly adds it as a bundle dependency.