### PR TITLE
[nikohomecontrol] fix basic alarm

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -382,7 +382,8 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             addVideoDevice(device);
         } else if ("accesscontrol".equals(device.model) || "bellbutton".equals(device.model)) {
             addAccessDevice(device, location);
-        } else if ("alarms".equals(device.model)) {
+        } else if ("alarms".equals(device.model) && (device.properties != null)
+                && (device.properties.stream().anyMatch(p -> (p.alarmActive != null)))) {
             addAlarmDevice(device, location);
         } else if ("action".equals(device.type) || "virtual".equals(device.type)) {
             addActionDevice(device, location);
@@ -403,6 +404,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             case "pir":
             case "simulation":
             case "comfort":
+            case "alarms":
             case "alloff":
             case "overallcomfort":
             case "garagedoor":


### PR DESCRIPTION
https://github.com/openhab/openhab-addons/pull/16834 introduced better support for alarm systems in Niko Home Control.

It broke the functionality when the alarm is not a full alarm system with arming/disarming functionality, but just an trigger. This fix restores basic functionality.