### PR TITLE
[tplinksmarthome] Add new device: EP25

### DIFF
--- a/bundles/org.openhab.binding.tplinksmarthome/README.md
+++ b/bundles/org.openhab.binding.tplinksmarthome/README.md
@@ -12,6 +12,12 @@ The following TP-Link Smart Devices are supported:
 - LED On/Off
 - Wi-Fi signal strength (RSSI)
 
+### EP25 Kasa Smart WiFi Plug Slim with Energy Monitoring
+
+- Power On/Off
+- Energy readings
+- Wi-Fi signal strength (RSSI)
+
 ### EP40 Kasa Smart Wi-Fi Outdoor Plug
 
 - Power On/Off Group
@@ -385,13 +391,13 @@ All devices support some of the following channels:
 
 | Channel Type ID     | Item Type                | Description                                    | Thing types supporting this channel                                                                                                                    |
 |---------------------|--------------------------|------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| switch              | Switch                   | Power the device on or off.                    | EP10, EP40, HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS300, KP100, KP105, KP115, KP200, KP303, KP400, KP401, KS230, RE270K, RE370K             |
+| switch              | Switch                   | Power the device on or off.                    | EP10, EP25, EP40, HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS300, KP100, KP105, KP115, KP200, KP303, KP400, KP401, KS230, RE270K, RE370K       |
 | brightness          | Dimmer                   | Set the brightness of device or dimmer.        | ES20M, HS220, KB100, KL50, KL60, KL110, KL120, KP405, LB100, LB110, LB120, LB200                                                                       |
 | colorTemperature    | Dimmer                   | Set the color temperature in percentage.       | KB130, KL120, KL125, KL130, KL135, KL400, KL430, LB120, LB130, LB230                                                                                   |
 | colorTemperatureAbs | Number                   | Set the color temperature in Kelvin.           | KB130, KL120, KL125, KL130, KL135, KL400, KL430, LB120, LB130, LB230                                                                                   |
 | color               | Color                    | Set the color of the light.                    | KB130, KL125, KL130, KL135, KL400, KL430, LB130, LB230                                                                                                 |
-| power               | Number:Power             | Actual energy usage in Watt.                   | HS110, HS300, KLxxx, KP115, KP125, LBxxx,                                                                                                              |
-| eneryUsage          | Number:Energy            | Energy Usage in kWh.                           | HS110, HS300, KP115, KP125                                                                                                                             |
+| power               | Number:Power             | Actual energy usage in Watt.                   | EP25, HS110, HS300, KLxxx, KP115, KP125, LBxxx,                                                                                                        |
+| eneryUsage          | Number:Energy            | Energy Usage in kWh.                           | EP25, HS110, HS300, KP115, KP125                                                                                                                       |
 | current             | Number:ElectricCurrent   | Actual current usage in Ampere.                | HS110, HS300, KP115, KP125                                                                                                                             |
 | voltage             | Number:ElectricPotential | Actual voltage usage in Volt.                  | HS110, HS300, KP115, KP125                                                                                                                             |
 | led                 | Switch                   | Switch the status LED on the device on or off. | ES20M, EP10, EP40, HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS220, HS300, KP100, KP105, KP115, KP125, KP303, KP200, KP400, KP401, KP405, KS230 |

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -55,6 +55,7 @@ public enum TPLinkSmartHomeThingType {
 
     // Plug Thing Type UIDs
     EP10("ep10", DeviceType.PLUG),
+    EP25("ep25", DeviceType.PLUG_WITH_ENERGY),
     HS100("hs100", DeviceType.PLUG),
     HS103("hs103", DeviceType.PLUG),
     HS105("hs105", DeviceType.PLUG),

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/i18n/tplinksmarthome.properties
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/i18n/tplinksmarthome.properties
@@ -7,6 +7,8 @@ addon.tplinksmarthome.description = This binding integrates the TP-Link Wi-Fi Sm
 
 thing-type.tplinksmarthome.ep10.label = EP10
 thing-type.tplinksmarthome.ep10.description = TP-Link EP10 Kasa Smart Wi-Fi Plug Mini
+thing-type.tplinksmarthome.ep25.label = EP25
+thing-type.tplinksmarthome.ep25.description = TP-Link EP25 Kasa Smart WiFi Plug Slim with Energy Monitoring
 thing-type.tplinksmarthome.ep40.label = EP40
 thing-type.tplinksmarthome.ep40.description = TP-Link EP40 Kasa Smart Wi-Fi Outdoor Plug
 thing-type.tplinksmarthome.ep40.group.outlet1.label = Outlet 1

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/EP25.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/EP25.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="ep25">
+		<label>EP25</label>
+		<description>TP-Link EP25 Kasa Smart WiFi Plug Slim with Energy Monitoring</description>
+		<category>PowerOutlet</category>
+
+		<channels>
+			<channel id="switch" typeId="system.power"/>
+			<channel id="rssi" typeId="rssi"/>
+			<channel id="power" typeId="power"/>
+			<channel id="energyUsage" typeId="energy-usage"/>
+			<channel id="current" typeId="current"/>
+			<channel id="voltage" typeId="voltage"/>
+		</channels>
+
+		<representation-property>deviceId</representation-property>
+
+		<config-description-ref uri="thing-type:tplinksmarthome:device-plug"/>
+	</thing-type>
+</thing:thing-descriptions>


### PR DESCRIPTION
The Kasa EP25 appears to be a version of the KP125 that lacks the LED. Because of this, and per the comments in #16027, this simply copies the KP125, without the LED channel.

This is my attempt at contributing to this project, so I'm sure I've missed something. I haven't run any testing or build steps, all I've done is use the code that I saw in PR #1171 (Adding the KP125) as a template and add the EP25 device. I'm hoping this at least provides a base for someone more familiar with the project to do a quick review and test so we can get the device added! As mentioned in #16027, the EP25 appears to behave properly when added manually as a KP125 device, but that is the only testing that I've done, I have *not* figured out how to take this PR into my live OpenHAB environment to test it.

If accepted, this closes #16027 