### PR TITLE
[solarman] Sync inverter definition files from upstream.

### DIFF
--- a/bundles/org.openhab.binding.solarman/README.md
+++ b/bundles/org.openhab.binding.solarman/README.md
@@ -38,19 +38,24 @@ The `inverterType` parameter governs what registers the binding will read from t
 
 Possible values:
 
-| Inverter Type      | Inverters supported                         | Notes                                                            |
-|--------------------|---------------------------------------------|------------------------------------------------------------------|
-| deye_hybrid        | DEYE/Sunsynk/SolArk Hybrid inverters        | used when no lookup specified                                    |
-| deye_sg04lp3       | DEYE/Sunsynk/SolArk Hybrid 8/12K-SG04LP3    | e.g. 12K-SG04LP3-EU                                              |
-| deye_string        | DEYE/Sunsynk/SolArk String inverters        | e.g. SUN-4/5/6/7/8/10/12K-G03 Plus                               |
-| deye_2mppt         | DEYE Microinverter with 2 MPPT Trackers     | e.g. SUN600G3-EU-230 / SUN800G3-EU-230 / SUN1000G3-EU-230        |
-| deye_4mppt         | DEYE Microinverter with 4 MPPT Trackers     | e.g. SUN1300G3-EU-230 / SUN1600G3-EU-230 / SUN2000G3-EU-230      |
-| sofar_lsw3         | SOFAR Inverters                             |                                                                  |
-| sofar_g3hyd        | SOFAR Hybrid Three-Phase inverter           | HYD 6000 or rebranded (three-phase), ex. ZCS Azzurro 3PH HYD-ZSS |
-| sofar_hyd3k-6k-es  | SOFAR Hybrid Single-Phase inverter          | HYD 6000 or rebranded (single-phase), ex. ZCS Azzurro HYD-ZSS    |
-| solis_hybrid       | SOLIS Hybrid inverter                       |                                                                  |
-| solid_1p8k-5g      | SOLIS 1P8K-5G                               |                                                                  |
-| zcs_azzurro-ktl-v3 | ZCS Azzurro KTL-V3 inverters                | ZCS Azzurro 3.3/4.4/5.5/6.6 KTL-V3 (rebranded Sofar KTLX-G3)     |
+| Inverter Type        | Inverters supported                               | Notes                                                            |
+|----------------------|---------------------------------------------------|------------------------------------------------------------------|
+| deye_hybrid          | DEYE/Sunsynk/SolArk Hybrid inverters              | used when no lookup specified                                    |
+| deye_sg04lp3         | DEYE/Sunsynk/SolArk Hybrid 8/12K-SG04LP3          | e.g. 12K-SG04LP3-EU                                              |
+| deye_string          | DEYE/Sunsynk/SolArk String inverters              | e.g. SUN-4/5/6/7/8/10/12K-G03 Plus                               |
+| deye_2mppt           | DEYE Microinverter with 2 MPPT Trackers           | e.g. SUN600G3-EU-230 / SUN800G3-EU-230 / SUN1000G3-EU-230        |
+| deye_4mppt           | DEYE Microinverter with 4 MPPT Trackers           | e.g. SUN1300G3-EU-230 / SUN1600G3-EU-230 / SUN2000G3-EU-230      |
+| sofar_lsw3           | SOFAR Inverters                                   |                                                                  |
+| sofar_g3hyd          | SOFAR Hybrid Three-Phase inverter                 | HYD 6000 or rebranded (three-phase), ex. ZCS Azzurro 3PH HYD-ZSS |
+| sofar_hyd3k-6k-es    | SOFAR Hybrid Single-Phase inverter                | HYD 6000 or rebranded (single-phase), ex. ZCS Azzurro HYD-ZSS    |
+| solis_hybrid         | SOLIS Hybrid inverter                             |                                                                  |
+| solid_1p8k-5g        | SOLIS 1P8K-5G                                     |                                                                  |
+| solis_3p-4g          | SOLIS Three-Phase Inverter 4G Series              |                                                                  |
+| solis_s6-gr1p        | SOLIS Single-Phase Inverter S6-GR1P               |                                                                  |
+| hyd-zss-hp-3k-6k     | ZCS Azzurro Hybrid HP 3K-6K inverters             | Rebranded Sofar models                                           |
+| kstar_hybrid         | KSTAR Hybrid inverters                            |                                                                  |
+| sofar_wifikit        | SOFAR WiFi Kit                                    |                                                                  |
+| zcs_azzurro-ktl-v3   | ZCS Azzurro KTL-V3 inverters                      | ZCS Azzurro 3.3/4.4/5.5/6.6 KTL-V3 (rebranded Sofar KTLX-G3)     |
 
 The `additionalRequests` allows the user to specify additional address ranges to be polled. The format of the value is `mb_functioncode1:start1-end1, mb_functioncode2:start2-end2,...`
 For example `"0x03:0x27D-0x27E"` will issue an additional read for Holding Registers between `0x27D` and `0x27E`.
@@ -60,7 +65,7 @@ This is useful when coupled with user defined channels, for example a thing defi
 ```java
 Thing solarman:logger:local [ hostname="x.x.x.x", inverterType="deye_sg04lp3", serialNumber="1234567890", additionalRequests="0x03:0x27D-0x27E" ] {
         Channels:
-            Type number : Inverter_Frequency [scale="0.01", uom="Hz", rule="3", registers="0x27E"]
+            Type number : inverter-frequency [scale="0.01", uom="Hz", rule="3", registers="0x27E"]
 }
 ```
 
@@ -85,6 +90,13 @@ This is the list you get for the `deye_sg04lp3` inverter type:
 | battery-daily-battery-discharge          | Number | R            | Daily Battery Discharge \[0x0203\]                    |
 | battery-total-battery-charge             | Number | R            | Total Battery Charge \[0x0204,0x0205\]                |
 | battery-total-battery-discharge          | Number | R            | Total Battery Discharge \[0x0206,0x0207\]             |
+| battery-battery-absorption-v             | Number | R            | Battery Absorption V \[0x0064\]                       |
+| battery-battery-empty-v                  | Number | R            | Battery Empty V \[0x0066\]                            |
+| battery-battery-equalization-v           | Number | R            | Battery Equalization V \[0x0063\]                     |
+| battery-battery-float-v                  | Number | R            | Battery Float V \[0x0065\]                            |
+| battery-battery-capacity                 | Number | R            | Battery Capacity \[0x0066\]                           |
+| battery-battery-max-a-charge             | Number | R            | Battery Max A Charge \[0x006C\]                       |
+| battery-battery-max-a-discharge          | Number | R            | Battery Max A Discharge \[0x006D\]                    |
 | grid-daily-energy-bought                 | Number | R            | Daily Energy Bought \[0x0208\]                        |
 | grid-daily-energy-sold                   | Number | R            | Daily Energy Sold \[0x0209\]                          |
 | grid-external-ct-l1-power                | Number | R            | External CT L1 Power \[0x0268\]                       |
@@ -97,7 +109,7 @@ This is the list you get for the `deye_sg04lp3` inverter type:
 | grid-internal-ct-l2-power                | Number | R            | Internal CT L2 Power \[0x025D\]                       |
 | grid-internal-ct-l3-power                | Number | R            | Internal CT L3 Power \[0x025E\]                       |
 | grid-total-energy-bought                 | Number | R            | Total Energy Bought \[0x020A,0x020B\]                 |
-| grid-total-energy-sold                   | Number | R            | Total Energy Sold \[0x020C\]                          |
+| grid-total-energy-sold                   | Number | R            | Total Energy Sold \[0x020C,0x020D\]                   |
 | grid-total-grid-power                    | Number | R            | Total Grid Power \[0x0271\]                           |
 | grid-total-grid-production               | Number | R            | Total Grid Production \[0x020C,0x020D\]               |
 | inverter-ac-temperature                  | Number | R            | AC Temperature \[0x021D\]                             |
@@ -107,7 +119,7 @@ This is the list you get for the `deye_sg04lp3` inverter type:
 | inverter-current-l2                      | Number | R            | Current L2 \[0x0277\]                                 |
 | inverter-current-l3                      | Number | R            | Current L3 \[0x0278\]                                 |
 | inverter-dc-temperature                  | Number | R            | DC Temperature \[0x021C\]                             |
-| inverter-frequency                       | Number | R            | Number Value \[0x27E\]                                |
+| inverter-frequency                       | Number | R            | Inverter Frequency \[0x27E\]                          |
 | inverter-inverter-id                     | String | R            | Inverter ID \[0x0003,0x0004,0x0005,0x0006,0x0007\]    |
 | inverter-inverter-l1-power               | Number | R            | Inverter L1 Power \[0x0279\]                          |
 | inverter-inverter-l2-power               | Number | R            | Inverter L2 Power \[0x027A\]                          |
@@ -147,61 +159,78 @@ Thing solarman:logger:local [hostname="x.x.x.x",inverterType="deye_sg04lp3",seri
 Items file example for a SUN-12K-SG04LP3-EU inverter
 
 ```text
+Number:Temperature        AC_Temperature                  "AC Temperature [%.1f °C]"             (solarman)  {channel="solarman:logger:local:inverter-ac-temperature", unit="°C"}
+Number                    Alert                           "Alert [%s]"                           (solarman)  {channel="solarman:logger:local:alert-alert"}
+Number:ElectricPotential  Battery_Absorption_V            "Battery Absorption V [%.2f V]"        (solarman)  {channel="solarman:logger:local:battery-battery-absorption-v", unit="V"}
+Number:ElectricCharge     Battery_Capacity                "Battery Capacity [%d Ah]"             (solarman)  {channel="solarman:logger:local:battery-battery-capacity", unit="Ah"}
+Number:ElectricCurrent    Battery_Current                 "Battery Current [%.1f A]"             (solarman)  {channel="solarman:logger:local:battery-battery-current", unit="A"}
+Number:Energy             Daily_Battery_Charge            "Daily Battery Charge [%.1f kWh]"      (solarman)  {channel="solarman:logger:local:battery-daily-battery-charge", unit="kWh"}
+Number:Energy             Daily_Battery_Discharge         "Daily Battery Discharge [%.1f kWh]"   (solarman)  {channel="solarman:logger:local:battery-daily-battery-discharge", unit="kWh"}
+Number:ElectricPotential  Battery_Empty_V                 "Battery Empty V [%.2f V]"             (solarman)  {channel="solarman:logger:local:battery-battery-empty-v", unit="V"}
+Number:ElectricPotential  Battery_Equalization_V          "Battery Equalization V [%.2f V]"      (solarman)  {channel="solarman:logger:local:battery-battery-equalization-v", unit="V"}
+Number:ElectricPotential  Battery_Float_V                 "Battery Float V [%.2f V]"             (solarman)  {channel="solarman:logger:local:battery-battery-float-v", unit="V"}
+Number:ElectricCurrent    Battery_Max_A_Charge            "Battery Max A Charge [%d A]"          (solarman)  {channel="solarman:logger:local:battery-battery-max-a-charge", unit="A"}
+Number:ElectricCurrent    Battery_Max_A_Discharge         "Battery Max A Discharge [%d A]"       (solarman)  {channel="solarman:logger:local:battery-battery-max-a-discharge", unit="A"}
+Number:Dimensionless      Battery_SOC                     "Battery SOC [%d %%]"                  (solarman)  {channel="solarman:logger:local:battery-battery-soc", unit="%"}
+Number:Power              Battery_Power                   "Battery Power [%d W]"                 (solarman)  {channel="solarman:logger:local:battery-battery-power", unit="W"}
+Number:Temperature        Battery_Temperature             "Battery Temperature [%.1f °C]"        (solarman)  {channel="solarman:logger:local:battery-battery-temperature", unit="°C"}
+Number:ElectricPotential  Battery_Voltage                 "Battery Voltage [%.2f V]"             (solarman)  {channel="solarman:logger:local:battery-battery-voltage", unit="V"}
 Number:Dimensionless      Communication_Board_Version_No  "Communication Board Version No [%s]"  (solarman)  {channel="solarman:logger:local:inverter-communication-board-version-no-"}
 Number:Dimensionless      Control_Board_Version_No        "Control Board Version No [%s]"        (solarman)  {channel="solarman:logger:local:inverter-control-board-version-no-"}
-String                    Inverter_Id                     "Inverter Id [%s]"                     (solarman)  {channel="solarman:logger:local:inverter-inverter-id"}
-Number:Temperature        AC_Temperature                  "AC Temperature [%.1f °C]"             (solarman)  {channel="solarman:logger:local:inverter-ac-temperature", unit="°C"}
-Number:Temperature        DC_Temperature                  "DC Temperature [%.1f °C]"             (solarman)  {channel="solarman:logger:local:inverter-dc-temperature", unit="°C"}
-Number:Power              Inverter_L1_Power               "Inverter L1 Power [%d W]"             (solarman)  {channel="solarman:logger:local:inverter-inverter-l1-power", unit="W"}
-Number:Power              Inverter_L2_Power               "Inverter L2 Power [%d W]"             (solarman)  {channel="solarman:logger:local:inverter-inverter-l2-power", unit="W"}
-Number:Power              Inverter_L3_Power               "Inverter L3 Power [%d W]"             (solarman)  {channel="solarman:logger:local:inverter-inverter-l3-power", unit="W"}
 Number:ElectricCurrent    Current_L1                      "Current L1 [%.1f A]"                  (solarman)  {channel="solarman:logger:local:inverter-current-l1", unit="A"}
 Number:ElectricCurrent    Current_L2                      "Current L2 [%.1f A]"                  (solarman)  {channel="solarman:logger:local:inverter-current-l2", unit="A"}
 Number:ElectricCurrent    Current_L3                      "Current L3 [%.1f A]"                  (solarman)  {channel="solarman:logger:local:inverter-current-l3", unit="A"}
+Number:Energy             Daily_Energy_Bought             "Daily Energy Bought [%d kWh]"         (solarman)  {channel="solarman:logger:local:grid-daily-energy-bought", unit="kWh"}
+Number:Energy             Daily_Energy_Sold               "Daily Energy Sold [%d Wh]"            (solarman)  {channel="solarman:logger:local:grid-daily-energy-sold", unit="Wh"}
+Number:Energy             Daily_Load_Consumption          "Daily Load Consumption [%.1f kWh]"    (solarman)  {channel="solarman:logger:local:upload-daily-load-consumption", unit="kWh"}
+Number:Energy             Daily_Production                "Daily Production [%.1f kWh]"          (solarman)  {channel="solarman:logger:local:solar-daily-production", unit="kWh"}
+Number:Temperature        DC_Temperature                  "DC Temperature [%.1f °C]"             (solarman)  {channel="solarman:logger:local:inverter-dc-temperature", unit="°C"}
 Number:Power              External_CT_L1_Power            "External CT L1 Power [%d W]"          (solarman)  {channel="solarman:logger:local:grid-external-ct-l1-power", unit="W"}
 Number:Power              External_CT_L2_Power            "External CT L2 Power [%d W]"          (solarman)  {channel="solarman:logger:local:grid-external-ct-l2-power", unit="W"}
 Number:Power              External_CT_L3_Power            "External CT L3 Power [%d W]"          (solarman)  {channel="solarman:logger:local:grid-external-ct-l3-power", unit="W"}
+Number:Power              Gen_Port_A_Phase_Power          "Phase Power of Gen Port A [%d W]"     (solarman)  {channel="solarman:logger:local:smartload-phase-power-of-gen-port-a", unit="W"}
+Number:Power              Gen_Port_B_Phase_Power          "Phase Power of Gen Port B [%d W]"     (solarman)  {channel="solarman:logger:local:smartload-phase-power-of-gen-port-b", unit="W"}
+Number:Power              Gen_Port_C_Phase_Power          "Phase Power of Gen Port C [%d W]"     (solarman)  {channel="solarman:logger:local:smartload-phase-power-of-gen-port-c", unit="W"}
+Number:ElectricPotential  Gen_Port_A_Phase_Voltage        "Phase Voltage of Gen Port A [%d V]"   (solarman)  {channel="solarman:logger:local:smartload-phase-voltage-of-gen-port-a", unit="V"}
+Number:ElectricPotential  Gen_Port_B_Phase_Voltage        "Phase Voltage of Gen Port B [%d V]"   (solarman)  {channel="solarman:logger:local:smartload-phase-voltage-of-gen-port-b", unit="V"}
+Number:ElectricPotential  Gen_Port_C_Phase_Voltage        "Phase Voltage of Gen Port C [%d V]"   (solarman)  {channel="solarman:logger:local:smartload-phase-voltage-of-gen-port-c", unit="V"}
+String                    Inverter_Id                     "Inverter Id [%s]"                     (solarman)  {channel="solarman:logger:local:inverter-inverter-id"}
+Number:Power              Inverter_L1_Power               "Inverter L1 Power [%d W]"             (solarman)  {channel="solarman:logger:local:inverter-inverter-l1-power", unit="W"}
+Number:Power              Inverter_L2_Power               "Inverter L2 Power [%d W]"             (solarman)  {channel="solarman:logger:local:inverter-inverter-l2-power", unit="W"}
+Number:Power              Inverter_L3_Power               "Inverter L3 Power [%d W]"             (solarman)  {channel="solarman:logger:local:inverter-inverter-l3-power", unit="W"}
 Number:Power              Internal_CT_L1_Power            "Internal CT L1 Power [%d W]"          (solarman)  {channel="solarman:logger:local:grid-internal-ct-l1-power", unit="W"}
 Number:Power              Internal_CT_L2_Power            "Internal CT L2 Power [%d W]"          (solarman)  {channel="solarman:logger:local:grid-internal-ct-l2-power", unit="W"}
 Number:Power              Internal_CT_L3_Power            "Internal CT L3 Power [%d W]"          (solarman)  {channel="solarman:logger:local:grid-internal-ct-l3-power", unit="W"}
-Number:ElectricPotential  Grid_Voltage_L1                 "Grid Voltage L1 [%d V]"               (solarman)  {channel="solarman:logger:local:grid-grid-voltage-l1", unit="V"}
-Number:ElectricPotential  Grid_Voltage_L2                 "Grid Voltage L2 [%d V]"               (solarman)  {channel="solarman:logger:local:grid-grid-voltage-l2", unit="V"}
-Number:ElectricPotential  Grid_Voltage_L3                 "Grid Voltage L3 [%d V]"               (solarman)  {channel="solarman:logger:local:grid-grid-voltage-l3", unit="V"}
-Number:Power              Total_Grid_Power                "Total Instant Grid Power [%d W]"      (solarman)  {channel="solarman:logger:local:grid-total-grid-power", unit="W"}
-Number:Energy             Total_Grid_Production           "Total Grid Feed-in [%.1f kWh]"        (solarman)  {channel="solarman:logger:local:grid-total-grid-production", unit="kWh"}
-Number:Energy             Daily_Energy_Sold               "Daily Energy Sold [%d Wh]"            (solarman)  {channel="solarman:logger:local:grid-daily-energy-sold", unit="Wh"}
-Number:Energy             Total_Energy_Sold               "Total Energy Sold [%d kWh]"           (solarman)  {channel="solarman:logger:local:grid-total-energy-sold", unit="kWh"}
-Number:Energy             Total_Energy_Bought             "Total Energy Bought [%d kWh]"         (solarman)  {channel="solarman:logger:local:grid-total-energy-bought", unit="kWh"}
-Number:Energy             Daily_Energy_Bought             "Daily Energy Bought [%d kWh]"         (solarman)  {channel="solarman:logger:local:grid-daily-energy-bought", unit="kWh"}
-Number:Energy             Daily_Production                "Daily Production [%.1f kWh]"          (solarman)  {channel="solarman:logger:local:solar-daily-production", unit="kWh"}
-Number:Energy             Total_Production                "Total Production [%d kWh]"            (solarman)  {channel="solarman:logger:local:solar-total-production", unit="kWh"}
-Number:Energy             Daily_Load_Consumption          "Daily Load Consumption [%.1f kWh]"    (solarman)  {channel="solarman:logger:local:upload-daily-load-consumption", unit="kWh"}
-Number:Energy             Total_Load_Consumption          "Total Load Consumption [%d kWh]"      (solarman)  {channel="solarman:logger:local:upload-total-load-consumption", unit="kWh"}
-Number:Power              Load_L1_Power                   "Load L1 Power [%d W]"                 (solarman)  {channel="solarman:logger:local:upload-load-l1-power", unit="W"}
-Number:Power              Load_L2_Power                   "Load L2 Power [%d W]"                 (solarman)  {channel="solarman:logger:local:upload-load-l2-power", unit="W"}
-Number:Power              Load_L3_Power                   "Load L3 Power [%d W]"                 (solarman)  {channel="solarman:logger:local:upload-load-l3-power", unit="W"}
-Number:Power              Total_Load_Power                "Total Load Power [%d W]"              (solarman)  {channel="solarman:logger:local:upload-total-load-power", unit="W"}
 Number:ElectricPotential  Load_Voltage_L1                 "Load Voltage L1 [%d V]"               (solarman)  {channel="solarman:logger:local:upload-load-voltage-l1", unit="V"}
 Number:ElectricPotential  Load_Voltage_L2                 "Load Voltage L2 [%d V]"               (solarman)  {channel="solarman:logger:local:upload-load-voltage-l2", unit="V"}
 Number:ElectricPotential  Load_Voltage_L3                 "Load Voltage L3 [%d V]"               (solarman)  {channel="solarman:logger:local:upload-load-voltage-l3", unit="V"}
-Number:Energy             Daily_Energy_Consumption        "Daily Energy Consumption [%d kWh]"    (solarman)  {channel="solarman:logger:local:upload-daily-load-consumption", unit="kWh"}
-Number:Energy             Total_Energy_Consumption        "Total Energy Consumption [%d kWh]"    (solarman)  {channel="solarman:logger:local:upload-total-load-consumption", unit="kWh"}
-Number:ElectricCurrent    PV1_Current                     "PV1 Current [%.1f A]"                 (solarman)  {channel="solarman:logger:local:solar-pv1-current", unit="A"}
-Number:Power              PV1_Power                       "PV1 Power [%d W]"                     (solarman)  {channel="solarman:logger:local:solar-pv1-power", unit="W"}
-Number:ElectricPotential  PV1_Voltage                     "PV1 Voltage [%d V]"                   (solarman)  {channel="solarman:logger:local:solar-pv1-voltage", unit="V"}
-Number:ElectricCurrent    PV2_Current                     "PV2 Current [%.1f A]"                 (solarman)  {channel="solarman:logger:local:solar-pv2-current", unit="A"}
-Number:Power              PV2_Power                       "PV2 Power [%d W]"                     (solarman)  {channel="solarman:logger:local:solar-pv2-power", unit="W"}
-Number:ElectricPotential  PV2_Voltage                     "PV2 Voltage [%d V]"                   (solarman)  {channel="solarman:logger:local:solar-pv2-voltage", unit="V"}
-Number:Dimensionless      Battery_SOC                     "Battery SOC [%d %%]"                  (solarman)  {channel="solarman:logger:local:battery-battery-soc", unit="%"}
-Number:ElectricCurrent    Battery_Current                 "Battery Current [%.1f A]"             (solarman)  {channel="solarman:logger:local:battery-battery-current", unit="A"}
-Number:Power              Battery_Power                   "Battery Power [%d W]"                 (solarman)  {channel="solarman:logger:local:battery-battery-power", unit="W"}
-Number:ElectricPotential  Battery_Voltage                 "Battery Voltage [%.2f V]"             (solarman)  {channel="solarman:logger:local:battery-battery-voltage", unit="V"}
-Number:Temperature        Battery_Temperature             "Battery Temperature [%.1f °C]"        (solarman)  {channel="solarman:logger:local:battery-battery-temperature", unit="°C"}
-Number:Energy             Daily_Battery_Charge            "Daily Battery Charge [%.1f kWh]"      (solarman)  {channel="solarman:logger:local:battery-daily-battery-charge", unit="kWh"}
-Number:Energy             Daily_Battery_Discharge         "Daily Battery Discharge [%.1f kWh]"   (solarman)  {channel="solarman:logger:local:battery-daily-battery-discharge", unit="kWh"}
+Number:Power              Load_L1_Power                   "Load L1 Power [%d W]"                 (solarman)  {channel="solarman:logger:local:upload-load-l1-power", unit="W"}
+Number:Power              Load_L2_Power                   "Load L2 Power [%d W]"                 (solarman)  {channel="solarman:logger:local:upload-load-l2-power", unit="W"}
+Number:Power              Load_L3_Power                   "Load L3 Power [%d W]"                 (solarman)  {channel="solarman:logger:local:upload-load-l3-power", unit="W"}
+Number:ElectricPotential  Grid_Voltage_L1                 "Grid Voltage L1 [%d V]"               (solarman)  {channel="solarman:logger:local:grid-grid-voltage-l1", unit="V"}
+Number:ElectricPotential  Grid_Voltage_L2                 "Grid Voltage L2 [%d V]"               (solarman)  {channel="solarman:logger:local:grid-grid-voltage-l2", unit="V"}
+Number:ElectricPotential  Grid_Voltage_L3                 "Grid Voltage L3 [%d V]"               (solarman)  {channel="solarman:logger:local:grid-grid-voltage-l3", unit="V"}
+Number:Energy             Generator_Daily_Power_Generation "Generator Daily Power Generation [%.1f kWh]" (solarman) {channel="solarman:logger:local:smartload-generator-daily-power-generation", unit="kWh"}
+Number:Energy             Generator_Total_Power_Generation "Generator Total Power Generation [%.1f kWh]" (solarman) {channel="solarman:logger:local:smartload-generator-total-power-generation", unit="kWh"}
+Number:Dimensionless      Smartload_Enable_Status         "Smartload Enable Status [%d]"         (solarman)  {channel="solarman:logger:local:smartload-smartload-enable-status"}
 Number:Energy             Total_Battery_Charge            "Total Battery Charge [%d kWh]"        (solarman)  {channel="solarman:logger:local:battery-total-battery-charge", unit="kWh"}
 Number:Energy             Total_Battery_Discharge         "Total Battery Discharge [%d kWh]"     (solarman)  {channel="solarman:logger:local:battery-total-battery-discharge", unit="kWh"}
-Number                    Alert                           "Alert [%s]"                           (solarman)  {channel="solarman:logger:local:alert-alert"}
+Number:Energy             Total_Energy_Bought             "Total Energy Bought [%d kWh]"         (solarman)  {channel="solarman:logger:local:grid-total-energy-bought", unit="kWh"}
+Number:Energy             Total_Energy_Sold               "Total Energy Sold [%d kWh]"           (solarman)  {channel="solarman:logger:local:grid-total-energy-sold", unit="kWh"}
+Number:Power              Total_Gen_Port_Power            "Total Power of Gen Port [%d W]"       (solarman)  {channel="solarman:logger:local:smartload-total-power-of-gen-port", unit="W"}
+Number:Power              Total_Grid_Power                "Total Instant Grid Power [%d W]"      (solarman)  {channel="solarman:logger:local:grid-total-grid-power", unit="W"}
+Number:Energy             Total_Grid_Production           "Total Grid Feed-in [%.1f kWh]"        (solarman)  {channel="solarman:logger:local:grid-total-grid-production", unit="kWh"}
+Number:Energy             Total_Load_Consumption          "Total Load Consumption [%d kWh]"      (solarman)  {channel="solarman:logger:local:upload-total-load-consumption", unit="kWh"}
+Number:Power              Total_Load_Power                "Total Load Power [%d W]"              (solarman)  {channel="solarman:logger:local:upload-total-load-power", unit="W"}
+Number:Energy             Total_Solar_Production          "Total Solar Production [%.1f kWh]"    (solarman)  {channel="solarman:logger:local:solar-total-production", unit="kWh"}
+Number:Power              PV1_Power                       "PV1 Power [%d W]"                     (solarman)  {channel="solarman:logger:local:solar-pv1-power", unit="W"}
+Number:ElectricCurrent    PV1_Current                     "PV1 Current [%.1f A]"                 (solarman)  {channel="solarman:logger:local:solar-pv1-current", unit="A"}
+Number:ElectricPotential  PV1_Voltage                     "PV1 Voltage [%d V]"                   (solarman)  {channel="solarman:logger:local:solar-pv1-voltage", unit="V"}
+Number:Power              PV2_Power                       "PV2 Power [%d W]"                     (solarman)  {channel="solarman:logger:local:solar-pv2-power", unit="W"}
+Number:ElectricCurrent    PV2_Current                     "PV2 Current [%.1f A]"                 (solarman)  {channel="solarman:logger:local:solar-pv2-current", unit="A"}
+Number:ElectricPotential  PV2_Voltage                     "PV2 Voltage [%d V]"                   (solarman)  {channel="solarman:logger:local:solar-pv2-voltage", unit="V"}
+
+Number:Frequency          Inverter_Frequency              "Inverter Frequency [%.2f Hz]"         (solarman)  {channel="solarman:logger:local:inverter-frequency", unit="Hz"}
 ```
 
 ### `solarman.sitemap`
@@ -223,6 +252,7 @@ sitemap solarman label="Solarman"
         Text item=Current_L1 icon="line"
         Text item=Current_L2 icon="line"
         Text item=Current_L3 icon="line"
+        Text item=Inverter_Frequency icon="line"
     }
     
     Frame label="Battery"{
@@ -235,10 +265,17 @@ sitemap solarman label="Solarman"
         Text item=Daily_Battery_Discharge icon="battery"
         Text item=Total_Battery_Charge icon="renewable"
         Text item=Total_Battery_Discharge icon="battery"
+        Text item=Battery_Absorption_V icon="voltage"
+        Text item=Battery_Equalization_V icon="voltage"
+        Text item=Battery_Float_V icon="voltage"
+        Text item=Battery_Empty_V icon="voltage"
+        Text item=Battery_Capacity icon="battery"
+        Text item=Battery_Max_A_Charge icon="battery"
+        Text item=Battery_Max_A_Discharge icon="battery"
     }
     
     Frame label="Solar"{
-        Text item=Total_Production icon="solar"
+        Text item=Total_Solar_Production icon="solar"
         Text item=Daily_Production icon="solar"
         Text item=PV1_Current icon="solar"
         Text item=PV1_Power icon="solar"
@@ -278,8 +315,20 @@ sitemap solarman label="Solarman"
         Text item=Total_Load_Power icon="power"
     }
 
-        Frame label="Alert"{
-            Text item=Alert icon="alert"
+    Frame label="Generator"{
+        Text item=Gen_Port_A_Phase_Power icon="poweroutlet"
+        Text item=Gen_Port_B_Phase_Power icon="poweroutlet"
+        Text item=Gen_Port_C_Phase_Power icon="poweroutlet"
+        Text item=Gen_Port_A_Phase_Voltage icon="voltage"
+        Text item=Gen_Port_B_Phase_Voltage icon="voltage"
+        Text item=Gen_Port_C_Phase_Voltage icon="voltage"
+        Text item=Total_Gen_Port_Power icon="power"
+        Text item=Generator_Daily_Power_Generation icon="power"
+        Text item=Generator_Total_Power_Generation icon="power"
+    }
+
+    Frame label="Alert"{
+        Text item=Alert icon="alert"
     }
 }
 ```

--- a/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
@@ -39,7 +39,10 @@
 					<option value="sofar_lsw3">SOFAR Inverters (sofar_lsw3)</option>
 					<option value="sofar_wifikit">SOFAR WifiKit (sofar_wifikit)</option>
 					<option value="solis_1p8k-5g">SOLIS 1P8K-5G (solis_1p8k-5g)</option>
+					<option value="solis_3p-4g">SOLIS Three-Phase Inverter 4G Series (solis_3p-4g)</option>
+					<option value="solis_s6-gr1p">SOLIS Single-Phase Inverter S6-GR1P (solis_s6-gr1p)</option>
 					<option value="solis_hybrid">SOLIS Hybrid Inverter (solis_hybrid)</option>
+					<option value="hyd-zss-hp-3k-6k">ZCS Azzurro Hybrid HP 3K-6K Inverters (hyd-zss-hp-3k-6k)</option>
 					<option value="zcs_azzurro-ktl-v3">ZCS Azzurro KTL-V3 Inverters (zcs_azzurro-ktl-v3)</option>
 				</options>
 			</parameter>

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_2mppt.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_2mppt.yaml
@@ -1,11 +1,12 @@
-# First version : 22.2.2023
+# First version: 22.02.2023
+# Latest update: 08.09.2023
 # Microinverter SUN600G3 (DEYE/VESDAS)
 # 2x MPPT, 2x inverter
 # 1x Logger, 2x Module, 
 
 requests:
-  - start: 0x0003
-    end:  0x0080
+  - start: 0x0001
+    end:  0x007D
     mb_functioncode: 0x03
 
 parameters:
@@ -31,6 +32,7 @@ parameters:
 
     - name: "PV1 Current"
       class: "current"
+      state_class: "measurement"
       uom: "A"
       scale: 0.1
       rule: 1
@@ -55,6 +57,24 @@ parameters:
       registers: [0x003C]
       icon: 'mdi:solar-power'
 
+    - name: "Daily Production 1"
+      class: "energy"
+      state_class: "total"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0041]
+      icon: 'mdi:solar-power'
+
+    - name: "Daily Production 2"
+      class: "energy"
+      state_class: "total"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0042]
+      icon: 'mdi:solar-power'
+
     - name: "Total Production"
       class: "energy"
       state_class: "total_increasing"
@@ -65,6 +85,33 @@ parameters:
       icon: 'mdi:solar-power'
       validation:
         min: 0.1
+
+    - name: "Total Production 1"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0045]
+      icon: 'mdi:solar-power'
+
+    - name: "Total Production 2"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0047]
+      icon: 'mdi:solar-power'
+
+    - name: "Active Power Regulations"
+      class: ""
+      state_class: ""
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [0x0028]
+      icon: 'mdi:solar-power'
 
   - group: Grid
     items:
@@ -77,6 +124,15 @@ parameters:
       registers: [0x0049]
       icon: 'mdi:transmission-tower'
 
+    - name: "Grid Current"
+      class: "current"
+      state_class: "measurement"      
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x004C]
+      icon: 'mdi:home-lightning-bolt'
+
     - name: "AC Output Frequency"
       class: "frequency"
       state_class: "measurement"
@@ -85,6 +141,105 @@ parameters:
       rule: 1
       registers: [0x004F]
       icon: 'mdi:home-lightning-bolt'
+
+    - name: "Grid Voltage Upp Limit"
+      class: "voltage"
+      state_class: ""
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x001B]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Voltage Lower Limit"
+      class: "voltage"
+      state_class: ""
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x001C]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Frequency Upper Limit"
+      class: "frequency"
+      state_class: ""
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x001D]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Grid Frequency Lower Limit"
+      class: "frequency"
+      state_class: ""
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x001E]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Overfrequency And Load Reduction Starting Point"
+      class: "frequency"
+      state_class: ""
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x0022]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Overfrequency And Load Reduction Percentage"
+      class: ""
+      state_class: ""
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [0x0023]
+      icon: ''
+
+    - name: "ON-OFF Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002B]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "OFF"
+      - key: 1
+        value: "ON"
+      icon: 'mdi:toggle-switch'
+
+    - name: "Island Protection Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002E]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:island'
+
+    - name: "Overfrequency&Load-shedding Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0031]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:toggle-switch'
 
   - group: Inverter
     items:
@@ -135,3 +290,105 @@ parameters:
       rule: 5
       registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
       isstr: true
+
+    - name: "Hardware Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x000C]
+      isstr: true
+
+    - name: "DC Master Firmware Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x000D]
+      isstr: true
+
+    - name: "AC Version. Number"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x000E]
+      isstr: true
+
+    - name: "Rated Power"
+      class: "energy"
+      state_class: ""
+      uom: "W"
+      scale: 0.1
+      rule: 1
+      registers: [0x0010]
+      icon: 'mdi:solar-power'
+
+    - name: "Communication Protocol Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x0012]
+      isstr: true
+
+    - name: "Start-up Self-checking Time "
+      class: ""
+      state_class: ""
+      uom: "s"
+      scale: 1
+      rule: 1
+      registers: [0x0015]
+      icon: 'mdi:solar-power'
+
+    - name: "Update Time"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 8
+      registers: [0x0016,0x0017,0x0018]
+      isstr: true
+
+    - name: "Soft Start Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002F]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:toggle-switch'
+
+    - name: "Power Factor Regulation"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 0.1
+      rule: 2
+      registers: [0x0032]
+      icon: ''
+
+    - name: "Restore Factory Settings"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0036]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:factory'

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_4mppt.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_4mppt.yaml
@@ -1,470 +1,251 @@
-#
-# Borrowed form https://github.com/StephanJoubert/home_assistant_solarman/
-# Additional info from https://github.com/kbialek/deye-inverter-mqtt/blob/19ace123339beec7a574b983f631309f8d285883/deye_sensor.py
-#
-# First version : 22.2.2023
-# Microinverter SUN600G3 (DEYE/VESDAS)
-# 2x MPPT, 2x inverter
-# 1x Logger, 2x Module,
-# Added info for 4x MPPT Microinverters on 2023-06-23
+# First version: 08.05.2022
+# Latest update: 08.09.2023
+# Microinverter SUN2000G3 (DEYE/VESDAS)
+# 4x MPPT, 4x inverter
+# 1x Logger, 4x Module, 
 
 requests:
-  - start: 0x0003
-    end:  0x0080
+  - start: 0x0001
+    end:  0x007D
     mb_functioncode: 0x03
 
 parameters:
   - group: solar
-    items:
-      - name: "PV1 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x006D]
-        icon: 'mdi:solar-power'
+    items: 
+    - name: "PV1 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x006D]
+      icon: 'mdi:solar-power'
 
-      - name: "PV2 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x006F]
-        icon: 'mdi:solar-power'
+    - name: "PV2 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x006F]
+      icon: 'mdi:solar-power'
 
-      - name: "PV3 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x0071]
-        icon: 'mdi:solar-power'
+    - name: "PV3 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0071]
+      icon: 'mdi:solar-power'
 
-      - name: "PV4 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x0073]
-        icon: 'mdi:solar-power'
+    - name: "PV4 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0073]
+      icon: 'mdi:solar-power'
 
-      - name: "PV1 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x006E]
-        icon: 'mdi:solar-power'
+    - name: "PV1 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x006E]
+      icon: 'mdi:solar-power'
 
-      - name: "PV2 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x0070]
-        icon: 'mdi:solar-power'
+    - name: "PV2 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x0070]
+      icon: 'mdi:solar-power'
 
-      - name: "PV3 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x0072]
-        icon: 'mdi:solar-power'
+    - name: "PV3 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x0072]
+      icon: 'mdi:solar-power'
 
-      - name: "PV4 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x0074]
-        icon: 'mdi:solar-power'
+    - name: "PV4 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x0074]
+      icon: 'mdi:solar-power'
 
-      - name: "Daily Production"
-        class: "energy"
-        state_class: "total"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x003C]
-        icon: 'mdi:solar-power'
+    - name: "Daily Production"
+      class: "energy"
+      state_class: "total"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x003C]
+      icon: 'mdi:solar-power'
 
-      - name: "Daily Production 1"
-        class: "energy"
-        state_class: "total"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x0041]
-        icon: 'mdi:solar-power'
+    - name: "Total Production"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x003F,0x0040]
+      icon: 'mdi:solar-power'
+      validation:
+        min: 0.1
+        invalidate_all:
 
-      - name: "Daily Production 2"
-        class: "energy"
-        state_class: "total"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x0042]
-        icon: 'mdi:solar-power'
-
-      - name: "Daily Production 3"
-        class: "energy"
-        state_class: "total"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x0043]
-        icon: 'mdi:solar-power'
-
-      - name: "Daily Production 4"
-        class: "energy"
-        state_class: "total"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x0044]
-        icon: 'mdi:solar-power'
-
-      - name: "Total Production"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x003F,0x0040]
-        icon: 'mdi:solar-power'
-        validation:
-          min: 0.1
-
-      - name: "Total Production 1"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x0045]
-        icon: 'mdi:solar-power'
-
-      - name: "Total Production 2"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x0047]
-        icon: 'mdi:solar-power'
-
-      - name: "Total Production 3"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x0046]
-        icon: 'mdi:solar-power'
-
-      - name: "Total Production 4"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x0048]
-        icon: 'mdi:solar-power'
-
-      - name: "Active Power Regulations"
-        class: ""
-        state_class: ""
-        uom: "%"
-        scale: 1
-        rule: 1
-        registers: [0x0028]
-        icon: 'mdi:solar-power'
+    - name: "Active Power Regulations"
+      class: ""
+      state_class: ""
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [0x0028]
+      icon: 'mdi:solar-power'
 
   - group: Grid
     items:
-      - name: "AC Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x0049]
-        icon: 'mdi:transmission-tower'
+    - name: "AC Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0049]
+      icon: 'mdi:transmission-tower'
 
-      - name: "Grid Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 2
-        registers: [0x004C]
-        icon: 'mdi:home-lightning-bolt'
+    - name: "Grid Current"
+      class: "current"
+      state_class: "measurement"      
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x004C]
+      icon: 'mdi:home-lightning-bolt'
 
-      - name: "AC Output Frequency"
-        class: "frequency"
-        state_class: "measurement"
-        uom: "Hz"
-        scale: 0.01
-        rule: 1
-        registers: [0x004F]
-        icon: 'mdi:home-lightning-bolt'
-
-      - name: "Grid Voltage Upp Limit"
-        class: "voltage"
-        state_class: ""
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x001B]
-        icon: 'mdi:transmission-tower'
-
-      - name: "Grid Voltage Lower Limit"
-        class: "voltage"
-        state_class: ""
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x001C]
-        icon: 'mdi:transmission-tower'
-
-      - name: "Grid Frequency Upper Limit"
-        class: "frequency"
-        state_class: ""
-        uom: "Hz"
-        scale: 0.01
-        rule: 1
-        registers: [0x001D]
-        icon: 'mdi:home-lightning-bolt'
-
-      - name: "Grid Frequency Lower Limit"
-        class: "frequency"
-        state_class: ""
-        uom: "Hz"
-        scale: 0.01
-        rule: 1
-        registers: [0x001E]
-        icon: 'mdi:home-lightning-bolt'
-
-      - name: "Overfrequency And Load Reduction Starting Point"
-        class: "frequency"
-        state_class: ""
-        uom: "Hz"
-        scale: 0.01
-        rule: 1
-        registers: [0x0022]
-        icon: 'mdi:home-lightning-bolt'
-
-      - name: "Overfrequency And Load Reduction Percentage"
-        class: ""
-        state_class: ""
-        uom: "%"
-        scale: 1
-        rule: 1
-        registers: [0x0023]
-        icon: ''
-
-      - name: "ON-OFF Enable"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x002B]
-        isstr: true
-        lookup:
-          - key: 0
-            value: "OFF"
-          - key: 1
-            value: "ON"
-        icon: 'mdi:toggle-switch'
-
-      - name: "Island Protection Enable"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x002E]
-        isstr: true
-        lookup:
-          - key: 0
-            value: "Disabled"
-          - key: 1
-            value: "Enabled"
-        icon: 'mdi:island'
-
-      - name: "Overfrequency&Load-shedding Enable"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x0031]
-        isstr: true
-        lookup:
-          - key: 0
-            value: "Disabled"
-          - key: 1
-            value: "Enabled"
-        icon: 'mdi:toggle-switch'
+    - name: "AC Output Frequency"
+      class: "frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x004F]
+      icon: 'mdi:home-lightning-bolt'
 
   - group: Inverter
     items:
-      - name: "Running Status"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x003B]
-        isstr: true
-        lookup:
-          - key: 0
-            value: "Stand-by"
-          - key: 1
-            value: "Self-check"
-          - key: 2
-            value: "Normal"
-          - key: 3
-            value: "Warning"
-          - key: 4
-            value: "Fault"
-        icon: 'mdi:home-lightning-bolt'
+    - name: "Running Status"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x003B]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Stand-by"
+      - key: 1
+        value: "Self-check"
+      - key: 2
+        value: "Normal"
+      - key: 3
+        value: "Warning"
+      - key: 4
+        value: "Fault"
+      icon: 'mdi:home-lightning-bolt'
 
-      - name: "Total AC Output Power (Active)"
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        scale: 0.1
-        rule: 3
-        registers: [0x0056, 0x0057]
-        icon: 'mdi:home-lightning-bolt'
+    - name: "Total AC Output Power (Active)"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 0.1
+      rule: 3
+      registers: [0x0056, 0x0057]
+      icon: 'mdi:home-lightning-bolt'
+      
+    - name: "Radiator Temperature"
+      class: "temperature"
+      uom: "°C"
+      state_class: "measurement"
+      scale: 0.01
+      rule: 1
+      offset: 1000
+      registers: [0x005a]
 
-      - name: "Radiator Temperature"
-        class: "temperature"
-        uom: "°C"
-        state_class: "measurement"
-        scale: 0.01
-        rule: 1
-        offset: 1000
-        registers: [0x005a]
+    - name: "Inverter ID"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 5
+      registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
+      isstr: true
 
-      - name: "Inverter ID"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 5
-        registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
-        isstr: true
+    - name: "Rated Power"
+      class: "energy"
+      state_class: ""
+      uom: "W"
+      scale: 0.1
+      rule: 1
+      registers: [0x0010]
+      icon: 'mdi:solar-power'
 
-      - name: "Hardware Version"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 7
-        registers: [0x000C]
-        isstr: true
+    - name: "Start-up Self-checking Time "
+      class: ""
+      state_class: ""
+      uom: "s"
+      scale: 1
+      rule: 1
+      registers: [0x0015]
+      icon: 'mdi:solar-power'
 
-      - name: "DC Master Firmware Version"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 7
-        registers: [0x000D]
-        isstr: true
+    - name: "Soft Start Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002F]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:toggle-switch'
 
-      - name: "AC Version. Number"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 7
-        registers: [0x000E]
-        isstr: true
+    - name: "Power Factor Regulation"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 0.1
+      rule: 2
+      registers: [0x0032]
+      icon: ''
 
-      - name: "Rated Power"
-        class: "energy"
-        state_class: ""
-        uom: "W"
-        scale: 0.1
-        rule: 1
-        registers: [0x0010]
-        icon: 'mdi:solar-power'
-
-      - name: "Communication Protocol Version"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 7
-        registers: [0x0012]
-        isstr: true
-
-      - name: "Start-up Self-checking Time "
-        class: ""
-        state_class: ""
-        uom: "s"
-        scale: 1
-        rule: 1
-        registers: [0x0015]
-        icon: 'mdi:solar-power'
-
-      - name: "Update Time"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 8
-        registers: [0x0016,0x0017,0x0018]
-        isstr: true
-
-      - name: "Soft Start Enable"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x002F]
-        isstr: true
-        lookup:
-          - key: 0
-            value: "Disabled"
-          - key: 1
-            value: "Enabled"
-        icon: 'mdi:toggle-switch'
-
-      - name: "Power Factor Regulation"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 0.1
-        rule: 2
-        registers: [0x0032]
-        icon: ''
-
-      - name: "Restore Factory Settings"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x0036]
-        isstr: true
-        lookup:
-          - key: 0
-            value: "Disabled"
-          - key: 1
-            value: "Enabled"
-        icon: 'mdi:factory'
+    - name: "Restore Factory Settings"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0036]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:factory'

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_hybrid.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_hybrid.yaml
@@ -2,8 +2,11 @@ requests:
   - start: 0x0003
     end: 0x0070
     mb_functioncode: 0x03
-  - start: 0x0096  
-    end: 0x00f8
+  - start: 0x0096
+    end: 0x00f9
+    mb_functioncode: 0x03
+  - start: 0x00FA
+    end: 0x0117
     mb_functioncode: 0x03
 
 parameters:
@@ -109,6 +112,24 @@ parameters:
       registers: [0x004A,0x004B]
       icon: 'mdi:battery-minus'
 
+    - name: "Daily Battery Charge"
+      class: "energy"
+      state_class: "total_increasing"      
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0046]
+      icon: 'mdi:battery-plus'
+      
+    - name: "Daily Battery Discharge"
+      class: "energy"
+      state_class: "total_increasing"      
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0047]
+      icon: 'mdi:battery-minus'
+
     - name: "Battery Status"
       class: ""
       state_class: "measurement"
@@ -192,6 +213,14 @@ parameters:
       registers: [0x0096]
       icon: 'mdi:transmission-tower'
 
+    - name: "Grid Current L1"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 1
+      registers: [0x00A0]
+      icon: 'mdi:current-ac'
     - name: "Grid Voltage L2"
       class: "voltage"
       state_class: "measurement"
@@ -201,6 +230,15 @@ parameters:
       registers: [0x0097]
       icon: 'mdi:transmission-tower'
 
+    - name: "Grid Current L2"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 1
+      registers: [0x00A1]
+      icon: 'mdi:current-ac'
+      
     - name: "Internal CT L1 Power"
       class: "power"
       state_class: "measurement"
@@ -227,7 +265,7 @@ parameters:
       rule: 2
       registers: [0x00AA]
       icon: 'mdi:transmission-tower'
-
+      
     - name: "External CT L2 Power"
       class: "power"
       state_class: "measurement"
@@ -384,6 +422,15 @@ parameters:
       registers: [0x00AF]
       icon: 'mdi:home-lightning-bolt'
 
+    - name: "Grid Frequency"
+      class: "frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x004F]
+      icon: 'mdi:sine-wave'
+
     - name: "Current L1"
       class: "current"
       state_class: "measurement"      
@@ -418,6 +465,15 @@ parameters:
       rule: 2
       registers: [0x00AE]
       icon: 'mdi:home-lightning-bolt'
+      
+    - name: "Load Frequency"
+      class: ""
+      state_class: "measurement"      
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x00C0]
+      icon: 'mdi:sine-wave'
 
     - name: "DC Temperature"
       class: "temperature"
@@ -502,20 +558,6 @@ parameters:
       rule: 1
       registers: [0x00A6]
 
-    - name: "Time of use"
-      class: ""
-      state_class: ""      
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x00F8]
-      isstr: true
-      lookup: 
-      -  key: 0
-         value: "Disable"
-      -  key: 1
-         value: "Enable"
-
     - name: "Work Mode"
       class: ""
       state_class: ""      
@@ -546,3 +588,243 @@ parameters:
       scale: 1
       rule: 6
       registers: [0x0065,0x0066,0x0067,0x0068,0x0069,0x006A]
+
+ - group: Time of Use
+   items:
+    - name: "Time of use Time 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FA]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of use Time 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FB]
+      icon: "mdi:timelapse"
+      
+    - name: "Time of Use Time 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FC]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of Use Time 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FD]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of Use Time 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FE]
+      icon: "mdi:timelapse"
+
+    - name: "Time of Use Time 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FF]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of Use Power 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0100]
+      icon: "mdi:lightning-bolt-outline"
+
+    - name: "Time of Use Power 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0101]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0102]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0103]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0104]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0105]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use SOC 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010C]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010D]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010E]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010F]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0110]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0111]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use Enable 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x0112]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x0113]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x0114]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x0115]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x0116]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x0117]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of use"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      mask: 1
+      registers: [0x00F8]
+      icon: 'mdi:checkbox-marked-outline'
+      isstr: true
+      lookup:
+        - key: 0
+          value: "Disable"
+        - key: 1
+          value: "Enable"

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_sg04lp3.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/deye_sg04lp3.yaml
@@ -5,519 +5,705 @@ requests:
   - start: 0x0003
     end: 0x0059
     mb_functioncode: 0x03
-  - start: 0x0202  
+  - start: 0x0063
+    end: 0x006D
+    mb_functioncode: 0x03
+  - start: 0x0085
+    end: 0x0085
+    mb_functioncode: 0x03
+  - start: 0x0202
     end: 0x022E
-    mb_functioncode: 0x03 
-  - start: 0x024A  
+    mb_functioncode: 0x03
+  - start: 0x0218
+    end: 0x021A
+    mb_functioncode: 0x03
+  - start: 0x024A
     end: 0x024F
-    mb_functioncode: 0x03  
+    mb_functioncode: 0x03
   - start: 0x0256
     end: 0x027C
-    mb_functioncode: 0x03    
-  - start: 0x0284  
+    mb_functioncode: 0x03
+  - start: 0x0284
     end: 0x028D
-    mb_functioncode: 0x03   
-  - start: 0x02A0  
+    mb_functioncode: 0x03
+  - start: 0x0295
+    end: 0x029F
+    mb_functioncode: 0x03
+  - start: 0x02A0
     end: 0x02A7
     mb_functioncode: 0x03
-  
+
 parameters:
- - group: solar
-   items: 
-    - name: "PV1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x02A0]
-      icon: 'mdi:solar-power'
+  - group: solar
+    items:
+      - name: "PV1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x02A0]
+        icon: "mdi:solar-power"
 
-    - name: "PV2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x02A1]
-      icon: 'mdi:solar-power'
+      - name: "PV2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x02A1]
+        icon: "mdi:solar-power"
 
-    - name: "PV1 Voltage"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A4]
-      icon: 'mdi:solar-power'
+      - name: "PV1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A4]
+        icon: "mdi:solar-power"
 
-    - name: "PV2 Voltage"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A6]
-      icon: 'mdi:solar-power'
+      - name: "PV2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A6]
+        icon: "mdi:solar-power"
 
-    - name: "PV1 Current"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A5]
-      icon: 'mdi:solar-power'
+      - name: "PV1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A5]
+        icon: "mdi:solar-power"
 
-    - name: "PV2 Current"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A7]
-      icon: 'mdi:solar-power'
+      - name: "PV2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A7]
+        icon: "mdi:solar-power"
 
-    - name: "Daily Production"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0211]
-      icon: 'mdi:solar-power'
-      validation:
-        max: 100
-        invalidate_all:
+      - name: "Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0211]
+        icon: "mdi:solar-power"
+        validation:
+          max: 100
+          invalidate_all:
 
-    - name: "Total Production"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x0216,0x0217]
-      icon: 'mdi:solar-power'
+      - name: "Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0216, 0x0217]
+        icon: "mdi:solar-power"
 
- - group: Battery
-   items: 
+  - group: Battery
+    items:
+      - name: "Battery Equalization V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0063]
+        icon: "mdi:battery"
 
-    - name: "Daily Battery Charge"
-      class: "energy"
-      state_class: "total_increasing"      
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0202]
-      icon: 'mdi:battery-plus'
-    - name: "Daily Battery Discharge"
-      class: "energy"
-      state_class: "total_increasing"      
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0203]
-      icon: 'mdi:battery-plus'
+      - name: "Battery Absorption V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0064]
+        icon: "mdi:battery"
 
-    - name: "Total Battery Charge"
-      class: "energy"
-      state_class: "total_increasing"      
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x0204,0x0205]
-      icon: 'mdi:battery-plus'
+      - name: "Battery Float V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0065]
+        icon: "mdi:battery"
 
-    - name: "Total Battery Discharge"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x0206,0x0207]
-      icon: 'mdi:battery-minus'
+      - name: "Battery Capacity"
+        class: "battery"
+        state_class: "measurement"
+        uom: "Ah"
+        scale: 1
+        rule: 1
+        registers: [0x0066]
+        icon: "mdi:battery"
 
-    - name: "Battery Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x024E]
-      icon: 'mdi:battery'
+      - name: "Battery Empty V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0066]
+        icon: "mdi:battery"
 
-    - name: "Battery Voltage"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.01
-      rule: 1
-      registers: [0x024B]
-      icon: 'mdi:battery'
+      - name: "Battery Max A Charge"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 1
+        rule: 1
+        registers: [0x006C]
+        icon: "mdi:battery"
 
-    - name: "Battery SOC"
-      class: "battery"
-      state_class: "measurement"
-      uom: "%"
-      scale: 1
-      rule: 1
-      registers: [0x024C]
-      icon: 'mdi:battery'
-      validation:
-        min: 0
-        max: 101
+      - name: "Battery Max A Discharge"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 1
+        rule: 1
+        registers: [0x006D]
+        icon: "mdi:battery"
 
-    - name: "Battery Current"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x024F]
-      icon: 'mdi:battery'
+      - name: "Daily Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0202]
+        icon: "mdi:battery-plus"
 
-    - name: "Battery Temperature"
-      class: "temperature"
-      state_class: "measurement"
-      uom: "°C"
-      scale: 0.1
-      rule: 1
-      offset: 1000      
-      registers: [0x024A]
-      icon: 'mdi:battery'
-      validation:
-        min: 1
-        max: 99
-        invalidate_all:
- 
- - group: Grid
-   items: 
-    - name: "Total Grid Power"
-      class: "measurement"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0271]
-      icon: 'mdi:transmission-tower'
+      - name: "Daily Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0203]
+        icon: "mdi:battery-plus"
 
-    - name: "Grid Voltage L1"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0256]
-      icon: 'mdi:transmission-tower'
+      - name: "Total Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0204, 0x0205]
+        icon: "mdi:battery-plus"
 
-    - name: "Grid Voltage L2"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0257]
-      icon: 'mdi:transmission-tower'
-      
-    - name: "Grid Voltage L3"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0258]
-      icon: 'mdi:transmission-tower'  
+      - name: "Total Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0206, 0x0207]
+        icon: "mdi:battery-minus"
 
-    - name: "Internal CT L1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x025C]
-      icon: 'mdi:transmission-tower'
+      - name: "Battery Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x024E]
+        icon: "mdi:battery"
 
-    - name: "Internal CT L2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x025D]
-      icon: 'mdi:transmission-tower'
-      
-    - name: "Internal CT L3 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x025E]
-      icon: 'mdi:transmission-tower'  
+      - name: "Battery Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x024B]
+        icon: "mdi:battery"
 
-    - name: "External CT L1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0268]
-      icon: 'mdi:transmission-tower'
+      - name: "Battery SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [0x024C]
+        icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 101
 
-    - name: "External CT L2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0269]
-      icon: 'mdi:transmission-tower'
-      
-    - name: "External CT L3 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x026A]
-      icon: 'mdi:transmission-tower'
-      
-    - name: "Daily Energy Bought"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0208]
-      icon: 'mdi:transmission-tower-export'
+      - name: "Battery Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x024F]
+        icon: "mdi:battery"
 
-    - name: "Total Energy Bought"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x020A,0x020B]
-      icon: 'mdi:transmission-tower-export'
-      
-    - name: "Daily Energy Sold"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0209]
-      icon: 'mdi:transmission-tower-import'
+      - name: "Battery Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x024A]
+        icon: "mdi:battery"
+        validation:
+          min: 1
+          max: 99
 
-    - name: "Total Energy Sold"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x020C,0x020D]
-      icon: 'mdi:transmission-tower-import'
+  - group: Grid
+    items:
+      - name: "Total Grid Power"
+        class: "measurement"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0271]
+        icon: "mdi:transmission-tower"
 
-    - name: "Total Grid Production"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 4
-      registers: [0x020C,0x020D]
-      icon: 'mdi:transmission-tower'
-      
- - group: Upload
-   items: 
-    - name: "Total Load Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028D]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Grid Voltage L1"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0256]
+        icon: "mdi:transmission-tower"
 
-    - name: "Load L1 Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028A]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Grid Voltage L2"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0257]
+        icon: "mdi:transmission-tower"
 
-    - name: "Load L2 Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028B]
-      icon: 'mdi:lightning-bolt-outline'
-      
-    - name: "Load L3 Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028C]
-      icon: 'mdi:lightning-bolt-outline'
-      
-    - name: "Load Voltage L1"
-      class: "voltage"
-      state_class: "measurement"      
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0284]
-      icon: 'mdi:lightning-bolt-outline'
-      
-    - name: "Load Voltage L2"
-      class: "voltage"
-      state_class: "measurement"      
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0285]
-      icon: 'mdi:lightning-bolt-outline'
-      
-    - name: "Load Voltage L3"
-      class: "voltage"
-      state_class: "measurement"      
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0286]
-      icon: 'mdi:lightning-bolt-outline'
-      
-    - name: "Daily Load Consumption"
-      class: "energy"
-      state_class: "total_increasing"      
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x020E]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Grid Voltage L3"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0258]
+        icon: "mdi:transmission-tower"
 
-    - name: "Total Load Consumption"
-      class: "energy"
-      state_class: "total_increasing"      
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x020F,0x0210]
-      icon: 'mdi:lightning-bolt-outline'
-     
- - group: Inverter
-   items:
-    - name: "Current L1"
-      class: "current"
-      state_class: "measurement"      
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x0276]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Internal CT L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025C]
+        icon: "mdi:transmission-tower"
 
-    - name: "Current L2"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x0277]
-      icon: 'mdi:home-lightning-bolt'
-      
-    - name: "Current L3"
-      class: "current"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x0278]
-      icon: 'mdi:home-lightning-bolt'
-      
-    - name: "Inverter L1 Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0279]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Internal CT L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025D]
+        icon: "mdi:transmission-tower"
 
-    - name: "Inverter L2 Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x027A]
-      icon: 'mdi:home-lightning-bolt'
-      
-    - name: "Inverter L3 Power"
-      class: "power"
-      state_class: "measurement"      
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x027B]
-      icon: 'mdi:home-lightning-bolt'
-      
-    - name: "DC Temperature"
-      class: "temperature"
-      state_class: "measurement"      
-      uom: "°C"
-      scale: 0.1
-      rule: 2
-      offset: 1000      
-      registers: [0x021C]
-      icon: 'mdi:thermometer'
+      - name: "Internal CT L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025E]
+        icon: "mdi:transmission-tower"
 
-    - name: "AC Temperature"
-      class: "temperature"
-      state_class: "measurement"      
-      uom: "°C"
-      scale: 0.1
-      rule: 2
-      offset: 1000      
-      registers: [0x021D]
-      icon: 'mdi:thermometer'
+      - name: "External CT L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0268]
+        icon: "mdi:transmission-tower"
 
-    - name: "Inverter ID"
-      class: ""
-      state_class: ""      
-      uom: ""
-      scale: 1
-      rule: 5
-      registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
-      isstr: true
-    
-    - name: "Communication Board Version No."
-      class: ""
-      state_class: ""      
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x0011]
-      isstr: true
+      - name: "External CT L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0269]
+        icon: "mdi:transmission-tower"
 
-    - name: "Control Board Version No."
-      class: ""
-      state_class: ""      
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x000D]
-      isstr: true
+      - name: "External CT L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x026A]
+        icon: "mdi:transmission-tower"
 
- - group: Alert
-   items: 
-    - name: "Alert"
-      class: ""
-      state_class: ""      
-      uom: ""
-      scale: 1
-      rule: 6
-      registers: [0x0229,0x022A,0x22B,0x022C,0x022D,0x022E]
+      - name: "Daily Energy Bought"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0208]
+        icon: "mdi:transmission-tower-export"
+
+      - name: "Total Energy Bought"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x020A, 0x020B]
+        icon: "mdi:transmission-tower-export"
+
+      - name: "Daily Energy Sold"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0209]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Total Energy Sold"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020C, 0x020D]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Total Grid Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 4
+        registers: [0x020C, 0x020D]
+        icon: "mdi:transmission-tower"
+
+  - group: Upload
+    items:
+      - name: "Total Load Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028D]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028A]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028B]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028C]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load Voltage L1"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0284]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load Voltage L2"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0285]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Load Voltage L3"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0286]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Daily Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x020E]
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Total Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020F, 0x0210]
+        icon: "mdi:lightning-bolt-outline"
+
+  - group: Inverter
+    items:
+      - name: "Current L1"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0276]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Current L2"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0277]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Current L3"
+        class: "current"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0278]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Inverter L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0279]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Inverter L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x027A]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Inverter L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x027B]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "DC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        offset: 1000
+        registers: [0x021C]
+        icon: "mdi:thermometer"
+
+      - name: "AC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        offset: 1000
+        registers: [0x021D]
+        icon: "mdi:thermometer"
+
+      - name: "Inverter ID"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [0x0003, 0x0004, 0x0005, 0x0006, 0x0007]
+        isstr: true
+
+      - name: "Communication Board Version No."
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x0011]
+        isstr: true
+
+      - name: "Control Board Version No."
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x000D]
+        isstr: true
+
+  - group: SmartLoad
+    items:
+      - name: "SmartLoad Enable Status"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x0085]
+        isstr: true
+        lookup:
+          - key: 0
+            value: "GEN Use"
+          - key: 1
+            value: "SMART Load output"
+          - key: 2
+            value: "Microinverter"
+        icon: "mdi:lightning-bolt-outline"
+
+      - name: "Phase voltage of Gen port A"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0295]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase voltage of Gen port B"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0296]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase voltage of Gen port C"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0297]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase power of Gen port A"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x0298, 0x029C]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Phase power of Gen port B"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x0299, 0x029D]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Phase power of Gen port C"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x029A, 0x029E]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Total Power of Gen port"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x029B, 0x029F]
+        icon: "mdi:home-l1ghtning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Generator daily power generation"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0218]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Generator total power generation"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0219, 0x021A]
+        icon: "mdi:transmission-tower-import"
+
+  - group: Alert
+    items:
+      - name: "Alert"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 6
+        registers: [0x0229, 0x022A, 0x22B, 0x022C, 0x022D, 0x022E]

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/hyd-zss-hp-3k-6k.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/hyd-zss-hp-3k-6k.yaml
@@ -1,0 +1,919 @@
+# ZCS Azzurro 3-phase hybrid inverters
+# with LSW-3 WiFi logger with SN 27xxxxxxxx and FW LSW3_15_270A_1.53:
+
+requests:
+  - start: 0x0404
+    end: 0x0410
+    mb_functioncode: 0x03
+  - start: 0x0418
+    end: 0x041A
+    mb_functioncode: 0x03    
+  - start: 0x042b
+    end: 0x042b
+    mb_functioncode: 0x03
+  - start: 0x0484
+    end: 0x048d
+    mb_functioncode: 0x03    
+  - start: 0x04AF
+    end: 0x04AF
+    mb_functioncode: 0x03      
+  - start: 0x0504
+    end: 0x0504
+    mb_functioncode: 0x03
+  - start: 0x0584
+    end: 0x0589
+    mb_functioncode: 0x03
+  - start: 0x0604
+    end: 0x060A
+    mb_functioncode: 0x03
+  - start: 0x0683
+    end: 0x069B
+    mb_functioncode: 0x03
+
+parameters:
+  - group: Solar
+    items:
+      - name: 'PV Generation today'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.01
+        rule: 3
+        registers: [0x0685,0x0684]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV Generation total'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.1
+        rule: 3
+        registers: [0x0687,0x0686]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV1 Power'
+        class: 'power'
+        state_class: 'measurement'
+        uom: 'W'
+        scale: 10
+        rule: 1
+        registers: [0x0586]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV2 Power'
+        class: 'power'
+        state_class: 'measurement'
+        uom: 'W'
+        scale: 10
+        rule: 1
+        registers: [0x0589]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV1 Voltage'
+        class: 'voltage'
+        state_class: 'measurement'
+        uom: 'V'
+        scale: 0.1
+        rule: 1
+        registers: [0x0584]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV2 Voltage'
+        class: 'voltage'
+        state_class: 'measurement'
+        uom: 'V'
+        scale: 0.1
+        rule: 1
+        registers: [0x0587]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV1 Current'
+        class: 'current'
+        state_class: 'measurement'
+        uom: 'A'
+        scale: 0.01
+        rule: 1
+        registers: [0x0585]
+        icon: 'mdi:solar-power'
+
+      - name: 'PV2 Current'
+        class: 'current'
+        state_class: 'measurement'
+        uom: 'A'
+        scale: 0.01
+        rule: 1
+        registers: [0x0588]
+        icon: 'mdi:solar-power'
+
+  - group: batteries
+    items:
+      - name: "Battery 1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0604]
+        icon: 'mdi:battery-charging'
+
+      - name: "Battery Charge / Discharge current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0605]
+        icon: 'mdi:battery-charging-10'
+
+      - name: "Battery SoC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [0x0608]
+        icon: 'mdi:battery'
+
+      - name: "Battery SoH"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [0x0609]
+        icon: 'mdi:battery'
+
+      - name: "Battery Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 1
+        #se non funziona cambia questo in 2
+        rule: 1
+        registers: [0x0607]
+        icon: 'mdi:battery-heart-outline'
+
+      - name: "Battery Charge Total"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0697,0x0696]
+        icon: 'mdi:battery-clock'
+
+      - name: "Battery Discharge Total"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x069B,0x069A]
+        icon: 'mdi:battery-clock-outline'
+
+      - name: "Battery Cycles"
+        class: ""
+        state_class: ""
+        uom: "Charges"
+        scale: 1
+        rule: 1
+        registers: [0x060A]
+        icon: 'mdi:battery-check-outline'
+
+      - name: "Battery Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [0x0606]
+        icon: 'mdi:battery-charging-high'
+
+      - name: 'Battery Charge Today'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.01        
+        rule: 3
+        registers: [0x0695,0x0694]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: 'Battery Discharge Today'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.01        
+        rule: 3
+        registers: [0x0699,0x0698]
+        icon: 'mdi:home-lightning-bolt'
+
+  - group: Grid
+    items:
+      - name: "Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [0x0488]
+        icon: 'mdi:transmission-tower'
+        
+      - name: 'Grid Voltage'
+        class: 'voltage'
+        state_class: 'measurement'
+        uom: 'V'
+        scale: 0.1
+        rule: 1
+        registers: [0x048d]
+        icon: 'mdi:transmission-tower'        
+        
+      - name: 'Grid Frequency'
+        class: 'frequency'
+        state_class: 'measurement'
+        uom: 'Hz'
+        scale: 0.01
+        rule: 1
+        registers: [0x0484]
+        icon: 'mdi:transmission-tower'
+
+      - name: 'Active Power Output Total'
+        class: 'power'
+        state_class: 'measurement'
+        uom: 'W'
+        scale: 10
+        rule: 2
+        registers: [0x0485]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: 'Home Consumption'
+        class: 'power'
+        state_class: 'measurement'
+        uom: 'W'
+        scale: 10
+        rule: 2
+        registers: [0x04AF]
+        icon: 'mdi:home-lightning-bolt'
+                
+      - name: 'Active Power Load Total'
+        class: 'power'
+        state_class: 'measurement'
+        uom: 'W'
+        scale: 10
+        rule: 2
+        registers: [0x0504]
+        icon: 'mdi:home-lightning-bolt'
+        
+      - name: 'Energy Purchase Today'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.01        
+        rule: 3
+        registers: [0x068D,0x068C]
+        icon: 'mdi:home-lightning-bolt'
+        
+      - name: 'Energy Purchase Total'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.1        
+        rule: 3
+        registers: [0x068F,0x068E]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: 'Energy Selling Today'
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.01        
+        rule: 3
+        registers: [0x0691,0x0690]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: 'Energy Selling Total'      
+        class: 'energy'
+        state_class: 'total_increasing'
+        uom: 'kWh'
+        scale: 0.1        
+        rule: 3
+        registers: [0x0693,0x0692]
+        icon: 'mdi:home-lightning-bolt'
+
+  - group: Inverter
+    items:
+      - name: 'Inverter status'
+        class: ''
+        state_class: 'measurement'
+        uom: ''
+        scale: 1
+        rule: 1
+        registers: [0x0404]
+        lookup:
+          - key: 0
+            value: 'Stand-by'
+          - key: 1
+            value: 'Self-checking'
+          - key: 2
+            value: 'Normal'
+          - key: 3
+            value: 'FAULT'
+          - key: 4
+            value: 'Permanent'
+        icon: 'mdi:wrench'
+
+      - name: 'Module temperature'
+        class: 'temperature'
+        uom: '°C'
+        scale: 0.1
+        rule: 2
+        registers: [0x0683]
+        icon: 'mdi:thermometer'
+
+      - name: 'Ambient temperature'
+        class: 'temperature'
+        uom: '°C'
+        scale: 1
+        rule: 2
+        registers: [0x0418]
+        icon: 'mdi:thermometer'
+
+      - name: 'Radiator temperature'
+        class: 'temperature'
+        uom: '°C'
+        scale: 1
+        rule: 2
+        registers: [0x041A]
+        icon: 'mdi:thermometer'
+
+      - name: 'Insulation Resistance'
+        class: ''
+        state_class: 'measurement'
+        uom: 'kΩ'
+        scale: 1
+        rule: 1
+        registers: [0x042B]
+        icon: 'mdi:omega'
+
+  - group: Alert
+    items:
+      - name: 'Alert'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 6
+        registers:
+          [
+            0x0405,
+            0x0406,
+            0x0407,
+            0x0408,
+            0x0409,
+            0x040A,
+            0x040B,
+            0x040C,
+            0x040D,
+            0x040E,
+            0x040F,
+            0x0410,
+          ]
+
+      - name: 'Fault 1'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        registers: [0x0405]
+        isstr: true
+        icon: 'mdi:wrench'
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID01 Grid Over Voltage Protection'
+          - key: 2
+            value: 'ID02 Grid Under Voltage Protection'
+          - key: 4
+            value: 'ID03 Grid Over Frequency Protection'
+          - key: 8
+            value: 'ID04 Grid Under Frequency Protection'
+          - key: 16
+            value: 'ID05 Leakage current fault'
+          - key: 32
+            value: 'ID06 High penetration error'
+          - key: 64
+            value: 'ID07 Low penetration error'
+          - key: 128
+            value: 'ID08 Islanding error'
+          - key: 256
+            value: 'ID09 Grid voltage transient value overvoltage 1'
+          - key: 512
+            value: 'ID10 Grid voltage transient value overvoltage 2'
+          - key: 1024
+            value: 'ID11 Grid line voltage error'
+          - key: 2048
+            value: 'ID12 Inverter voltage error'
+          - key: 4096
+            value: 'ID13 Anti-backflow overload'
+          - key: 8192
+            value: 'ID14'
+          - key: 16384
+            value: 'ID15'
+          - key: 32768
+            value: 'ID16'
+
+      - name: 'Fault 2'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        isstr: true
+        registers: [0x0406]
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID17 Grid current sampling error'
+          - key: 2
+            value: 'ID18 Grid current DC component sampling error (AC side)'
+          - key: 4
+            value: 'ID19 Grid voltage sampling error (DC side)'
+          - key: 8
+            value: 'ID20 Grid voltage sampling error (AC side)'
+          - key: 16
+            value: 'ID21 Leakage current sampling error (DC side)'
+          - key: 32
+            value: 'ID22 Leakage current sampling error (AC side)'
+          - key: 64
+            value: 'ID23 Load voltage DC component sampling error'
+          - key: 128
+            value: 'ID24 DC input current sampling error'
+          - key: 256
+            value: 'ID25 DC component sampling error of grid current (DC side)'
+          - key: 512
+            value: 'ID26 DC input branch current sampling error'
+          - key: 1024
+            value: 'ID27'
+          - key: 2048
+            value: 'ID28'
+          - key: 4096
+            value: 'ID29 Leakage current consistency error'
+          - key: 8192
+            value: 'ID30 Grid voltage consistency error'
+          - key: 16384
+            value: 'ID31 DCI consistency error'
+          - key: 32768
+            value: 'ID32'
+
+      - name: 'Fault 3'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        isstr: true
+        registers: [0x0407]
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID033 SPI communication error (DC side)'
+          - key: 2
+            value: 'ID034 SPI communication error (AC side)'
+          - key: 4
+            value: 'ID035 Chip error (DC side)'
+          - key: 8
+            value: 'ID036 Chip error (AC side)'
+          - key: 16
+            value: 'ID037 Auxiliary power error'
+          - key: 32
+            value: 'ID038 Inverter soft start failure'
+          - key: 64
+            value: 'ID039 '
+          - key: 128
+            value: 'ID040 '
+          - key: 256
+            value: 'ID041 Relay detection failure'
+          - key: 512
+            value: 'ID042 Low insulation impedance'
+          - key: 1024
+            value: 'ID043 Grounding error'
+          - key: 2048
+            value: 'ID044 Input mode setting error'
+          - key: 4096
+            value: 'ID045 CT error'
+          - key: 8192
+            value: 'ID046 Input reversal error'
+          - key: 16384
+            value: 'ID047 Parallel error'
+          - key: 32768
+            value: 'ID048 Serial number error'
+
+      - name: 'Fault 4'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        registers: [0x0408]
+        isstr: true
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID049 Battery temperature protection'
+          - key: 2
+            value: 'ID050 Heat sink 1 temperature protection'
+          - key: 4
+            value: 'ID051 Heater 2 temperature protection'
+          - key: 8
+            value: 'ID052 Heater 3 temperature protection'
+          - key: 16
+            value: 'ID053 Heatsink 4 temperature protection'
+          - key: 32
+            value: 'ID054 Heatsink 5 temperature protection'
+          - key: 64
+            value: 'ID055 Radiator 6 temperature protection'
+          - key: 128
+            value: 'ID056 '
+          - key: 256
+            value: 'ID057 Ambient temperature 1 protection'
+          - key: 512
+            value: 'ID058 Ambient temperature 2 protection'
+          - key: 1024
+            value: 'ID059 Module 1 temperature protection'
+          - key: 2048
+            value: 'ID060 Module 2 temperature protection'
+          - key: 4096
+            value: 'ID061 Module 3 temperature protection'
+          - key: 8192
+            value: 'ID062 Module temperature difference is too large'
+          - key: 16384
+            value: 'ID063 '
+          - key: 32768
+            value: 'ID064 '
+
+      - name: 'Fault 5'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        registers: [0x0409]
+        isstr: true
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID065 Bus voltage RMS unbalance'
+          - key: 2
+            value: 'ID066 Bus voltage transient   value unbalance'
+          - key: 4
+            value: 'ID067 Undervoltage of busbar during grid connection'
+          - key: 8
+            value: 'ID068 Bus bar low voltage'
+          - key: 16
+            value: 'ID069 PV overvoltage'
+          - key: 32
+            value: 'ID070 Battery over-voltage'
+          - key: 64
+            value: 'ID071 LLCBus overvoltage protection'
+          - key: 128
+            value: 'ID072 Inverter bus voltage RMS software overvoltage'
+          - key: 256
+            value: 'ID073 Inverter bus voltage transient value software overvoltage'
+          - key: 512
+            value: 'ID074 Flying Cross Capacitor Overvoltage Protection'
+          - key: 1024
+            value: 'ID075 Flying Cross capacitor undervoltage protection'
+          - key: 2048
+            value: 'ID076 '
+          - key: 4096
+            value: 'ID077 '
+          - key: 8192
+            value: 'ID078 '
+          - key: 16384
+            value: 'ID079 '
+          - key: 32768
+            value: 'ID080 '
+
+      - name: 'Fault 6'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        isstr: true
+        registers: [0x040A]
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID081 Battery overcurrent software protection'
+          - key: 2
+            value: 'ID082 Dci overcurrent protection'
+          - key: 4
+            value: 'ID083 Output transient current protection'
+          - key: 8
+            value: 'ID084 BuckBoost software overcurrent'
+          - key: 16
+            value: 'ID085 Output RMS current protection'
+          - key: 32
+            value: 'ID086 PV instantaneous current overcurrent software protection'
+          - key: 64
+            value: 'ID087 PV parallel uneven current'
+          - key: 128
+            value: 'ID088 Output current unbalance'
+          - key: 256
+            value: 'ID089 PV software overcurrent protection'
+          - key: 512
+            value: 'ID090 Balanced circuit overcurrent protection'
+          - key: 1024
+            value: 'ID091 Resonance protection'
+          - key: 2048
+            value: 'ID092 '
+          - key: 4096
+            value: 'ID093 '
+          - key: 8192
+            value: 'ID094 '
+          - key: 16384
+            value: 'ID095 '
+          - key: 32768
+            value: 'ID096 '
+
+      - name: 'Fault 7'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        isstr: true
+        registers: [0x040B]
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID097 LLC bus hardware overvoltage'
+          - key: 2
+            value: 'ID098 Inverter bus hardware overvoltage'
+          - key: 4
+            value: 'ID099 BuckBoost hardware overcurrent'
+          - key: 8
+            value: 'ID100 Battery hardware overcurrent'
+          - key: 16
+            value: 'ID101 '
+          - key: 32
+            value: 'ID102 PV hardware overcurrent'
+          - key: 64
+            value: 'ID103 AC output hardware overcurrent'
+          - key: 128
+            value: 'ID104 '
+          - key: 256
+            value: 'ID105 Power meter error'
+          - key: 512
+            value: 'ID106 Serial number model error'
+          - key: 1024
+            value: 'ID107 '
+          - key: 2048
+            value: 'ID108 '
+          - key: 4096
+            value: 'ID109 '
+          - key: 8192
+            value: 'ID110 Overload protection 1'
+          - key: 16384
+            value: 'ID111 Overload protection 2'
+          - key: 32768
+            value: 'ID112 Overload protection 3'
+
+      - name: 'Fault 8'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        registers: [0x040C]
+        isstr: true
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID113 Overtemperature derating'
+          - key: 2
+            value: 'ID114 Frequency down load'
+          - key: 4
+            value: 'ID115 Frequency loading'
+          - key: 8
+            value: 'ID116 Voltage down load'
+          - key: 16
+            value: 'ID117 Voltage loading'
+          - key: 32
+            value: 'ID118 '
+          - key: 64
+            value: 'ID119 '
+          - key: 128
+            value: 'ID120 '
+          - key: 256
+            value: 'ID121 Lightning protection failure (DC)'
+          - key: 512
+            value: 'ID122 Lightning protection failure (AC)'
+          - key: 1024
+            value: 'ID123 '
+          - key: 2048
+            value: 'ID124 Battery low voltage protection'
+          - key: 4096
+            value: 'ID125 Battery low voltage shutdown'
+          - key: 8192
+            value: 'ID126 Battery low voltage pre-alarm'
+          - key: 16384
+            value: 'ID127 '
+          - key: 32768
+            value: 'ID128 '
+
+      - name: 'Fault 9'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        isstr: true
+        registers: [0x040D]
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID129 Output hardware overcurrent permanent fault'
+          - key: 2
+            value: 'ID130 Bus overvoltage permanent fault'
+          - key: 4
+            value: 'ID131 Bus hardware over-voltage permanent fault'
+          - key: 8
+            value: 'ID132 PV uneven flow permanent fault'
+          - key: 16
+            value: 'ID133 Battery overcurrent permanent fault in EPS mode'
+          - key: 32
+            value: 'ID134 Output transient overcurrent permanent fault'
+          - key: 64
+            value: 'ID135 Output current unbalance permanent fault'
+          - key: 128
+            value: 'ID136 '
+          - key: 256
+            value: 'ID137 Input mode setting error permanent fault'
+          - key: 512
+            value: 'ID138 Input overcurrent permanent fault'
+          - key: 1024
+            value: 'ID139 Input hardware overcurrent permanent fault'
+          - key: 2048
+            value: 'ID140 Relay permanent fault'
+          - key: 4096
+            value: 'ID141 Bus unbalance permanent fault'
+          - key: 8192
+            value: 'ID142 Lightning protection permanent fault - DC side'
+          - key: 16384
+            value: 'ID143 Lightning protection permanent fault - AC side'
+          - key: 32768
+            value: 'ID144 '
+
+      - name: 'Fault 10'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        isstr: true
+        registers: [0x040E]
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID145 USB fault'
+          - key: 2
+            value: 'ID146 WIFI fault'
+          - key: 4
+            value: 'ID147 Bluetooth fault'
+          - key: 8
+            value: 'ID148 RTC clock fault'
+          - key: 16
+            value: 'ID149 Communication board EEPROM error'
+          - key: 32
+            value: 'ID150 Communication board FLASH error'
+          - key: 64
+            value: 'ID151 '
+          - key: 128
+            value: 'ID152 Safety regulation version error'
+          - key: 256
+            value: 'ID153 SCI communication error (DC side)'
+          - key: 512
+            value: 'ID154 SCI communication error (AC side)'
+          - key: 1024
+            value: 'ID155 SCI communication error (convergence board side)'
+          - key: 2048
+            value: 'ID156 Software version inconsistency'
+          - key: 4096
+            value: 'ID157 Lithium battery 1 communication error'
+          - key: 8192
+            value: 'ID158 Li-ion battery 2 communication error'
+          - key: 16384
+            value: 'ID159 Lithium battery 3 communication error'
+          - key: 32768
+            value: 'ID160 Lithium battery 4 communication failure'
+
+      - name: 'Fault 11'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        registers: [0x040F]
+        isstr: true
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID161 Forced shutdown'
+          - key: 2
+            value: 'ID162 Remote shutdown'
+          - key: 4
+            value: 'ID163 Drms0 shutdown'
+          - key: 8
+            value: 'ID164 '
+          - key: 16
+            value: 'ID165 Remote down load'
+          - key: 32
+            value: 'ID166 Logic interface down load'
+          - key: 64
+            value: 'ID167 Anti-Reverse Flow Downgrade'
+          - key: 128
+            value: 'ID168 '
+          - key: 256
+            value: 'ID169 Fan 1 failure'
+          - key: 512
+            value: 'ID170 Fan 2 failure'
+          - key: 1024
+            value: 'ID171 Fan 3 failure'
+          - key: 2048
+            value: 'ID172 Fan 4 failure'
+          - key: 4096
+            value: 'ID173 Fan 5 failure'
+          - key: 8192
+            value: 'ID174 Fan 6 failure'
+          - key: 16384
+            value: 'ID175 Fan 7 fault'
+          - key: 32768
+            value: 'ID176 Meter communication failure'
+
+      - name: 'Fault 12'
+        class: ''
+        state_class: ''
+        uom: ''
+        scale: 1
+        rule: 1
+        icon: 'mdi:wrench'
+        registers: [0x0410]
+        isstr: true
+        lookup:
+          - key: 0
+            value: 'No error'
+          - key: 1
+            value: 'ID177 BMS over-voltage alarm'
+          - key: 2
+            value: 'ID178 BMS undervoltage alarm'
+          - key: 4
+            value: 'ID179 BMS high temperature alarm'
+          - key: 8
+            value: 'ID180 BMS low temperature alarm'
+          - key: 16
+            value: 'ID181 BMS charge/discharge overload alarm'
+          - key: 32
+            value: 'ID182 BMS short circuit alarm'
+          - key: 64
+            value: 'ID183 BMS version inconsistency'
+          - key: 128
+            value: 'ID184 BMS CAN version inconsistency'
+          - key: 256
+            value: 'ID185 BMS CAN version is too low'
+          - key: 512
+            value: 'ID186 '
+          - key: 1024
+            value: 'ID187 '
+          - key: 2048
+            value: 'ID188 '
+          - key: 4096
+            value: 'ID189 Arc device communication failure'
+          - key: 8192
+            value: 'ID190 DC arc alarm fault'
+          - key: 16384
+            value: 'ID191 PID repair failed'
+          - key: 32768
+            value: 'ID192 PLC module heartbeat loss'

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/kstar_hybrid.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/kstar_hybrid.yaml
@@ -1,36 +1,39 @@
 # KSTAR Hybrid Inverter
 # Modbus information taken from "MODBUS RS485 Communication Protocol V2.5" document provided by KSTAR
 
-#INPUT_REGISTERS = 3000 - 3660    # 0x0BB8 - 0x0E4C
-#HOLDING_REGISTERS = 3200 - 3237  # 0x0C80 - 0x0C9B
+# This inverter exposes its data in the following registers (although not all of them are used by this definition file):
+#
+#  - INPUT_REGISTERS   3000 - 3660 decimal, 0x0BB8 - 0x0E4C hexadecimal
+#  - HOLDING_REGISTERS 3200 - 3237 decimal. 0x0C80 - 0x0C9B  hexadecimal
+#
+# Each request can get a maximum of 125 registers as per modbus protocol (start and end included), so we need to
+# split up the list of used registers into multiple requests of maximum 125 registers each.
 
 requests:
-  # Input registers 3000 - 3667
+  # Start requesting from the first needed register (3000)
   - start: 3000
-    end: 3125
+    end: 3124
     mb_functioncode: 0x04
 
-  # Input registers 3200 - 3228 not read as they would clash with holding registers
+  # Input registers 3200 - 3227 can't be read as they would clash with holding registers of same number
   - start: 3125
-    end: 3200
+    end: 3199
     mb_functioncode: 0x04
 
-  - start: 3228
-    end: 3250
-    mb_functioncode: 0x04
-
-  - start: 3250
-    end: 3375
-    mb_functioncode: 0x04
-
-  - start: 3375
-    end: 3500
-    mb_functioncode: 0x04
-
-  # Holding registers 3200 - 3237. Inverter system information.
+  # Change to holding registers 3200 - 3237 (mb_functioncode 3) for the inverter system information.
   - start: 3200
-    end: 3218
+    end: 3217
     mb_functioncode: 0x03
+
+  # Continue with the needed input registers
+  - start: 3228
+    end: 3249
+    mb_functioncode: 0x04
+
+  # Last input register currently used by this definition file is 3301, so we can skip the rest for now.
+  - start: 3250
+    end: 3301
+    mb_functioncode: 0x04
 
 parameters:
   - group: solar
@@ -699,7 +702,7 @@ parameters:
         scale: 0.01
         rule: 1
         registers: [ 3098 ]
-        icon: 'mdi:home-lightning-bolt'
+        icon: 'mdi:sine-wave'
 
       - name: "R-phase Meter Current"
         class: "current"
@@ -744,7 +747,7 @@ parameters:
         scale: 0.01
         rule: 1
         registers: [ 3125 ]
-        icon: 'mdi:home-lightning-bolt'
+        icon: 'mdi:sine-wave'
 
       - name: "R-phase Inverter Power"
         class: "power"

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/sofar_g3hyd.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/sofar_g3hyd.yaml
@@ -1,26 +1,35 @@
 # Sofar G3 also HYD 5-20KTL-3PH
-# This works also for rebranded ZCS Azzurro 3-Phase inverters such as the 3PH HYD6000 ZSS
+# This works also for rebranded ZCS Azzurro 3-Phase inverters such as the 3PH HYD6000 ZSS, or single phase such as 1PH HY6000 ZSS HP
 # Note that this won't work if your ZCS inverter is connected via Connext, you have to be using a Wi-Fi or Ethernet Kit such as ZSM-WIFI-USB.
 requests:
-  - start: 0x0404
-    end: 0x0420
+  - start: 0x0404 # inverter and faults
+    end: 0x042B
     mb_functioncode: 0x03
-  - start: 0x0484
+  - start: 0x0445 # serial number, hw, sw and firmare versions
+    end: 0x0465
+    mb_functioncode: 0x03
+  - start: 0x0484 # on-grid
     end: 0x04AF
     mb_functioncode: 0x03
-# off - grid info
-#  - start: 0x0504
-#    end: 0x051F
-#    mb_functioncode: 0x03
-  - start: 0x0584
+  - start: 0x0504 # off-grid
+    end: 0x051F
+    mb_functioncode: 0x03
+  - start: 0x0584 # dc
     end: 0x0589
     mb_functioncode: 0x03
-  - start: 0x0604
-    end: 0x060A # end of first battery after this continue battery pack 2,3,4
+  - start: 0x0604 # battery 1
+    end: 0x060A # end of first battery, last battery (8th) ends in 0x063A
     mb_functioncode: 0x03
-  - start: 0x0684
+  - start: 0x0684 # generation
     end: 0x069B
     mb_functioncode: 0x03
+  - start: 0x104D # battery dod and eod
+    end: 0x104E
+    mb_functioncode: 0x03
+  - start: 0x1052 # battery eps buffer
+    end: 0x1052
+    mb_functioncode: 0x03
+
 parameters:
 
   - group: Inverter
@@ -128,6 +137,77 @@ parameters:
         rule: 2
         registers: [ 0x0422 ]
         icon: 'mdi:thermometer'
+      - name: "Generation Time Today"
+        class: "duration"
+        state_class: "measurement"
+        uom: "min"
+        scale: 1
+        rule: 1
+        registers: [ 0x0426 ]
+        icon: 'mdi:clock'
+      - name: "Insulation resistance"
+        class: ""
+        state_class: "measurement"
+        uom: "kΩ"
+        scale: 1
+        rule: 1
+        registers: [ 0x042B ]
+        icon: 'mdi:omega'
+      - name: "Serial Number"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        isstr: true
+        registers: [ 0x0445,0x0446,0x0447,0x0448,0x0449,0x044A,0x044B,0x044C ] # serial number 17th to 20th digits are in 0x0470 and 0x0471
+        icon: 'mdi:barcode'
+      - name: "Hardware Version"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        isstr: true
+        registers: [ 0x044D,0x044E ]
+        icon: 'mdi:alpha-v'
+      - name: "Software Version Master"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        isstr: true
+        registers: [ 0x0453,0x0454,0x0455,0x0456 ]
+        icon: 'mdi:alpha-v'
+      - name: "Software Version Slave"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        isstr: true
+        registers: [ 0x0457,0x0458,0x0459,0x045A ]
+        icon: 'mdi:alpha-v'
+      - name: "Safety Version"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 7
+        registers: [ 0x045B,0x045C ]
+        icon: 'mdi:alpha-v'
+      - name: "Safety Firmware Version"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        isstr: true
+        registers: [ 0x0460,0x0461,0x0462,0x0463 ]
+        icon: 'mdi:alpha-v'
+      - name: "Safety Hardware Version"
+        class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        isstr: true
+        registers: [ 0x0464,0x0465 ]
+        icon: 'mdi:alpha-v'
 
   - group: InverterDC
     items:
@@ -238,62 +318,30 @@ parameters:
         rule: 1
         registers: [ 0x060A ]
         icon: 'mdi:battery'
-      - name: "Battery 2 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [ 0x060B ]
-        icon: 'mdi:battery'
-      - name: "Battery 2 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.01
-        rule: 2
-        registers: [ 0x060C ]
-        icon: 'mdi:current-dc'
-      - name: "Battery 2 Power"
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        scale: 10
-        rule: 2
-        registers: [ 0x060D ]
-        icon: 'mdi:battery-charging'
-      - name: "Battery 2 Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 1
-        rule: 2
-        registers: [ 0x060E ]
-        icon: 'mdi:battery'
-      - name: "Battery 2 SOC"
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 1
-        rule: 1
-        registers: [ 0x060F ]
-        icon: 'mdi:battery'
-      - name: "Battery 2 SOH"
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 1
-        rule: 1
-        registers: [ 0x0610 ]
-        icon: 'mdi:battery'
-      - name: "Battery 2 Number of Cycles"
+      - name: "Battery DOD"
         class: ""
         state_class: "measurement"
-        uom: "cycle"
+        uom: "%"
         scale: 1
         rule: 1
-        registers: [ 0x0611 ]
+        registers: [ 0x104D ]
         icon: 'mdi:battery'
+      - name: "Battery EOD"
+        class: ""
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 0x104E ]
+        icon: 'mdi:battery'
+      - name: "Battery EPS Buffer"
+        class: ""
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 0x1052 ]
+        icon: 'mdi:battery-low'
 
   - group: GridAC
     items:
@@ -894,6 +942,10 @@ parameters:
             value: "ID03 Grid Over Frequency Protection"
           - key: 8
             value: "ID04 Grid Under Frequency Protection"
+          - key: 10
+            value: "LOOKUP" # off-grid
+          - key: 14
+            value: "ID03 Grid Over Frequency Protection" # also ID14 Grid voltage unbalance
           - key: 16
             value: "ID05 Leakage current fault"
           - key: 32

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/sofar_hyd3k-6k-es.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/sofar_hyd3k-6k-es.yaml
@@ -14,7 +14,7 @@ parameters:
  - group: solar
    items:
     - name: "PV Instant Generated PW"
-      class: "energy"
+      class: "power"
       state_class: "measurement"
       uom: "kW"
       scale: 0.01
@@ -143,16 +143,16 @@ parameters:
     - name: "Total Grid Return"
       class: "energy"
       state_class: "total"
-      uom: "KWh"
+      uom: "kWh"
       scale: 1
       rule: 3
       registers: [0x021F,0x021E]
       icon: 'mdi:transmission-tower-export'
 
     - name: "Total Grid Consumption"
-      class: "Energy"
+      class: "energy"
       state_class: "total"
-      uom: "KWh"
+      uom: "kWh"
       scale: 1
       rule: 3
       registers: [0x0221,0x0220]
@@ -161,7 +161,7 @@ parameters:
     - name: "Total Power Consumption"
       class: "energy"
       state_class: "total"
-      uom: "KWh"
+      uom: "kWh"
       scale: 1
       rule: 3
       registers: [0x0223,0x0222]
@@ -173,7 +173,7 @@ parameters:
     - name: "Power Consumption"
       class: ""
       state_class: ""
-      uom: "KW"
+      uom: "kW"
       scale: 0.01
       rule: 1
       registers: [0x0213]
@@ -303,7 +303,7 @@ parameters:
     - name: "Battery Power"
       class: "power"
       state_class: "measurement"
-      uom: "KW"
+      uom: "kW"
       scale: 0.01
       rule: 2
       registers: [0x0237]
@@ -327,7 +327,7 @@ parameters:
       registers: [0x10B1]
       icon: 'mdi:battery'
 
-    - name: "Battery daily Discharge"
+    - name: "Battery Daily Discharge"
       class: "energy"
       state_class: "total_increasing"
       uom: "kWh"
@@ -339,7 +339,7 @@ parameters:
     - name: "Battery Total Charge"
       class: "energy"
       state_class: "total"
-      uom: "KWh"
+      uom: "kWh"
       scale: 1
       rule: 3
       registers: [0x0227,0x0226]
@@ -348,7 +348,7 @@ parameters:
     - name: "Battery Total Discharge"
       class: "energy"
       state_class: "total"
-      uom: "KWh"
+      uom: "kWh"
       scale: 1
       rule: 3
       registers: [0x0229,0x0228]
@@ -448,11 +448,11 @@ parameters:
    items:
     - name: "Inverter status"
       class: ""
-      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [0x0200]
+      isstr: true
       lookup:
       -  key: 0
          value: "Stand-by"
@@ -572,11 +572,11 @@ parameters:
 
     - name: "Country"
       class: ""
-      state_class: ""
       uom: ""
       scale: 1
       rule: 1
       registers: [0x023A]
+      isstr: true
       lookup:
       -  key: 0
          value: "Germany"
@@ -649,6 +649,7 @@ parameters:
       scale: 1
       rule: 1
       registers: [0x022B]
+      isstr: true
       lookup:
       -  key: 0
          value: "No error"
@@ -803,6 +804,7 @@ parameters:
       scale: 1
       rule: 1
       registers: [0x0201]
+      isstr: true
       lookup:
       -  key: 0
          value: "No error"
@@ -848,6 +850,7 @@ parameters:
       scale: 1
       rule: 1
       registers: [0x0202]
+      isstr: true
       lookup:
       -  key: 0
          value: "No error"
@@ -892,6 +895,7 @@ parameters:
       scale: 1
       rule: 1
       registers: [0x0203]
+      isstr: true
       lookup:
       -  key: 0
          value: "No error"
@@ -936,6 +940,7 @@ parameters:
       scale: 1
       rule: 1
       registers: [0x0204]
+      isstr: true
       lookup:
       -  key: 0
          value: "No error"
@@ -980,6 +985,7 @@ parameters:
       scale: 1
       rule: 1
       registers: [0x0205]
+      isstr: true
       lookup:
       -  key: 0
          value: "No error"
@@ -1059,7 +1065,7 @@ parameters:
     - name: "Charge / Discharge Power"
       class: ""
       state_class: ""
-      uom: "KW"
+      uom: "kW"
       scale: 0.01
       rule: 2
       registers: [0x020D]
@@ -1068,7 +1074,7 @@ parameters:
     - name: "Feed in / out power"
       class: ""
       state_class: ""
-      uom: "KW"
+      uom: "kW"
       scale: 0.01
       rule: 2
       registers: [0x0212]
@@ -1077,7 +1083,7 @@ parameters:
     - name: "Input/Output Power"
       class: "power"
       state_class: "measurement"
-      uom: "KW"
+      uom: "kW"
       scale: 0.01
       rule: 2
       registers: [0x0214]

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/sofar_lsw3.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/sofar_lsw3.yaml
@@ -63,7 +63,7 @@ parameters:
 
     - name: "Daily Production"
       class: "energy"
-      state_class: "total"      
+      state_class: "total_increasing"      
       uom: "kWh"
       scale: 0.01
       rule: 1

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/solis_3p-4g.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/solis_3p-4g.yaml
@@ -1,0 +1,265 @@
+# Solis 4G Three Phase Inverter
+# Solis-3P(5-10)K-4G
+# refering to https://ginlongsolis.freshdesk.com/support/solutions/articles/36000340158-modbus-communication-for-solis-inverters
+# agirilovich June 2023
+#
+requests:
+  - start: 2999
+    end:  3044
+    mb_functioncode: 0x04
+
+
+parameters:
+ - group: Inverter
+   items:
+    - name: "Working Mode"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [3040]
+      icon: 'mdi:home-lightning-bolt'
+      lookup:
+          - key: 0
+            value: "No response mode"
+          - key: 1
+            value: "Volt–watt default"
+          - key: 2
+            value: "Volt–var"
+          - key: 3
+            value: "Fixed power factor"
+          - key: 4
+            value: "Fix reactive power"
+          - key: 5
+            value: "Power-PF"
+          - key: 6
+            value: "Rule21Volt–watt"
+
+    - name: "Inverter Temperature"
+      class: "temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 0.1
+      rule: 1
+      registers: [3041]
+      icon: 'mdi:thermometer'
+
+    - name: "Product Model"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [2999]
+      isstr: true
+
+    - name: "DSP Software Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [3000]
+      isstr: true
+
+    - name: "LCD Software Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [3001]
+      isstr: true
+
+    - name: "Inverter Status"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [3043]
+      icon: 'mdi:list-status'
+      isstr: true
+      lookup:
+        - key: 0
+          value: "Waiting"
+        - key: 1
+          value: "OpenRun"
+        - key: 2
+          value: "SoftRun"
+        - key: 3
+          value: "Generating"
+        - key: 1004
+          value: "Grid off"
+        - key: 2011
+          value: "Fail Safe"
+
+ - group: InverterDC
+   items:
+    - name: "DC Voltage 1"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3021]
+      icon: 'mdi:solar-power'
+
+    - name: "DC Voltage 2"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3023]
+      icon: 'mdi:solar-power'
+
+    - name: "DC Current 1"
+      class: "current"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3022]
+      icon: 'mdi:current-dc'
+
+    - name: "DC Current 2"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3024]
+      icon: 'mdi:current-dc'
+
+    - name: "Total DC Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "kW"
+      scale: 0.001
+      rule: 3
+      registers: [3007, 3006]
+      icon: 'mdi:solar-power'
+
+ - group: InverterAC
+   items:
+    - name: "Active power"
+      class: "power"
+      state_class: "measurement"
+      uom: "kW"
+      scale: 0.001
+      rule: 3
+      registers: [3005, 3004]
+      icon: 'mdi:solar-power'
+
+   
+    - name: "Inverter AC Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "kW"
+      scale: 0.001
+      rule: 3
+      registers: [3005, 3004]
+      icon: 'mdi:solar-power'
+
+    - name: "A phase voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3033]
+      icon: 'mdi:transmission-tower'
+
+    - name: "B phase voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3034]
+      icon: 'mdi:transmission-tower'
+
+    - name: "C phase voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3035]
+      icon: 'mdi:transmission-tower'
+
+    - name: "A phase current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3036]
+      icon: 'mdi:current-ac'
+
+    - name: "B phase current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3037]
+      icon: 'mdi:current-ac'
+
+    - name: "C phase current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3038]
+      icon: 'mdi:current-ac'
+
+
+    - name: "Inverter Frequency"
+      class: "frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [3042]
+      icon: 'mdi:sine-wave'
+
+ - group: Generation
+   items:
+    - name: "Daily Generation"
+      class: "energy"
+      state_class: "measurement"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [3014]
+      icon: 'mdi:solar-power'
+
+    - name: "Monthly Generation"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 1
+      rule: 3
+      registers: [3011, 3010]
+      icon: 'mdi:solar-power'
+
+    - name: "Yearly Generation"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 1
+      rule: 3
+      registers: [3017, 3016]
+      icon: 'mdi:solar-power'
+
+    - name: "Total Generation"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 1
+      rule: 3
+      registers: [3009, 3008]
+      icon: 'mdi:solar-power'

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/solis_hybrid.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/solis_hybrid.yaml
@@ -1,10 +1,10 @@
 # Solis Single Phase Hybrid
 # RHI-(3-6)K-48ES-5G
 # Modbus information retrieved from:
-# https://www.scss.tcd.ie/coghlan/Elios4you/RS485_MODBUS-Hybrid-BACoghlan-201811228-1854.pdf
+# https://www.scss.tcd.ie/Brian.Coghlan/Elios4you/RS485_MODBUS-Hybrid-BACoghlan-201811228-1854.pdf
 
 requests:
-  - start: 33029
+  - start: 33022
     end:  33095
     mb_functioncode: 0x04
   - start: 33116
@@ -13,19 +13,23 @@ requests:
   - start: 33206
     end:  33282
     mb_functioncode: 0x04
+  - start: 43000
+    end: 43150
+    mb_functioncode: 0x03
 
 parameters:
  - group: InverterStatus
-   items: 
+   items:
     - name: "Inverter Status"
       class: ""
-      state_class: ""      
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33095]
       icon: 'mdi:home-lightning-bolt'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x0
          value: "Waiting State"
       -  key:  0x1
@@ -35,103 +39,104 @@ parameters:
       -  key: 0x3
          value: "On Grid/Generating"
       -  key: 0x1004
-         value: "Grid OverVoltage"         
+         value: "Grid OverVoltage"
       -  key: 0x1010
-         value: "Grid UnderVoltage"        
+         value: "Grid UnderVoltage"
       -  key: 0x1012
-         value: "Grid OverFrequency"         
+         value: "Grid OverFrequency"
       -  key: 0x1013
-         value: "Grid UnderFrequency"          
+         value: "Grid UnderFrequency"
       -  key: 0x1014
          value: "Grid Imp too large"
       -  key: 0x1015
-         value: "No Grid"         
+         value: "No Grid"
       -  key: 0x1016
-         value: "Grid Imbalance"         
+         value: "Grid Imbalance"
       -  key: 0x1017
-         value: "Grid Freq Jitter"         
+         value: "Grid Freq Jitter"
       -  key: 0x1018
-         value: "Grid Overcurrent"         
+         value: "Grid Overcurrent"
       -  key: 0x1019
-         value: "Grid Tracking Fault"         
+         value: "Grid Tracking Fault"
       -  key: 0x1020
-         value: "DC OverVoltage"         
+         value: "DC OverVoltage"
       -  key: 0x1021
          value: "DC Bus Overvoltage"
       -  key: 0x1022
-         value: "DC Bus Uneven Voltage"         
+         value: "DC Bus Uneven Voltage"
       -  key: 0x1024
          value: "DC Bus Uneven Voltage2"
       -  key: 0x1025
          value: "DC A path OverCurrent"
       -  key: 0x1026
-         value: "DC B path OverCurrent"         
+         value: "DC B path OverCurrent"
       -  key: 0x1027
-         value: "DC Input Disturbance"         
+         value: "DC Input Disturbance"
       -  key: 0x1030
-         value: "Grid Disturbance"         
+         value: "Grid Disturbance"
       -  key: 0x1031
-         value: "DSP Initialization Protection "         
+         value: "DSP Initialization Protection"
       -  key: 0x1032
-         value: "Over Temp Protection"         
+         value: "Over Temp Protection"
       -  key: 0x1033
-         value: "PV Insulation Fault"         
+         value: "PV Insulation Fault"
       -  key: 0x1034
-         value: "Leakage Current Protection"         
+         value: "Leakage Current Protection"
       -  key: 0x1035
-         value: "Relay Detection Protection"         
+         value: "Relay Detection Protection"
       -  key: 0x1036
-         value: "DSP_B Protection"         
+         value: "DSP_B Protection"
       -  key: 0x1037
-         value: "DC Component too Large"         
+         value: "DC Component too Large"
       -  key: 0x1038
-         value: "12v UnderVoltage Protection"         
+         value: "12v UnderVoltage Protection"
       -  key: 0x1039
-         value: "Under Temperature Protection"         
+         value: "Under Temperature Protection"
       -  key: 0x1040
-         value: "Arc Self-Test Protection"         
+         value: "Arc Self-Test Protection"
       -  key: 0x1041
-         value: "Arc Protection"         
+         value: "Arc Protection"
       -  key: 0x1042
-         value: "DSP on-chip SRAM exception"         
+         value: "DSP on-chip SRAM exception"
       -  key: 0x1043
          value: "DSP on-chip FLASH exception"
       -  key: 0x1044
-         value: "DSP on-chip PC pointer is abnormal"        
+         value: "DSP on-chip PC pointer is abnormal"
       -  key: 0x1045
          value: "DSP key register exception"
       -  key: 0x1046
-         value: "Grid disturbance 02"         
+         value: "Grid disturbance 02"
       -  key: 0x1047
-         value: "Grid current sampling abnormality"         
+         value: "Grid current sampling abnormality"
       -  key: 0x1048
          value: "IGBT overcurrent"
       -  key: 0x1050
-         value: "Network current transient overcurrent"         
+         value: "Network current transient overcurrent"
       -  key: 0x1051
-         value: "Battery overvoltage hardware failure"         
+         value: "Battery overvoltage hardware failure"
       -  key: 0x1052
-         value: "LLC hardware overcurrent"         
+         value: "LLC hardware overcurrent"
       -  key: 0x1053
-         value: "Battery overvoltage detection"         
+         value: "Battery overvoltage detection"
       -  key: 0x1054
-         value: "Battery undervoltage detection"         
+         value: "Battery undervoltage detection"
       -  key: 0x1055
-         value: "Battery no connected"         
+         value: "Battery no connected"
       -  key: 0x1056
-         value: "Bypass overvoltage fault"         
+         value: "Bypass overvoltage fault"
       -  key: 0x1057
-         value: "Bypass overload fault"      
+         value: "Bypass overload fault"
 
     - name: "Operating Status"
       class: ""
-      state_class: ""
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33121]
       icon: 'mdi:home-lightning-bolt'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x701
          value: "Normal Operation"
       -  key: 0x702
@@ -141,23 +146,24 @@ parameters:
       -  key: 0x708
          value: "Downtime"
       -  key: 0x710
-         value: "Standby"         
+         value: "Standby"
       -  key: 0x720
-         value: "Derating Operation"        
+         value: "Derating Operation"
       -  key: 0x740
-         value: "Limit Operation"      
+         value: "Limit Operation"
       -  key: 0x780
-         value: "Bypass Overload"              
-                     
+         value: "Bypass Overload"
+
     - name: "Grid Fault Status"
       class: ""
-      state_class: ""
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33116]
       icon: 'mdi:alert'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x0000
          value: "No Fault"
       -  key: 0x1
@@ -167,7 +173,7 @@ parameters:
       -  key: 0x4
          value: "Grid UnderVoltage"
       -  key: 0x8
-         value: "Grid OverFrequency"         
+         value: "Grid OverFrequency"
       -  key: 0x10
          value: "Grid UnderFrequency"
       -  key: 0x20
@@ -177,36 +183,39 @@ parameters:
       -  key: 0x80
          value: "Grid Impedence too Large"
       -  key: 0x100
-         value: "Grid Tracking Fault"        
+         value: "Grid Tracking Fault"
       -  key: 0x200
-         value: "Meter Comm Failure"        
+         value: "Meter Comm Failure"
       -  key: 0x400
-         value: "Failsafe"              
-                                                                                                     
+         value: "Failsafe"
+
     - name: "Backup Load Fault Status"
       class: ""
-      state_class: ""
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33117]
       icon: 'mdi:alert'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x0
          value: "No Fault"
       -  key: 0x1
          value: "Bypass OverVoltage Fault"
       -  key: 0x2
-         value: "Bypass Overload Fault"             
+         value: "Bypass Overload Fault"
+
     - name: "Battery Fault Status"
       class: ""
-      state_class: ""
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33118]
       icon: 'mdi:alert'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x0
          value: "No Fault"
       -  key: 0x1
@@ -214,17 +223,18 @@ parameters:
       -  key: 0x2
          value: "Battery OverVoltage Detection"
       -  key: 0x4
-         value: "Battery UnderVoltage Detection"              
-                                               
+         value: "Battery UnderVoltage Detection"
+
     - name: "Fault Status 04 (Device)"
       class: ""
-      state_class: ""
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33119]
       icon: 'mdi:alert'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x0000
          value: "No Fault"
       -  key: 0x1
@@ -234,7 +244,7 @@ parameters:
       -  key: 0x4
          value: "DC Bus Uneven Voltage"
       -  key: 0x8
-         value: "DC Bus UnderVoltage"         
+         value: "DC Bus UnderVoltage"
       -  key: 0x10
          value: "DC Bus2 Uneven Voltage"
       -  key: 0x20
@@ -244,17 +254,18 @@ parameters:
       -  key: 0x80
          value: "DC Input Disturbance"
       -  key: 0x100
-         value: "Grid OverCurrent"        
+         value: "Grid OverCurrent"
       -  key: 0x200
-         value: "IGBT OverCurrent"        
+         value: "IGBT OverCurrent"
       -  key: 0x400
-         value: "Grid Disturbance 2"      
+         value: "Grid Disturbance 2"
       -  key: 0x800
          value: "Arc Self-Test Protection"
       -  key: 0x1000
          value: "Arc Fault Reservation"
       -  key: 0x2000
-         value: "Grid Current Sample Abnormality"  
+         value: "Grid Current Sample Abnormality"
+
     - name: "Fault Status 05 (Device)"
       class: ""
       state_class: ""
@@ -263,7 +274,8 @@ parameters:
       rule: 1
       registers: [33120]
       icon: 'mdi:alert'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x0000
          value: "No Fault"
       -  key: 0x1
@@ -273,7 +285,7 @@ parameters:
       -  key: 0x4
          value: "Over Temp Protection"
       -  key: 0x8
-         value: "Relay Detection Protection"         
+         value: "Relay Detection Protection"
       -  key: 0x10
          value: "Under Temp Protection"
       -  key: 0x20
@@ -283,45 +295,55 @@ parameters:
       -  key: 0x80
          value: "Leakage Current Protection"
       -  key: 0x100
-         value: "Leakage Current Self-Test"        
+         value: "Leakage Current Self-Test"
       -  key: 0x200
-         value: "DSP Initialization Protect"        
+         value: "DSP Initialization Protect"
       -  key: 0x400
-         value: "DSP B Protection"      
+         value: "DSP B Protection"
       -  key: 0x800
          value: "Battery Overvoltage H/W Failure"
       -  key: 0x1000
-         value: "LLC Hardware OverCurrent"      
+         value: "LLC Hardware OverCurrent"
       -  key: 0x2000
          value: "Network Side Transient OverCurrent"
       -  key: 0x4000
-         value: "CAN Communication Failed"         
+         value: "CAN Communication Failed"
       -  key: 0x8000
-         value: "DSP Communication Failed"         
+         value: "DSP Communication Failed"
+
     - name: "Inverter Temperature"
       class: "temperature"
-      state_class: "measurement"      
+      state_class: "measurement"
       uom: "°C"
       scale: 0.1
       rule: 2
       registers: [33093]
       icon: 'mdi:thermometer'
 
+    - name: "Inverter Datetime Array"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 10
+      registers: [33022,33023,33024,33025,33026,33027]
+      icon: 'mdi:calendar-clock'
+
 # Sensors below are outside of modbus request ranges.
 # If enabling, ensure to amend the request start register.
-# 
+#
 #    - name: "Inverter ID"
 #      class: ""
-#      state_class: ""      
+#      state_class: ""
 #      uom: ""
 #      scale: 1
 #      rule: 5
 #      registers: [33004,33005,33006,33007,33008,33009,33010,33011,33012,33013,33014,33015,33016,33017,33018,33019]
 #      isstr: true
-      
+
 #    - name: "Product Model"
 #      class: ""
-#      state_class: ""      
+#      state_class: ""
 #      uom: ""
 #      scale: 1
 #      rule: 6
@@ -330,25 +352,25 @@ parameters:
 
 #    - name: "DSP Software Version"
 #      class: ""
-#      state_class: ""      
+#      state_class: ""
 #      uom: ""
 #      scale: 1
 #      rule: 6
 #      registers: [33001]
 #      isstr: true
-    
+
 #    - name: "LCD Software Version"
 #      class: ""
-#      state_class: ""      
+#      state_class: ""
 #      uom: ""
 #      scale: 1
 #      rule: 6
 #      registers: [33002]
 #      isstr: true
-    
+
 #    - name: "Protocol Software Version"
 #      class: ""
-#      state_class: ""      
+#      state_class: ""
 #      uom: ""
 #      scale: 1
 #      rule: 6
@@ -357,25 +379,29 @@ parameters:
 
     - name: "Storage Control Mode"
       class: ""
-      state_class: ""      
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
       registers: [33132]
       icon: 'mdi:battery-clock'
-      lookup: 
+      isstr: true
+      lookup:
       -  key: 0x21
-         value: "Spontaneous Mode"
+         value: "Self Use"
       -  key: 0x22
-         value: "Optimized Revenue Mode"
+         value: "Optimized Revenue"
       -  key: 0x23
-         value: "Charging from Grid"        
+         value: "Time of Use"
       -  key: 0x24
-         value: "Off-Grid Storage Mode"
-      -  key: 0x28      
-         value: "Battery Wake-Up"                                
+         value: "Off-Grid Storage"
+      -  key: 0x28
+         value: "Battery Wake-Up"
+      -  key: 0x60
+         value: "Feed-In Priority"
+
  - group: InverterDC
-   items: 
+   items:
     - name: "PV1 Voltage"
       class: "voltage"
       state_class: "measurement"
@@ -410,7 +436,7 @@ parameters:
       rule: 1
       registers: [33052]
       icon: 'mdi:current-dc'
-    
+
     - name: "Inverter DC Power"
       class: "power"
       state_class: "measurement"
@@ -420,8 +446,17 @@ parameters:
       registers: [33058,33057]
       icon: 'mdi:solar-power'
 
+    - name: "Inverting/Rectifing Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 10
+      rule: 2
+      registers: [33157]
+      icon: 'mdi:solar-power'
+
  - group: InverterAC
-   items: 
+   items:
     - name: "Inverter AC Power"
       class: "power"
       state_class: "measurement"
@@ -439,7 +474,7 @@ parameters:
       rule: 1
       registers: [33073]
       icon: 'mdi:transmission-tower'
-    
+
     - name: "Inverter Current"
       class: "current"
       state_class: "measurement"
@@ -470,7 +505,7 @@ parameters:
       rule: 4
       registers: [33082]
       icon: 'mdi:transmission-tower'
-    
+
     - name: "Inverter Apparent Power"
       class: "apparent_power"
       state_class: "measurement"
@@ -490,7 +525,7 @@ parameters:
       icon: 'mdi:sine-wave'
 
  - group: Generation
-   items: 
+   items:
     - name: "Daily Generation"
       class: "energy"
       state_class: "total_increasing"
@@ -528,7 +563,7 @@ parameters:
       icon: 'mdi:solar-power'
 
  - group: Grid
-   items: 
+   items:
     - name: "Meter Frequency"
       class: "frequency"
       state_class: "measurement"
@@ -541,7 +576,7 @@ parameters:
     - name: "Meter Power Factor"
       class: "power_factor"
       state_class: "measurement"
-      uom: "%"
+      uom: ""
       scale: 0.01
       rule: 2
       registers: [33281]
@@ -582,7 +617,7 @@ parameters:
       rule: 4
       registers: [33266,33265]
       icon: 'mdi:transmission-tower'
-    
+
     - name: "Meter Apparent Power"
       class: "apparent_power"
       state_class: "measurement"
@@ -609,7 +644,7 @@ parameters:
       rule: 3
       registers: [33170,33169]
       icon: 'mdi:home-import-outline'
-      
+
     - name: "Daily Energy Exported"
       class: "energy"
       state_class: "total_increasing"
@@ -629,10 +664,10 @@ parameters:
       icon: 'mdi:home-export-outline'
 
  - group: Load
-   items: 
+   items:
     - name: "House Load Power"
       class: "power"
-      state_class: "measurement"      
+      state_class: "measurement"
       uom: "W"
       scale: 1
       rule: 1
@@ -641,7 +676,7 @@ parameters:
 
     - name: "Backup Load Power"
       class: "power"
-      state_class: "measurement"      
+      state_class: "measurement"
       uom: "W"
       scale: 1
       rule: 1
@@ -650,7 +685,7 @@ parameters:
 
     - name: "Daily House+Backup Load Consumption"
       class: "energy"
-      state_class: "total_increasing"      
+      state_class: "total_increasing"
       uom: "kWh"
       scale: 0.1
       rule: 1
@@ -659,7 +694,7 @@ parameters:
 
     - name: "Total House+Backup Load Consumption"
       class: "energy"
-      state_class: "total_increasing"      
+      state_class: "total_increasing"
       uom: "kWh"
       scale: 1
       rule: 3
@@ -667,7 +702,7 @@ parameters:
       icon: 'mdi:lightning-bolt-outline'
 
  - group: Battery
-   items: 
+   items:
     - name: "Battery Status"
       class: ""
       state_class: "measurement"
@@ -676,7 +711,7 @@ parameters:
       rule: 1
       registers: [33135]
       isstr: true
-      lookup: 
+      lookup:
       -  key: 0
          value: "Charge"
       -  key: 1
@@ -700,7 +735,7 @@ parameters:
       rule: 1
       registers: [33139]
       icon: 'mdi:battery'
-    
+
     - name: "Battery SOH"
       class: "battery"
       state_class: "measurement"
@@ -718,7 +753,7 @@ parameters:
       rule: 2
       registers: [33134]
       icon: 'mdi:current-dc'
- 
+
     - name: "Battery Voltage"
       class: "voltage"
       state_class: "measurement"
@@ -730,7 +765,7 @@ parameters:
 
     - name: "Today Battery Charge"
       class: "energy"
-      state_class: "total_increasing"      
+      state_class: "total_increasing"
       uom: "kWh"
       scale: 0.1
       rule: 1
@@ -748,7 +783,7 @@ parameters:
 
     - name: "Total Battery Charge"
       class: "energy"
-      state_class: "total_increasing"      
+      state_class: "total_increasing"
       uom: "kWh"
       scale: 1
       rule: 3
@@ -763,7 +798,7 @@ parameters:
       rule: 3
       registers: [33166,33165]
       icon: 'mdi:battery-minus'
-    
+
     - name: "Battery Charge Current Limit"
       class: "current"
       state_class: "measurement"
@@ -781,3 +816,149 @@ parameters:
       rule: 1
       registers: [33207]
       icon: 'mdi:battery-arrow-down'
+
+    - name: "BMS Battery Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [33142]
+      icon: 'mdi:current-dc'
+
+    - name: "BMS Battery Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.01
+      rule: 1
+      registers: [33141]
+      icon: 'mdi:battery'
+
+    - name: "BMS Battery Charge Current Limit"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [33143]
+      icon: 'mdi:battery-arrow-up'
+
+    - name: "BMS Battery Discharge Current Limit"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [33144]
+      icon: 'mdi:battery-arrow-down'
+
+    - name: "Backup Mode SOC"
+      class: "battery"
+      state_class: "measurement"
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [43024]
+      icon: 'mdi:battery'
+
+    - name: "Overdischarge SOC"
+      class: "battery"
+      state_class: "measurement"
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [43011]
+      icon: 'mdi:battery'  
+
+ - group: TimedCharge
+   items: 
+    - name: "Timed Charge Current"
+      class: ""
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [43141]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Discharge Current"
+      class: ""
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [43142]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Charge Start Hour"
+      class: ""
+      state_class: "measurement"
+      uom: "H"
+      scale: 1
+      rule: 1
+      registers: [43143]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Charge Start Minute"
+      class: ""
+      state_class: "measurement"
+      uom: "M"
+      scale: 1
+      rule: 1
+      registers: [43144]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Charge End Hour"
+      class: ""
+      state_class: "measurement"
+      uom: "H"
+      scale: 1
+      rule: 1
+      registers: [43145]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Charge End Minute"
+      class: ""
+      state_class: "measurement"
+      uom: "M"
+      scale: 1
+      rule: 1
+      registers: [43146]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Discharge Start Hour"
+      class: ""
+      state_class: "measurement"
+      uom: "H"
+      scale: 1
+      rule: 1
+      registers: [43147]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Discharge Start Minute"
+      class: ""
+      state_class: "measurement"
+      uom: "M"
+      scale: 1
+      rule: 1
+      registers: [43148]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Discharge End Hour"
+      class: ""
+      state_class: "measurement"
+      uom: "H"
+      scale: 1
+      rule: 1
+      registers: [43149]
+      icon: 'mdi:wrench-clock'
+
+    - name: "Timed Discharge End Minute"
+      class: ""
+      state_class: "measurement"
+      uom: "M"
+      scale: 1
+      rule: 1
+      registers: [43150]
+      icon: 'mdi:wrench-clock'

--- a/bundles/org.openhab.binding.solarman/src/main/resources/definitions/solis_s6-gr1p.yaml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/definitions/solis_s6-gr1p.yaml
@@ -1,0 +1,318 @@
+# Solis S6-GR1P4.6K Configuration
+# NH-Networks 2023
+#
+requests:
+  - start: 2999
+    end:  3024
+    mb_functioncode: 0x04
+  - start: 3035
+    end:  3043
+    mb_functioncode: 0x04
+  - start: 3071
+    end:  3071
+    mb_functioncode: 0x04
+
+parameters:
+ - group: InverterStatus
+   items:
+    - name: "Inverter Status"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [3043]
+      icon: 'mdi:home-lightning-bolt'
+      lookup: 
+      -  key: 0x0
+         value: "Waiting State"
+      -  key:  0x1
+         value: "Open Loop Operation"
+      -  key: 0x2
+         value: "Soft Start"
+      -  key: 0x3
+         value: "On Grid/Generating"
+      -  key: 0x1004
+         value: "Grid OverVoltage"         
+      -  key: 0x1010
+         value: "Grid UnderVoltage"        
+      -  key: 0x1012
+         value: "Grid OverFrequency"         
+      -  key: 0x1013
+         value: "Grid UnderFrequency"          
+      -  key: 0x1014
+         value: "Grid Imp too large"
+      -  key: 0x1015
+         value: "No Grid"         
+      -  key: 0x1016
+         value: "Grid Imbalance"         
+      -  key: 0x1017
+         value: "Grid Freq Jitter"         
+      -  key: 0x1018
+         value: "Grid Overcurrent"         
+      -  key: 0x1019
+         value: "Grid Tracking Fault"         
+      -  key: 0x1020
+         value: "DC OverVoltage"         
+      -  key: 0x1021
+         value: "DC Bus Overvoltage"
+      -  key: 0x1022
+         value: "DC Bus Uneven Voltage"         
+      -  key: 0x1024
+         value: "DC Bus Uneven Voltage2"
+      -  key: 0x1025
+         value: "DC A path OverCurrent"
+      -  key: 0x1026
+         value: "DC B path OverCurrent"         
+      -  key: 0x1027
+         value: "DC Input Disturbance"         
+      -  key: 0x1030
+         value: "Grid Disturbance"         
+      -  key: 0x1031
+         value: "DSP Initialization Protection "         
+      -  key: 0x1032
+         value: "Over Temp Protection"         
+      -  key: 0x1033
+         value: "PV Insulation Fault"         
+      -  key: 0x1034
+         value: "Leakage Current Protection"         
+      -  key: 0x1035
+         value: "Relay Detection Protection"         
+      -  key: 0x1036
+         value: "DSP_B Protection"         
+      -  key: 0x1037
+         value: "DC Component too Large"         
+      -  key: 0x1038
+         value: "12v UnderVoltage Protection"         
+      -  key: 0x1039
+         value: "Under Temperature Protection"         
+      -  key: 0x1040
+         value: "Arc Self-Test Protection"         
+      -  key: 0x1041
+         value: "Arc Protection"         
+      -  key: 0x1042
+         value: "DSP on-chip SRAM exception"         
+      -  key: 0x1043
+         value: "DSP on-chip FLASH exception"
+      -  key: 0x1044
+         value: "DSP on-chip PC pointer is abnormal"        
+      -  key: 0x1045
+         value: "DSP key register exception"
+      -  key: 0x1046
+         value: "Grid disturbance 02"         
+      -  key: 0x1047
+         value: "Grid current sampling abnormality"         
+      -  key: 0x1048
+         value: "IGBT overcurrent"
+      -  key: 0x1050
+         value: "Network current transient overcurrent"         
+      -  key: 0x1051
+         value: "Battery overvoltage hardware failure"         
+      -  key: 0x1052
+         value: "LLC hardware overcurrent"         
+      -  key: 0x1053
+         value: "Battery overvoltage detection"         
+      -  key: 0x1054
+         value: "Battery undervoltage detection"         
+      -  key: 0x1055
+         value: "Battery no connected"         
+      -  key: 0x1056
+         value: "Bypass overvoltage fault"         
+      -  key: 0x1057
+         value: "Bypass overload fault"        
+
+    - name: "Operating Status"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [3071]
+      icon: 'mdi:home-lightning-bolt'
+      lookup: 
+      -  key: 0x1
+         value: "Normal Operation"
+      -  key: 0x2
+         value: "Initial Standby"
+      -  key: 0x4
+         value: "Control Shutdown"
+      -  key: 0x8
+         value: "Downtime"
+      -  key: 0x10
+         value: "Standby"         
+      -  key: 0x20
+         value: "Derating Operation"        
+      -  key: 0x40
+         value: "Limit Operation"      
+      -  key: 0x80
+         value: "Bypass Overload" 
+
+    - name: "Inverter Temperature"
+      class: "temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 0.1
+      rule: 2
+      registers: [3041]
+      icon: 'mdi:thermometer'
+      
+# Sensors below are outside of modbus request ranges.
+# If enabling, ensure to amend the request start register.
+#    - name: "Inverter ID"
+#      class: ""
+#      state_class: ""
+#      uom: ""
+#      scale: 1
+#      rule: 5
+#      registers: [33004,33005,33006,33007,33008,33009,33010,33011,33012,33013,33014,33015,33016,33017,33018,33019]
+#      isstr: true
+
+#    - name: "Product Model"
+#      class: ""
+#     state_class: ""
+#     uom: ""
+#      scale: 1
+#      rule: 6
+#      registers: [2999]
+#      isstr: true
+
+#    - name: "DSP Software Version"
+#      class: ""
+#      state_class: ""
+#      uom: ""
+#      scale: 1
+#      rule: 6
+#     registers: [3000]
+#      isstr: true
+
+#    - name: "LCD Software Version"
+#      class: ""
+#      state_class: ""
+#      uom: ""
+#      scale: 1
+#      rule: 6
+#      registers: [3001]
+#      isstr: true
+
+ - group: InverterDC
+   items:
+    - name: "PV1 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3021]
+      icon: 'mdi:solar-power'
+
+    - name: "PV2 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3023]
+      icon: 'mdi:solar-power'
+
+    - name: "PV1 Current"
+      class: "current"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3022]
+      icon: 'mdi:current-dc'
+
+    - name: "PV2 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3024]
+      icon: 'mdi:current-dc'
+
+    - name: "Total DC Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "kW"
+      scale: 0.001
+      rule: 3
+      registers: [3007, 3006]
+      icon: 'mdi:solar-power'
+
+ - group: InverterAC
+   items:
+    - name: "Inverter AC Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [3005, 3004]
+      icon: 'mdi:solar-power'
+
+    - name: "Inverter Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [3035]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Inverter Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [3038]
+      icon: 'mdi:current-ac'
+
+    - name: "Inverter Frequency"
+      class: "frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [3042]
+      icon: 'mdi:sine-wave'
+
+ - group: Generation
+   items:
+    - name: "Daily Generation"
+      class: "energy"
+      state_class: "measurement"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [3014]
+      icon: 'mdi:solar-power'
+
+    - name: "Monthly Generation"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 1
+      rule: 3
+      registers: [3011, 3010]
+      icon: 'mdi:solar-power'
+
+    - name: "Yearly Generation"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 1
+      rule: 3
+      registers: [3017, 3016]
+      icon: 'mdi:solar-power'
+
+    - name: "Total Generation"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 1
+      rule: 3
+      registers: [3009, 3008]
+      icon: 'mdi:solar-power'
+


### PR DESCRIPTION
This PR implements the following changes:
1. Syncs the inverter definition files from upstream (https://github.com/StephanJoubert/home_assistant_solarman/tree/main/custom_components/solarman/inverter_definitions).
2. Updates README.md to add the new channels which have been made available.
3. Updates thing-types.xml to add the new supported inverters.