### PR TITLE
[ipcamera]Add missing motion detection topic for VivoTek FD9388-HTV cameras

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -667,6 +667,13 @@ public class OnvifConnection {
                     ipCameraHandler.noMotionDetected(CHANNEL_CELL_MOTION_ALARM);
                 }
                 break;
+            case "VideoAnalytics/Motion":
+                if ("Trigger".equals(dataValue)) {
+                    ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
+                } else if ("Normal".equals(dataValue)) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_MOTION_ALARM);
+                }
+                break;
             case "VideoSource/MotionAlarm":
                 if ("true".equals(dataValue)) {
                     ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);


### PR DESCRIPTION
Added a missing motion detection topic for VivoTek cameras as reported on the forum by a user here:

https://community.openhab.org/t/unimplemented-onvif-event-videoanalytics-motion/157364

Signed-off-by: Matthew Skinner <matt@pcmus.com>