### PR TITLE
[gree] Use GCM encryption when bind fails

### DIFF
--- a/bundles/org.openhab.binding.gree/README.md
+++ b/bundles/org.openhab.binding.gree/README.md
@@ -29,7 +29,8 @@ No binding configuration is required.
 
 The Air Conditioner's IP address is mandatory, all other parameters are optional.
 If the broadcast is not set (default) it will be derived from openHAB's network setting (Check Network Settings in the openHAB UI).
-Encryption type will be filled by the binding proccess automatically in case the bind process to the AC device successed. In case of problems with binding to the AC device the user set manually the encription type.
+The binding tries to automatically detect the encryption type when communicating with the AC.
+If this fails, you might need need to set the encryption type manually.
 Only change this if you have a good reason to.
 
 ## Channels

--- a/bundles/org.openhab.binding.gree/README.md
+++ b/bundles/org.openhab.binding.gree/README.md
@@ -19,15 +19,17 @@ No binding configuration is required.
 
 ## Thing Configuration
 
-| Channel Name             | Type       | Description                                                                                   |
-|--------------------------|------------|-----------------------------------------------------------------------------------------------|
-| ipAddress                | IP Address | IP address of the unit.                                                                       |
-| broadcastAddress         | IP Address | Broadcast address being used for discovery, usually derived from the IP interface address.    |
-| refresh                  | Integer    | Refresh interval in seconds for polling the device status.                                    |
-| currentTemperatureOffset | Decimal    | Offset in Celsius for the current temperature value received from the device.                 |
+| Channel Name             | Type            | Description                                                                                   |
+|--------------------------|-----------------|-----------------------------------------------------------------------------------------------|
+| ipAddress                | IP Address      | IP address of the unit.                                                                       |
+| broadcastAddress         | IP Address      | Broadcast address being used for discovery, usually derived from the IP interface address.    |
+| refresh                  | Integer         | Refresh interval in seconds for polling the device status.                                    |
+| currentTemperatureOffset | Decimal         | Offset in Celsius for the current temperature value received from the device.                 |
+| encryptionType           | EncryptionTypes | Encryption type (ECB or GCM) used for communicating with the AC device                        |
 
 The Air Conditioner's IP address is mandatory, all other parameters are optional.
 If the broadcast is not set (default) it will be derived from openHAB's network setting (Check Network Settings in the openHAB UI).
+Encryption type will be filled by the binding proccess automatically in case the bind process to the AC device successed. In case of problems with binding to the AC device the user set manually the encription type.
 Only change this if you have a good reason to.
 
 ## Channels
@@ -64,7 +66,7 @@ When changing mode, the air conditioner will be turned on unless "off" is select
 ### Things
 
 ```java
-Thing gree:airconditioner:a1234561 [ ipAddress="192.168.1.111", refresh=2 ]
+Thing gree:airconditioner:a1234561 [ ipAddress="192.168.1.111", refresh=2, encryptionType="ECB" ]
 ```
 
 ### Items

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -174,4 +174,12 @@ public class GreeBindingConstants {
      *      for more details.
      */
     public static final double INTERNAL_TEMP_SENSOR_OFFSET = -40.0;
+
+    public static enum ENCRYPTION_TYPES {
+        UNKNOWN,
+        ECB,
+        GCM
+    };
+
+    public static final ENCRYPTION_TYPES PROPERTY_ENCRYPTION_TYPE = ENCRYPTION_TYPES.UNKNOWN;
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.binding.gree.internal;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
@@ -38,6 +42,8 @@ public class GreeBindingConstants {
     // Thing configuration items
     public static final String PROPERTY_IP = "ipAddress";
     public static final String PROPERTY_BROADCAST = "broadcastAddress";
+
+    public static final String PROPERTY_ENCRYPTION_TYPE = "encryptionType";
 
     // List of all Channel ids
     public static final String POWER_CHANNEL = "power";
@@ -175,11 +181,16 @@ public class GreeBindingConstants {
      */
     public static final double INTERNAL_TEMP_SENSOR_OFFSET = -40.0;
 
-    public static enum ENCRYPTION_TYPES {
+    public enum EncryptionTypes {
         UNKNOWN,
         ECB,
-        GCM
-    };
+        GCM;
 
-    public static final ENCRYPTION_TYPES PROPERTY_ENCRYPTION_TYPE = ENCRYPTION_TYPES.UNKNOWN;
+        private static final Map<String, EncryptionTypes> MAP = Stream.of(EncryptionTypes.values())
+                .collect(Collectors.toMap(Enum::name, Function.identity()));
+
+        public static EncryptionTypes of(final String name) {
+            return MAP.getOrDefault(name, UNKNOWN);
+        }
+    };
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
@@ -34,11 +34,11 @@ public class GreeConfiguration {
      * of the temperature sensor.
      */
     public BigDecimal currentTemperatureOffset = new BigDecimal(0.0);
-    public ENCRYPTION_TYPES encryptionType = ENCRYPTION_TYPES.UNKNOWN;
+    public EncryptionTypes encryptionType = EncryptionTypes.UNKNOWN;
 
     @Override
     public String toString() {
         return "Config: ipAddress=" + ipAddress + ", broadcastAddress=" + broadcastAddress + ", refresh=" + refresh
-                + ", currentTemperatureOffset=" + currentTemperatureOffset + ", encriptionType=" + encryptionType;
+                + ", currentTemperatureOffset=" + currentTemperatureOffset + ", encryptionType=" + encryptionType;
     }
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.gree.internal;
 
+import static org.openhab.binding.gree.internal.GreeBindingConstants.*;
+
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -32,10 +34,11 @@ public class GreeConfiguration {
      * of the temperature sensor.
      */
     public BigDecimal currentTemperatureOffset = new BigDecimal(0.0);
+    public ENCRYPTION_TYPES encryptionType = ENCRYPTION_TYPES.UNKNOWN;
 
     @Override
     public String toString() {
         return "Config: ipAddress=" + ipAddress + ", broadcastAddress=" + broadcastAddress + ", refresh=" + refresh
-                + ", currentTemperatureOffset=" + currentTemperatureOffset;
+                + ", currentTemperatureOffset=" + currentTemperatureOffset + ", encriptionType=" + encryptionType;
     }
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.gree.internal;
 
-import static org.openhab.binding.gree.internal.GreeBindingConstants.ENCRYPTION_TYPES;
+import static org.openhab.binding.gree.internal.GreeBindingConstants.EncryptionTypes;
 
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
@@ -55,8 +55,8 @@ public class GreeCryptoUtil {
         return GCM_KEY.getBytes(StandardCharsets.UTF_8);
     }
 
-    public static byte[] getGeneralKeyByteArray(ENCRYPTION_TYPES encType) {
-        if (encType == ENCRYPTION_TYPES.GCM) {
+    public static byte[] getGeneralKeyByteArray(EncryptionTypes encType) {
+        if (encType == EncryptionTypes.GCM) {
             return getGCMGeneralKeyByteArray();
         }
         return getAESGeneralKeyByteArray();
@@ -70,8 +70,8 @@ public class GreeCryptoUtil {
         return GCM_ADD.getBytes(StandardCharsets.UTF_8);
     }
 
-    public static <T extends GreeBaseDTO> ENCRYPTION_TYPES getEncryptionType(T response) {
-        return response.tag != null ? ENCRYPTION_TYPES.GCM : ENCRYPTION_TYPES.ECB;
+    public static <T extends GreeBaseDTO> EncryptionTypes getEncryptionType(T response) {
+        return response.tag != null ? EncryptionTypes.GCM : EncryptionTypes.ECB;
     }
 
     public static <T extends GreeBaseDTO> String decrypt(T response) throws GreeException {
@@ -82,25 +82,25 @@ public class GreeCryptoUtil {
         return decrypt(keyarray, response, getEncryptionType(response));
     }
 
-    public static <T extends GreeBaseDTO> String decrypt(T response, ENCRYPTION_TYPES encType) throws GreeException {
-        if (encType == ENCRYPTION_TYPES.UNKNOWN) {
+    public static <T extends GreeBaseDTO> String decrypt(T response, EncryptionTypes encType) throws GreeException {
+        if (encType == EncryptionTypes.UNKNOWN) {
             encType = getEncryptionType(response);
         }
 
-        if (encType == ENCRYPTION_TYPES.GCM) {
+        if (encType == EncryptionTypes.GCM) {
             return decrypt(getGCMGeneralKeyByteArray(), response, encType);
         } else {
             return decrypt(getAESGeneralKeyByteArray(), response, encType);
         }
     }
 
-    public static <T extends GreeBaseDTO> String decrypt(byte[] keyarray, T response, ENCRYPTION_TYPES encType)
+    public static <T extends GreeBaseDTO> String decrypt(byte[] keyarray, T response, EncryptionTypes encType)
             throws GreeException {
-        if (encType == ENCRYPTION_TYPES.UNKNOWN) {
+        if (encType == EncryptionTypes.UNKNOWN) {
             encType = getEncryptionType(response);
         }
 
-        if (encType == ENCRYPTION_TYPES.GCM) {
+        if (encType == EncryptionTypes.GCM) {
             return decryptGCMPack(keyarray, response.pack, response.tag);
         } else {
             return decryptPack(keyarray, response.pack);
@@ -149,8 +149,8 @@ public class GreeCryptoUtil {
         }
     }
 
-    public static String[] encrypt(byte[] keyarray, String message, ENCRYPTION_TYPES encType) throws GreeException {
-        if (encType == ENCRYPTION_TYPES.GCM) {
+    public static String[] encrypt(byte[] keyarray, String message, EncryptionTypes encType) throws GreeException {
+        if (encType == EncryptionTypes.GCM) {
             return encryptGCMPack(keyarray, message);
         } else {
             String[] res = new String[1];

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
@@ -19,8 +19,6 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.HexFormat;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -31,9 +29,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.gree.internal.gson.GreeBaseDTO;
-import org.openhab.binding.gree.internal.gson.GreeScanResponseDTO;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The CryptoUtil class provides functionality for encrypting and decrypting
@@ -44,7 +39,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class GreeCryptoUtil {
-    private static final Logger logger = LoggerFactory.getLogger(GreeCryptoUtil.class);
     private static final String AES_KEY = "a3K8Bx%2r8Y7#xDh";
     private static final String GCM_KEY = "{yxAHAY_Lm6pbC/<";
     private static final String GCM_IV = "5440784449675a516c5e6313";
@@ -81,26 +75,6 @@ public class GreeCryptoUtil {
 
     public static <T extends GreeBaseDTO> EncryptionTypes getEncryptionType(T response) {
         return response.tag != null ? EncryptionTypes.GCM : EncryptionTypes.ECB;
-    }
-
-    public static EncryptionTypes getEncryptionType(GreeScanResponseDTO response) {
-        if (response.tag != null) {
-            return EncryptionTypes.GCM;
-        }
-
-        // Devices with ver 2.0.0 or later use GCM encryption
-        logger.debug("Getting the encryption type from a scan response that doesn't have a tag property");
-        if (response.packJson != null) {
-            logger.debug("Scan responce already decrypted: {}", response.packJson);
-            Pattern patternVersion = Pattern.compile("V\\d+\\.");
-            Matcher matcherVersion = patternVersion.matcher(response.packJson.ver);
-            if (matcherVersion.find() && Integer.parseInt(matcherVersion.group()) >= 2) {
-                logger.debug("Device version detected greather than or equal to 2, set encryption to GCM");
-                return EncryptionTypes.GCM;
-            }
-        }
-
-        return EncryptionTypes.ECB;
     }
 
     public static <T extends GreeBaseDTO> String decrypt(T response) throws GreeException {

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.gree.internal;
 
+import static org.openhab.binding.gree.internal.GreeBindingConstants.ENCRYPTION_TYPES;
+
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -45,11 +47,6 @@ public class GreeCryptoUtil {
     private static final String GCM_ADD = "qualcomm-test";
     private static final int TAG_LENGTH = 16;
 
-    public enum EncryptionTypes {
-        ECB,
-        GCM
-    };
-
     public static byte[] getAESGeneralKeyByteArray() {
         return AES_KEY.getBytes(StandardCharsets.UTF_8);
     }
@@ -58,8 +55,8 @@ public class GreeCryptoUtil {
         return GCM_KEY.getBytes(StandardCharsets.UTF_8);
     }
 
-    public static byte[] getGeneralKeyByteArray(EncryptionTypes encType) {
-        if (encType == EncryptionTypes.GCM) {
+    public static byte[] getGeneralKeyByteArray(ENCRYPTION_TYPES encType) {
+        if (encType == ENCRYPTION_TYPES.GCM) {
             return getGCMGeneralKeyByteArray();
         }
         return getAESGeneralKeyByteArray();
@@ -73,8 +70,8 @@ public class GreeCryptoUtil {
         return GCM_ADD.getBytes(StandardCharsets.UTF_8);
     }
 
-    public static <T extends GreeBaseDTO> EncryptionTypes getEncryptionType(T response) {
-        return response.tag != null ? EncryptionTypes.GCM : EncryptionTypes.ECB;
+    public static <T extends GreeBaseDTO> ENCRYPTION_TYPES getEncryptionType(T response) {
+        return response.tag != null ? ENCRYPTION_TYPES.GCM : ENCRYPTION_TYPES.ECB;
     }
 
     public static <T extends GreeBaseDTO> String decrypt(T response) throws GreeException {
@@ -85,17 +82,25 @@ public class GreeCryptoUtil {
         return decrypt(keyarray, response, getEncryptionType(response));
     }
 
-    public static <T extends GreeBaseDTO> String decrypt(T response, EncryptionTypes encType) throws GreeException {
-        if (encType == EncryptionTypes.GCM) {
+    public static <T extends GreeBaseDTO> String decrypt(T response, ENCRYPTION_TYPES encType) throws GreeException {
+        if (encType == ENCRYPTION_TYPES.UNKNOWN) {
+            encType = getEncryptionType(response);
+        }
+
+        if (encType == ENCRYPTION_TYPES.GCM) {
             return decrypt(getGCMGeneralKeyByteArray(), response, encType);
         } else {
             return decrypt(getAESGeneralKeyByteArray(), response, encType);
         }
     }
 
-    public static <T extends GreeBaseDTO> String decrypt(byte[] keyarray, T response, EncryptionTypes encType)
+    public static <T extends GreeBaseDTO> String decrypt(byte[] keyarray, T response, ENCRYPTION_TYPES encType)
             throws GreeException {
-        if (encType == EncryptionTypes.GCM) {
+        if (encType == ENCRYPTION_TYPES.UNKNOWN) {
+            encType = getEncryptionType(response);
+        }
+
+        if (encType == ENCRYPTION_TYPES.GCM) {
             return decryptGCMPack(keyarray, response.pack, response.tag);
         } else {
             return decryptPack(keyarray, response.pack);
@@ -144,8 +149,8 @@ public class GreeCryptoUtil {
         }
     }
 
-    public static String[] encrypt(byte[] keyarray, String message, EncryptionTypes encType) throws GreeException {
-        if (encType == EncryptionTypes.GCM) {
+    public static String[] encrypt(byte[] keyarray, String message, ENCRYPTION_TYPES encType) throws GreeException {
+        if (encType == ENCRYPTION_TYPES.GCM) {
             return encryptGCMPack(keyarray, message);
         } else {
             String[] res = new String[1];

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeCryptoUtil.java
@@ -88,14 +88,14 @@ public class GreeCryptoUtil {
             return EncryptionTypes.GCM;
         }
 
-        // Devices with ver 2.0.0 or bigger use GCM encription
-        logger.debug("Getting the encryption type from a scan responce which doesn't has tag property");
+        // Devices with ver 2.0.0 or later use GCM encryption
+        logger.debug("Getting the encryption type from a scan response that doesn't have a tag property");
         if (response.packJson != null) {
             logger.debug("Scan responce already decrypted: {}", response.packJson);
             Pattern patternVersion = Pattern.compile("V\\d+\\.");
             Matcher matcherVersion = patternVersion.matcher(response.packJson.ver);
             if (matcherVersion.find() && Integer.parseInt(matcherVersion.group()) >= 2) {
-                logger.debug("Device verion detected bigger than or equal to 2, set encryption to GCM");
+                logger.debug("Device version detected greather than or equal to 2, set encryption to GCM");
                 return EncryptionTypes.GCM;
             }
         }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeException.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeException.java
@@ -106,7 +106,7 @@ public class GreeException extends Exception {
 
     private Class<?> getCauseClass() {
         Throwable cause = getCause();
-        if (getCause() != null) {
+        if (cause != null) {
             return cause.getClass();
         }
         return GreeException.class;

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDeviceFinder.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDeviceFinder.java
@@ -62,7 +62,7 @@ public class GreeDeviceFinder {
     }
 
     public void scan(DatagramSocket clientSocket, String broadcastAddress, boolean scanNetwork,
-            ENCRYPTION_TYPES encryptionTypeConfig) throws GreeException {
+            EncryptionTypes encryptionTypeConfig) throws GreeException {
         InetAddress ipAddress;
         try {
             ipAddress = InetAddress.getByName(broadcastAddress);

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDeviceFinder.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDeviceFinder.java
@@ -61,7 +61,8 @@ public class GreeDeviceFinder {
     public GreeDeviceFinder() {
     }
 
-    public void scan(DatagramSocket clientSocket, String broadcastAddress, boolean scanNetwork) throws GreeException {
+    public void scan(DatagramSocket clientSocket, String broadcastAddress, boolean scanNetwork,
+            ENCRYPTION_TYPES encryptionTypeConfig) throws GreeException {
         InetAddress ipAddress;
         try {
             ipAddress = InetAddress.getByName(broadcastAddress);
@@ -103,7 +104,8 @@ public class GreeDeviceFinder {
                     }
 
                     // Decrypt message - a GreeException is thrown when something went wrong
-                    String decryptedMsg = scanResponseGson.decryptedPack = GreeCryptoUtil.decrypt(scanResponseGson);
+                    String decryptedMsg = scanResponseGson.decryptedPack = GreeCryptoUtil.decrypt(scanResponseGson,
+                            encryptionTypeConfig);
 
                     logger.debug("Response received from address {}: {}", remoteAddress.getHostAddress(), decryptedMsg);
 

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDiscoveryService.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDiscoveryService.java
@@ -87,7 +87,7 @@ public class GreeDiscoveryService extends AbstractDiscoveryService {
     @Override
     protected void startScan() {
         try (DatagramSocket clientSocket = new DatagramSocket()) {
-            deviceFinder.scan(clientSocket, broadcastAddress, true);
+            deviceFinder.scan(clientSocket, broadcastAddress, true, ENCRYPTION_TYPES.UNKNOWN);
 
             int count = deviceFinder.getScannedDeviceCount();
             logger.debug("{}", messages.get("discovery.result", count));

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDiscoveryService.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDiscoveryService.java
@@ -87,7 +87,7 @@ public class GreeDiscoveryService extends AbstractDiscoveryService {
     @Override
     protected void startScan() {
         try (DatagramSocket clientSocket = new DatagramSocket()) {
-            deviceFinder.scan(clientSocket, broadcastAddress, true, ENCRYPTION_TYPES.UNKNOWN);
+            deviceFinder.scan(clientSocket, broadcastAddress, true, EncryptionTypes.UNKNOWN);
 
             int count = deviceFinder.getScannedDeviceCount();
             logger.debug("{}", messages.get("discovery.result", count));
@@ -112,6 +112,7 @@ public class GreeDiscoveryService extends AbstractDiscoveryService {
             properties.put(Thing.PROPERTY_MAC_ADDRESS, device.getId());
             properties.put(PROPERTY_IP, ipAddress);
             properties.put(PROPERTY_BROADCAST, broadcastAddress);
+            properties.put(PROPERTY_ENCRYPTION_TYPE, device.getEncryptionType());
             ThingUID thingUID = new ThingUID(THING_TYPE_GREEAIRCON, device.getId());
             DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
                     .withRepresentationProperty(Thing.PROPERTY_MAC_ADDRESS).withLabel(device.getName()).build();

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
@@ -173,7 +173,7 @@ public class GreeAirDevice {
                     sendPacket = createPackRequest(1, encryptedBindReqData);
                     clientSocket.send(sendPacket);
                 } else {
-                    throw new GreeException("Unable to bind to device", e);
+                    throw new GreeException("Unable to bind to device using GCM encryption", e);
                 }
             }
 

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
@@ -166,7 +166,7 @@ public class GreeAirDevice {
                 clientSocket.send(sendPacket);
             } catch (SocketTimeoutException e) {
                 if (encType != GreeCryptoUtil.EncryptionTypes.GCM) {
-                    logger.debug("Unable to bind to device - change the encryption mode to GCM and trying agin", e);
+                    logger.debug("Unable to bind to device - changing the encryption mode to GCM and trying again", e);
                     encType = GreeCryptoUtil.EncryptionTypes.GCM;
                     encryptedBindReqData = GreeCryptoUtil.encrypt(GreeCryptoUtil.getGeneralKeyByteArray(encType),
                             bindReqPackStr, encType);

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -108,12 +108,12 @@ public class GreeHandler extends BaseThingHandler {
                 clientSocket.get().setSoTimeout(DATAGRAM_SOCKET_TIMEOUT);
             }
             // Find the GREE device
-            deviceFinder.scan(clientSocket.get(), config.ipAddress, false);
+            deviceFinder.scan(clientSocket.get(), config.ipAddress, false, config.encryptionType);
             GreeAirDevice newDevice = deviceFinder.getDeviceByIPAddress(config.ipAddress);
             if (newDevice != null) {
                 // Ok, our device responded, now let's Bind with it
                 device = newDevice;
-                device.bindWithDevice(clientSocket.get());
+                device.bindWithDevice(clientSocket.get(), config.encryptionType);
                 if (device.getIsBound()) {
                     updateStatus(ThingStatus.ONLINE);
                     return;

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -138,7 +138,7 @@ public class GreeHandler extends BaseThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
-            // The thing is updated by the scheduled automatic refresh so do nothing here.
+            initializeThing();
         } else {
             logger.debug("{}: Issue command {} to channe {}", thingId, command, channelUID.getIdWithoutGroup());
             String channelId = channelUID.getIdWithoutGroup();
@@ -377,8 +377,9 @@ public class GreeHandler extends BaseThingHandler {
                 }
             } catch (GreeException e) {
                 String subcode = "";
-                if (e.getCause() != null) {
-                    subcode = " (" + e.getCause().getMessage() + ")";
+                Throwable cause = e.getCause();
+                if (cause != null) {
+                    subcode = " (" + cause.getMessage() + ")";
                 }
                 String message = messages.get("update.exception", e.getMessageString() + subcode);
                 if (getThing().getStatus() == ThingStatus.OFFLINE) {

--- a/bundles/org.openhab.binding.gree/src/main/resources/OH-INF/i18n/gree.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/OH-INF/i18n/gree.properties
@@ -1,12 +1,15 @@
-# GREE Binding
+# add-on
+
 addon.gree.name = GREE Binding
-addon.gree.description = This binding integrates the GREE series of air conditioners
+addon.gree.description = This is the binding for GREE air conditioners.
 
 # thing types
+
 thing-type.gree.airconditioner.label = Air Conditioner
 thing-type.gree.airconditioner.description = A GREE Air Conditioner with WiFi Module
 
 # thing type config description
+
 thing-type.config.gree.airconditioner.ipAddress.label = IP Address
 thing-type.config.gree.airconditioner.ipAddress.description = IP Address of the GREE unit.
 thing-type.config.gree.airconditioner.broadcastAddress.label = Subnet Broadcast Address
@@ -15,8 +18,13 @@ thing-type.config.gree.airconditioner.refresh.label = Refresh Interval
 thing-type.config.gree.airconditioner.refresh.description = Interval to query an update from the device.
 thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset for Current Temperature
 thing-type.config.gree.airconditioner.currentTemperatureOffset.description = The offset in Celsius for the current temperature value received from the device.
+thing-type.config.gree.airconditioner.encryptionType.label = Encryption type
+thing-type.config.gree.airconditioner.encryptionType.description = The encryption type used for encrypting the data send to the AC device.
+thing-type.config.gree.airconditioner.encryptionType.state.option.ECB = ECB
+thing-type.config.gree.airconditioner.encryptionType.state.option.GCM = GCM
 
 # channel types
+
 channel-type.gree.power.label = Power
 channel-type.gree.power.description = Turn power on/off
 channel-type.gree.mode.label = Unit Mode
@@ -70,7 +78,7 @@ channel-type.gree.swingupdown.option.11 = Swing Upmost
 channel-type.gree.swingleftright.label = Horizontal Swing Mode
 channel-type.gree.swingleftright.description = Sets the horizontal swing action on the Air Conditioner: 0=OFF, 1=Full Swing, 2=Left, 3=Mid-Left, 4=Mid, 5=Mid-Right, 6=Right
 channel-type.gree.swingleftright.option.0 = OFF
-channel-type.gree.swingleftright.option.1 = Full Swing 
+channel-type.gree.swingleftright.option.1 = Full Swing
 channel-type.gree.swingleftright.option.2 = Left
 channel-type.gree.swingleftright.option.3 = Mid-Left
 channel-type.gree.swingleftright.option.4 = Mid
@@ -83,7 +91,8 @@ channel-type.gree.light.description = Enable/disable the front display on the Ai
 channel-type.gree.health.label = Health Mode
 channel-type.gree.health.description = Set on/off the Air Conditioner's Health function if applicable to the Air Conditioner model.
 
-# User Messages
+# user messages
+
 message.thinginit.failed = Unable to connect to air conditioner
 message.thinginit.invconf = Invalid configuration data
 message.thinginit.exception = Thing initialization failed: {0}
@@ -92,5 +101,5 @@ message.command.exception = Unable to execute command {0} for channel {1}
 message.update.exception = Unable to perform auto-update: {0}
 message.channel.exception = Unable to update channel {0} with {1}
 message.discovery.result = {0} units discovered.
-message.discovery.newunit = Device {0} discovered at {1}, MAC={2} 
-message.discovery.exception = Device Discovery failed: {0} 
+message.discovery.newunit = Device {0} discovered at {1}, MAC={2}
+message.discovery.exception = Device Discovery failed: {0}

--- a/bundles/org.openhab.binding.gree/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/OH-INF/thing/thing-types.xml
@@ -41,6 +41,13 @@
 				<unitLabel>Degrees Celsius</unitLabel>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="encryptionType" type="text">
+				<options>
+					<option value="ECB">@text/thing-type.config.gree.airconditioner.encryptionType.state.option.ECB</option>
+					<option value="GCM">@text/thing-type.config.gree.airconditioner.encryptionType.state.option.GCM</option>
+				</options>
+				<advanced>true</advanced>
+			</parameter>
 		</config-description>
 
 	</thing-type>


### PR DESCRIPTION
Change the encryption mode to GCM if different when binding to AC device fails with SocketTimeoutException and try again. Detect if device version is bigger than or equal to 2 and set encryption to GCM

Fixes #16911

# Additional info:
There are gree devices that on scan request responds with package encrypted with ECB encryption using the old key, but expects GCM encryption bind request in response. Such behavior is described in #16911 
Also in [openhab community forum](https://community.openhab.org/t/new-gree-air-conditioner-binding/36429/487) a few people are saying that they have the same problem.

Not sure which approach is better to change the encryption mode to GCM when SocketTimeoutException was catched and try again or try to determine is the AC expects GCM encryption bind request base on the value of `ver` property of the scan response, so I am leaving them both and I am open to suggestion.

# Testing
Builded jar file can be found [here](https://drive.google.com/file/d/1eaf0HpEZX77YPXpkfeDFFins2HEJPKmz/view?usp=sharing).
