### PR TITLE
[mqtt.homeassistant] Fix jinja usage in availability templates

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.mqtt.generic;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -40,6 +39,7 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.generic.ChannelTransformation;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
@@ -302,19 +302,17 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler
     @Override
     public void addAvailabilityTopic(String availability_topic, String payload_available,
             String payload_not_available) {
-        addAvailabilityTopic(availability_topic, payload_available, payload_not_available, List.of());
+        addAvailabilityTopic(availability_topic, payload_available, payload_not_available, null);
     }
 
     @Override
     public void addAvailabilityTopic(String availability_topic, String payload_available, String payload_not_available,
-            List<String> transformation_pattern) {
+            @Nullable ChannelTransformation transformation) {
         availabilityStates.computeIfAbsent(availability_topic, topic -> {
             Value value = new OnOffValue(payload_available, payload_not_available);
             ChannelGroupUID groupUID = new ChannelGroupUID(getThing().getUID(), "availability");
             ChannelUID channelUID = new ChannelUID(groupUID, UIDUtils.encode(topic));
-            ChannelState state = new ChannelState(
-                    ChannelConfigBuilder.create().withStateTopic(topic)
-                            .withTransformationPattern(transformation_pattern).build(),
+            ChannelState state = new ChannelState(ChannelConfigBuilder.create().withStateTopic(topic).build(),
                     channelUID, value, new ChannelStateUpdateListener() {
                         @Override
                         public void updateChannelState(ChannelUID channelUID, State value) {
@@ -329,7 +327,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler
                         @Override
                         public void postChannelCommand(ChannelUID channelUID, Command value) {
                         }
-                    });
+                    }, transformation, null);
             MqttBrokerConnection connection = getConnection();
             if (connection != null) {
                 state.start(connection, scheduler, 0);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AvailabilityTracker.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AvailabilityTracker.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.mqtt.generic;
 
-import java.util.List;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.binding.generic.ChannelTransformation;
 
 /**
  * Interface to keep track of the availability of device using an availability topic or messages received
@@ -71,11 +71,11 @@ public interface AvailabilityTracker {
      * @param availability_topic The MQTT topic where availability is published to.
      * @param payload_available The value for the topic to indicate the device is online.
      * @param payload_not_available The value for the topic to indicate the device is offline.
-     * @param transformation_pattern A transformation pattern to process the value before comparing to
+     * @param transformation A transformation to process the value before comparing to
      *            payload_available/payload_not_available.
      */
     void addAvailabilityTopic(String availability_topic, String payload_available, String payload_not_available,
-            List<String> transformation_pattern);
+            @Nullable ChannelTransformation transformation);
 
     void removeAvailabilityTopic(String availability_topic);
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -42,6 +42,7 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.binding.generic.ChannelTransformation;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.util.UnitUtils;
@@ -219,7 +220,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
 
         if (availabilityTopic != null) {
             addAvailabilityTopic(availabilityTopic, config.payloadAvailable, config.payloadNotAvailable,
-                    config.transformationPattern);
+                    new ChannelTransformation(config.transformationPattern));
         } else {
             clearAllAvailabilityTopics();
         }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -57,8 +57,6 @@ import org.openhab.core.types.StateDescription;
  */
 @NonNullByDefault
 public class ComponentChannel {
-    private static final String JINJA = "JINJA";
-
     private final ChannelState channelState;
     private final Channel channel;
     private final @Nullable StateDescription stateDescription;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -31,6 +31,7 @@ import org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConsta
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.HaID;
+import org.openhab.binding.mqtt.homeassistant.internal.HomeAssistantChannelTransformation;
 import org.openhab.binding.mqtt.homeassistant.internal.component.ComponentFactory.ComponentConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.Availability;
@@ -40,6 +41,7 @@ import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.binding.generic.ChannelTransformation;
 import org.openhab.core.thing.type.ChannelDefinition;
 import org.openhab.core.thing.type.ChannelGroupDefinition;
 import org.openhab.core.thing.type.ChannelGroupType;
@@ -60,7 +62,6 @@ import com.hubspot.jinjava.Jinjava;
  */
 @NonNullByDefault
 public abstract class AbstractComponent<C extends AbstractChannelConfiguration> {
-    private static final String JINJA_PREFIX = "JINJA:";
 
     // Component location fields
     protected final ComponentConfiguration componentConfiguration;
@@ -132,27 +133,24 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
             componentConfiguration.getTracker().setAvailabilityMode(availabilityTrackerMode);
             for (Availability availability : availabilities) {
                 String availabilityTemplate = availability.getValueTemplate();
-                List<String> availabilityTemplates = List.of();
+                ChannelTransformation transformation = null;
                 if (availabilityTemplate != null) {
-                    availabilityTemplate = JINJA_PREFIX + availabilityTemplate;
-                    availabilityTemplates = List.of(availabilityTemplate);
+                    transformation = new HomeAssistantChannelTransformation(getJinjava(), this, availabilityTemplate);
                 }
                 componentConfiguration.getTracker().addAvailabilityTopic(availability.getTopic(),
-                        availability.getPayloadAvailable(), availability.getPayloadNotAvailable(),
-                        availabilityTemplates);
+                        availability.getPayloadAvailable(), availability.getPayloadNotAvailable(), transformation);
             }
         } else {
             String availabilityTopic = this.channelConfiguration.getAvailabilityTopic();
             if (availabilityTopic != null) {
                 String availabilityTemplate = this.channelConfiguration.getAvailabilityTemplate();
-                List<String> availabilityTemplates = List.of();
+                ChannelTransformation transformation = null;
                 if (availabilityTemplate != null) {
-                    availabilityTemplate = JINJA_PREFIX + availabilityTemplate;
-                    availabilityTemplates = List.of(availabilityTemplate);
+                    transformation = new HomeAssistantChannelTransformation(getJinjava(), this, availabilityTemplate);
                 }
                 componentConfiguration.getTracker().addAvailabilityTopic(availabilityTopic,
                         this.channelConfiguration.getPayloadAvailable(),
-                        this.channelConfiguration.getPayloadNotAvailable(), availabilityTemplates);
+                        this.channelConfiguration.getPayloadNotAvailable(), transformation);
             }
         }
     }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -44,6 +44,7 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.generic.ChannelTransformation;
 import org.openhab.core.thing.type.ChannelGroupDefinition;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ThingType;
@@ -326,5 +327,12 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
         }
 
         return device.nodes.keySet();
+    }
+
+    // This odd method resolves a compilation issue (possibly with Mockito?) where for some reason
+    // it doesn't realize it needs to import this class which is used by AvailabilityTracker, but
+    // not directly from this bundle
+    // See https://github.com/openhab/openhab-addons/pull/17400
+    private void doNothing(ChannelTransformation transform) {
     }
 }


### PR DESCRIPTION
Use the local Jinjava, instead of implicitly depending on the Jinja transformation service.

This was missed in the recent conversion to using Jinjava for transformations in "normal" channels.