### PR TITLE
[jdbc] Fix error in addon info for Oracle

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-oracle.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/addon/addon-oracle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon:addon id="jdbc-postgresql" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<addon:addon id="jdbc-oracle" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/i18n/jdbc.properties
+++ b/bundles/org.openhab.persistence.jdbc/src/main/resources/OH-INF/i18n/jdbc.properties
@@ -49,6 +49,6 @@ persistence.config.jdbc.tableUseRealItemNames.description = Enables Tablename pr
 persistence.config.jdbc.tableUseRealItemNames.option.true = Enable
 persistence.config.jdbc.tableUseRealItemNames.option.false = Disable
 persistence.config.jdbc.url.label = Database URL
-persistence.config.jdbc.url.description = Defines required database URL and optional path and parameters.<br> Required database url like 'jdbc:<service>:<host>[:<port>;<attributes>]'<br> Parameter 'service' is used as identifier for the selected jdbc driver. URL-Examples:<br> jdbc:derby:./testDerby;create=true<br> jdbc:h2:./testH2;NON_KEYWORDS=VALUE<br> jdbc:hsqldb:./testHsqlDb<br> jdbc:mariadb://192.168.0.1:3306/testMariadb<br> jdbc:mysql://192.168.0.1:3306/testMysql<br> jdbc:postgresql://192.168.0.1:5432/testPostgresql<br> jdbc:sqlite:./testSqlite.db
+persistence.config.jdbc.url.description = Defines required database URL and optional path and parameters.<br> Required database url like 'jdbc:<service>:<host>[:<port>;<attributes>]'<br> Parameter 'service' is used as identifier for the selected jdbc driver. URL-Examples:<br> jdbc:derby:./testDerby;create=true<br> jdbc:h2:./testH2;NON_KEYWORDS=VALUE<br> jdbc:hsqldb:./testHsqlDb<br> jdbc:mariadb://192.168.0.1:3306/testMariadb<br> jdbc:mysql://192.168.0.1:3306/testMysql<br> jdbc:postgresql://192.168.0.1:5432/testPostgresql<br> jdbc:sqlite:./testSqlite.db<br> jdbc:oracle:thin:@dbname?TNS_ADMIN=./dbname_tns_admin_folder
 persistence.config.jdbc.user.label = Database User
 persistence.config.jdbc.user.description = Defines the database user.

--- a/features/openhab-addons-external/src/main/resources/conf/jdbc.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/jdbc.cfg
@@ -3,7 +3,7 @@
 #
 # https://github.com/openhab/openhab/wiki/JDBC-Persistence
 #
-# Tested databases/url-prefix: jdbc:derby, jdbc:h2, jdbc:hsqldb, jdbc:mariadb, jdbc:mysql, jdbc:postgresql, jdbc:sqlite
+# Tested databases/url-prefix: jdbc:derby, jdbc:h2, jdbc:hsqldb, jdbc:mariadb, jdbc:mysql, jdbc:postgresql, jdbc:sqlite, jdbc:oracle
 # 
 # derby, h2, hsqldb, sqlite can be embedded, 
 # If no database is available it will be created, for example the url 'jdbc:h2:./testH2' creates a new DB in OpenHab Folder. 
@@ -21,6 +21,7 @@
 # url=jdbc:mysql://192.168.0.1:3306/testMysql
 # url=jdbc:postgresql://192.168.0.1:5432/testPostgresql
 # url=jdbc:sqlite:./testSqlite.db
+# url=jdbc:oracle:thin:@dbname?TNS_ADMIN=./dbname_tns_admin_folder
 # url=
 
 # required database user


### PR DESCRIPTION
- Fixes an error in `addon-oracle.xml` which was copied from another file and not updated completely
- Updates i8n
- Updates content of `jdbc.cfg` to include Oracle url example