### PR TITLE
[hue] Apply 'autoUpdatePolicy=veto' on more channels

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/Clip2Thing.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/Clip2Thing.xml
@@ -128,9 +128,11 @@
 		<channels>
 			<channel id="brightness" typeId="system.brightness">
 				<description>Controls the brightness and switches on/off the group of lights in the room.</description>
+				<autoUpdatePolicy>veto</autoUpdatePolicy>
 			</channel>
 			<channel id="switch" typeId="system.power">
 				<description>Switch on/off the group of lights in the room.</description>
+				<autoUpdatePolicy>veto</autoUpdatePolicy>
 			</channel>
 			<channel id="scene" typeId="scene-v2">
 				<description>Activate the scene for the group of lights in the room.</description>
@@ -171,9 +173,11 @@
 		<channels>
 			<channel id="brightness" typeId="system.brightness">
 				<description>Controls the brightness and switches on/off the group of lights in the zone.</description>
+				<autoUpdatePolicy>veto</autoUpdatePolicy>
 			</channel>
 			<channel id="switch" typeId="system.power">
 				<description>Switch on/off the group of lights in the zone.</description>
+				<autoUpdatePolicy>veto</autoUpdatePolicy>
 			</channel>
 			<channel id="scene" typeId="scene-v2">
 				<description>Activate the scene for the group of lights in the zone.</description>

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/channels.xml
@@ -207,6 +207,7 @@
 		<label>Scene</label>
 		<category>MediaControl</category>
 		<state pattern="%s"/>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="last-updated-v2" advanced="true">
@@ -221,12 +222,14 @@
 		<item-type>String</item-type>
 		<label>Alert</label>
 		<state pattern="%s"/>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="effect-v2" advanced="true">
 		<item-type>String</item-type>
 		<label>Effect</label>
 		<state pattern="%s"/>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="dynamics" advanced="true">


### PR DESCRIPTION
Follows on from #15984 by applying `autoUpdatePolicy=veto` on several more channels which **_both_** a) are writable, and b) send immediate SSE notifications. See forum discussion [here](https://community.openhab.org/t/philips-hue-clip-2-api-v2-discussion-thread/142111/502)

Signed-off-by: AndrewFG <software@whitebear.ch>
