### PR TITLE
[rrd4j] Improved the interpolation workaround

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -373,7 +373,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
                 if (timestamp - 1 > db.getLastUpdateTime()) {
                     // only do it if there is not already a value
                     double lastValue = db.getLastDatasourceValue(DATASOURCE_STATE);
-                    if (!Double.isNaN(lastValue)) {
+                    if (!Double.isNaN(lastValue) && lastValue != value) {
                         Sample sample = db.createSample();
                         sample.setTime(timestamp - 1);
                         sample.setValue(DATASOURCE_STATE, lastValue);


### PR DESCRIPTION
This change will limit the interpolation workaround to updates to different values.
In case we write the same value again, there should be no interpolation between the same value and the workaround can be skipped.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>