### PR TITLE
[mqtt.homeassistant] Remove channels for no-longer-configured components

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -215,6 +215,13 @@ public class HaID {
     }
 
     /**
+     * Return the topic for this component, without /config
+     */
+    public String getTopic() {
+        return topic;
+    }
+
+    /**
      * Return a topic, which can be used for a mqtt subscription.
      * Defined values for suffix are:
      * <ul>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -150,8 +150,18 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
             // Already restored component?
             @Nullable
             AbstractComponent<?> component = haComponents.get(groupID);
-
+            if (component != null) {
+                continue;
+            }
             HaID haID = HaID.fromConfig(config.basetopic, channel.getConfiguration());
+
+            if (!config.topics.contains(haID.getTopic())) {
+                // don't add a component for this channel that isn't configured on the thing
+                // anymore
+                // It will disappear from the thing when the thing type is updated below
+                continue;
+            }
+
             discoveryHomeAssistantIDs.add(haID);
             ThingUID thingUID = channel.getUID().getThingUID();
             String channelConfigurationJSON = (String) channel.getConfiguration().get("config");


### PR DESCRIPTION
Refs #17182.

This does not (yet) handle component discovery topics getting deleted from MQTT, just channels left over after you've manually removed a component topic from the thing config.