### PR TITLE
[mqtt.homeassistant] Include the details of JSON syntax errors when parsing fails

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/config/dto/AbstractChannelConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/config/dto/AbstractChannelConfiguration.java
@@ -226,7 +226,7 @@ public abstract class AbstractChannelConfiguration {
             }
             return config;
         } catch (JsonSyntaxException e) {
-            throw new ConfigurationException("Cannot parse channel configuration JSON", e);
+            throw new ConfigurationException("Cannot parse channel configuration JSON: " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
While it's useful in general to not have to copy/paste a MQTT message into a JSON parser to verify syntax, it also includes details about fields that are the wrong data type that a generic JSON parser won't catch. A la #17375.

Example log line:
```
2024-09-20 11:06:17.539 [WARN ] [nal.discovery.HomeAssistantDiscovery] - HomeAssistant discover error: invalid configuration of thing smartlock component lock: Cannot parse channel configuration JSON: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 213 path $.avty
```
