### PR TITLE
[oppo] Set autoUpdatePolicy for remote_button channel

### DIFF
--- a/bundles/org.openhab.binding.oppo/README.md
+++ b/bundles/org.openhab.binding.oppo/README.md
@@ -114,7 +114,7 @@ The following channels are available:
 | sub_shift         | Number      | Sets the subtitle shift (-10 to 10) [10x models and up] (note more than 5 from 0 throws an error on the BDP103)                       |
 | hdmi_mode         | String      | Sets the current HDMI output mode (options vary by model; see notes above for allowed values)                                         |
 | hdr_mode          | String      | Sets current HDR output mode (Auto, On, Off) [UDP-203/205 only]                                                                       |
-| remote_button     | String      | Simulate pressing a button on the remote control (3 letter code; codes can be found in Appendix A below)                              |
+| remote_button     | String      | Simulate pressing a button on the remote control [3 letter code; codes can be found in Appendix A below] (WriteOnly)                  |
 
 ## Full Example
 
@@ -160,7 +160,7 @@ Number oppo_osd_position "OSD Position [%s]" { channel="oppo:player:myoppo:osd_p
 Number oppo_sub_shift "Subtitle Shift [%s]" { channel="oppo:player:myoppo:sub_shift" }
 String oppo_hdmi_mode "HDMI Mode [%s]" { channel="oppo:player:myoppo:hdmi_mode" }
 String oppo_hdr_mode "HDR Mode [%s]" { channel="oppo:player:myoppo:hdr_mode" }
-String oppo_remote_button "Remote Button [%s]" { channel="oppo:player:myoppo:remote_button", autoupdate="false" }
+String oppo_remote_button "Remote Button [%s]" { channel="oppo:player:myoppo:remote_button" }
 ```
 
 secondsformat.js:

--- a/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/thing/channels.xml
@@ -341,5 +341,6 @@
 				<option value="GPA">Gapless Play</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Replaces #17439
Set autoUpdatePolicy=veto for `remote_button` channel