### PR TITLE
[wemo] Disable wemo itest to fix build issue

### DIFF
--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.mockito.ArgumentCaptor;
@@ -68,6 +69,7 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         removeThing();
     }
 
+    @Disabled
     @Test
     public void assertThatThingHandlesOnOffCommandCorrectly()
             throws MalformedURLException, URISyntaxException, ValidationException, IOException {


### PR DESCRIPTION
Hopefully this (temporary) fixes the build issues. Not sure what casused this itest to fail, probably something in core or a dependency as there does not seem to be a wemo binding related PR.

Somewhere between 18/19 september all  (except 1 ?!) seem to fail.