### PR TITLE
[tacmi] Unit of Measurement fixes, added missing DateTime support

### DIFF
--- a/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/ChangerX2Entry.java
+++ b/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/ChangerX2Entry.java
@@ -33,6 +33,7 @@ public class ChangerX2Entry {
     enum OptionType {
         NUMBER,
         SELECT,
+        TIME,
     }
 
     /**

--- a/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/TACmiSchemaHandler.java
+++ b/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/TACmiSchemaHandler.java
@@ -39,6 +39,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.openhab.binding.tacmi.internal.TACmiChannelTypeProvider;
+import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Channel;
@@ -257,6 +258,10 @@ public class TACmiSchemaHandler extends BaseThingHandler {
                     String val;
                     if (command instanceof Number qt) {
                         val = String.format(Locale.US, "%.2f", qt.floatValue());
+                    } else if (command instanceof DateTimeType dtt) {
+                        // time is transferred as minutes since midnight...
+                        var zdt = dtt.getZonedDateTime();
+                        val = Integer.toString(zdt.getHour() * 60 + zdt.getMinute());
                     } else {
                         val = command.format("%.2f");
                     }

--- a/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/TACmiSchemaHandler.java
+++ b/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/TACmiSchemaHandler.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -253,8 +254,14 @@ public class TACmiSchemaHandler extends BaseThingHandler {
             case NUMERIC_FORM:
                 ChangerX2Entry cx2en = e.changerX2Entry;
                 if (cx2en != null) {
-                    reqUpdate = prepareRequest(buildUri("INCLUDE/change.cgi?changeadrx2=" + cx2en.address
-                            + "&changetox2=" + command.format("%.2f")));
+                    String val;
+                    if (command instanceof Number qt) {
+                        val = String.format(Locale.US, "%.2f", qt.floatValue());
+                    } else {
+                        val = command.format("%.2f");
+                    }
+                    reqUpdate = prepareRequest(
+                            buildUri("INCLUDE/change.cgi?changeadrx2=" + cx2en.address + "&changetox2=" + val));
                     reqUpdate.header(HttpHeader.REFERER, this.serverBase + "schema.html"); // required...
                 } else {
                     logger.debug("Got command for uninitalized channel {}: {}", channelUID, command);


### PR DESCRIPTION
Hi,

* This PR fixes some wrong Unit of Measurement mappings for some values provided by the C.M.I.. I haven't used them, so I didn't notice the problem.
* It also improves the handling of the values themselves.
The changes should fix #12445 
Finally (the 3rd commit) adds support for the time values provided by the C.M.I.. Since only hour/minutes are provided, the current day is used for the date part in the DateTimeType.

Bye,
    chris