### PR TITLE
Remove space before colon

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/README.md
+++ b/bundles/org.openhab.binding.androiddebugbridge/README.md
@@ -8,7 +8,7 @@ If you are not familiar with adb I suggest you to search "How to enable adb over
 
 ## Supported Things
 
-This binding was tested on :
+This binding was tested on:
 
 | Device                 | Android version | Comments                           |
 |------------------------|-----------------|------------------------------------|

--- a/bundles/org.openhab.binding.ephemeris/README.md
+++ b/bundles/org.openhab.binding.ephemeris/README.md
@@ -3,7 +3,7 @@
 The Ephemeris Binding makes the bridge with Ephemeris core actions.
 It provides access to Ephemeris data via Items without requiring usage of a scripting language.
 
-The binding will search your Jollyday event definition files in the sub folder `/misc/ephemeris` located in the configuration folder of openHAB (e.g. for a linux system : /etc/openhab/misc/ephemeris/)
+The binding will search your Jollyday event definition files in the sub folder `/misc/ephemeris` located in the configuration folder of openHAB (e.g. for a linux system: /etc/openhab/misc/ephemeris/)
 
 ## Supported Things
 
@@ -30,7 +30,7 @@ There is no configuration at binding level.
 |-----------------|---------|---------------------------------------------------|---------|----------|----------|
 | fileName        | text    | Name of the XML file in the configuration folder  | N/A     | yes      | no       |
 
-The file has to use the syntax described here : https://www.openhab.org/docs/configuration/actions.html#custom-bank-holidays
+The file has to use the syntax described here: https://www.openhab.org/docs/configuration/actions.html#custom-bank-holidays
 
 ### `dayset` Thing Configuration
 

--- a/bundles/org.openhab.binding.loxone/README.md
+++ b/bundles/org.openhab.binding.loxone/README.md
@@ -73,7 +73,7 @@ There can be following reasons why Miniserver status is `OFFLINE`:
   - _Internal error_
     - Probably a code defect, collect debug data and submit an issue. Binding will try to reconnect, but with unknown chance for success.
   - _Other_
-    - An exception occured and its details will be displayed
+    - An exception occurred and its details will be displayed
 - **Communication Error**
   - _Error communicating with Miniserver_
     - I/O error occurred during established communication with the Miniserver, most likely due to network connectivity issues, Miniserver going offline or Loxone Config is uploading a new configuration. A reconnect attempt will be made soon. Please consult detailed message against one of the following:
@@ -84,7 +84,7 @@ There can be following reasons why Miniserver status is `OFFLINE`:
   - _Timeout due to no activity_
     - Miniserver closed connection because there was no activity from binding. It should not occur under normal conditions, as it is prevented by sending keep-alive messages from the binding to the Miniserver. By default Miniserver's timeout is 5 minutes and period between binding's keep-alive messages is 4 minutes. If you see this error, try changing the keep-alive period in binding's configuration to a smaller value.
   - _Other_
-    - An exception occured and its details will be displayed
+    - An exception occurred and its details will be displayed
 
 ### Security
 

--- a/bundles/org.openhab.binding.mycroft/README.md
+++ b/bundles/org.openhab.binding.mycroft/README.md
@@ -50,7 +50,7 @@ A Mycroft thing has the following channels:
 | utterance                    | String    | The last utterance Mycroft receive                                                             |
 | player                       | Player    | The music player Mycroft is currently controlling                                              |
 | volume_mute                  | Switch    | Mute the Mycroft speaker                                                                       |
-| volume                       | Dimmer    | The volume of the Mycroft speaker. (Note : Value unreliable until a volume change occured)     |
+| volume                       | Dimmer    | The volume of the Mycroft speaker. (Note: Value unreliable until a volume change occurred)     |
 | full_message                 | String    | The last message (full json) seen on the Mycroft Bus. Filtered by the messageTypes properties  |
 
 The channel 'full_message' has the following configuration available:

--- a/bundles/org.openhab.binding.mynice/README.md
+++ b/bundles/org.openhab.binding.mynice/README.md
@@ -42,7 +42,7 @@ Once done, you can also create your things via *.things file.
 
 There is no channel associated with the bridge.
 
-Channels available for the gates are :
+Channels available for the gates are:
 
 | Channel   | Type   | Read/Write | Description                                              |
 |-----------|--------|------------|----------------------------------------------------------|
@@ -65,7 +65,7 @@ Depending upon your gate model and motor capabilities, some T4 commands can be u
 The list of available commands for your model will be automatically discovered by the binding.
 This information is stored in the `allowedT4` property held by the gate Thing itself.
 
-Complete list of T4 Commands :
+Complete list of T4 Commands:
 
 | Command | Action                     |
 |---------|----------------------------|

--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -358,13 +358,13 @@ It will auto-adapt to stick as closely as possible to the last data availability
 | signal        | strength            | Number               | Signal strength (0 for no signal, 1 for weak...) |
 | signal        | value               | Number:Power         | Signal strength in dBm                           |
 
-(*) Health index values :
+(*) Health index values:
 
-- 0 : healthy
-- 1 : fine
-- 2 : fair
-- 3 : poor
-- 4 : unhealthy
+- 0: healthy
+- 1: fine
+- 2: fair
+- 3: poor
+- 4: unhealthy
 
 All these channels are read only.
 
@@ -449,7 +449,7 @@ All these channels except setpoint and setpoint-mode are read only.
 
 ### Home
 
-A Home is the Thing holding various modules and devices. They can hold two areas of equipments : Security and Energy.
+A Home is the Thing holding various modules and devices. They can hold two areas of equipments: Security and Energy.
 Depending on the way it is configured the behaviour will be adapted and available channels can vary.
 
 **Home Configuration**
@@ -462,7 +462,7 @@ The Home thing has the following configuration elements:
 | securityId      | String  | No       | Id of a home holding security monitoring devices                                    |
 | refreshInterval | Integer | No       | Refresh interval for refreshing the data in seconds. Default 180.                   |
 
-At least one of these parameter must be filled - at most two :
+At least one of these parameter must be filled - at most two:
 
 - id or securityId
 - id or energyId
@@ -545,7 +545,7 @@ Warnings:
 | last-event     | video-status         | String       | Read-only  | Status of the video (recording, deleted or available)                                                                                       |
 | last-event     | person-id            | String       | Read-only  | Id of the person the event is about (if any)                                                                                                |
 
-(*) This channel is configurable : low, poor, high.
+(*) This channel is configurable: low, poor, high.
 (**) This channel handles the REFRESH command for on demand update.
 
 **Supported channels for the Presence Camera thing:**
@@ -586,7 +586,7 @@ Warnings:
 | sub-event      | snapshot             | Image        | Read-only  | picture of the snapshot                                                                                                                     |
 | sub-event      | vignette             | Image        | Read-only  | picture of the vignette                                                                                                                     |
 
-(*) This channel is configurable : low, poor, high.
+(*) This channel is configurable: low, poor, high.
 
 **Supported channels for the Doorbell thing:**
 
@@ -642,8 +642,8 @@ Note: live feeds either locally or via VPN are not available in Netatmo API.
 
 Netatmo API distinguishes two kinds of persons:
 
-- Known persons : have been identified by the camera and you have defined a name for those.
-- Unknown persons : identified by the camera, but no name defined.
+- Known persons: have been identified by the camera and you have defined a name for those.
+- Unknown persons: identified by the camera, but no name defined.
 
 Person things are automatically created in discovery process for all known persons.
 

--- a/bundles/org.openhab.binding.nikobus/README.md
+++ b/bundles/org.openhab.binding.nikobus/README.md
@@ -33,11 +33,11 @@ The bridge enables communication with other Nikobus components:
 - `rollershutter-module` - Nikobus roller shutter module,
 - `push-button` - Nikobus physical push button.
 
-## Warning : PC-Link software addresses writing convention
+## Warning: PC-Link software addresses writing convention
 
-This binding and Niko's PC-Link software don't have the same address writing convention ! **You must invert the MSB & LSB**.
+This binding and Niko's PC-Link software don't have the same address writing convention! **You must invert the MSB & LSB**.
 
-example : PC Link's address == `23F0` --> nikobus binding address == `F023`
+example: PC Link's address == `23F0` --> nikobus binding address == `F023`
 
 ## Bridge Configuration
 

--- a/bundles/org.openhab.binding.openuv/README.md
+++ b/bundles/org.openhab.binding.openuv/README.md
@@ -14,7 +14,7 @@ The binding has no configuration options, all configuration is done at Bridge an
 
 ## Bridge Configuration
 
-The bridge has only one configuration parameter :
+The bridge has only one configuration parameter:
 
 | Parameter | Description                                                  |
 |-----------|--------------------------------------------------------------|
@@ -24,7 +24,7 @@ Will accept a Refresh command in order to reinitiate connexion (eg in case of Qu
 
 ## Thing Configuration
 
-The thing has a few configuration parameters :
+The thing has a few configuration parameters:
 
 | Parameter | Description                                                  |
 |-----------|--------------------------------------------------------------|

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -103,10 +103,10 @@ sudo usermod -a -G dialout openhab
 
 Configuration parameters are:
 
-- `host` : IP address / hostname of the BUS/SCS gateway (`String`, _mandatory_)
+- `host`: IP address / hostname of the BUS/SCS gateway (`String`, _mandatory_)
   - Example: `192.168.1.35`
-- `port` : port (`int`, _optional_, default: `20000`)
-- `passwd` : gateway password (`String`, _required_ for gateways that have a password. Default: `12345`)
+- `port`: port (`int`, _optional_, default: `20000`)
+- `passwd`: gateway password (`String`, _required_ for gateways that have a password. Default: `12345`)
   - Example: `abcde` or `12345`
   - if the BUS/SCS gateway is configured to accept connections from the openHAB computer IP address, no password should be required
   - in all other cases, a password must be configured. This includes gateways that have been discovered and added from Inbox: without a password configured they will remain OFFLINE
@@ -119,7 +119,7 @@ Alternatively the MyHOME - BUS/SCS Gateway Thing can be configured using the `.t
 
 Configuration parameters are:
 
-- `serialPort` : the serial port where the  MyHOME Radio - Zigbee USB Gateway is connected (`String`, _mandatory_)
+- `serialPort`: the serial port where the  MyHOME Radio - Zigbee USB Gateway is connected (`String`, _mandatory_)
   - Examples: `/dev/ttyUSB0` (Linux/RaPi), `COM3` (Windows)
 
 Alternatively the MyHOME Radio - Zigbee USB Gateway thing can be configured using the `.things` file, see `openwebnet.things` example [below](#full-example).

--- a/bundles/org.openhab.binding.smsmodem/README.md
+++ b/bundles/org.openhab.binding.smsmodem/README.md
@@ -6,7 +6,7 @@ Serial modem should all use the same communication protocol (AT message) and the
 However, there is a gap between theory and reality and success may vary.
 The protocol stack is based on the no longer supported smslib project (more precisely a v4 fork), and all modems supported by this library should be OK.
 
-The following devices have been reported functional :
+The following devices have been reported functional:
 
 - Huawei E180
 - Huawei E173
@@ -19,7 +19,7 @@ Devices that are reported to have issues:
 
 ## Supported Things
 
-Two things are supported by this binding :
+Two things are supported by this binding:
 
 - A _smsmodembridge_, representing the dongle connected on the local computer
 - A _smsmodemremotebridge_, representing the dongle exposed over the network (with ser2net or other similar software)
@@ -48,7 +48,7 @@ For remote _smsmodemremotebridge_:
 | ip             | text    | IP address of the computer hosting the ser2net service |
 | networkPort    | integer | The network port of the ser2net service                |
 
-The other parameters are optional :
+The other parameters are optional:
 
 | Parameter Name   | type    | description                                                                                  |
 | ---------------- | ------- | -------------------------------------------------------------------------------------------- |
@@ -66,7 +66,8 @@ The _smsconversation_ thing is just a shortcut to address/receive messages with 
 
 ## Channels
 
-The _smsconversation_ supports the following channels :
+The _smsconversation_ supports the following channels:
+
 | channel        | type   | description                                                                                                                                                          |
 | -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | receive        | String | The last message received                                                                                                                                            |
@@ -75,7 +76,8 @@ The _smsconversation_ supports the following channels :
 
 ## Trigger channels
 
-The _smsmodembridge_ and _smsmodemremotebridge_ has the following trigger channel :
+The _smsmodembridge_ and _smsmodemremotebridge_ has the following trigger channel:
+
 | Channel ID     | event                                                                               |
 | -------------- | ----------------------------------------------------------------------------------- |
 | receivetrigger | The msisdn and message received (concatened with the '\|' character as a separator) |
@@ -136,7 +138,7 @@ end
 
 ### Receive and forward SMS
 
-`sms.py` with the python helper library :
+`sms.py` with the python helper library:
 
 ```python
 @rule("smscommand.receive", description="Receive SMS and resend it")

--- a/bundles/org.openhab.binding.sncf/README.md
+++ b/bundles/org.openhab.binding.sncf/README.md
@@ -5,7 +5,7 @@ This is based on live API provided by DIGITALSNCF.
 
 Get your API key on [DIGITALSNCF web site](https://www.digital.sncf.com/startup/api/token-developpeur)
 
-Note : SNCF Api is based on the open [API Navitia](https://doc.navitia.io/#getting-started).
+Note: SNCF Api is based on the open [API Navitia](https://doc.navitia.io/#getting-started).
 This binding uses a very small subset of it, restricted to its primary purpose.
 
 (*) According to DIGITALSNCF Transilien may only be available for schedule, maybe not real-time.
@@ -33,7 +33,7 @@ The binding has no configuration options, all configuration is done at Thing lev
 
 ## Bridge Configuration
 
-The bridge configuration only holds the api key :
+The bridge configuration only holds the api key:
 
 | Parameter | Description                                            |
 | --------- | ------------------------------------------------------ |

--- a/bundles/org.openhab.binding.synopanalyzer/README.md
+++ b/bundles/org.openhab.binding.synopanalyzer/README.md
@@ -44,7 +44,7 @@ The weather information that is retrieved is available as these channels:
 
 ### Things
 
-Here is an example of thing definition :
+Here is an example of thing definition:
 
 ```java
 synopanalyzer:synopanalyzer:orly [ stationId=7149 ]

--- a/bundles/org.openhab.binding.teleinfo/README.md
+++ b/bundles/org.openhab.binding.teleinfo/README.md
@@ -194,7 +194,7 @@ These channels are available on the following telemeters:
 
 ### Historical TIC mode
 
-The following `things` file declare a serial USB controller on `/dev/ttyUSB0` for a Single-phase Electricity meter with HC/HP option - CBEMM Evolution ICC and adco `031528042289` :
+The following `things` file declare a serial USB controller on `/dev/ttyUSB0` for a Single-phase Electricity meter with HC/HP option - CBEMM Evolution ICC and adco `031528042289`:
 
 ```java
 Bridge teleinfo:serialcontroller:teleinfoUSB [ serialport="/dev/ttyUSB0" ]{
@@ -220,7 +220,7 @@ String TLInfoEDF_HHPHC "HHPHC" <energy> {channel="teleinfo:cbemm_evolution_icc_h
 
 ### Standard TIC mode
 
-The following `things` file declare a serial USB controller on `/dev/ttyUSB0` for a Linky Single-phase Electricity meter in standard TIC mode and adsc `031528042289` :
+The following `things` file declare a serial USB controller on `/dev/ttyUSB0` for a Linky Single-phase Electricity meter in standard TIC mode and adsc `031528042289`:
 
 ```java
 Bridge teleinfo:serialcontroller:teleinfoUSB [ serialport="/dev/ttyUSB0", ticMode="STANDARD" ]{

--- a/bundles/org.openhab.binding.vektiva/README.md
+++ b/bundles/org.openhab.binding.vektiva/README.md
@@ -18,7 +18,7 @@ If you are running 203.2.4 or newer firmware you can enable the websockets suppo
 
 ## Channels
 
-The exposed channels are :
+The exposed channels are:
 
 | Name    | Type           | Description |
 | ------- |:--------------:|:-----------:|

--- a/bundles/org.openhab.binding.vigicrues/README.md
+++ b/bundles/org.openhab.binding.vigicrues/README.md
@@ -8,7 +8,7 @@ These data are made public through OpenDataSoft website.
 There is exactly one supported thing type, which represents a river level measurement station.
 It is identified by the `id`.
 
-To get your station id :
+To get your station id:
 
 1. open <https://www.vigicrues.gouv.fr/>
 

--- a/bundles/org.openhab.binding.xmltv/README.md
+++ b/bundles/org.openhab.binding.xmltv/README.md
@@ -8,7 +8,7 @@ The building of the XMLTV file itself is taken in charge by so called "grabbers"
 
 Some websites provides updated XMLTV files than can be directly downloaded.
 
-Here is a sample for France and Switzerland : <https://xmltv.ch/>
+Here is a sample for France and Switzerland: <https://xmltv.ch/>
 
 This binding takes an XMLTV file as input and creates a thing for each channel contained in it.
 XmlTV channels are called Media Channels in this binding in order to avoid messing with openHAB Channels.

--- a/bundles/org.openhab.binding.yamahamusiccast/README.md
+++ b/bundles/org.openhab.binding.yamahamusiccast/README.md
@@ -1,7 +1,7 @@
 # Yamaha MusicCast Binding
 
 Binding to control Yamaha models via their MusicCast protocol (aka Yamaha Extended Control).
-With support for 4 zones : main, zone2, zone3, zone4. Main is always present. Zone2, Zone3, Zone4 are read from the model.
+With support for 4 zones: main, zone2, zone3, zone4. Main is always present. Zone2, Zone3, Zone4 are read from the model.
 
 UDP events are captured to reflect changes in the binding for
 
@@ -56,7 +56,7 @@ You can also use _RADIO / TUNER_ (as _tuner_).
 | input          | String               | See below for list                                                  |
 | soundProgram   | String               | See below for list                                                  |
 | selectPreset   | String               | Select Netradio/USB preset (fetched from Model)                     |
-| sleep          | Number               | Fixed values for Sleep : 0/30/60/90/120 in minutes                  |
+| sleep          | Number               | Fixed values for Sleep: 0/30/60/90/120 in minutes                   |
 | recallScene    | Number               | Select a scene (8 defaults scenes are foreseen)                     |
 | player         | Player               | PLAY/PAUSE/NEXT/PREVIOUS/REWIND/FASTFORWARD                         |
 | artist         | String               | Artist                                                              |

--- a/bundles/org.openhab.io.openhabcloud/README.md
+++ b/bundles/org.openhab.io.openhabcloud/README.md
@@ -136,7 +136,7 @@ To specify media attachments and actions, there is another variant of the `sendN
 
 The additional parameter for these variants have the following meaning:
 
-- `tag` : A user supplied tag to group messages for removing using the `hideNotificationByTag` action or grouping messages when displayed in the app. This renames the `severity` parameter, both are functionally identical.
+- `tag`: A user supplied tag to group messages for removing using the `hideNotificationByTag` action or grouping messages when displayed in the app. This renames the `severity` parameter, both are functionally identical.
 - `title`: The title of the notification. Defaults to "openHAB" inside the Android and iOS apps.
 - `referenceId`: A user supplied id to both replace existing messages when pushed, and later remove messages with the `hideNotificationByReferenceId` actions.
 - `onClickAction`: The action to be performed when the user clicks on the notification. Specified using the [action syntax](#action-syntax).
@@ -157,7 +157,7 @@ There are several types of actions available:
 - `ui`: Controls the UI in two possible ways:
   - `ui:$path` where `$path` is either `/basicui/app?...` for navigating sitemaps (using the native renderer) or `/some/absolute/path` for navigating (using the web view).
   - `ui:$commandItemSyntax` where `$commandItemSyntax` is the same syntax as used for the [UI Command Item]({{base}}/mainui/about.html#ui-command-item).
-- `http:` or `https:` : Opens the fully qualified URL in an embedded browser on the device.
+- `http:` or `https:`: Opens the fully qualified URL in an embedded browser on the device.
 - `rule`: Runs a rule by using the following syntax: `rule:$ruleId:$prop1Key=$prop1Value,$prop2Key=$prop2Value,...` where `$ruleId` is the id of the rule, and optional properties to send to the rule are in the format `name=value` separated by commas. Most rules can omit the properties.
 - `app`: Launches a native app when possible using the following syntax: `app:android=$appId,ios=$appId:$path` where `$appId` on Android is a qualified app id like `com.acme.app` (see [partial list of Android ids](https://github.com/petarov/google-android-app-ids)), and on iOS is the registered URL scheme along with an optional `$path` like `acme://foo` (see [partial list of iOS ids](https://github.com/bhagyas/app-urls)). Either `android` or `ios` can be omitted if that platform is not used.
 

--- a/bundles/org.openhab.transform.scale/README.md
+++ b/bundles/org.openhab.transform.scale/README.md
@@ -39,11 +39,11 @@ Scale transform is designed to work with numeric or quantity states. When the va
 
 ### Formatting output
 
-At last, Scale transform can take care of formatting an output with this entry :
+At last, Scale transform can take care of formatting an output with this entry:
 
 `format=%label% (%value%) !`
 
-Where :
+Where:
 
 - `%label%` will be replaced by transformed value and
 - `%value%` is the numeric value presen

--- a/bundles/org.openhab.voice.mimictts/README.md
+++ b/bundles/org.openhab.voice.mimictts/README.md
@@ -6,7 +6,7 @@ Its neural network is built upon some very good and some not-so-good models, so 
 
 Mimic3 doesn't need Mycroft, and it can be run as a simple command line utility, or as a web server with an API.
 
-This TTS bundle makes use of this last feature, so please take note : this openHAB TTS bundle is NOT a standalone, and it requires the Mimic web server to run somewhere (on your openHAB computer, or your network).
+This TTS bundle makes use of this last feature, so please take note: this openHAB TTS bundle is NOT a standalone, and it requires the Mimic web server to run somewhere (on your openHAB computer, or your network).
 
 You can find more information about the Mimic web server, and how to install it, on the [official documentation](https://mycroft-ai.gitbook.io/docs/mycroft-technologies/mimic-tts/mimic-3#installation).
 


### PR DESCRIPTION
In French, there is a space before a colon, whereas in English, there is not.

Also fix spelling occured → occurred.