### PR TITLE
[mqtt.homeassistant] fix newStyleChannels

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -51,13 +51,13 @@ public class ChannelState implements MqttMessageSubscriber {
 
     // Immutable channel configuration
     protected final boolean readOnly;
-    protected final ChannelUID channelUID;
     protected final ChannelConfig config;
 
     /** Channel value **/
     protected final Value cachedValue;
 
     // Runtime variables
+    protected ChannelUID channelUID;
     private @Nullable MqttBrokerConnection connection;
     protected final ChannelTransformation incomingTransformation;
     protected final ChannelTransformation outgoingTransformation;
@@ -130,6 +130,11 @@ public class ChannelState implements MqttMessageSubscriber {
      */
     public ChannelUID channelUID() {
         return channelUID;
+    }
+
+    // If the UID of the channel changed after it was initially created
+    public void setChannelUID(ChannelUID channelUID) {
+        this.channelUID = channelUID;
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -82,6 +82,7 @@ public class ComponentChannel {
                 .withKind(channel.getKind()).withLabel(Objects.requireNonNull(channel.getLabel()))
                 .withConfiguration(channel.getConfiguration()).withAutoUpdatePolicy(channel.getAutoUpdatePolicy())
                 .build();
+        channelState.setChannelUID(channelUID);
     }
 
     public void clearConfiguration() {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -77,11 +77,15 @@ public class ComponentChannel {
         return channel;
     }
 
-    public void replaceChannelUID(ChannelUID channelUID) {
+    public void resetUID(ChannelUID channelUID) {
         channel = ChannelBuilder.create(channelUID, channel.getAcceptedItemType()).withType(channel.getChannelTypeUID())
                 .withKind(channel.getKind()).withLabel(Objects.requireNonNull(channel.getLabel()))
                 .withConfiguration(channel.getConfiguration()).withAutoUpdatePolicy(channel.getAutoUpdatePolicy())
                 .build();
+    }
+
+    public void clearConfiguration() {
+        channel = ChannelBuilder.create(channel).withConfiguration(new Configuration()).build();
     }
 
     public ChannelState getState() {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -58,7 +58,7 @@ import org.openhab.core.types.StateDescription;
 @NonNullByDefault
 public class ComponentChannel {
     private final ChannelState channelState;
-    private final Channel channel;
+    private Channel channel;
     private final @Nullable StateDescription stateDescription;
     private final @Nullable CommandDescription commandDescription;
     private final ChannelStateUpdateListener channelStateUpdateListener;
@@ -75,6 +75,13 @@ public class ComponentChannel {
 
     public Channel getChannel() {
         return channel;
+    }
+
+    public void replaceChannelUID(ChannelUID channelUID) {
+        channel = ChannelBuilder.create(channelUID, channel.getAcceptedItemType()).withType(channel.getChannelTypeUID())
+                .withKind(channel.getKind()).withLabel(Objects.requireNonNull(channel.getLabel()))
+                .withConfiguration(channel.getConfiguration()).withAutoUpdatePolicy(channel.getAutoUpdatePolicy())
+                .build();
     }
 
     public ChannelState getState() {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponent.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.AvailabilityTracker;
+import org.openhab.binding.mqtt.generic.ChannelState;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.MqttChannelStateDescriptionProvider;
 import org.openhab.binding.mqtt.generic.values.Value;
@@ -39,7 +40,6 @@ import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AvailabilityMo
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.Device;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.thing.Channel;
-import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.binding.generic.ChannelTransformation;
 import org.openhab.core.thing.type.ChannelDefinition;
@@ -65,7 +65,6 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
 
     // Component location fields
     protected final ComponentConfiguration componentConfiguration;
-    protected final @Nullable ChannelGroupUID channelGroupUID;
     protected final HaID haID;
 
     // Channels and configuration
@@ -79,14 +78,10 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     protected final C channelConfiguration;
 
     protected boolean configSeen;
-    protected final boolean singleChannelComponent;
-    protected final String groupId;
+    protected final boolean newStyleChannels;
     protected final String uniqueId;
-
-    public AbstractComponent(ComponentFactory.ComponentConfiguration componentConfiguration, Class<C> clazz,
-            boolean newStyleChannels) {
-        this(componentConfiguration, clazz, newStyleChannels, false);
-    }
+    protected @Nullable String groupId;
+    protected String componentId;
 
     /**
      * Creates component based on generic configuration and component configuration type.
@@ -98,9 +93,9 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
      *            (only if newStyleChannels is true)
      */
     public AbstractComponent(ComponentFactory.ComponentConfiguration componentConfiguration, Class<C> clazz,
-            boolean newStyleChannels, boolean singleChannelComponent) {
+            boolean newStyleChannels) {
         this.componentConfiguration = componentConfiguration;
-        this.singleChannelComponent = newStyleChannels && singleChannelComponent;
+        this.newStyleChannels = newStyleChannels;
 
         this.channelConfigurationJson = componentConfiguration.getConfigJSON();
         this.channelConfiguration = componentConfiguration.getConfig(clazz);
@@ -109,14 +104,11 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
         this.haID = componentConfiguration.getHaID();
 
         String name = channelConfiguration.getName();
-        if (name != null && !name.isEmpty()) {
-            groupId = this.haID.getGroupId(channelConfiguration.getUniqueId(), newStyleChannels);
-
-            this.channelGroupUID = this.singleChannelComponent ? null
-                    : new ChannelGroupUID(componentConfiguration.getThingUID(), groupId);
+        if (newStyleChannels || (name != null && !name.isEmpty())) {
+            groupId = componentId = this.haID.getGroupId(channelConfiguration.getUniqueId(), newStyleChannels);
         } else {
-            this.groupId = this.singleChannelComponent ? haID.component : "";
-            this.channelGroupUID = null;
+            groupId = null;
+            componentId = "";
         }
         uniqueId = this.haID.getGroupId(channelConfiguration.getUniqueId(), false);
 
@@ -155,10 +147,18 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
         }
     }
 
+    protected void finalizeChannels() {
+        if (newStyleChannels && channels.size() == 1) {
+            groupId = null;
+            channels.forEach(
+                    (id, componentChannel) -> componentChannel.replaceChannelUID(buildChannelUID(componentId)));
+        }
+    }
+
     protected ComponentChannel.Builder buildChannel(String channelID, ComponentChannelType channelType,
             Value valueState, String label, ChannelStateUpdateListener channelStateUpdateListener) {
-        if (singleChannelComponent) {
-            channelID = groupId;
+        if (groupId == null) {
+            channelID = componentId;
         }
         return new ComponentChannel.Builder(this, channelID, channelType.getChannelTypeUID(), valueState, label,
                 channelStateUpdateListener);
@@ -216,15 +216,15 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     }
 
     public ChannelUID buildChannelUID(String channelID) {
-        final ChannelGroupUID groupUID = channelGroupUID;
-        if (groupUID != null) {
-            return new ChannelUID(groupUID, channelID);
+        final String localGroupID = groupId;
+        if (localGroupID != null) {
+            return new ChannelUID(componentConfiguration.getThingUID(), localGroupID, channelID);
         }
         return new ChannelUID(componentConfiguration.getThingUID(), channelID);
     }
 
-    public String getGroupId() {
-        return groupId;
+    public String getComponentId() {
+        return componentId;
     }
 
     /**
@@ -273,7 +273,7 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
      * Return the channel group type.
      */
     public @Nullable ChannelGroupType getChannelGroupType(String prefix) {
-        if (channelGroupUID == null) {
+        if (groupId == null) {
             return null;
         }
         return ChannelGroupTypeBuilder.instance(getChannelGroupTypeUID(prefix), getName())
@@ -281,7 +281,7 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
     }
 
     public List<ChannelDefinition> getChannelDefinitions() {
-        if (channelGroupUID != null) {
+        if (groupId != null) {
             return List.of();
         }
         return getAllChannelDefinitions();
@@ -293,6 +293,10 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
 
     public List<Channel> getChannels() {
         return channels.values().stream().map(ComponentChannel::getChannel).toList();
+    }
+
+    public void getChannelStates(Map<ChannelUID, ChannelState> states) {
+        channels.values().forEach(c -> states.put(c.getChannel().getUID(), c.getState()));
     }
 
     /**
@@ -307,14 +311,15 @@ public abstract class AbstractComponent<C extends AbstractChannelConfiguration> 
      * Return the channel group definition for this component.
      */
     public @Nullable ChannelGroupDefinition getGroupDefinition(String prefix) {
-        if (channelGroupUID == null) {
+        String localGroupId = groupId;
+        if (localGroupId == null) {
             return null;
         }
-        return new ChannelGroupDefinition(channelGroupUID.getId(), getChannelGroupTypeUID(prefix), getName(), null);
+        return new ChannelGroupDefinition(localGroupId, getChannelGroupTypeUID(prefix), getName(), null);
     }
 
     public boolean hasGroup() {
-        return channelGroupUID != null;
+        return groupId != null;
     }
 
     public HaID getHaID() {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -97,5 +97,6 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
         }
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensor.java
@@ -69,7 +69,7 @@ public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfigur
     }
 
     public BinarySensor(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         OnOffValue value = new OnOffValue(channelConfiguration.payloadOn, channelConfiguration.payloadOff);
 
@@ -77,6 +77,7 @@ public class BinarySensor extends AbstractComponent<BinarySensor.ChannelConfigur
                 getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+        finalizeChannels();
     }
 
     private ChannelStateUpdateListener getListener(ComponentFactory.ComponentConfiguration componentConfiguration,

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Button.java
@@ -48,7 +48,7 @@ public class Button extends AbstractComponent<Button.ChannelConfiguration> {
     }
 
     public Button(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadPress });
 
@@ -57,5 +57,6 @@ public class Button extends AbstractComponent<Button.ChannelConfiguration> {
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Camera.java
@@ -46,5 +46,6 @@ public class Camera extends AbstractComponent<Camera.ChannelConfiguration> {
 
         buildChannel(CAMERA_CHANNEL_ID, ComponentChannelType.IMAGE, value, getName(),
                 componentConfiguration.getUpdateListener()).stateTopic(channelConfiguration.topic).build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -284,6 +284,7 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
 
         buildOptionalChannel(POWER_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(), updateListener, null,
                 channelConfiguration.powerCommandTopic, null, null, null);
+        finalizeChannels();
     }
 
     @Nullable

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Cover.java
@@ -150,5 +150,6 @@ public class Cover extends AbstractComponent<Cover.ChannelConfiguration> {
                     }
                     return true;
                 }).build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -112,6 +112,7 @@ public class DefaultSchemaLight extends Light {
                     .build();
         }
 
+        boolean hasColorChannel = false;
         if (channelConfiguration.rgbStateTopic != null || channelConfiguration.rgbCommandTopic != null) {
             hasColorChannel = true;
             hiddenChannels.add(rgbChannel = buildChannel(RGB_CHANNEL_ID, ComponentChannelType.COLOR,
@@ -167,7 +168,7 @@ public class DefaultSchemaLight extends Light {
             if (localBrightnessChannel != null) {
                 hiddenChannels.add(localBrightnessChannel);
             }
-            buildChannel(COLOR_CHANNEL_ID, ComponentChannelType.COLOR, colorValue, "Color", this)
+            colorChannel = buildChannel(COLOR_CHANNEL_ID, ComponentChannelType.COLOR, colorValue, "Color", this)
                     .commandTopic(DUMMY_TOPIC, channelConfiguration.isRetain(), channelConfiguration.getQos())
                     .commandFilter(this::handleColorCommand).build();
         } else if (localBrightnessChannel != null) {
@@ -280,74 +281,76 @@ public class DefaultSchemaLight extends Light {
     @Override
     public void updateChannelState(ChannelUID channel, State state) {
         ChannelStateUpdateListener listener = this.channelStateUpdateListener;
-        switch (channel.getIdWithoutGroup()) {
-            case ON_OFF_CHANNEL_ID:
-                if (hasColorChannel) {
-                    HSBType newOnState = colorValue.getChannelState() instanceof HSBType
-                            ? (HSBType) colorValue.getChannelState()
-                            : HSBType.WHITE;
-                    if (state.equals(OnOffType.ON)) {
-                        colorValue.update(newOnState);
-                    }
-
-                    listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID),
-                            state.equals(OnOffType.ON) ? newOnState : HSBType.BLACK);
-                } else if (brightnessChannel != null) {
-                    listener.updateChannelState(new ChannelUID(channel.getThingUID(), BRIGHTNESS_CHANNEL_ID),
-                            state.equals(OnOffType.ON) ? brightnessValue.getChannelState() : PercentType.ZERO);
-                } else {
-                    listener.updateChannelState(channel, state);
-                }
-                return;
-            case BRIGHTNESS_CHANNEL_ID:
-                onOffValue.update(Objects.requireNonNull(state.as(OnOffType.class)));
-                if (hasColorChannel) {
-                    if (colorValue.getChannelState() instanceof HSBType) {
-                        HSBType hsb = (HSBType) (colorValue.getChannelState());
-                        colorValue.update(new HSBType(hsb.getHue(), hsb.getSaturation(),
-                                (PercentType) brightnessValue.getChannelState()));
-                    } else {
-                        colorValue.update(new HSBType(DecimalType.ZERO, PercentType.ZERO,
-                                (PercentType) brightnessValue.getChannelState()));
-                    }
-                    listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
-                } else {
-                    listener.updateChannelState(channel, state);
-                }
-                return;
-            case COLOR_TEMP_CHANNEL_ID:
-            case EFFECT_CHANNEL_ID:
-                // Real channels; pass through
-                listener.updateChannelState(channel, state);
-                return;
-            case HS_CHANNEL_ID:
-            case XY_CHANNEL_ID:
-                if (brightnessValue.getChannelState() instanceof UnDefType) {
-                    brightnessValue.update(PercentType.HUNDRED);
-                }
-                String[] split = state.toString().split(",");
-                if (split.length != 2) {
-                    throw new IllegalArgumentException(state.toString() + " is not a valid string syntax");
-                }
-                float x = Float.parseFloat(split[0]);
-                float y = Float.parseFloat(split[1]);
-                PercentType brightness = (PercentType) brightnessValue.getChannelState();
-                if (channel.getIdWithoutGroup().equals(HS_CHANNEL_ID)) {
-                    colorValue.update(new HSBType(new DecimalType(x), new PercentType(new BigDecimal(y)), brightness));
-                } else {
-                    HSBType xyColor = HSBType.fromXY(x, y);
-                    colorValue.update(new HSBType(xyColor.getHue(), xyColor.getSaturation(), brightness));
-                }
-                listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
-                return;
-            case RGB_CHANNEL_ID:
-                colorValue.update((HSBType) state);
-                listener.updateChannelState(buildChannelUID(COLOR_CHANNEL_ID), colorValue.getChannelState());
-                break;
-            case RGBW_CHANNEL_ID:
-            case RGBWW_CHANNEL_ID:
-                // TODO: update color value
-                break;
+        String id = channel.getIdWithoutGroup();
+        ComponentChannel localBrightnessChannel = brightnessChannel;
+        ComponentChannel localColorChannel = colorChannel;
+        ChannelUID primaryChannelUID;
+        if (localColorChannel != null) {
+            primaryChannelUID = localColorChannel.getChannel().getUID();
+        } else if (localBrightnessChannel != null) {
+            primaryChannelUID = localBrightnessChannel.getChannel().getUID();
+        } else {
+            primaryChannelUID = onOffChannel.getChannel().getUID();
         }
+        // on_off, brightness, and color might exist as a sole channel, which means
+        // they got renamed. they need to be compared against the actual UID of the
+        // channel. all the rest we can just check against the basic ID
+        if (channel.equals(onOffChannel.getChannel().getUID())) {
+            if (localColorChannel != null) {
+                HSBType newOnState = colorValue.getChannelState() instanceof HSBType
+                        ? (HSBType) colorValue.getChannelState()
+                        : HSBType.WHITE;
+                if (state.equals(OnOffType.ON)) {
+                    colorValue.update(newOnState);
+                }
+
+                listener.updateChannelState(primaryChannelUID, state.equals(OnOffType.ON) ? newOnState : HSBType.BLACK);
+            } else if (brightnessChannel != null) {
+                listener.updateChannelState(primaryChannelUID,
+                        state.equals(OnOffType.ON) ? brightnessValue.getChannelState() : PercentType.ZERO);
+            } else {
+                listener.updateChannelState(primaryChannelUID, state);
+            }
+        } else if (localBrightnessChannel != null && localBrightnessChannel.getChannel().getUID().equals(channel)) {
+            onOffValue.update(Objects.requireNonNull(state.as(OnOffType.class)));
+            if (localColorChannel != null) {
+                if (colorValue.getChannelState() instanceof HSBType) {
+                    HSBType hsb = (HSBType) (colorValue.getChannelState());
+                    colorValue.update(new HSBType(hsb.getHue(), hsb.getSaturation(),
+                            (PercentType) brightnessValue.getChannelState()));
+                } else {
+                    colorValue.update(new HSBType(DecimalType.ZERO, PercentType.ZERO,
+                            (PercentType) brightnessValue.getChannelState()));
+                }
+                listener.updateChannelState(primaryChannelUID, colorValue.getChannelState());
+            } else {
+                listener.updateChannelState(primaryChannelUID, state);
+            }
+        } else if (id.equals(COLOR_TEMP_CHANNEL_ID) || channel.getIdWithoutGroup().equals(EFFECT_CHANNEL_ID)) {
+            // Real channels; pass through
+            listener.updateChannelState(channel, state);
+        } else if (id.equals(HS_CHANNEL_ID) || id.equals(XY_CHANNEL_ID)) {
+            if (brightnessValue.getChannelState() instanceof UnDefType) {
+                brightnessValue.update(PercentType.HUNDRED);
+            }
+            String[] split = state.toString().split(",");
+            if (split.length != 2) {
+                throw new IllegalArgumentException(state.toString() + " is not a valid string syntax");
+            }
+            float x = Float.parseFloat(split[0]);
+            float y = Float.parseFloat(split[1]);
+            PercentType brightness = (PercentType) brightnessValue.getChannelState();
+            if (channel.getIdWithoutGroup().equals(HS_CHANNEL_ID)) {
+                colorValue.update(new HSBType(new DecimalType(x), new PercentType(new BigDecimal(y)), brightness));
+            } else {
+                HSBType xyColor = HSBType.fromXY(x, y);
+                colorValue.update(new HSBType(xyColor.getHue(), xyColor.getSaturation(), brightness));
+            }
+            listener.updateChannelState(primaryChannelUID, colorValue.getChannelState());
+        } else if (id.equals(RGB_CHANNEL_ID)) {
+            colorValue.update((HSBType) state);
+            listener.updateChannelState(primaryChannelUID, colorValue.getChannelState());
+        }
+        // else rgbw channel, rgbww channel
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -297,8 +297,8 @@ public class DefaultSchemaLight extends Light {
         // channel. all the rest we can just check against the basic ID
         if (channel.equals(onOffChannel.getChannel().getUID())) {
             if (localColorChannel != null) {
-                HSBType newOnState = colorValue.getChannelState() instanceof HSBType
-                        ? (HSBType) colorValue.getChannelState()
+                HSBType newOnState = colorValue.getChannelState() instanceof HSBType newOnStateTmp
+                        ? newOnStateTmp
                         : HSBType.WHITE;
                 if (state.equals(OnOffType.ON)) {
                     colorValue.update(newOnState);
@@ -314,8 +314,7 @@ public class DefaultSchemaLight extends Light {
         } else if (localBrightnessChannel != null && localBrightnessChannel.getChannel().getUID().equals(channel)) {
             onOffValue.update(Objects.requireNonNull(state.as(OnOffType.class)));
             if (localColorChannel != null) {
-                if (colorValue.getChannelState() instanceof HSBType) {
-                    HSBType hsb = (HSBType) (colorValue.getChannelState());
+                if (colorValue.getChannelState() instanceof HSBType hsb) {
                     colorValue.update(new HSBType(hsb.getHue(), hsb.getSaturation(),
                             (PercentType) brightnessValue.getChannelState()));
                 } else {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -297,8 +297,7 @@ public class DefaultSchemaLight extends Light {
         // channel. all the rest we can just check against the basic ID
         if (channel.equals(onOffChannel.getChannel().getUID())) {
             if (localColorChannel != null) {
-                HSBType newOnState = colorValue.getChannelState() instanceof HSBType newOnStateTmp
-                        ? newOnStateTmp
+                HSBType newOnState = colorValue.getChannelState() instanceof HSBType newOnStateTmp ? newOnStateTmp
                         : HSBType.WHITE;
                 if (state.equals(OnOffType.ON)) {
                     colorValue.update(newOnState);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
@@ -46,7 +46,7 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
     }
 
     public DeviceTrigger(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         if (!"trigger".equals(channelConfiguration.automationType)) {
             throw new ConfigurationException("Component:DeviceTrigger must have automation_type 'trigger'");
@@ -69,5 +69,6 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
         buildChannel(channelConfiguration.type, ComponentChannelType.TRIGGER, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.topic, channelConfiguration.getValueTemplate()).trigger(true).build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -118,6 +119,8 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements 
     private final PercentageValue speedValue;
     private State rawSpeedState;
     private final ComponentChannel onOffChannel;
+    private final @Nullable ComponentChannel speedChannel;
+    private final ComponentChannel primaryChannel;
     private final ChannelStateUpdateListener channelStateUpdateListener;
 
     public Fan(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
@@ -144,11 +147,15 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements 
 
         if (channelConfiguration.percentageCommandTopic != null) {
             hiddenChannels.add(onOffChannel);
-            buildChannel(SPEED_CHANNEL_ID, ComponentChannelType.DIMMER, speedValue, "Speed", this)
+            primaryChannel = speedChannel = buildChannel(SPEED_CHANNEL_ID, ComponentChannelType.DIMMER, speedValue,
+                    "Speed", this)
                     .stateTopic(channelConfiguration.percentageStateTopic, channelConfiguration.percentageValueTemplate)
                     .commandTopic(channelConfiguration.percentageCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos(), channelConfiguration.percentageCommandTemplate)
                     .commandFilter(this::handlePercentageCommand).build();
+        } else {
+            primaryChannel = onOffChannel;
+            speedChannel = null;
         }
 
         List<String> presetModes = channelConfiguration.presetModes;
@@ -198,7 +205,7 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements 
 
     @Override
     public void updateChannelState(ChannelUID channel, State state) {
-        if (channel.getIdWithoutGroup().equals(SWITCH_CHANNEL_ID)) {
+        if (onOffChannel.getChannel().getUID().equals(channel)) {
             if (rawSpeedState instanceof UnDefType && state.equals(OnOffType.ON)) {
                 // Assume full on if we don't yet know the actual speed
                 state = PercentType.HUNDRED;
@@ -207,7 +214,7 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements 
             } else {
                 state = rawSpeedState;
             }
-        } else if (channel.getIdWithoutGroup().equals(SPEED_CHANNEL_ID)) {
+        } else if (Objects.requireNonNull(speedChannel).getChannel().getUID().equals(channel)) {
             rawSpeedState = state;
             if (onOffValue.getChannelState().equals(OnOffType.OFF)) {
                 // Don't pass on percentage values while the fan is off
@@ -215,7 +222,7 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements 
             }
         }
         speedValue.update(state);
-        channelStateUpdateListener.updateChannelState(buildChannelUID(SPEED_CHANNEL_ID), state);
+        channelStateUpdateListener.updateChannelState(primaryChannel.getChannel().getUID(), state);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -184,6 +184,7 @@ public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements 
                             channelConfiguration.getQos(), channelConfiguration.directionCommandTemplate)
                     .build();
         }
+        finalizeChannels();
     }
 
     private boolean handlePercentageCommand(Command command) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
@@ -292,6 +292,7 @@ public abstract class Light extends AbstractComponent<Light.ChannelConfiguration
         colorTempValue = new NumberValue(min, max, BigDecimal.ONE, Units.MIRED);
 
         buildChannels();
+        finalizeChannels();
     }
 
     protected abstract void buildChannels();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
@@ -228,10 +228,10 @@ public abstract class Light extends AbstractComponent<Light.ChannelConfiguration
     }
 
     protected final boolean optimistic;
-    protected boolean hasColorChannel = false;
 
     protected @Nullable ComponentChannel onOffChannel;
     protected @Nullable ComponentChannel brightnessChannel;
+    protected @Nullable ComponentChannel colorChannel;
 
     // State has to be stored here, in order to mux multiple
     // MQTT sources into single OpenHAB channels

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Lock.java
@@ -121,6 +121,7 @@ public class Lock extends AbstractComponent<Lock.ChannelConfiguration> {
                     }
                     return true;
                 }).build();
+        finalizeChannels();
     }
 
     private void autoUpdate(boolean locking) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Number.java
@@ -71,7 +71,7 @@ public class Number extends AbstractComponent<Number.ChannelConfiguration> {
     }
 
     public Number(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
                 : channelConfiguration.stateTopic.isBlank();
@@ -89,5 +89,6 @@ public class Number extends AbstractComponent<Number.ChannelConfiguration> {
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)
                 .build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Scene.java
@@ -46,7 +46,7 @@ public class Scene extends AbstractComponent<Scene.ChannelConfiguration> {
     }
 
     public Scene(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         TextValue value = new TextValue(new String[] { channelConfiguration.payloadOn });
 
@@ -55,5 +55,6 @@ public class Scene extends AbstractComponent<Scene.ChannelConfiguration> {
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
                 .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Select.java
@@ -56,7 +56,7 @@ public class Select extends AbstractComponent<Select.ChannelConfiguration> {
     }
 
     public Select(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
                 : channelConfiguration.stateTopic.isBlank();
@@ -73,5 +73,6 @@ public class Select extends AbstractComponent<Select.ChannelConfiguration> {
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos(), channelConfiguration.commandTemplate)
                 .build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Sensor.java
@@ -69,7 +69,7 @@ public class Sensor extends AbstractComponent<Sensor.ChannelConfiguration> {
     }
 
     public Sensor(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         Value value;
         String uom = channelConfiguration.unitOfMeasurement;
@@ -96,6 +96,7 @@ public class Sensor extends AbstractComponent<Sensor.ChannelConfiguration> {
         buildChannel(SENSOR_CHANNEL_ID, type, value, getName(), getListener(componentConfiguration, value))
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
                 .trigger(trigger).build();
+        finalizeChannels();
     }
 
     private ChannelStateUpdateListener getListener(ComponentFactory.ComponentConfiguration componentConfiguration,

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Switch.java
@@ -61,7 +61,7 @@ public class Switch extends AbstractComponent<Switch.ChannelConfiguration> {
     }
 
     public Switch(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
-        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels, true);
+        super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
         boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
                 : channelConfiguration.stateTopic.isBlank();
@@ -79,5 +79,6 @@ public class Switch extends AbstractComponent<Switch.ChannelConfiguration> {
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
                 .build();
+        finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -290,6 +290,7 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
 
         buildOptionalChannel(JSON_ATTRIBUTES_CH_ID, ComponentChannelType.STRING, new TextValue(), updateListener, null,
                 null, channelConfiguration.jsonAttributesTemplate, channelConfiguration.jsonAttributesTopic);
+        finalizeChannels();
     }
 
     @Nullable

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -184,7 +184,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
 
                 addComponent(component);
             } catch (ConfigurationException e) {
-                logger.error("Cannot restore component {}: {}", thing, e.getMessage());
+                logger.warn("Cannot restore component {}: {}", thing, e.getMessage());
             }
         }
         if (updateThingType(typeID)) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/config/homeassistant-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/config/homeassistant-channel-config.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="channel-type:mqtt:ha-channel">
-		<parameter name="component" type="text" readOnly="true" required="true">
+		<parameter name="component" type="text" readOnly="true">
 			<label>Component</label>
 			<description>Home Assistant component type (e.g. binary_sensor, switch, light)</description>
 			<default></default>
@@ -15,12 +15,12 @@
 			<description>Optional node name of the component</description>
 			<default></default>
 		</parameter>
-		<parameter name="objectid" type="text" readOnly="true" required="true">
+		<parameter name="objectid" type="text" readOnly="true">
 			<label>Object ID</label>
 			<description>Object ID of the component</description>
 			<default></default>
 		</parameter>
-		<parameter name="config" type="text" readOnly="true" required="true">
+		<parameter name="config" type="text" readOnly="true">
 			<label>JSON Configuration</label>
 			<description>The JSON configuration string received by the component via MQTT.</description>
 			<default></default>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensorTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/BinarySensorTests.java
@@ -65,7 +65,7 @@ public class BinarySensorTests extends AbstractComponentTests {
 
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("onoffsensor"));
-        assertThat(component.getGroupId(), is("sn1"));
+        assertThat(component.getComponentId(), is("sn1"));
 
         assertChannel(component, BinarySensor.SENSOR_CHANNEL_ID, "zigbee2mqtt/sensor/state", "", "onoffsensor",
                 OnOffValue.class);

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SensorTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/SensorTests.java
@@ -65,7 +65,7 @@ public class SensorTests extends AbstractComponentTests {
 
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("sensor1"));
-        assertThat(component.getGroupId(), is("sn1"));
+        assertThat(component.getComponentId(), is("sn1"));
 
         assertChannel(component, Sensor.SENSOR_CHANNEL_ID, "zigbee2mqtt/sensor/state", "", "sensor1",
                 NumberValue.class);

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
@@ -155,7 +155,7 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         // and add the types to the channelTypeProvider, like in the real Thing handler.
         final CountDownLatch latch = new CountDownLatch(1);
         ComponentDiscovered cd = (haID, c) -> {
-            haComponents.put(c.getGroupId(), c);
+            haComponents.put(c.getComponentId(), c);
             latch.countDown();
         };
 

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/homeassistant/HomeAssistantMQTTImplementationTest.java
@@ -174,11 +174,10 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         assertNull(failure);
         assertThat(haComponents.size(), is(1));
 
-        String channelGroupId = "switch_" + ThingChannelConstants.TEST_HOME_ASSISTANT_THING.getId();
+        String componentId = ThingChannelConstants.TEST_HOME_ASSISTANT_THING.getId();
         String channelId = Switch.SWITCH_CHANNEL_ID;
 
-        State value = haComponents.get(channelGroupId).getChannel(channelGroupId).getState().getCache()
-                .getChannelState();
+        State value = haComponents.get(componentId).getChannel(channelId).getState().getCache().getChannelState();
         assertThat(value, is(UnDefType.UNDEF));
 
         haComponents.values().stream().map(e -> e.start(haConnection, scheduler, 100))
@@ -191,7 +190,7 @@ public class HomeAssistantMQTTImplementationTest extends MqttOSGiTest {
         verify(channelStateUpdateListener, timeout(4000).times(1)).updateChannelState(any(), any());
 
         // Value should be ON now.
-        value = haComponents.get(channelGroupId).getChannel(channelGroupId).getState().getCache().getChannelState();
+        value = haComponents.get(componentId).getChannel(channelId).getState().getCache().getChannelState();
         assertThat(value, is(OnOffType.ON));
     }
 }


### PR DESCRIPTION
This fixes a couple of problems. The biggest is that if multiple components were single channel OR no-name, they would all get mapped to a "groupId" of "", and the next time the Thing started, all but one of them would disappear unless new discovery information was received. While fixing that, I fixed two other issues:
 * Multi-channel components with a blank name were getting all their channels dumped into the top level of no group. In the newStyleChannels world, we don't care about the component's name anymore - multi-channel components get a group, single-channel components do not.
 * Instead of statically saying that certain components are only ever single or multi-channel components, determine at runtime if a component only added a single channel, and if so re-classify it as a single-channel component, moving its channel out of the group (and just naming it as the group was named)

As part of this, I needed to keep a separate mapping of Channel ID to Channel State, instead of relying on the component ID matching the channel ID. Doing this enabled further simplifying of channel IDs by not including the component type at all in the channel ID, unless it's necessary to resolve a conflict from a duplicate object id of a different component type (which should be rare to never). In practice, this simplifies _lots_ of channels like `light_dimmer`, `switch_switch`, `cover_cover`, `lock_lock` to just `dimmer`, `switch`, `cover`, and `lock`.
