### PR TITLE
[wemo] Disable more unstable tests

### DIFF
--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.mockito.ArgumentCaptor;
@@ -68,6 +69,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
     }
 
     @Test
+    @Disabled("https://github.com/openhab/openhab-addons/issues/12474")
     public void assertThatThingHandlesOnOffCommandCorrectly()
             throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = OnOffType.OFF;
@@ -104,6 +106,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
     }
 
     @Test
+    @Disabled("https://github.com/openhab/openhab-addons/issues/12474")
     public void assertThatThingHandlesREFRESHCommandCorrectly()
             throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = RefreshType.REFRESH;

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
@@ -69,8 +69,8 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         removeThing();
     }
 
-    @Disabled
     @Test
+    @Disabled("https://github.com/openhab/openhab-addons/issues/12474")
     public void assertThatThingHandlesOnOffCommandCorrectly()
             throws MalformedURLException, URISyntaxException, ValidationException, IOException {
         Command command = OnOffType.OFF;


### PR DESCRIPTION
Related to #12474

See latest failure today: https://github.com/openhab/openhab-addons/actions/runs/11166591581/job/31040917173?pr=17501

```
TEST org.openhab.binding.wemo.internal.handler.test.WemoHandlerOSGiTest#assertThatThingHandlesOnOffCommandCorrectly() <<< ERROR: 
Expected: is <UNKNOWN>
     but: was <OFFLINE>
java.lang.AssertionError: 
Expected: is <UNKNOWN>
     but: was <OFFLINE>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.openhab.binding.wemo.internal.handler.test.WemoHandlerOSGiTest.lambda$0(WemoHandlerOSGiTest.java:78)
	at org.openhab.core.test.java.JavaTest.waitForAssert(JavaTest.java:245)
	at org.openhab.core.test.java.JavaTest.waitForAssert(JavaTest.java:213)
	at org.openhab.core.test.java.JavaTest.waitForAssert(JavaTest.java:166)
	at org.openhab.binding.wemo.internal.handler.test.WemoHandlerOSGiTest.assertThatThingHandlesOnOffCommandCorrectly(WemoHandlerOSGiTest.java:77)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at aQute.tester.bundle.engine.BundleDescriptor.executeChild(BundleDescriptor.java:49)
	at aQute.tester.bundle.engine.BundleEngine.lambda$executeBundle$7(BundleEngine.java:120)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at aQute.tester.bundle.engine.BundleEngine.executeBundle(BundleEngine.java:120)
	at aQute.tester.bundle.engine.BundleEngine.lambda$executeBundle$8(BundleEngine.java:133)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at aQute.tester.bundle.engine.BundleEngine.executeBundle(BundleEngine.java:133)
	at aQute.tester.bundle.engine.BundleEngine.lambda$execute$5(BundleEngine.java:100)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at aQute.tester.bundle.engine.BundleEngine.execute(BundleEngine.java:100)
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoHandler] WARN : Failed to get actual state for device 'wemo:socket:TestThing': java.util.concurrent.ExecutionException: java.net.ConnectException: Connection refused
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoLightHandler] WARN : Failed to send command 'ON' for device 'wemo:MZ100:TestThing': java.util.concurrent.ExecutionException: java.net.ConnectException: Connection refused
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoLightHandler] WARN : Required bridge not defined for device MZ100.
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoLightHandler] WARN : Required bridge not defined for device MZ100.
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoLightHandler] WARN : Required bridge not defined for device MZ100.
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoLightHandler] WARN : Required bridge not defined for device MZ100.
org.openhab.binding.wemo [org.openhab.binding.wemo.internal.handler.WemoLightHandler] WARN : Failed to send command 'DECREASE' for device 'wemo:MZ100:TestThing': java.util.concurrent.ExecutionException: java.net.ConnectException: Connection refused
```