### PR TITLE
[kaleidescape] Switch to SDDP discovery

### DIFF
--- a/bundles/org.openhab.binding.kaleidescape/README.md
+++ b/bundles/org.openhab.binding.kaleidescape/README.md
@@ -22,7 +22,7 @@ The binding supports either a TCP/IP connection or direct serial port connection
 
 ## Discovery
 
-Auto-discovery is supported for Alto and Strato components if the device can be located on the local network using UPnP.
+Auto-discovery is supported for Alto and Strato components if the device can be located on the local network using SDDP.
 Manually initiated discovery will locate all legacy Premiere line components if they are on the same IP subnet of the openHAB server.
 In the Inbox, select Search For Things and then choose the Kaleidescape Binding to initiate a discovery scan.
 

--- a/bundles/org.openhab.binding.kaleidescape/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-binding-kaleidescape" description="Kaleidescape Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
-		<feature>openhab-transport-upnp</feature>
+		<feature>openhab-core-config-discovery-sddp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.kaleidescape/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/addon/addon.xml
@@ -10,15 +10,11 @@
 
 	<discovery-methods>
 		<discovery-method>
-			<service-type>upnp</service-type>
+			<service-type>sddp</service-type>
 			<match-properties>
 				<match-property>
 					<name>manufacturer</name>
-					<regex>(?i)Kaleidescape</regex>
-				</match-property>
-				<match-property>
-					<name>deviceType</name>
-					<regex>.*Basic.*</regex>
+					<regex>(?i).*kaleidescape.*</regex>
 				</match-property>
 			</match-properties>
 		</discovery-method>


### PR DESCRIPTION
Regression of #17371. UPnP discovery does not work due to an invalid deviceType field in the device description.xml. Accordingly, this PR changes the discovery participant to use SDDP instead.