### PR TITLE
[unifi] Provide basic properties for access point

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/UniFiBindingConstants.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/UniFiBindingConstants.java
@@ -116,7 +116,6 @@ public final class UniFiBindingConstants {
     public static final String PARAMETER_VOUCHER_DATA_QUOTA = "voucherDataQuota";
     public static final String PARAMETER_PORT_NUMBER = "portNumber";
     public static final String PARAMETER_MAC_ADDRESS = "macAddress";
-    public static final String PARAMETER_WIFI_NAME = "wifi";
 
     // UniFi device types
     public static final String DEVICE_TYPE_UAP = "uap";

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiDevice.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/dto/UniFiDevice.java
@@ -38,6 +38,10 @@ public class UniFiDevice implements HasId {
 
     private String model;
 
+    private String version;
+
+    private String serial;
+
     private String type;
 
     private String name;
@@ -65,6 +69,14 @@ public class UniFiDevice implements HasId {
 
     public String getModel() {
         return model;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getSerial() {
+        return serial;
     }
 
     public String getName() {

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiAccessPointThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiAccessPointThingHandler.java
@@ -15,6 +15,8 @@ package org.openhab.binding.unifi.internal.handler;
 import static org.openhab.binding.unifi.internal.UniFiBindingConstants.CHANNEL_AP_ENABLE;
 import static org.openhab.binding.unifi.internal.UniFiBindingConstants.DEVICE_TYPE_UAP;
 
+import java.util.Map;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.unifi.internal.UniFiAccessPointThingConfig;
@@ -30,8 +32,6 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An access point managed by the UniFi controller software.
@@ -40,8 +40,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class UniFiAccessPointThingHandler extends UniFiBaseThingHandler<UniFiDevice, UniFiAccessPointThingConfig> {
-
-    private final Logger logger = LoggerFactory.getLogger(UniFiAccessPointThingHandler.class);
 
     private UniFiAccessPointThingConfig config = new UniFiAccessPointThingConfig();
 
@@ -90,6 +88,14 @@ public class UniFiAccessPointThingHandler extends UniFiBaseThingHandler<UniFiDev
                 break;
         }
         return state;
+    }
+
+    @Override
+    protected void updateProperties(final UniFiDevice device) {
+        updateProperties(Map.of( //
+                Thing.PROPERTY_MODEL_ID, device.getModel(), //
+                Thing.PROPERTY_FIRMWARE_VERSION, device.getVersion(), //
+                Thing.PROPERTY_SERIAL_NUMBER, device.getSerial()));
     }
 
     @Override

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiBaseThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiBaseThingHandler.java
@@ -132,6 +132,8 @@ public abstract class UniFiBaseThingHandler<E, C> extends BaseThingHandler {
             final @Nullable E entity = getEntity();
 
             getThing().getChannels().forEach(channel -> updateState(entity, channel.getUID()));
+
+            updateProperties(entity);
         }
     }
 
@@ -182,6 +184,15 @@ public abstract class UniFiBaseThingHandler<E, C> extends BaseThingHandler {
      * @return state to set or {@link UnDefType#NULL} if channel state should not be updated.
      */
     protected abstract State getChannelState(E entity, String channelId);
+
+    /**
+     * Updates relevant Thing properties from the UniFi entity object.
+     * Default implementation does not update any properties.
+     *
+     * @param entity UniFi entity object to get the properties information from
+     */
+    protected void updateProperties(E entity) {
+    }
 
     /**
      * Send the given command to the UniFi controller.

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiThingDiscoveryService.java
@@ -19,7 +19,6 @@ import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER
 import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER_SID;
 import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER_SITE;
 import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER_WID;
-import static org.openhab.binding.unifi.internal.UniFiBindingConstants.PARAMETER_WIFI_NAME;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -107,9 +106,7 @@ public class UniFiThingDiscoveryService extends AbstractThingHandlerDiscoverySer
         for (final UniFiWlan wlan : cache.getWlans()) {
             final ThingUID thingUID = new ThingUID(UniFiBindingConstants.THING_TYPE_WLAN, bridgeUID,
                     stripIdShort(wlan.getId()));
-            final String siteName = wlan.getSite() == null ? "" : wlan.getSite().getName();
-            final Map<String, Object> properties = Map.of(PARAMETER_WID, wlan.getId(), PARAMETER_SITE, siteName,
-                    PARAMETER_WIFI_NAME, wlan.getName());
+            final Map<String, Object> properties = Map.of(PARAMETER_WID, wlan.getId());
 
             thingDiscovered(DiscoveryResultBuilder.create(thingUID).withThingType(UniFiBindingConstants.THING_TYPE_WLAN)
                     .withBridge(bridgeUID).withRepresentationProperty(PARAMETER_WID).withTTL(TTL_SECONDS)


### PR DESCRIPTION
This provides a few basic properties for the `accessPoint` Thing.

Also removes two properties for the `wlan` being provided (only) by discovery. They were probably mistakenly copied from another Thing type for which they are parameters. They are not parameters the `wlan` Thing:
https://github.com/openhab/openhab-addons/blob/6b411899cc5cbe2e0822b1b3939ed2a2867489e6/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/config/config.xml#L47-L52

`site` is parameter for the `client` Thing:
https://github.com/openhab/openhab-addons/blob/6b411899cc5cbe2e0822b1b3939ed2a2867489e6/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/config/config.xml#L59-L62