### PR TITLE
[evcc] API change on duration channels

### DIFF
--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -758,7 +758,7 @@ public class EvccHandler extends BaseThingHandler {
 
         long chargeDuration = loadpoint.getChargeDuration();
         channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_CHARGE_DURATION);
-        updateState(channel, new QuantityType<>(chargeDuration, MetricPrefix.NANO(Units.SECOND)));
+        updateState(channel, new QuantityType<>(chargeDuration, Units.SECOND));
 
         float chargePower = loadpoint.getChargePower();
         channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_CHARGE_POWER);
@@ -766,7 +766,7 @@ public class EvccHandler extends BaseThingHandler {
 
         long chargeRemainingDuration = loadpoint.getChargeRemainingDuration();
         channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_CHARGE_REMAINING_DURATION);
-        updateState(channel, new QuantityType<>(chargeRemainingDuration, MetricPrefix.NANO(Units.SECOND)));
+        updateState(channel, new QuantityType<>(chargeRemainingDuration, Units.SECOND));
 
         float chargeRemainingEnergy = loadpoint.getChargeRemainingEnergy();
         channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_CHARGE_REMAINING_ENERGY);
@@ -786,7 +786,7 @@ public class EvccHandler extends BaseThingHandler {
 
         long connectedDuration = loadpoint.getConnectedDuration();
         channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_CONNECTED_DURATION);
-        updateState(channel, new QuantityType<>(connectedDuration, MetricPrefix.NANO(Units.SECOND)));
+        updateState(channel, new QuantityType<>(connectedDuration, Units.SECOND));
 
         boolean enabled = loadpoint.getEnabled();
         channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_ENABLED);


### PR DESCRIPTION
# [evcc] API change on duration channels

Since EVCC version 0.127.0 (https://github.com/evcc-io/evcc/pull/13319) the [EVCC Rest API](https://docs.evcc.io/docs/integrations/rest-api) duration states are in seconds instead of nanoseconds.

Current EVCC implementation still treats them as Nano-Seconds. E.g.:
```
        long chargeDuration = loadpoint.getChargeDuration();
        channel = new ChannelUID(uid, channelGroup, CHANNEL_LOADPOINT_CHARGE_DURATION);
        updateState(channel, new QuantityType<>(chargeDuration, MetricPrefix.NANO(Units.SECOND)));
```

Fixes the following issues:
- https://github.com/openhab/openhab-addons/issues/17485
- https://github.com/openhab/openhab-addons/issues/17432
