### PR TITLE
[automower] fix automower command channels

### DIFF
--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerCommand.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerCommand.java
@@ -25,12 +25,12 @@ import org.openhab.core.thing.ChannelUID;
  */
 @NonNullByDefault
 public enum AutomowerCommand {
-    START("Start", "mower#start"),
-    RESUME_SCHEDULE("ResumeSchedule", "mower#resume_schedule"),
-    PAUSE("Pause", "mower#pause"),
-    PARK("Park", "mower#park"),
-    PARK_UNTIL_NEXT_SCHEDULE("ParkUntilNextSchedule", "mower#park_until_next_schedule"),
-    PARK_UNTIL_FURTHER_NOTICE("ParkUntilFurtherNotice", "mower#park_until_further_notice");
+    START("Start", "start"),
+    RESUME_SCHEDULE("ResumeSchedule", "resume_schedule"),
+    PAUSE("Pause", "pause"),
+    PARK("Park", "park"),
+    PARK_UNTIL_NEXT_SCHEDULE("ParkUntilNextSchedule", "park_until_next_schedule"),
+    PARK_UNTIL_FURTHER_NOTICE("ParkUntilFurtherNotice", "park_until_further_notice");
 
     private static final Map<String, AutomowerCommand> CHANNEL_TO_CMD_MAP = new HashMap<>();
 


### PR DESCRIPTION
# [automower] fix automower command channels

Fixed the problem of non-working automower command channels reported via [automower-missing-channels/122319/4](https://community.openhab.org/t/automower-missing-channels/122319/4).