### PR TITLE
[fmiweather] Add time series support for forecasts

### DIFF
--- a/bundles/org.openhab.binding.fmiweather/README.md
+++ b/bundles/org.openhab.binding.fmiweather/README.md
@@ -28,13 +28,13 @@ The binding automatically discovers weather stations and forecasts for nearby pl
 
 ## Thing Configuration
 
-### `observation` thing configuration
+### `observation` Thing Configuration
 
 | Parameter | Type | Required | Description                                                                                                                                                                                                                                                                                                                                                         | Example                              |
 | --------- | ---- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `fmisid`  | text | ✓        | FMI Station ID. You can FMISID of see all weathers stations at [FMI web site](https://en.ilmatieteenlaitos.fi/observation-stations?p_p_id=stationlistingportlet_WAR_fmiwwwweatherportlets&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&p_p_col_id=column-4&p_p_col_count=1&_stationlistingportlet_WAR_fmiwwwweatherportlets_stationGroup=WEATHER#station-listing) | `"852678"` for Espoo Nuuksio station |
 
-### `forecast` thing configuration
+### `forecast` Thing Configuration
 
 | Parameter  | Type | Required | Description                                                                                          | Example                           |
 | ---------- | ---- | -------- | ---------------------------------------------------------------------------------------------------- | --------------------------------- |
@@ -44,7 +44,7 @@ The binding automatically discovers weather stations and forecasts for nearby pl
 
 Observation and forecast things provide slightly different details on weather.
 
-### `observation` thing channels
+### `observation` Thing Channels
 
 Observation channels are grouped in single group, `current`.
 
@@ -67,11 +67,12 @@ You can check the exact observation time by using the `time` channel.
 
 To refer to certain channel, use the normal convention `THING_ID:GROUP_ID#CHANNEL_ID`, e.g. `fmiweather:observation:station_874863_Espoo_Tapiola:current#temperature`.
 
-### `forecast` thing channels
+### `forecast` Thing Channels
 
 Forecast has multiple channel groups, one for each forecasted time. The groups are named as follows:
 
-- `forecastNow`: Forecasted weather for the current time
+- `forecast`: Forecasted weather (with time series support)
+- `forecastNow`: Forecasted weather for the current time (deprecated, please use `forecast` instead)
 - `forecastHours01`: Forecasted weather for 1 hours from now
 - `forecastHours02`: Forecasted weather for 2 hours from now
 - etc.

--- a/bundles/org.openhab.binding.fmiweather/src/main/java/org/openhab/binding/fmiweather/internal/AbstractWeatherHandler.java
+++ b/bundles/org.openhab.binding.fmiweather/src/main/java/org/openhab/binding/fmiweather/internal/AbstractWeatherHandler.java
@@ -44,6 +44,7 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,13 +211,24 @@ public abstract class AbstractWeatherHandler extends BaseThingHandler {
      */
     protected void updateStateIfLinked(ChannelUID channelUID, @Nullable BigDecimal value, @Nullable Unit<?> unit) {
         if (isLinked(channelUID)) {
-            if (value == null) {
-                updateState(channelUID, UnDefType.UNDEF);
-            } else if (unit == null) {
-                updateState(channelUID, new DecimalType(value));
-            } else {
-                updateState(channelUID, new QuantityType<>(value, unit));
-            }
+            updateState(channelUID, getState(value, unit));
+        }
+    }
+
+    /**
+     * Return QuantityType or DecimalType channel state
+     *
+     * @param value value to update
+     * @param unit unit associated with the value
+     * @return UNDEF state when value is null, otherwise QuantityType or DecimalType
+     */
+    protected State getState(@Nullable BigDecimal value, @Nullable Unit<?> unit) {
+        if (value == null) {
+            return UnDefType.UNDEF;
+        } else if (unit == null) {
+            return new DecimalType(value);
+        } else {
+            return new QuantityType<>(value, unit);
         }
     }
 

--- a/bundles/org.openhab.binding.fmiweather/src/main/java/org/openhab/binding/fmiweather/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.fmiweather/src/main/java/org/openhab/binding/fmiweather/internal/BindingConstants.java
@@ -35,6 +35,9 @@ public class BindingConstants {
     public static final ThingTypeUID THING_TYPE_FORECAST = new ThingTypeUID(BINDING_ID, "forecast");
     public static final ThingUID UID_LOCAL_FORECAST = new ThingUID(BINDING_ID, "forecast", "local");
 
+    // List of all static Channel Group IDs
+    public static final String CHANNEL_GROUP_FORECAST = "forecast";
+
     // List of all Channel ids
     public static final String CHANNEL_TIME = "time";
     public static final String CHANNEL_TEMPERATURE = "temperature";

--- a/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/i18n/fmiweather.properties
+++ b/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/i18n/fmiweather.properties
@@ -7,6 +7,8 @@ addon.fmiweather.description = This is the binding for Finnish Meteorological In
 
 thing-type.fmiweather.forecast.label = FMI Weather Forecast
 thing-type.fmiweather.forecast.description = Finnish Meteorological Institute (FMI) weather forecast
+thing-type.fmiweather.forecast.group.forecast.label = Forecast
+thing-type.fmiweather.forecast.group.forecast.description = This is the weather forecast
 thing-type.fmiweather.forecast.group.forecastHours01.label = 1 Hours Forecast
 thing-type.fmiweather.forecast.group.forecastHours01.description = This is the weather forecast in 1 hours.
 thing-type.fmiweather.forecast.group.forecastHours02.label = 2 Hours Forecast

--- a/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/thing/thing-types.xml
@@ -28,6 +28,10 @@
 		<description>Finnish Meteorological Institute (FMI) weather forecast</description>
 
 		<channel-groups>
+			<channel-group id="forecast" typeId="group-forecast">
+				<label>Forecast</label>
+				<description>This is the weather forecast</description>
+			</channel-group>
 			<channel-group id="forecastNow" typeId="group-forecast">
 				<label>Forecast for the Current Time</label>
 				<description>This is the weather forecast for the current time</description>
@@ -233,6 +237,10 @@
 				<description>This is the weather forecast in 50 hours.</description>
 			</channel-group>
 		</channel-groups>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 
 		<config-description>
 			<parameter name="location" type="text" required="true">

--- a/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.fmiweather/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="fmiweather:forecast">
+
+		<instruction-set targetVersion="1">
+			<add-channel id="time" groupIds="forecast">
+				<type>fmiweather:forecast-time-channel</type>
+			</add-channel>
+			<add-channel id="temperature" groupIds="forecast">
+				<type>fmiweather:temperature-channel</type>
+			</add-channel>
+			<add-channel id="humidity" groupIds="forecast">
+				<type>fmiweather:humidity-channel</type>
+			</add-channel>
+			<add-channel id="wind-direction" groupIds="forecast">
+				<type>fmiweather:wind-direction-channel</type>
+			</add-channel>
+			<add-channel id="wind-speed" groupIds="forecast">
+				<type>fmiweather:wind-speed-channel</type>
+			</add-channel>
+			<add-channel id="wind-gust" groupIds="forecast">
+				<type>fmiweather:wind-gust-channel</type>
+			</add-channel>
+			<add-channel id="pressure" groupIds="forecast">
+				<type>fmiweather:pressure-channel</type>
+			</add-channel>
+			<add-channel id="precipitation-intensity" groupIds="forecast">
+				<type>fmiweather:precipitation-intensity-channel</type>
+			</add-channel>
+			<add-channel id="total-cloud-cover" groupIds="forecast">
+				<type>fmiweather:total-cloud-cover-channel</type>
+			</add-channel>
+			<add-channel id="weather-id" groupIds="forecast">
+				<type>fmiweather:weather-id-channel</type>
+			</add-channel>
+		</instruction-set>
+
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
This introduces a new channel group `forecast` with channels receiving both current and future values (through time series).

See https://community.openhab.org/t/spot-price-optimizer-advanced-algorhitms-to-optimize-heating-charging-of-electric-vehicles-water-boilers-and-more/159539/5

JARs for testing:
- [org.openhab.binding.fmiweather-4.2.3-SNAPSHOT.jar](https://drive.google.com/file/d/1r06S6I5y39bJADQTSX95CBx1gh2nruSC/view?usp=sharing)
- [org.openhab.binding.fmiweather-4.3.0-SNAPSHOT.jar](https://drive.google.com/file/d/1a4xXLUrygSLLkBN3mNFBAoIBcHixscsw/view?usp=sharing)