### PR TITLE
[ipcamera]Fix mjpeg does not work if overridden by user

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -452,7 +452,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetIrLights" + ipCameraHandler.reolinkAuth,
                             "[{\"cmd\": \"SetIrLights\",\"action\": 0,\"param\": {\"IrLights\": {\"channel\": "
                                     + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"state\": \"Off\"}}}]");
-                } else if (OnOffType.ON.equals(command) || command instanceof PercentType percentCommand) {
+                } else if (OnOffType.ON.equals(command) || command instanceof PercentType) {
                     ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetIrLights" + ipCameraHandler.reolinkAuth,
                             "[{\"cmd\": \"SetIrLights\",\"action\": 0,\"param\": {\"IrLights\": {\"channel\": "
                                     + ipCameraHandler.cameraConfig.getNvrChannel() + ",\"state\": \"On\"}}}]");

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -241,7 +241,7 @@ public class IpCameraHandler extends BaseThingHandler {
                             }
                             if (contentType.contains("multipart")) {
                                 boundary = Helper.searchString(contentType, "boundary=");
-                                if (mjpegUri.equals(requestUrl)) {
+                                if (mjpegUri.endsWith(requestUrl)) {
                                     if (msg instanceof HttpMessage) {
                                         // very start of stream only
                                         mjpegContentType = contentType;

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -124,7 +124,7 @@ public class OnvifConnection {
     private String user = "";
     private String password = "";
     private int onvifPort = 80;
-    private String deviceXAddr = "http://" + ipAddress + "/onvif/device_service";
+    public String deviceXAddr = "http://" + ipAddress + "/onvif/device_service";
     private String eventXAddr = "http://" + ipAddress + "/onvif/device_service";
     private String mediaXAddr = "http://" + ipAddress + "/onvif/device_service";
     @SuppressWarnings("unused")


### PR DESCRIPTION
PR does the following:

+ Fixes a major bug that stops mjpeg from getting fetched from a camera if the user enters their own URL. Code strips the IP and port from the requestUrl so it never matches the user entered URL.
+ Minor improvements for Dahua users that were picked up when running tests with a newer camera.
+ Fix minor compiler warnings.

User reported this bug here on the forum
https://community.openhab.org/t/ipcamera-new-ip-camera-binding/42771/2977

Signed-off-by: Matthew Skinner <matt@pcmus.com>