### PR TITLE
[ipcamera]Fix bug where port numbers in a URL stop MJPEG from camera working

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -266,7 +266,7 @@ public class IpCameraHandler extends BaseThingHandler {
                     }
                 }
                 if (msg instanceof HttpContent content) {
-                    if (mjpegUri.equals(requestUrl) && !(content instanceof LastHttpContent)) {
+                    if (mjpegUri.endsWith(requestUrl) && !(content instanceof LastHttpContent)) {
                         // multiple MJPEG stream packets come back as this.
                         byte[] chunkedFrame = new byte[content.content().readableBytes()];
                         content.content().getBytes(content.content().readerIndex(), chunkedFrame);


### PR DESCRIPTION
Fix a bug where `http://192.XXX.YYY.17:80/ISAPI/Streaming/channels/103/httpPreview` this url was getting compared as:
`:80/ISAPI/Streaming/channels/103/httpPreview` to `/ISAPI/Streaming/channels/103/httpPreview`
Change will now allow users to specify a URL containing a port for the cameras MJPEG stream.