### PR TITLE
[aWATTar] include fees in calculation

### DIFF
--- a/bundles/org.openhab.binding.awattar/README.md
+++ b/bundles/org.openhab.binding.awattar/README.md
@@ -36,8 +36,7 @@ Auto discovery is not supported.
 | basePrice  | The net(!) base price you have to pay for every kWh. Optional, but you most probably want to set it based on you delivery contract.                                                                                                                                                                             |
 | timeZone   | The time zone the hour definitions of the things below refer to. Default is `CET`, as it corresponds to the aWATTar API. It is strongly recommended not to change this. However, if you do so, be aware that the prices delivered by the API will not cover a whole calendar day in this timezone. **Advanced** |
 | country    | The country prices should be received for. Use `DE` for Germany or `AT` for Austria. `DE` is the default.                                                                                                                                                                                                       |
-
-Note: The prices include already the 3% and 1.5 €cent per kWh fees for the aWATTar service.
+| serviceFee | The service fee in percent. Will be added to the total price. Will be calculated on top of the absolute price per hour. Default is `0`.                                                                                                                                                                         |
 
 ### Prices Thing
 
@@ -110,7 +109,7 @@ All prices are available in each of the following channel groups:
 awattar.things:
 
 ```java
-Bridge awattar:bridge:bridge1 "aWATTar Bridge" [ country="DE", vatPercent="19", basePrice="17.22"] {
+Bridge awattar:bridge:bridge1 "aWATTar Bridge" [ country="DE", vatPercent="19", basePrice="17.22", serviceFee="3" ] {
  Thing prices price1 "aWATTar Price" []
 // The car should be loaded for 4 hours during the night
  Thing bestprice carloader "Car Loader" [ rangeStart="22", rangeDuration="8", length="4", consecutive="true" ]

--- a/bundles/org.openhab.binding.awattar/README.md
+++ b/bundles/org.openhab.binding.awattar/README.md
@@ -37,6 +37,8 @@ Auto discovery is not supported.
 | timeZone   | The time zone the hour definitions of the things below refer to. Default is `CET`, as it corresponds to the aWATTar API. It is strongly recommended not to change this. However, if you do so, be aware that the prices delivered by the API will not cover a whole calendar day in this timezone. **Advanced** |
 | country    | The country prices should be received for. Use `DE` for Germany or `AT` for Austria. `DE` is the default.                                                                                                                                                                                                       |
 
+Note: The prices include already the 3% and 1.5 €cent per kWh fees for the aWATTar service.
+
 ### Prices Thing
 
 The prices thing does not need any configuration.

--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/AwattarBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/AwattarBridgeConfiguration.java
@@ -23,5 +23,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class AwattarBridgeConfiguration {
     public double basePrice;
     public double vatPercent;
+    public double serviceFee;
     public String country = "";
 }

--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/AwattarPrice.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/AwattarPrice.java
@@ -23,8 +23,8 @@ import org.openhab.binding.awattar.internal.handler.TimeRange;
  *
  * @param netPrice the net price in €/kWh
  * @param grossPrice the gross price in €/kWh
- * @param netTotal the net total price in €
- * @param grossTotal the gross total price in €
+ * @param netTotal the net total price in €/kWh
+ * @param grossTotal the gross total price in €/kWh
  * @param timerange the time range of the price
  */
 @NonNullByDefault

--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/api/AwattarApi.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/api/AwattarApi.java
@@ -57,12 +57,11 @@ public class AwattarApi {
 
     private double vatFactor;
     private double basePrice;
+    private double serviceFee;
 
     private ZoneId zone;
 
     private Gson gson;
-
-    private String country;
 
     /**
      * Generic exception for the aWATTar API.
@@ -84,12 +83,12 @@ public class AwattarApi {
     public AwattarApi(HttpClient httpClient, ZoneId zone, AwattarBridgeConfiguration config) {
         this.zone = zone;
         this.httpClient = httpClient;
-        this.country = config.country;
 
         this.gson = new Gson();
 
         vatFactor = 1 + (config.vatPercent / 100);
         basePrice = config.basePrice;
+        serviceFee = config.serviceFee;
 
         if (config.country.equals("DE")) {
             this.url = URL_DE;
@@ -145,16 +144,10 @@ public class AwattarApi {
                     double grossMarket = netMarket * vatFactor;
                     double netTotal = netMarket + basePrice;
 
-                    // in Austria the fee is added as absolute value
-                    if ("AT".equals(country)) {
-                        // add 3% absolute fee for the aWATTar service (Ausgleichskomponente)
-                        netTotal += Math.abs(netTotal) * 0.03;
-                    } else if ("DE".equals(country)) {
-                        // add 3% fee for the aWATTar service (Ausgleichskomponente)
-                        netTotal = netTotal * 1.03;
+                    // add service fee for the aWATTar service (Ausgleichskomponente)
+                    if (serviceFee > 0) {
+                        netTotal += Math.abs(netTotal) * (serviceFee / 100);
                     }
-
-                    netTotal = netTotal + 1.5; // add 1.5 €/MWh for aWATTar service (Beschaffungskomponente)
 
                     double grossTotal = netTotal * vatFactor;
 

--- a/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/api/AwattarApi.java
+++ b/bundles/org.openhab.binding.awattar/src/main/java/org/openhab/binding/awattar/internal/api/AwattarApi.java
@@ -62,6 +62,8 @@ public class AwattarApi {
 
     private Gson gson;
 
+    private String country;
+
     /**
      * Generic exception for the aWATTar API.
      */
@@ -82,6 +84,7 @@ public class AwattarApi {
     public AwattarApi(HttpClient httpClient, ZoneId zone, AwattarBridgeConfiguration config) {
         this.zone = zone;
         this.httpClient = httpClient;
+        this.country = config.country;
 
         this.gson = new Gson();
 
@@ -141,6 +144,18 @@ public class AwattarApi {
                     double netMarket = d.marketprice / 10.0;
                     double grossMarket = netMarket * vatFactor;
                     double netTotal = netMarket + basePrice;
+
+                    // in Austria the fee is added as absolute value
+                    if ("AT".equals(country)) {
+                        // add 3% absolute fee for the aWATTar service (Ausgleichskomponente)
+                        netTotal += Math.abs(netTotal) * 0.03;
+                    } else if ("DE".equals(country)) {
+                        // add 3% fee for the aWATTar service (Ausgleichskomponente)
+                        netTotal = netTotal * 1.03;
+                    }
+
+                    netTotal = netTotal + 1.5; // add 1.5 €/MWh for aWATTar service (Beschaffungskomponente)
+
                     double grossTotal = netTotal * vatFactor;
 
                     result.add(new AwattarPrice(netMarket, grossMarket, netTotal, grossTotal,

--- a/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/config/config.xml
@@ -24,6 +24,11 @@
 			<description>Specifies the net base price per kWh</description>
 			<default>0</default>
 		</parameter>
+		<parameter name="serviceFee" type="decimal" min="0" max="100">
+			<label>Service Fee</label>
+			<description>Specifies the service fee in percent.</description>
+			<default>0</default>
+		</parameter>
 	</config-description>
 
 	<config-description uri="thing-type:awattar:bestprice">

--- a/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/i18n/awattar.properties
+++ b/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/i18n/awattar.properties
@@ -12,7 +12,7 @@ bridge-type.config.awattar.bridge.basePrice.label = Base price
 bridge-type.config.awattar.bridge.basePrice.description = Specifies the net base price per kWh
 bridge-type.config.awattar.bridge.timeZone.label = Time zone
 bridge-type.config.awattar.bridge.timeZone.description = Time zone to apply to the hour definitions. Default CET aligns to the aWATTar API
-brifge-type.config.awattar.bridge.serviceFee.label = Service fee
+bridge-type.config.awattar.bridge.serviceFee.label = Service fee
 bridge-type.config.awattar.bridge.serviceFee.description = Specifies the service fee in percent
 
 # thing types

--- a/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/i18n/awattar.properties
+++ b/bundles/org.openhab.binding.awattar/src/main/resources/OH-INF/i18n/awattar.properties
@@ -12,6 +12,8 @@ bridge-type.config.awattar.bridge.basePrice.label = Base price
 bridge-type.config.awattar.bridge.basePrice.description = Specifies the net base price per kWh
 bridge-type.config.awattar.bridge.timeZone.label = Time zone
 bridge-type.config.awattar.bridge.timeZone.description = Time zone to apply to the hour definitions. Default CET aligns to the aWATTar API
+brifge-type.config.awattar.bridge.serviceFee.label = Service fee
+bridge-type.config.awattar.bridge.serviceFee.description = Specifies the service fee in percent
 
 # thing types
 thing-type.awattar.prices.label = aWATTar Hourly Prices

--- a/bundles/org.openhab.binding.awattar/src/test/java/org/openhab/binding/awattar/internal/api/AwattarApiTest.java
+++ b/bundles/org.openhab.binding.awattar/src/test/java/org/openhab/binding/awattar/internal/api/AwattarApiTest.java
@@ -92,6 +92,7 @@ class AwattarApiTest extends JavaTest {
 
         config.basePrice = 0.0;
         config.vatPercent = 0.0;
+        config.serviceFee = 0.0;
         config.country = "DE";
 
         api = new AwattarApi(httpClientMock, ZoneId.of("GMT+2"), config);


### PR DESCRIPTION
The current calculations are a bit off and the config is not able to compensate for this.

This MR would include the correct fees for the service directly in the calculation. 

There seems to be a little diverge:
In [DE](https://de.energy-support.tado.com/de/articles/9496158-wie-setzt-sich-der-hourly-tarif-zusammen) the 3% fee seems to be calculated directly from the net price, while in [AT](https://www.awattar.at/tariffs/hourly) the absolute value of the net prices is used to calculate the fee.

Maybe there is another way of reflecting that in config, I'm open for suggestions. 