### PR TITLE
[solarman] Support for LAN Stick Logger LSE-3

### DIFF
--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/SolarmanLoggerConfiguration.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/SolarmanLoggerConfiguration.java
@@ -31,6 +31,7 @@ public class SolarmanLoggerConfiguration {
     public String serialNumber = "";
     public String inverterType = "sg04lp3";
     public int refreshInterval = 30;
+    public boolean rawLanMode = false;
     @Nullable
     public String additionalRequests;
 
@@ -38,12 +39,13 @@ public class SolarmanLoggerConfiguration {
     }
 
     public SolarmanLoggerConfiguration(String hostname, Integer port, String serialNumber, String inverterType,
-            int refreshInterval, @Nullable String additionalRequests) {
+            int refreshInterval, boolean rawLanMode, @Nullable String additionalRequests) {
         this.hostname = hostname;
         this.port = port;
         this.serialNumber = serialNumber;
         this.inverterType = inverterType;
         this.refreshInterval = refreshInterval;
+        this.rawLanMode = rawLanMode;
         this.additionalRequests = additionalRequests;
     }
 
@@ -65,6 +67,10 @@ public class SolarmanLoggerConfiguration {
 
     public int getRefreshInterval() {
         return refreshInterval;
+    }
+
+    public boolean getRawLanMode() {
+        return rawLanMode;
     }
 
     @Nullable

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/SolarmanLoggerHandler.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/SolarmanLoggerHandler.java
@@ -95,11 +95,11 @@ public class SolarmanLoggerHandler extends BaseThingHandler {
                 logger.debug("Found definition for {}", config.inverterType);
             }
         }
-        
+
         if (logger.isDebugEnabled()) {
             logger.debug("Raw Type {}", config.rawLanMode);
         }
-        
+
         ISolarmanProtocol solarmanProtocol = SolarmanProtocolFactory.CreateSolarmanProtocol(config);
 
         String additionalRequests = Objects.requireNonNullElse(config.getAdditionalRequests(), "");
@@ -122,7 +122,7 @@ public class SolarmanLoggerHandler extends BaseThingHandler {
     }
 
     private void queryLoggerAndUpdateState(SolarmanLoggerConnector solarmanLoggerConnector,
-    		ISolarmanProtocol solarmanProtocol, List<Request> mergedRequests,
+            ISolarmanProtocol solarmanProtocol, List<Request> mergedRequests,
             Map<ParameterItem, ChannelUID> paramToChannelMapping, SolarmanChannelUpdater solarmanChannelUpdater) {
         try {
             SolarmanProcessResult solarmanProcessResult = solarmanChannelUpdater.fetchDataFromLogger(mergedRequests,

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/ISolarmanProtocol.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/ISolarmanProtocol.java
@@ -23,6 +23,6 @@ import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
 @NonNullByDefault
 public interface ISolarmanProtocol {
 
-	Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
-			int firstReg, int lastReg) throws SolarmanException;
+    Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
+            int firstReg, int lastReg) throws SolarmanException;
 }

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/ISolarmanProtocol.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/ISolarmanProtocol.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solarman.internal.modbus;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
+
+/**
+ * @author Peter Kretz - Initial contribution
+ */
+@NonNullByDefault
+public interface ISolarmanProtocol {
+
+	Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
+			int firstReg, int lastReg) throws SolarmanException;
+}

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocolFactory.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocolFactory.java
@@ -1,0 +1,24 @@
+package org.openhab.binding.solarman.internal.modbus;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import org.openhab.binding.solarman.internal.SolarmanLoggerConfiguration;
+
+/**
+ * @author Peter Kretz - Added RAW Modbus for LAN Stick
+ */
+@NonNullByDefault
+public class SolarmanProtocolFactory {
+    
+	public static ISolarmanProtocol CreateSolarmanProtocol(SolarmanLoggerConfiguration solarmanLoggerConfiguration)
+    {
+	    if(solarmanLoggerConfiguration.getRawLanMode())
+	    {
+	    	return new SolarmanRawProtocol(solarmanLoggerConfiguration);
+	    }
+	    else
+	    {
+	    	return new SolarmanV5Protocol(solarmanLoggerConfiguration);	
+	    }
+    }
+}

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocolFactory.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocolFactory.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.solarman.internal.modbus;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocolFactory.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanProtocolFactory.java
@@ -1,7 +1,6 @@
 package org.openhab.binding.solarman.internal.modbus;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-
 import org.openhab.binding.solarman.internal.SolarmanLoggerConfiguration;
 
 /**
@@ -9,16 +8,12 @@ import org.openhab.binding.solarman.internal.SolarmanLoggerConfiguration;
  */
 @NonNullByDefault
 public class SolarmanProtocolFactory {
-    
-	public static ISolarmanProtocol CreateSolarmanProtocol(SolarmanLoggerConfiguration solarmanLoggerConfiguration)
-    {
-	    if(solarmanLoggerConfiguration.getRawLanMode())
-	    {
-	    	return new SolarmanRawProtocol(solarmanLoggerConfiguration);
-	    }
-	    else
-	    {
-	    	return new SolarmanV5Protocol(solarmanLoggerConfiguration);	
-	    }
+
+    public static ISolarmanProtocol CreateSolarmanProtocol(SolarmanLoggerConfiguration solarmanLoggerConfiguration) {
+        if (solarmanLoggerConfiguration.getRawLanMode()) {
+            return new SolarmanRawProtocol(solarmanLoggerConfiguration);
+        } else {
+            return new SolarmanV5Protocol(solarmanLoggerConfiguration);
+        }
     }
 }

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocol.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocol.java
@@ -31,24 +31,24 @@ import org.openhab.binding.solarman.internal.modbus.exception.SolarmanProtocolEx
  */
 @NonNullByDefault
 public class SolarmanRawProtocol implements ISolarmanProtocol {
-	private final SolarmanLoggerConfiguration solarmanLoggerConfiguration;
+    private final SolarmanLoggerConfiguration solarmanLoggerConfiguration;
 
     public SolarmanRawProtocol(SolarmanLoggerConfiguration solarmanLoggerConfiguration) {
-    	this.solarmanLoggerConfiguration = solarmanLoggerConfiguration;
+        this.solarmanLoggerConfiguration = solarmanLoggerConfiguration;
     }
 
     public Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
             int firstReg, int lastReg) throws SolarmanException {
-    	byte[] solarmanRawFrame = buildSolarmanRawFrame(mbFunctionCode, firstReg, lastReg);
+        byte[] solarmanRawFrame = buildSolarmanRawFrame(mbFunctionCode, firstReg, lastReg);
         byte[] respFrame = solarmanLoggerConnection.sendRequest(solarmanRawFrame);
         if (respFrame.length > 0) {
             byte[] modbusRespFrame = extractModbusRawResponseFrame(respFrame, solarmanRawFrame);
             return parseRawModbusReadHoldingRegistersResponse(modbusRespFrame, firstReg, lastReg);
         } else {
-        	throw new SolarmanConnectionException("Response frame was empty");
+            throw new SolarmanConnectionException("Response frame was empty");
         }
     }
-    
+
     protected byte[] extractModbusRawResponseFrame(byte @Nullable [] responseFrame, byte[] requestFrame)
             throws SolarmanException {
         if (responseFrame == null || responseFrame.length == 0) {
@@ -61,7 +61,7 @@ public class SolarmanRawProtocol implements ISolarmanProtocol {
 
         return Arrays.copyOfRange(responseFrame, 6, responseFrame.length);
     }
-    
+
     protected Map<Integer, byte[]> parseRawModbusReadHoldingRegistersResponse(byte @Nullable [] frame, int firstReg,
             int lastReg) throws SolarmanProtocolException {
         int regCount = lastReg - firstReg + 1;
@@ -80,20 +80,21 @@ public class SolarmanRawProtocol implements ISolarmanProtocol {
 
         return registers;
     }
-    
+
     /**
      * Builds a SolarMAN Raw frame to request data from firstReg to lastReg.
      * Frame format is based on
      * <a href="https://github.com/StephanJoubert/home_assistant_solarman/issues/247">Solarman RAW Protocol</a>
-     *     Request send: 
-     * Header       03e8: Transaction identifier
-     * Header       0000: Protocol identifier
-     * Header       0006: Message length (w/o CRC)
-     * Payload         01: Slave ID
-     * Payload         03: Read function
-     * Payload      0003: 1st register address
-     * Payload      006e: Nb of registers to read 
-     * Trailer      3426: CRC-16 ModBus
+     * Request send:
+     * Header 03e8: Transaction identifier
+     * Header 0000: Protocol identifier
+     * Header 0006: Message length (w/o CRC)
+     * Payload 01: Slave ID
+     * Payload 03: Read function
+     * Payload 0003: 1st register address
+     * Payload 006e: Nb of registers to read
+     * Trailer 3426: CRC-16 ModBus
+     * 
      * @param mbFunctionCode
      * @param firstReg - the start register
      * @param lastReg - the end register
@@ -102,52 +103,52 @@ public class SolarmanRawProtocol implements ISolarmanProtocol {
     protected byte[] buildSolarmanRawFrame(byte mbFunctionCode, int firstReg, int lastReg) {
         byte[] requestPayload = buildSolarmanRawFrameRequestPayload(mbFunctionCode, firstReg, lastReg);
         byte[] header = buildSolarmanRawFrameHeader(requestPayload.length);
-        
-        return ByteBuffer.allocate(header.length + requestPayload.length).put(header)
-                .put(requestPayload).array();
+
+        return ByteBuffer.allocate(header.length + requestPayload.length).put(header).put(requestPayload).array();
     }
-    
+
     /**
      * Builds a SolarMAN Raw frame Header
      * Frame format is based on
      * <a href="https://github.com/StephanJoubert/home_assistant_solarman/issues/247">Solarman RAW Protocol</a>
-     *     Request send: 
-     * Header       03e8: Transaction identifier
-     * Header       0000: Protocol identifier
-     * Header       0006: Message length (w/o CRC)
+     * Request send:
+     * Header 03e8: Transaction identifier
+     * Header 0000: Protocol identifier
+     * Header 0006: Message length (w/o CRC)
+     * 
      * @param payloadSize th
      * @return byte array containing the Solarman Raw frame header
      */
     private byte[] buildSolarmanRawFrameHeader(int payloadSize) {
         // (two byte) Denotes the start of the Raw frame. Always 0x03 0xE8.
-        byte[] transactionId = new byte[]{(byte) 0x03, (byte) 0xE8};
+        byte[] transactionId = new byte[] { (byte) 0x03, (byte) 0xE8 };
 
         // (two bytes) – Always 0x00 0x00
-        byte[] protocolId = new byte[]{(byte) 0x00, (byte) 0x00};
-        
+        byte[] protocolId = new byte[] { (byte) 0x00, (byte) 0x00 };
+
         // (two bytes) Payload length
-        byte[] messageLength = ByteBuffer.allocate(Short.BYTES).order(ByteOrder.BIG_ENDIAN).putShort((short) payloadSize)
-                .array();
+        byte[] messageLength = ByteBuffer.allocate(Short.BYTES).order(ByteOrder.BIG_ENDIAN)
+                .putShort((short) payloadSize).array();
 
         // Append all fields into the header
-        return ByteBuffer
-                .allocate(transactionId.length + protocolId.length + messageLength.length)
-                .put(transactionId).put(protocolId).put(messageLength).array();
+        return ByteBuffer.allocate(transactionId.length + protocolId.length + messageLength.length).put(transactionId)
+                .put(protocolId).put(messageLength).array();
     }
-    
+
     /**
      * Builds a SolarMAN Raw frame payload
      * Frame format is based on
      * <a href="https://github.com/StephanJoubert/home_assistant_solarman/issues/247">Solarman RAW Protocol</a>
-     *     Request send: 
-     * Payload         01: Slave ID
-     * Payload         03: Read function
-     * Payload      0003: 1st register address
-     * Payload      006e: Nb of registers to read 
-     * Trailer      3426: CRC-16 ModBus
+     * Request send:
+     * Payload 01: Slave ID
+     * Payload 03: Read function
+     * Payload 0003: 1st register address
+     * Payload 006e: Nb of registers to read
+     * Trailer 3426: CRC-16 ModBus
+     * 
      * @param mbFunctionCode
-     * @param firstReg       - the start register
-     * @param lastReg        - the end register
+     * @param firstReg - the start register
+     * @param lastReg - the end register
      * @return byte array containing the Solarman Raw frame payload
      */
     protected byte[] buildSolarmanRawFrameRequestPayload(byte mbFunctionCode, int firstReg, int lastReg) {

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocol.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocol.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solarman.internal.modbus;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.solarman.internal.SolarmanLoggerConfiguration;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanConnectionException;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanProtocolException;
+
+/**
+ * @author Catalin Sanda - Initial contribution
+ * @author Peter Kretz - Added RAW Modbus for LAN Stick
+ */
+@NonNullByDefault
+public class SolarmanRawProtocol implements ISolarmanProtocol {
+	private final SolarmanLoggerConfiguration solarmanLoggerConfiguration;
+
+    public SolarmanRawProtocol(SolarmanLoggerConfiguration solarmanLoggerConfiguration) {
+    	this.solarmanLoggerConfiguration = solarmanLoggerConfiguration;
+    }
+
+    public Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
+            int firstReg, int lastReg) throws SolarmanException {
+    	byte[] solarmanRawFrame = buildSolarmanRawFrame(mbFunctionCode, firstReg, lastReg);
+        byte[] respFrame = solarmanLoggerConnection.sendRequest(solarmanRawFrame);
+        if (respFrame.length > 0) {
+            byte[] modbusRespFrame = extractModbusRawResponseFrame(respFrame, solarmanRawFrame);
+            return parseRawModbusReadHoldingRegistersResponse(modbusRespFrame, firstReg, lastReg);
+        } else {
+        	throw new SolarmanConnectionException("Response frame was empty");
+        }
+    }
+    
+    protected byte[] extractModbusRawResponseFrame(byte @Nullable [] responseFrame, byte[] requestFrame)
+            throws SolarmanException {
+        if (responseFrame == null || responseFrame.length == 0) {
+            throw new SolarmanProtocolException("No response frame");
+        } else if (responseFrame.length < 13) {
+            throw new SolarmanProtocolException("Response frame is too short");
+        } else if (responseFrame[0] != (byte) 0x03) {
+            throw new SolarmanProtocolException("Response frame has invalid starting byte");
+        }
+
+        return Arrays.copyOfRange(responseFrame, 6, responseFrame.length);
+    }
+    
+    protected Map<Integer, byte[]> parseRawModbusReadHoldingRegistersResponse(byte @Nullable [] frame, int firstReg,
+            int lastReg) throws SolarmanProtocolException {
+        int regCount = lastReg - firstReg + 1;
+        Map<Integer, byte[]> registers = new HashMap<>();
+        int expectedFrameDataLen = 2 + 1 + regCount * 2;
+        if (frame == null || frame.length < expectedFrameDataLen) {
+            throw new SolarmanProtocolException("Modbus frame is too short or empty");
+        }
+
+        for (int i = 0; i < regCount; i++) {
+            int p1 = 3 + (i * 2);
+            ByteBuffer order = ByteBuffer.wrap(frame, p1, 2).order(ByteOrder.BIG_ENDIAN);
+            byte[] array = new byte[] { order.get(), order.get() };
+            registers.put(i + firstReg, array);
+        }
+
+        return registers;
+    }
+    
+    /**
+     * Builds a SolarMAN Raw frame to request data from firstReg to lastReg.
+     * Frame format is based on
+     * <a href="https://github.com/StephanJoubert/home_assistant_solarman/issues/247">Solarman RAW Protocol</a>
+     *     Request send: 
+     * Header       03e8: Transaction identifier
+     * Header       0000: Protocol identifier
+     * Header       0006: Message length (w/o CRC)
+     * Payload         01: Slave ID
+     * Payload         03: Read function
+     * Payload      0003: 1st register address
+     * Payload      006e: Nb of registers to read 
+     * Trailer      3426: CRC-16 ModBus
+     * @param mbFunctionCode
+     * @param firstReg - the start register
+     * @param lastReg - the end register
+     * @return byte array containing the Solarman Raw frame
+     */
+    protected byte[] buildSolarmanRawFrame(byte mbFunctionCode, int firstReg, int lastReg) {
+        byte[] requestPayload = buildSolarmanRawFrameRequestPayload(mbFunctionCode, firstReg, lastReg);
+        byte[] header = buildSolarmanRawFrameHeader(requestPayload.length);
+        
+        return ByteBuffer.allocate(header.length + requestPayload.length).put(header)
+                .put(requestPayload).array();
+    }
+    
+    /**
+     * Builds a SolarMAN Raw frame Header
+     * Frame format is based on
+     * <a href="https://github.com/StephanJoubert/home_assistant_solarman/issues/247">Solarman RAW Protocol</a>
+     *     Request send: 
+     * Header       03e8: Transaction identifier
+     * Header       0000: Protocol identifier
+     * Header       0006: Message length (w/o CRC)
+     * @param payloadSize th
+     * @return byte array containing the Solarman Raw frame header
+     */
+    private byte[] buildSolarmanRawFrameHeader(int payloadSize) {
+        // (two byte) Denotes the start of the Raw frame. Always 0x03 0xE8.
+        byte[] transactionId = new byte[]{(byte) 0x03, (byte) 0xE8};
+
+        // (two bytes) – Always 0x00 0x00
+        byte[] protocolId = new byte[]{(byte) 0x00, (byte) 0x00};
+        
+        // (two bytes) Payload length
+        byte[] messageLength = ByteBuffer.allocate(Short.BYTES).order(ByteOrder.BIG_ENDIAN).putShort((short) payloadSize)
+                .array();
+
+        // Append all fields into the header
+        return ByteBuffer
+                .allocate(transactionId.length + protocolId.length + messageLength.length)
+                .put(transactionId).put(protocolId).put(messageLength).array();
+    }
+    
+    /**
+     * Builds a SolarMAN Raw frame payload
+     * Frame format is based on
+     * <a href="https://github.com/StephanJoubert/home_assistant_solarman/issues/247">Solarman RAW Protocol</a>
+     *     Request send: 
+     * Payload         01: Slave ID
+     * Payload         03: Read function
+     * Payload      0003: 1st register address
+     * Payload      006e: Nb of registers to read 
+     * Trailer      3426: CRC-16 ModBus
+     * @param mbFunctionCode
+     * @param firstReg       - the start register
+     * @param lastReg        - the end register
+     * @return byte array containing the Solarman Raw frame payload
+     */
+    protected byte[] buildSolarmanRawFrameRequestPayload(byte mbFunctionCode, int firstReg, int lastReg) {
+        int regCount = lastReg - firstReg + 1;
+        byte[] req = ByteBuffer.allocate(6).put((byte) 0x01).put(mbFunctionCode).putShort((short) firstReg)
+                .putShort((short) regCount).array();
+        byte[] crc = ByteBuffer.allocate(Short.BYTES).order(ByteOrder.LITTLE_ENDIAN)
+                .putShort((short) CRC16Modbus.calculate(req)).array();
+
+        return ByteBuffer.allocate(req.length + crc.length).put(req).put(crc).array();
+    }
+}

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanV5Protocol.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/modbus/SolarmanV5Protocol.java
@@ -30,13 +30,14 @@ import org.openhab.binding.solarman.internal.modbus.exception.SolarmanProtocolEx
  * @author Catalin Sanda - Initial contribution
  */
 @NonNullByDefault
-public class SolarmanV5Protocol {
+public class SolarmanV5Protocol implements ISolarmanProtocol {
     private final SolarmanLoggerConfiguration solarmanLoggerConfiguration;
 
     public SolarmanV5Protocol(SolarmanLoggerConfiguration solarmanLoggerConfiguration) {
         this.solarmanLoggerConfiguration = solarmanLoggerConfiguration;
     }
 
+    @Override
     public Map<Integer, byte[]> readRegisters(SolarmanLoggerConnection solarmanLoggerConnection, byte mbFunctionCode,
             int firstReg, int lastReg) throws SolarmanException {
         byte[] solarmanV5Frame = buildSolarmanV5Frame(mbFunctionCode, firstReg, lastReg);

--- a/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/updater/SolarmanChannelUpdater.java
+++ b/bundles/org.openhab.binding.solarman/src/main/java/org/openhab/binding/solarman/internal/updater/SolarmanChannelUpdater.java
@@ -35,9 +35,9 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.solarman.internal.defmodel.ParameterItem;
 import org.openhab.binding.solarman.internal.defmodel.Request;
+import org.openhab.binding.solarman.internal.modbus.ISolarmanProtocol;
 import org.openhab.binding.solarman.internal.modbus.SolarmanLoggerConnection;
 import org.openhab.binding.solarman.internal.modbus.SolarmanLoggerConnector;
-import org.openhab.binding.solarman.internal.modbus.SolarmanV5Protocol;
 import org.openhab.binding.solarman.internal.modbus.exception.SolarmanConnectionException;
 import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
 import org.openhab.binding.solarman.internal.typeprovider.ChannelUtils;
@@ -64,7 +64,7 @@ public class SolarmanChannelUpdater {
     }
 
     public SolarmanProcessResult fetchDataFromLogger(List<Request> requests,
-            SolarmanLoggerConnector solarmanLoggerConnector, SolarmanV5Protocol solarmanV5Protocol,
+            SolarmanLoggerConnector solarmanLoggerConnector, ISolarmanProtocol solarmanProtocol,
             Map<ParameterItem, ChannelUID> paramToChannelMapping) {
         try (SolarmanLoggerConnection solarmanLoggerConnection = solarmanLoggerConnector.createConnection()) {
             logger.debug("Fetching data from logger");
@@ -77,7 +77,7 @@ public class SolarmanChannelUpdater {
             SolarmanProcessResult solarmanProcessResult = requests.stream().map(request -> {
                 try {
                     return SolarmanProcessResult.ofValue(request,
-                            solarmanV5Protocol.readRegisters(solarmanLoggerConnection,
+                            solarmanProtocol.readRegisters(solarmanLoggerConnection,
                                     (byte) request.getMbFunctioncode().intValue(), request.getStart(),
                                     request.getEnd()));
                 } catch (SolarmanException e) {

--- a/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
@@ -57,12 +57,13 @@
 				<default>60</default>
 				<advanced>true</advanced>
 			</parameter>
-            <parameter name="rawLanMode" type="boolean" required="false">
-                <label>Raw LAN Modbus</label>
-                <description>Use raw Modbus for LAN Stick an V5 for Wifi Stick. Unchecked for Wifi V5 Protocol, Checked for LAN Raw Protocol.</description>
-                <default>false</default>
-                <advanced>true</advanced>
-            </parameter>
+			<parameter name="rawLanMode" type="boolean" required="false">
+				<label>Raw LAN Modbus</label>
+				<description>Use raw Modbus for LAN Stick an V5 for Wifi Stick. Unchecked for Wifi V5 Protocol, Checked for LAN Raw
+					Protocol.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="additionalRequests" type="text" required="false">
 				<label>Additional Requests</label>
 				<description>Additional requests besides the ones defined in the inverter definition.

--- a/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.solarman/src/main/resources/OH-INF/thing/thing-types.xml
@@ -57,6 +57,12 @@
 				<default>60</default>
 				<advanced>true</advanced>
 			</parameter>
+            <parameter name="rawLanMode" type="boolean" required="false">
+                <label>Raw LAN Modbus</label>
+                <description>Use raw Modbus for LAN Stick an V5 for Wifi Stick. Unchecked for Wifi V5 Protocol, Checked for LAN Raw Protocol.</description>
+                <default>false</default>
+                <advanced>true</advanced>
+            </parameter>
 			<parameter name="additionalRequests" type="text" required="false">
 				<label>Additional Requests</label>
 				<description>Additional requests besides the ones defined in the inverter definition.

--- a/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocolTest.java
+++ b/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocolTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.solarman.internal.modbus;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.binding.solarman.internal.SolarmanLoggerConfiguration;
+import org.openhab.binding.solarman.internal.modbus.exception.SolarmanException;
+
+/**
+ * @author Catalin Sanda - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+class SolarmanRawProtocolTest {
+    SolarmanLoggerConnection solarmanLoggerConnection = (@NotNull SolarmanLoggerConnection) mock(
+            SolarmanLoggerConnection.class);
+
+    private SolarmanLoggerConfiguration loggerConfiguration = new SolarmanLoggerConfiguration("192.168.1.1", 8899,
+            "1234567890", "sg04lp3", 60, false, null);
+
+    private SolarmanRawProtocol solarmanRawProtocol = new SolarmanRawProtocol(loggerConfiguration);
+
+    @Test
+    void testbuildSolarmanRawFrame() {
+        byte[] requestFrame = solarmanRawProtocol.buildSolarmanRawFrame((byte) 0x03, 0x0063, 0x006D);
+        byte[] expectedFrame = { (byte) 0x03, (byte) 0xE8, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x08, (byte) 0x01,
+        		(byte) 0x03, (byte) 0x00, (byte) 0x63, (byte) 0x00, (byte) 0x0B, (byte) 0xF4, (byte) 0x13 };
+
+        assertArrayEquals(requestFrame, expectedFrame);
+    }
+
+    @Test
+    void testReadRegister0x01() throws SolarmanException {
+        // given
+        when(solarmanLoggerConnection.sendRequest(any())).thenReturn(
+                hexStringToByteArray("03E800000019010316168016801590012C11940014005A000000050096007D"));
+
+        // when
+        Map<Integer, byte[]> regValues = solarmanRawProtocol.readRegisters(solarmanLoggerConnection, (byte) 0x03, 1, 1);
+
+        // then
+        assertEquals(1, regValues.size());
+        assertTrue(regValues.containsKey(1));
+        assertEquals("1680", bytesToHex(regValues.get(1)));
+    }
+
+    @Test
+    void testReadRegisters0x02to0x03() throws SolarmanException {
+        // given
+        when(solarmanLoggerConnection.sendRequest(any())).thenReturn(
+                hexStringToByteArray("03E800000019010316168016801590012C11940014005A000000050096007D"));
+
+        // when
+        Map<Integer, byte[]> regValues = solarmanRawProtocol.readRegisters(solarmanLoggerConnection, (byte) 0x03, 2, 3);
+
+        // then
+        assertEquals(2, regValues.size());
+        assertTrue(regValues.containsKey(2));
+        assertTrue(regValues.containsKey(3));
+        assertEquals("1680", bytesToHex(regValues.get(2)));
+        assertEquals("1680", bytesToHex(regValues.get(3)));
+    }
+
+    @Test
+    void testReadRegisterSUN10KSG04LP3EUPart1() throws SolarmanException {
+        // given
+        when(solarmanLoggerConnection.sendRequest(any())).thenReturn(hexStringToByteArray(
+                "03E80000005101034E091A08FD092700000000000000020003000000050000138800800037002800A5004A003D000600010003000A00000000000600010003000A0000091B08F6091C006E00500014010E00C9003E0215"));
+
+        // when
+        Map<Integer, byte[]> regValues = solarmanRawProtocol.readRegisters(solarmanLoggerConnection, (byte) 0x03, 0x3c,
+                0x4f);
+
+        // then
+        assertEquals(20, regValues.size());
+        assertTrue(regValues.containsKey(0x3c));
+        assertTrue(regValues.containsKey(0x4f));
+        assertEquals("091A", bytesToHex(regValues.get(0x3c)));
+        assertEquals("0001", bytesToHex(regValues.get(0x4f)));
+    }
+
+    @Test
+    void testReadRegisterSUN10KSG04LP3EUPart2() throws SolarmanException {
+        // given
+        when(solarmanLoggerConnection.sendRequest(any())).thenReturn(hexStringToByteArray(
+                "03E80000005101034E091A08FD092700000000000000020003000000050000138800800037002800A5004A003D000600010003000A00000000000600010003000A0000091B08F6091C006E00500014010E00C9003E0215"));
+
+        // when
+        Map<Integer, byte[]> regValues = solarmanRawProtocol.readRegisters(solarmanLoggerConnection, (byte) 0x03, 0x50,
+                0x5f);
+
+        // then
+        assertEquals(16, regValues.size());
+        assertTrue(regValues.containsKey(0x50));
+        assertTrue(regValues.containsKey(0x5f));
+        assertEquals("091A", bytesToHex(regValues.get(0x50)));
+        assertEquals("00A5", bytesToHex(regValues.get(0x5f)));
+    }
+
+    private static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    @Nullable
+    private static String bytesToHex(byte @Nullable [] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+}

--- a/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocolTest.java
+++ b/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanRawProtocolTest.java
@@ -46,8 +46,9 @@ class SolarmanRawProtocolTest {
     @Test
     void testbuildSolarmanRawFrame() {
         byte[] requestFrame = solarmanRawProtocol.buildSolarmanRawFrame((byte) 0x03, 0x0063, 0x006D);
-        byte[] expectedFrame = { (byte) 0x03, (byte) 0xE8, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x08, (byte) 0x01,
-        		(byte) 0x03, (byte) 0x00, (byte) 0x63, (byte) 0x00, (byte) 0x0B, (byte) 0xF4, (byte) 0x13 };
+        byte[] expectedFrame = { (byte) 0x03, (byte) 0xE8, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x08,
+                (byte) 0x01, (byte) 0x03, (byte) 0x00, (byte) 0x63, (byte) 0x00, (byte) 0x0B, (byte) 0xF4,
+                (byte) 0x13 };
 
         assertArrayEquals(requestFrame, expectedFrame);
     }
@@ -55,8 +56,8 @@ class SolarmanRawProtocolTest {
     @Test
     void testReadRegister0x01() throws SolarmanException {
         // given
-        when(solarmanLoggerConnection.sendRequest(any())).thenReturn(
-                hexStringToByteArray("03E800000019010316168016801590012C11940014005A000000050096007D"));
+        when(solarmanLoggerConnection.sendRequest(any()))
+                .thenReturn(hexStringToByteArray("03E800000019010316168016801590012C11940014005A000000050096007D"));
 
         // when
         Map<Integer, byte[]> regValues = solarmanRawProtocol.readRegisters(solarmanLoggerConnection, (byte) 0x03, 1, 1);
@@ -70,8 +71,8 @@ class SolarmanRawProtocolTest {
     @Test
     void testReadRegisters0x02to0x03() throws SolarmanException {
         // given
-        when(solarmanLoggerConnection.sendRequest(any())).thenReturn(
-                hexStringToByteArray("03E800000019010316168016801590012C11940014005A000000050096007D"));
+        when(solarmanLoggerConnection.sendRequest(any()))
+                .thenReturn(hexStringToByteArray("03E800000019010316168016801590012C11940014005A000000050096007D"));
 
         // when
         Map<Integer, byte[]> regValues = solarmanRawProtocol.readRegisters(solarmanLoggerConnection, (byte) 0x03, 2, 3);

--- a/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanV5ProtocolTest.java
+++ b/bundles/org.openhab.binding.solarman/src/test/java/org/openhab/binding/solarman/internal/modbus/SolarmanV5ProtocolTest.java
@@ -39,7 +39,7 @@ class SolarmanV5ProtocolTest {
             SolarmanLoggerConnection.class);
 
     private SolarmanLoggerConfiguration loggerConfiguration = new SolarmanLoggerConfiguration("192.168.1.1", 8899,
-            "1234567890", "sg04lp3", 60, null);
+            "1234567890", "sg04lp3", 60, false, null);
 
     private SolarmanV5Protocol solarmanV5Protocol = new SolarmanV5Protocol(loggerConfiguration);
 


### PR DESCRIPTION
Added Stick Logger for Solarmen (Ethernet) Model: LSE-3
You can enable it by checking "Raw LAN Modbus" Checkbox
Use raw Modbus for LAN Stick an V5 for Wifi Stick. Unchecked for Wifi V5 Protocol, Checked for LAN Raw Protocol.