### PR TITLE
[emotiva] Fix main zone volume-db channel name

### DIFF
--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaBindingConstants.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaBindingConstants.java
@@ -118,7 +118,7 @@ public class EmotivaBindingConstants {
     public static final String CHANNEL_MODE_SURROUND = "general#mode-surround";
     public static final String CHANNEL_SPEAKER_PRESET = "general#speaker-preset";
     public static final String CHANNEL_MAIN_VOLUME = "main-zone#volume";
-    public static final String CHANNEL_MAIN_VOLUME_DB = "main-zone#volume_db";
+    public static final String CHANNEL_MAIN_VOLUME_DB = "main-zone#volume-db";
     public static final String CHANNEL_LOUDNESS = "general#loudness";
     public static final String CHANNEL_ZONE2_POWER = "zone2#power";
     public static final String CHANNEL_ZONE2_VOLUME = "zone2#volume";


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/17566

As stated in the issue. This was left out when I did some of the last refactoring on the initial PR. I have mostly been using the other volume channel, so did not notice it before now.

Can be backported to 4.2.x.
