### PR TITLE
[mqtt.homeassistant] Avoid improperly delivered triggers

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -173,6 +173,13 @@ public class ChannelState implements MqttMessageSubscriber {
 
         // Is trigger?: Special handling
         if (config.trigger) {
+            try {
+                cachedValue.parseMessage(new StringType(strValue));
+            } catch (IllegalArgumentException e) {
+                // invalid value for this trigger; ignore
+                receivedOrTimeout();
+                return;
+            }
             channelStateUpdateListener.triggerChannel(channelUID, strValue);
             receivedOrTimeout();
             return;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
@@ -238,6 +238,15 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
     }
 
     /**
+     * Assert a channel does not triggers=
+     */
+    protected void assertNotTriggered(AbstractComponent<@NonNull ? extends AbstractChannelConfiguration> component,
+            String channelId, String trigger) {
+        verify(thingHandler, never()).triggerChannel(eq(component.getChannel(channelId).getChannel().getUID()),
+                eq(trigger));
+    }
+
+    /**
      * Assert that given payload was published exact-once on given topic.
      *
      * @param mqttTopic Mqtt topic

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTriggerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTriggerTests.java
@@ -62,6 +62,9 @@ public class DeviceTriggerTests extends AbstractComponentTests {
         spyOnChannelUpdates(component, "action");
         publishMessage("zigbee2mqtt/Charge Now Button/action", "on");
         assertTriggered(component, "action", "on");
+
+        publishMessage("zigbee2mqtt/Charge Now Button/action", "off");
+        assertNotTriggered(component, "action", "off");
     }
 
     @Override


### PR DESCRIPTION
If multiple DeviceTrigger components share a topic, and each has a payload value configured, only messages matching that payload should be delivered to the corresponding channel.

The DeviceTrigger already sets up the TextValue with the appropriate (single) enumeration of allowed value(s). But the mqtt.generic binding processes trigger before any value processing is done. So do the most basic of processing, to make sure the value is pertinent.