### PR TITLE
[lgwebos] Fix representation property

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/WakeOnLanUtility.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/WakeOnLanUtility.java
@@ -47,7 +47,7 @@ public class WakeOnLanUtility {
 
     private static final String COMMAND;
     static {
-        String os = Objects.requireNonNullElse(System.getProperty("os.name"), "");
+        String os = Objects.requireNonNullElse(System.getProperty("os.name"), "").toLowerCase();
         LOGGER.debug("os: {}", os);
         if (os.contains("win")) {
             COMMAND = "arp -a %s";

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/WakeOnLanUtility.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/WakeOnLanUtility.java
@@ -20,6 +20,7 @@ import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.time.Duration;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -46,11 +47,11 @@ public class WakeOnLanUtility {
 
     private static final String COMMAND;
     static {
-        String os = System.getProperty("os.name").toLowerCase();
+        String os = Objects.requireNonNullElse(System.getProperty("os.name"), "");
         LOGGER.debug("os: {}", os);
-        if ((os.contains("win"))) {
+        if (os.contains("win")) {
             COMMAND = "arp -a %s";
-        } else if ((os.contains("mac"))) {
+        } else if (os.contains("mac")) {
             COMMAND = "arp %s";
         } else { // linux
             if (checkIfLinuxCommandExists("arp")) {

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSHandler.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSHandler.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -357,7 +358,8 @@ public class LGWebOSHandler extends BaseThingHandler
         if (job == null || job.isCancelled()) {
             logger.debug("Schedule channel subscription job");
             channelSubscriptionJob = scheduler.schedule(
-                    () -> channelHandlers.get(CHANNEL_CHANNEL).refreshSubscription(CHANNEL_CHANNEL, this),
+                    () -> Objects.requireNonNull(channelHandlers.get(CHANNEL_CHANNEL))
+                            .refreshSubscription(CHANNEL_CHANNEL, this),
                     CHANNEL_SUBSCRIPTION_DELAY_SECONDS, TimeUnit.SECONDS);
         }
     }
@@ -405,6 +407,7 @@ public class LGWebOSHandler extends BaseThingHandler
     }
 
     public List<String> reportChannels() {
-        return ((TVControlChannel) channelHandlers.get(CHANNEL_CHANNEL)).reportChannels(getThing().getUID());
+        return ((TVControlChannel) Objects.requireNonNull(channelHandlers.get(CHANNEL_CHANNEL)))
+                .reportChannels(getThing().getUID());
     }
 }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVKeyboardInput.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVKeyboardInput.java
@@ -35,6 +35,7 @@ package org.openhab.binding.lgwebos.internal.handler;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.lgwebos.internal.handler.command.ServiceCommand;
 import org.openhab.binding.lgwebos.internal.handler.command.ServiceSubscription;
 import org.openhab.binding.lgwebos.internal.handler.core.ResponseListener;
@@ -48,6 +49,8 @@ import com.google.gson.JsonObject;
  * @author Hyun Kook Khang - Connect SDK initial contribution
  * @author Sebastian Prehn - Adoption for openHAB
  */
+
+@NonNullByDefault
 public class LGWebOSTVKeyboardInput {
 
     private LGWebOSTVSocket service;

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -494,7 +494,10 @@ public class LGWebOSTVSocket {
                 map.put(PROPERTY_DEVICE_OS, jsonPayload.get("deviceOS").getAsString());
                 map.put(PROPERTY_DEVICE_OS_VERSION, jsonPayload.get("deviceOSVersion").getAsString());
                 map.put(PROPERTY_DEVICE_OS_RELEASE_VERSION, jsonPayload.get("deviceOSReleaseVersion").getAsString());
+                map.put(PROPERTY_DEVICE_ID, jsonPayload.get("deviceUUID").getAsString());
                 map.put(PROPERTY_LAST_CONNECTED, Instant.now().toString());
+                map.put(PROPERTY_LAST_CONNECTED, Instant.now().toString());
+
                 config.storeProperties(map);
                 sendRegister();
                 break;

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -496,8 +496,6 @@ public class LGWebOSTVSocket {
                 map.put(PROPERTY_DEVICE_OS_RELEASE_VERSION, jsonPayload.get("deviceOSReleaseVersion").getAsString());
                 map.put(PROPERTY_DEVICE_ID, jsonPayload.get("deviceUUID").getAsString());
                 map.put(PROPERTY_LAST_CONNECTED, Instant.now().toString());
-                map.put(PROPERTY_LAST_CONNECTED, Instant.now().toString());
-
                 config.storeProperties(map);
                 sendRegister();
                 break;

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -418,6 +418,10 @@ public class LGWebOSTVSocket {
     @OnWebSocketMessage
     public void onMessage(String message) {
         Response response = GSON.fromJson(message, Response.class);
+        if (response == null) {
+            logger.warn("Received an unexpected null response. Ignoring the response");
+            return;
+        }
         JsonElement payload = response.getPayload();
         JsonObject jsonPayload = payload == null ? null : payload.getAsJsonObject();
         String messageToLog = (jsonPayload != null && jsonPayload.has("client-key")) ? "***" : message;

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/command/ServiceCommand.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/command/ServiceCommand.java
@@ -36,6 +36,7 @@ package org.openhab.binding.lgwebos.internal.handler.command;
 
 import java.util.function.Function;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.lgwebos.internal.handler.core.ResponseListener;
 
@@ -48,6 +49,7 @@ import com.google.gson.JsonObject;
  * @author Hyun Kook Khang - Connect SDK initial contribution
  * @author Sebastian Prehn - Adoption for openHAB
  */
+@NonNullByDefault
 public class ServiceCommand<T> {
 
     protected enum Type {
@@ -56,13 +58,13 @@ public class ServiceCommand<T> {
     }
 
     protected Type type;
-    protected JsonObject payload;
+    protected @Nullable JsonObject payload;
     protected String target;
     protected Function<JsonObject, @Nullable T> converter;
 
     ResponseListener<T> responseListener;
 
-    public ServiceCommand(String targetURL, JsonObject payload, Function<JsonObject, @Nullable T> converter,
+    public ServiceCommand(String targetURL, @Nullable JsonObject payload, Function<JsonObject, @Nullable T> converter,
             ResponseListener<T> listener) {
         this.target = targetURL;
         this.payload = payload;
@@ -71,7 +73,7 @@ public class ServiceCommand<T> {
         this.type = Type.request;
     }
 
-    public JsonElement getPayload() {
+    public @Nullable JsonElement getPayload() {
         return payload;
     }
 
@@ -83,8 +85,10 @@ public class ServiceCommand<T> {
         return target;
     }
 
-    public void processResponse(JsonObject response) {
-        this.getResponseListener().onSuccess(this.converter.apply(response));
+    public void processResponse(@Nullable JsonObject response) {
+        if (response != null) {
+            this.getResponseListener().onSuccess(this.converter.apply(response));
+        }
     }
 
     public void processError(String error) {

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/command/ServiceSubscription.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/command/ServiceSubscription.java
@@ -35,6 +35,7 @@ package org.openhab.binding.lgwebos.internal.handler.command;
 
 import java.util.function.Function;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.lgwebos.internal.handler.core.ResponseListener;
 
@@ -47,9 +48,10 @@ import com.google.gson.JsonObject;
  * @author Hyun Kook Khang - Connect SDK initial contribution
  * @author Sebastian Prehn - Adoption for openHAB
  */
+@NonNullByDefault
 public class ServiceSubscription<T> extends ServiceCommand<T> {
 
-    public ServiceSubscription(String uri, JsonObject payload, Function<JsonObject, @Nullable T> converter,
+    public ServiceSubscription(String uri, @Nullable JsonObject payload, Function<JsonObject, @Nullable T> converter,
             ResponseListener<T> listener) {
         super(uri, payload, converter, listener);
         type = Type.subscribe;


### PR DESCRIPTION
Currently the representation property `deviceId` is only set when the device is added by auto-discovery (managed thing). When the device is configured by a file based configuration the property is not set.

This PR grabs this deviceId a.k.a UUID when performing the `hello` procedure similar to osVersion etc. This prevents the Thing to be added to the inbox while it already exists.

Also fixes some null annotations and compiler warnings while at it.