### PR TITLE
[ipcamera] Fix Reolink does not detect bad user or passwords.

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -173,7 +173,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                         }
                         if (getAbilityResponse[0].value.ability.supportAudioAlarmEnable == null
                                 || getAbilityResponse[0].value.ability.supportAudioAlarmEnable.permit == 0) {
-                            ipCameraHandler.logger.debug("Camera has no AudioAlarm support.");
+                            ipCameraHandler.logger.debug("Camera has no support for controlling AudioAlarms.");
                             channel = ipCameraHandler.getThing().getChannel(CHANNEL_THRESHOLD_AUDIO_ALARM);
                             if (channel != null) {
                                 removeChannels.add(channel);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -89,7 +89,8 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=GetAbility" + ipCameraHandler.reolinkAuth,
                                 "[{ \"cmd\":\"GetAbility\", \"param\":{ \"User\":{ \"userName\":\"admin\" }}}]");
                     } else {
-                        ipCameraHandler.logger.info("Your Reolink camera gave a bad login response:{}", content);
+                        ipCameraHandler.cameraConfigError(
+                                "Check your user and password are correct as the Reolink camera gave a bad login response");
                     }
                     break;
                 case "/api.cgi?cmd=GetAbility": // Used to check what channels the camera supports

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -357,8 +357,8 @@ public class IpCameraHandler extends BaseThingHandler {
                 logger.debug("Camera sent {} bytes when the content-length header was {}.", bytesAlreadyRecieved,
                         bytesToRecieve);
             } else {
-                logger.warn("!!!! Camera possibly closed the channel on the binding, cause reported is: {}",
-                        cause.getMessage());
+                logger.warn("Camera possibly closed the channel on the binding for URL: {}, cause reported is: {}",
+                        requestUrl, cause.getMessage());
             }
             ctx.close();
         }
@@ -386,7 +386,7 @@ public class IpCameraHandler extends BaseThingHandler {
                             return; // don't auto close this as it is for the alarms.
                         }
                     }
-                    logger.debug("Closing an idle channel for camera: {}", cameraConfig.getIp());
+                    logger.debug("Closing an idle channel for {}{}", cameraConfig.getIp(), requestUrl);
                     ctx.close();
                 }
             }

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifCodec.java
@@ -55,14 +55,12 @@ public class OnvifCodec extends ChannelDuplexHandler {
                         break;
                     case 401:
                         if (!response.headers().isEmpty()) {
-                            String authenticate = "";
                             for (CharSequence name : response.headers().names()) {
                                 for (CharSequence value : response.headers().getAll(name)) {
                                     if ("WWW-Authenticate".equalsIgnoreCase(name.toString())) {
-                                        authenticate = value.toString();
                                         logger.debug(
-                                                "ONVIF replied with WWW-Authenticate header:{}, camera may require ONVIF Profile-T support.",
-                                                authenticate);
+                                                "ONVIF {} replied with WWW-Authenticate header:{}, camera may require ONVIF Profile-T support.",
+                                                requestType, value.toString());
                                     }
                                 }
                             }
@@ -93,11 +91,11 @@ public class OnvifCodec extends ChannelDuplexHandler {
         }
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
-            logger.debug("IdleStateEvent received: {}", e.state());
+            logger.debug("IdleStateEvent received for {} : {}", requestType, e.state());
             onvifConnection.setIsConnected(false);
             ctx.close();
         } else {
-            logger.debug("ONVIF netty channel event occurred: {}", evt);
+            logger.debug("ONVIF {} netty channel event occurred: {}", requestType, evt);
         }
     }
 
@@ -106,7 +104,7 @@ public class OnvifCodec extends ChannelDuplexHandler {
         if (ctx == null || cause == null) {
             return;
         }
-        logger.debug("Exception on ONVIF connection: {}", cause.getMessage());
+        logger.debug("Exception on ONVIF {} connection: {}", requestType, cause.getMessage());
         ctx.close();
     }
 

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -700,7 +700,7 @@ public class OnvifConnection {
     public void eventRecieved(String eventMessage) {
         String topic = Helper.fetchXML(eventMessage, "Topic", "tns1:");
         if (topic.isEmpty()) {
-            logger.debug("No ONVIF Events occured in the last 8 seconds");
+            logger.trace("No ONVIF Events occured in the last 8 seconds");
             return;
         }
         String dataName = Helper.fetchXML(eventMessage, "tt:Data", "Name=\"");


### PR DESCRIPTION
Reolink cameras would not tell a user when the wrong user or password was entered, these changes make setup easier.