### PR TITLE
[jdbc] Additional fix for `tableCaseSensitiveItemNames` for PostgreSQL/TimescaleDB 

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcPostgresqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcPostgresqlDAO.java
@@ -264,6 +264,7 @@ public class JdbcPostgresqlDAO extends JdbcBaseDAO {
     @Override
     protected String histItemFilterQueryProvider(FilterCriteria filter, int numberDecimalcount, String table,
             String simpleName, ZoneId timeZone) {
+        table = "\"" + table + "\"";
         logger.debug(
                 "JDBC::getHistItemFilterQueryProvider filter = {}, numberDecimalcount = {}, table = {}, simpleName = {}",
                 filter.toString(), numberDecimalcount, table, simpleName);


### PR DESCRIPTION
# Last change for fix `tableCaseSensitiveItemNames` for PostgreSQL/TimescaleDB 
# Description
I overlooked one table while fixing the following [issue](https://github.com/openhab/openhab-addons/issues/14671). So this pull request is a sequence of an earlier [pull request](https://github.com/openhab/openhab-addons/pull/17587). I hope it's now finally fixed 😅.

For testing I enabled and disabled the setting: `tableCaseSensitiveItemNames`. I restarted the databasse at least once per setting and I can see for both cases the visuals in OpenHAB again. I also looked in the database itself using pgAdmin.