### PR TITLE
[mqtt.homeassistant] Use a single channel for all events from a single button

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentChannel.java
@@ -85,8 +85,12 @@ public class ComponentChannel {
         channelState.setChannelUID(channelUID);
     }
 
+    public void resetConfiguration(Configuration configuration) {
+        channel = ChannelBuilder.create(channel).withConfiguration(configuration).build();
+    }
+
     public void clearConfiguration() {
-        channel = ChannelBuilder.create(channel).withConfiguration(new Configuration()).build();
+        resetConfiguration(new Configuration());
     }
 
     public ChannelState getState() {
@@ -141,6 +145,8 @@ public class ComponentChannel {
 
         private @Nullable String templateIn;
         private @Nullable String templateOut;
+
+        private @Nullable Configuration configuration;
 
         private String format = "%s";
 
@@ -225,6 +231,11 @@ public class ComponentChannel {
             return this;
         }
 
+        public Builder withConfiguration(Configuration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
         // If the component explicitly specifies optimistic, or it's missing a state topic
         // put it in optimistic mode (which, in openHAB parlance, means to auto-update the
         // item).
@@ -286,9 +297,12 @@ public class ComponentChannel {
                 commandDescription = valueState.createCommandDescription().build();
             }
 
-            Configuration configuration = new Configuration();
-            configuration.put("config", component.getChannelConfigurationJson());
-            component.getHaID().toConfig(configuration);
+            Configuration configuration = this.configuration;
+            if (configuration == null) {
+                configuration = new Configuration();
+                configuration.put("config", component.getChannelConfigurationJson());
+                component.getHaID().toConfig(configuration);
+            }
 
             channel = ChannelBuilder.create(channelUID, channelState.getItemType()).withType(channelTypeUID)
                     .withKind(kind).withLabel(label).withConfiguration(configuration)

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/HaID.java
@@ -91,11 +91,11 @@ public class HaID {
 
     private static String createTopic(HaID id) {
         StringBuilder str = new StringBuilder();
-        str.append(id.baseTopic).append('/').append(id.component).append('/');
+        str.append(id.component).append('/');
         if (!id.nodeID.isBlank()) {
             str.append(id.nodeID).append('/');
         }
-        str.append(id.objectID).append('/');
+        str.append(id.objectID);
         return str.toString();
     }
 
@@ -232,7 +232,7 @@ public class HaID {
      * @return fallback group id
      */
     public String getTopic(String suffix) {
-        return topic + suffix;
+        return baseTopic + "/" + topic + "/" + suffix;
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTrigger.java
@@ -12,12 +12,18 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal.component;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
 import org.openhab.binding.mqtt.homeassistant.internal.exception.ConfigurationException;
+import org.openhab.core.config.core.Configuration;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -31,7 +37,7 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
     /**
      * Configuration class for MQTT component
      */
-    static class ChannelConfiguration extends AbstractChannelConfiguration {
+    public static class ChannelConfiguration extends AbstractChannelConfiguration {
         ChannelConfiguration() {
             super("MQTT Device Trigger");
         }
@@ -43,6 +49,14 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
         protected String subtype = "";
 
         protected @Nullable String payload;
+
+        public String getTopic() {
+            return topic;
+        }
+
+        public String getSubtype() {
+            return subtype;
+        }
     }
 
     public DeviceTrigger(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
@@ -58,6 +72,14 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
             throw new ConfigurationException("Component:DeviceTrigger must have a subtype");
         }
 
+        if (newStyleChannels) {
+            // Name the channel after the subtype, not the component ID
+            // So that we only end up with a single channel for all possible events
+            // for a single button (subtype is the button, type is type of press)
+            componentId = channelConfiguration.subtype;
+            groupId = null;
+        }
+
         TextValue value;
         String payload = channelConfiguration.payload;
         if (payload != null) {
@@ -69,6 +91,54 @@ public class DeviceTrigger extends AbstractComponent<DeviceTrigger.ChannelConfig
         buildChannel(channelConfiguration.type, ComponentChannelType.TRIGGER, value, getName(),
                 componentConfiguration.getUpdateListener())
                 .stateTopic(channelConfiguration.topic, channelConfiguration.getValueTemplate()).trigger(true).build();
-        finalizeChannels();
+    }
+
+    /**
+     * Take another DeviceTrigger (presumably whose subtype, topic, and value template match),
+     * and adjust this component's channel to accept the payload that trigger allows.
+     * 
+     * @return if the component was stopped, and thus needs restarted
+     */
+
+    public boolean merge(DeviceTrigger other) {
+        ComponentChannel channel = channels.get(componentId);
+        TextValue value = (TextValue) channel.getState().getCache();
+        Set<String> payloads = value.getStates();
+        // Append objectid/config to channel configuration
+        Configuration currentConfiguration = channel.getChannel().getConfiguration();
+        Configuration newConfiguration = new Configuration();
+        newConfiguration.put("component", currentConfiguration.get("component"));
+        newConfiguration.put("nodeid", currentConfiguration.get("nodeid"));
+        Object objectIdObject = currentConfiguration.get("objectid");
+        if (objectIdObject instanceof String objectIdString) {
+            newConfiguration.put("objectid", List.of(objectIdString, other.getHaID().objectID));
+        } else if (objectIdObject instanceof List<?> objectIdList) {
+            newConfiguration.put("objectid",
+                    Stream.concat(objectIdList.stream(), Stream.of(other.getHaID().objectID)).toList());
+        }
+        Object configObject = currentConfiguration.get("config");
+        if (configObject instanceof String configString) {
+            newConfiguration.put("config", List.of(configString, other.getChannelConfigurationJson()));
+        } else if (configObject instanceof List<?> configList) {
+            newConfiguration.put("config",
+                    Stream.concat(configList.stream(), Stream.of(other.getChannelConfigurationJson())).toList());
+        }
+
+        // Append payload to allowed values
+        String otherPayload = other.getChannelConfiguration().payload;
+        if (payloads == null || otherPayload == null) {
+            // Need to accept anything
+            value = new TextValue();
+        } else {
+            String[] newValues = Stream.concat(payloads.stream(), Stream.of(otherPayload)).toArray(String[]::new);
+            value = new TextValue(newValues);
+        }
+
+        // Recreate the channel
+        stop();
+        buildChannel(channelConfiguration.type, ComponentChannelType.TRIGGER, value, componentId,
+                componentConfiguration.getUpdateListener()).withConfiguration(newConfiguration)
+                .stateTopic(channelConfiguration.topic, channelConfiguration.getValueTemplate()).trigger(true).build();
+        return true;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/config/homeassistant-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/config/homeassistant-channel-config.xml
@@ -15,12 +15,12 @@
 			<description>Optional node name of the component</description>
 			<default></default>
 		</parameter>
-		<parameter name="objectid" type="text" readOnly="true">
+		<parameter name="objectid" type="text" readOnly="true" multiple="true">
 			<label>Object ID</label>
 			<description>Object ID of the component</description>
 			<default></default>
 		</parameter>
-		<parameter name="config" type="text" readOnly="true">
+		<parameter name="config" type="text" readOnly="true" multiple="true">
 			<label>JSON Configuration</label>
 			<description>The JSON configuration string received by the component via MQTT.</description>
 			<default></default>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractHomeAssistantTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractHomeAssistantTests.java
@@ -94,7 +94,7 @@ public abstract class AbstractHomeAssistantTests extends JavaTest {
 
     protected final Bridge bridgeThing = BridgeBuilder.create(BRIDGE_TYPE_UID, BRIDGE_UID).build();
     protected final BrokerHandler bridgeHandler = spy(new BrokerHandler(bridgeThing));
-    protected final Thing haThing = ThingBuilder.create(HA_TYPE_UID, HA_UID).withBridge(BRIDGE_UID).build();
+    protected Thing haThing = ThingBuilder.create(HA_TYPE_UID, HA_UID).withBridge(BRIDGE_UID).build();
     protected final ConcurrentMap<String, Set<MqttMessageSubscriber>> subscriptions = new ConcurrentHashMap<>();
 
     private @Mock @NonNullByDefault({}) TransformationService transformationService1Mock;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
@@ -36,6 +36,7 @@ public class HaIDTests {
         assertThat(subject.objectID, is("name"));
 
         assertThat(subject.component, is("switch"));
+        assertThat(subject.getTopic(), is("switch/name"));
         assertThat(subject.getTopic("suffix"), is("homeassistant/switch/name/suffix"));
 
         Configuration config = new Configuration();
@@ -58,6 +59,7 @@ public class HaIDTests {
         assertThat(subject.objectID, is("name"));
 
         assertThat(subject.component, is("switch"));
+        assertThat(subject.getTopic(), is("switch/node/name"));
         assertThat(subject.getTopic("suffix"), is("homeassistant/switch/node/name/suffix"));
 
         Configuration config = new Configuration();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AbstractComponentTests.java
@@ -80,6 +80,9 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
 
         when(callbackMock.getBridge(eq(BRIDGE_UID))).thenReturn(bridgeThing);
 
+        if (useNewStyleChannels()) {
+            haThing.setProperty("newStyleChannels", "true");
+        }
         thingHandler = new LatchThingHandler(haThing, channelTypeProvider, stateDescriptionProvider,
                 channelTypeRegistry, SUBSCRIBE_TIMEOUT, ATTRIBUTE_RECEIVE_TIMEOUT);
         thingHandler.setConnection(bridgeConnection);
@@ -103,6 +106,13 @@ public abstract class AbstractComponentTests extends AbstractHomeAssistantTests 
      * @return config topics
      */
     protected abstract Set<String> getConfigTopics();
+
+    /**
+     * If new style channels should be used for this test.
+     */
+    protected boolean useNewStyleChannels() {
+        return false;
+    }
 
     /**
      * Process payload to discover and configure component. Topic should be added to {@link #getConfigTopics()}

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTriggerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DeviceTriggerTests.java
@@ -14,12 +14,18 @@ package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannel;
+import org.openhab.core.config.core.Configuration;
 
 /**
  * Tests for {@link DeviceTrigger}
@@ -28,12 +34,13 @@ import org.openhab.binding.mqtt.generic.values.TextValue;
  */
 @NonNullByDefault
 public class DeviceTriggerTests extends AbstractComponentTests {
-    public static final String CONFIG_TOPIC = "device_automation/0x8cf681fffe2fd2a6";
+    public static final String CONFIG_TOPIC_1 = "device_automation/0x8cf681fffe2fd2a6/press";
+    public static final String CONFIG_TOPIC_2 = "device_automation/0x8cf681fffe2fd2a6/release";
 
     @SuppressWarnings("null")
     @Test
     public void test() throws InterruptedException {
-        var component = discoverComponent(configTopicToMqtt(CONFIG_TOPIC), """
+        var component = discoverComponent(configTopicToMqtt(CONFIG_TOPIC_1), """
                 {
                     "automation_type": "trigger",
                     "device": {
@@ -56,19 +63,93 @@ public class DeviceTriggerTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("MQTT Device Trigger"));
 
-        assertChannel(component, "action", "zigbee2mqtt/Charge Now Button/action", "", "MQTT Device Trigger",
+        assertChannel(component, "on", "zigbee2mqtt/Charge Now Button/action", "", "MQTT Device Trigger",
                 TextValue.class);
 
-        spyOnChannelUpdates(component, "action");
+        spyOnChannelUpdates(component, "on");
         publishMessage("zigbee2mqtt/Charge Now Button/action", "on");
-        assertTriggered(component, "action", "on");
+        assertTriggered(component, "on", "on");
 
         publishMessage("zigbee2mqtt/Charge Now Button/action", "off");
-        assertNotTriggered(component, "action", "off");
+        assertNotTriggered(component, "on", "off");
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testMerge() throws InterruptedException {
+        var component1 = (DeviceTrigger) discoverComponent(configTopicToMqtt(CONFIG_TOPIC_1), """
+                {
+                    "automation_type": "trigger",
+                    "device": {
+                        "configuration_url": "#/device/0x8cf681fffe2fd2a6/info",
+                        "identifiers": [
+                            "zigbee2mqtt_0x8cf681fffe2fd2a6"
+                        ],
+                        "manufacturer": "IKEA",
+                        "model": "TRADFRI shortcut button (E1812)",
+                        "name": "Charge Now Button",
+                        "sw_version": "2.3.015"
+                    },
+                    "payload": "press",
+                    "subtype": "turn_on",
+                    "topic": "zigbee2mqtt/Charge Now Button/action",
+                    "type": "button_long_press"
+                }
+                    """);
+        var component2 = (DeviceTrigger) discoverComponent(configTopicToMqtt(CONFIG_TOPIC_2), """
+                {
+                    "automation_type": "trigger",
+                    "device": {
+                        "configuration_url": "#/device/0x8cf681fffe2fd2a6/info",
+                        "identifiers": [
+                            "zigbee2mqtt_0x8cf681fffe2fd2a6"
+                        ],
+                        "manufacturer": "IKEA",
+                        "model": "TRADFRI shortcut button (E1812)",
+                        "name": "Charge Now Button",
+                        "sw_version": "2.3.015"
+                    },
+                    "payload": "release",
+                    "subtype": "turn_on",
+                    "topic": "zigbee2mqtt/Charge Now Button/action",
+                    "type": "button_long_release"
+                }
+                    """);
+
+        assertThat(component1.channels.size(), is(1));
+
+        ComponentChannel channel = Objects.requireNonNull(component1.getChannel("turn_on"));
+        TextValue value = (TextValue) channel.getState().getCache();
+        Set<String> payloads = value.getStates();
+        assertNotNull(payloads);
+        assertThat(payloads.size(), is(2));
+        assertThat(payloads.contains("press"), is(true));
+        assertThat(payloads.contains("release"), is(true));
+        Configuration channelConfig = channel.getChannel().getConfiguration();
+        Object config = channelConfig.get("config");
+        assertNotNull(config);
+        assertThat(config.getClass(), is(ArrayList.class));
+        List<?> configList = (List<?>) config;
+        assertThat(configList.size(), is(2));
+
+        spyOnChannelUpdates(component1, "turn_on");
+        publishMessage("zigbee2mqtt/Charge Now Button/action", "press");
+        assertTriggered(component1, "turn_on", "press");
+
+        publishMessage("zigbee2mqtt/Charge Now Button/action", "release");
+        assertTriggered(component1, "turn_on", "release");
+
+        publishMessage("zigbee2mqtt/Charge Now Button/action", "otherwise");
+        assertNotTriggered(component1, "turn_on", "otherwise");
     }
 
     @Override
     protected Set<String> getConfigTopics() {
-        return Set.of(CONFIG_TOPIC);
+        return Set.of(CONFIG_TOPIC_1, CONFIG_TOPIC_2);
+    }
+
+    @Override
+    protected boolean useNewStyleChannels() {
+        return true;
     }
 }


### PR DESCRIPTION
Use the `subtype` field to collapse multiple DeviceAutomation components into a single channel. this helps immensefuly if you have a device (an Inovelli switch) with 3 buttons (turn on, turn off, config) with 7 events each (hold, release, 1-5x taps)

This involves special casing the "colliding component name" code to merge the components together, rather than renaming them. Then we also have to persist the configuration JSON for each component into a single channel, and support restoring that when initializing the Thing handler.

I wrote new tests for restoring a Thing handler with persisted JSON, which also found an issue in HaID that was calculating topics wrong, causing channels to _all_ disappear on restore, and requiring waiting for new discovery messages to come in to restore the channels. This has been fixed as part of this commit.

And final note, this collapsing only happens under the newStyleChannels flag.
