### PR TITLE
[netatmo] Home properties are not persisted

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
@@ -80,8 +80,8 @@ public class CameraCapability extends HomeSecurityThingCapability {
 
     @Override
     public void initialize() {
-        hasSubEventGroup = !thing.getChannelsOfGroup(GROUP_SUB_EVENT).isEmpty();
-        hasLastEventGroup = !thing.getChannelsOfGroup(GROUP_LAST_EVENT).isEmpty();
+        hasSubEventGroup = !getThing().getChannelsOfGroup(GROUP_SUB_EVENT).isEmpty();
+        hasLastEventGroup = !getThing().getChannelsOfGroup(GROUP_LAST_EVENT).isEmpty();
     }
 
     @Override

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/Capability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/Capability.java
@@ -45,7 +45,6 @@ import org.openhab.core.types.Command;
  */
 @NonNullByDefault
 public class Capability {
-    protected final Thing thing;
     protected final CommonInterface handler;
     protected final ModuleType moduleType;
     protected final ThingUID thingUID;
@@ -56,9 +55,8 @@ public class Capability {
 
     Capability(CommonInterface handler) {
         this.handler = handler;
-        this.thing = handler.getThing();
-        this.thingUID = thing.getUID();
-        this.moduleType = ModuleType.from(thing.getThingTypeUID());
+        this.thingUID = getThing().getUID();
+        this.moduleType = ModuleType.from(getThing().getThingTypeUID());
     }
 
     public final @Nullable String setNewData(NAObject newData) {
@@ -100,13 +98,13 @@ public class Capability {
     }
 
     protected void beforeNewData() {
-        properties = new HashMap<>(thing.getProperties());
+        properties = new HashMap<>(getThing().getProperties());
         statusReason = null;
     }
 
     protected void afterNewData(@Nullable NAObject newData) {
-        if (!properties.equals(thing.getProperties())) {
-            thing.setProperties(properties);
+        if (!properties.equals(getThing().getProperties())) {
+            getThing().setProperties(properties);
         }
         firstLaunch = false;
     }
@@ -176,5 +174,9 @@ public class Capability {
 
     public List<NAObject> updateReadings() {
         return List.of();
+    }
+
+    protected Thing getThing() {
+        return handler.getThing();
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeCapability.java
@@ -27,7 +27,6 @@ import org.openhab.binding.netatmo.internal.api.HomeApi;
 import org.openhab.binding.netatmo.internal.api.NetatmoException;
 import org.openhab.binding.netatmo.internal.api.data.NetatmoConstants.FeatureArea;
 import org.openhab.binding.netatmo.internal.api.dto.HomeData;
-import org.openhab.binding.netatmo.internal.api.dto.Location;
 import org.openhab.binding.netatmo.internal.api.dto.NAError;
 import org.openhab.binding.netatmo.internal.api.dto.NAObject;
 import org.openhab.binding.netatmo.internal.config.HomeConfiguration;
@@ -82,17 +81,22 @@ public class HomeCapability extends CacheCapability<HomeApi> {
             if (featureAreas.contains(FeatureArea.SECURITY)) {
                 handler.getCapabilities().put(new SecurityCapability(handler));
             } else {
-                handler.removeChannels(thing.getChannelsOfGroup(GROUP_SECURITY));
+                handler.removeChannels(getThing().getChannelsOfGroup(GROUP_SECURITY));
             }
             if (featureAreas.contains(FeatureArea.ENERGY)) {
                 handler.getCapabilities().put(new EnergyCapability(handler, descriptionProvider));
             } else {
-                handler.removeChannels(thing.getChannelsOfGroup(GROUP_ENERGY));
+                handler.removeChannels(getThing().getChannelsOfGroup(GROUP_ENERGY));
             }
             home.getCountry().map(country -> properties.put(PROPERTY_COUNTRY, country));
+<<<<<<< Upstream, based on main
             zoneId = home.getZoneId(handler.getSystemTimeZone());
             properties.put(PROPERTY_TIMEZONE, zoneId.toString());
             properties.put(GROUP_LOCATION, ((Location) home).getLocation().toString());
+=======
+            home.getTimezone().map(tz -> properties.put(PROPERTY_TIMEZONE, tz));
+            properties.put(GROUP_LOCATION, home.getLocation().toString());
+>>>>>>> 212eed7 Lazy reading of thing in Capability
             properties.put(PROPERTY_FEATURE,
                     featureAreas.stream().map(FeatureArea::name).collect(Collectors.joining(",")));
         }
@@ -104,8 +108,9 @@ public class HomeCapability extends CacheCapability<HomeApi> {
      */
     @Override
     protected void updateErrors(NAError error) {
-        handler.getAllActiveChildren((Bridge) thing).stream().filter(handler -> handler.getId().equals(error.getId()))
-                .findFirst().ifPresent(handler -> handler.setNewData(error));
+        handler.getAllActiveChildren((Bridge) getThing()).stream()
+                .filter(handler -> handler.getId().equals(error.getId())).findFirst()
+                .ifPresent(handler -> handler.setNewData(error));
     }
 
     @Override

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeCapability.java
@@ -89,14 +89,9 @@ public class HomeCapability extends CacheCapability<HomeApi> {
                 handler.removeChannels(getThing().getChannelsOfGroup(GROUP_ENERGY));
             }
             home.getCountry().map(country -> properties.put(PROPERTY_COUNTRY, country));
-<<<<<<< Upstream, based on main
             zoneId = home.getZoneId(handler.getSystemTimeZone());
             properties.put(PROPERTY_TIMEZONE, zoneId.toString());
-            properties.put(GROUP_LOCATION, ((Location) home).getLocation().toString());
-=======
-            home.getTimezone().map(tz -> properties.put(PROPERTY_TIMEZONE, tz));
             properties.put(GROUP_LOCATION, home.getLocation().toString());
->>>>>>> 212eed7 Lazy reading of thing in Capability
             properties.put(PROPERTY_FEATURE,
                     featureAreas.stream().map(FeatureArea::name).collect(Collectors.joining(",")));
         }


### PR DESCRIPTION
Lazy reading of thing in Capability.

I had a hard time identifying this one. Apparently it's a bad option to store `thing` in the `Capability` - the framework may change it afterward (it's the only explanation I found).

I did not dig further as it solves the issue but it could also be a reason for some ghost scheduled job.

Resolves #17600