### PR TITLE
[mqtt.homeassistant] bring channel ids inline with coding standards

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -48,15 +48,20 @@ import com.google.gson.annotations.SerializedName;
 public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
     public static final String ACTION_CH_ID = "action";
     public static final String AUX_CH_ID = "aux";
-    public static final String AWAY_MODE_CH_ID = "awayMode";
-    public static final String CURRENT_TEMPERATURE_CH_ID = "currentTemperature";
-    public static final String FAN_MODE_CH_ID = "fanMode";
+    public static final String AWAY_MODE_CH_ID = "away-mode";
+    public static final String AWAY_MODE_CH_ID_DEPRECATED = "awayMode";
+    public static final String CURRENT_TEMPERATURE_CH_ID = "current-temperature";
+    public static final String CURRENT_TEMPERATURE_CH_ID_DEPRECATED = "currentTemperature";
+    public static final String FAN_MODE_CH_ID = "fan-mode";
+    public static final String FAN_MODE_CH_ID_DEPRECATED = "fanMode";
     public static final String HOLD_CH_ID = "hold";
     public static final String MODE_CH_ID = "mode";
     public static final String SWING_CH_ID = "swing";
     public static final String TEMPERATURE_CH_ID = "temperature";
-    public static final String TEMPERATURE_HIGH_CH_ID = "temperatureHigh";
-    public static final String TEMPERATURE_LOW_CH_ID = "temperatureLow";
+    public static final String TEMPERATURE_HIGH_CH_ID = "temperature-high";
+    public static final String TEMPERATURE_HIGH_CH_ID_DEPRECATED = "temperatureHigh";
+    public static final String TEMPERATURE_LOW_CH_ID = "temperature-low";
+    public static final String TEMPERATURE_LOW_CH_ID_DEPRECATED = "temperatureLow";
     public static final String POWER_CH_ID = "power";
 
     public enum TemperatureUnit {
@@ -231,16 +236,18 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
                 channelConfiguration.auxCommandTopic, channelConfiguration.auxStateTemplate,
                 channelConfiguration.auxStateTopic, commandFilter);
 
-        buildOptionalChannel(AWAY_MODE_CH_ID, ComponentChannelType.SWITCH, new OnOffValue(), updateListener, null,
+        buildOptionalChannel(newStyleChannels ? AWAY_MODE_CH_ID : AWAY_MODE_CH_ID_DEPRECATED,
+                ComponentChannelType.SWITCH, new OnOffValue(), updateListener, null,
                 channelConfiguration.awayModeCommandTopic, channelConfiguration.awayModeStateTemplate,
                 channelConfiguration.awayModeStateTopic, commandFilter);
 
-        buildOptionalChannel(CURRENT_TEMPERATURE_CH_ID, ComponentChannelType.NUMBER,
+        buildOptionalChannel(newStyleChannels ? CURRENT_TEMPERATURE_CH_ID : CURRENT_TEMPERATURE_CH_ID_DEPRECATED,
+                ComponentChannelType.NUMBER,
                 new NumberValue(null, null, precision, channelConfiguration.temperatureUnit.getUnit()), updateListener,
                 null, null, channelConfiguration.currentTemperatureTemplate,
                 channelConfiguration.currentTemperatureTopic, commandFilter);
 
-        buildOptionalChannel(FAN_MODE_CH_ID, ComponentChannelType.STRING,
+        buildOptionalChannel(newStyleChannels ? FAN_MODE_CH_ID : FAN_MODE_CH_ID_DEPRECATED, ComponentChannelType.STRING,
                 new TextValue(channelConfiguration.fanModes.toArray(new String[0])), updateListener,
                 channelConfiguration.fanModeCommandTemplate, channelConfiguration.fanModeCommandTopic,
                 channelConfiguration.fanModeStateTemplate, channelConfiguration.fanModeStateTopic, commandFilter);
@@ -270,14 +277,16 @@ public class Climate extends AbstractComponent<Climate.ChannelConfiguration> {
                 channelConfiguration.temperatureCommandTopic, channelConfiguration.temperatureStateTemplate,
                 channelConfiguration.temperatureStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_HIGH_CH_ID, ComponentChannelType.NUMBER,
+        buildOptionalChannel(newStyleChannels ? TEMPERATURE_HIGH_CH_ID : TEMPERATURE_HIGH_CH_ID_DEPRECATED,
+                ComponentChannelType.NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureHighCommandTemplate,
                 channelConfiguration.temperatureHighCommandTopic, channelConfiguration.temperatureHighStateTemplate,
                 channelConfiguration.temperatureHighStateTopic, commandFilter);
 
-        buildOptionalChannel(TEMPERATURE_LOW_CH_ID, ComponentChannelType.NUMBER,
+        buildOptionalChannel(newStyleChannels ? TEMPERATURE_LOW_CH_ID : TEMPERATURE_LOW_CH_ID_DEPRECATED,
+                ComponentChannelType.NUMBER,
                 new NumberValue(channelConfiguration.minTemp, channelConfiguration.maxTemp,
                         channelConfiguration.tempStep, channelConfiguration.temperatureUnit.getUnit()),
                 updateListener, channelConfiguration.temperatureLowCommandTemplate,

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLight.java
@@ -63,8 +63,9 @@ public class DefaultSchemaLight extends Light {
     protected void buildChannels() {
         AutoUpdatePolicy autoUpdatePolicy = optimistic ? AutoUpdatePolicy.RECOMMEND : null;
         ComponentChannel localOnOffChannel;
-        localOnOffChannel = onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, ComponentChannelType.SWITCH, onOffValue,
-                "On/Off State", this)
+        localOnOffChannel = onOffChannel = buildChannel(
+                newStyleChannels ? SWITCH_CHANNEL_ID : SWITCH_CHANNEL_ID_DEPRECATED, ComponentChannelType.SWITCH,
+                onOffValue, "On/Off State", this)
                 .stateTopic(channelConfiguration.stateTopic, channelConfiguration.stateValueTemplate)
                 .commandTopic(channelConfiguration.commandTopic, channelConfiguration.isRetain(),
                         channelConfiguration.getQos())
@@ -91,14 +92,15 @@ public class DefaultSchemaLight extends Light {
         }
 
         if (channelConfiguration.colorModeStateTopic != null) {
-            buildChannel(COLOR_MODE_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(), "Current color mode",
-                    this)
+            buildChannel(newStyleChannels ? COLOR_MODE_CHANNEL_ID : COLOR_MODE_CHANNEL_ID_DEPRECATED,
+                    ComponentChannelType.STRING, new TextValue(), "Current color mode", this)
                     .stateTopic(channelConfiguration.colorModeStateTopic, channelConfiguration.colorModeValueTemplate)
                     .inferOptimistic(channelConfiguration.optimistic).build();
         }
 
         if (channelConfiguration.colorTempStateTopic != null || channelConfiguration.colorTempCommandTopic != null) {
-            buildChannel(COLOR_TEMP_CHANNEL_ID, ComponentChannelType.NUMBER, colorTempValue, "Color Temperature", this)
+            buildChannel(newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED,
+                    ComponentChannelType.NUMBER, colorTempValue, "Color Temperature", this)
                     .stateTopic(channelConfiguration.colorTempStateTopic, channelConfiguration.colorTempValueTemplate)
                     .commandTopic(channelConfiguration.colorTempCommandTopic, channelConfiguration.isRetain(),
                             channelConfiguration.getQos())
@@ -178,7 +180,7 @@ public class DefaultSchemaLight extends Light {
             hiddenChannels.add(localOnOffChannel);
             channels.put(BRIGHTNESS_CHANNEL_ID, localBrightnessChannel);
         } else {
-            channels.put(ON_OFF_CHANNEL_ID, localOnOffChannel);
+            channels.put(newStyleChannels ? SWITCH_CHANNEL_ID : SWITCH_CHANNEL_ID_DEPRECATED, localOnOffChannel);
         }
     }
 
@@ -327,7 +329,8 @@ public class DefaultSchemaLight extends Light {
             } else {
                 listener.updateChannelState(primaryChannelUID, state);
             }
-        } else if (id.equals(COLOR_TEMP_CHANNEL_ID) || channel.getIdWithoutGroup().equals(EFFECT_CHANNEL_ID)) {
+        } else if (id.equals(newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED)
+                || channel.getIdWithoutGroup().equals(EFFECT_CHANNEL_ID)) {
             // Real channels; pass through
             listener.updateChannelState(channel, state);
         } else if (id.equals(HS_CHANNEL_ID) || id.equals(XY_CHANNEL_ID)) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Fan.java
@@ -45,7 +45,7 @@ import com.google.gson.annotations.SerializedName;
 public class Fan extends AbstractComponent<Fan.ChannelConfiguration> implements ChannelStateUpdateListener {
     public static final String SWITCH_CHANNEL_ID = "fan";
     public static final String SPEED_CHANNEL_ID = "speed";
-    public static final String PRESET_MODE_CHANNEL_ID = "preset_mode";
+    public static final String PRESET_MODE_CHANNEL_ID = "preset-mode";
     public static final String OSCILLATION_CHANNEL_ID = "oscillation";
     public static final String DIRECTION_CHANNEL_ID = "direction";
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLight.java
@@ -91,15 +91,17 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
             }
 
             if (supportedColorModes.contains(LightColorMode.COLOR_MODE_COLOR_TEMP)) {
-                colorTempChannel = buildChannel(COLOR_TEMP_CHANNEL_ID, ComponentChannelType.NUMBER, colorTempValue,
-                        "Color Temperature", this).commandTopic(DUMMY_TOPIC, true, 1)
-                        .commandFilter(command -> handleColorTempCommand(command))
+                colorTempChannel = buildChannel(
+                        newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED,
+                        ComponentChannelType.NUMBER, colorTempValue, "Color Temperature", this)
+                        .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(command -> handleColorTempCommand(command))
                         .withAutoUpdatePolicy(autoUpdatePolicy).build();
 
                 if (hasColorChannel) {
                     colorModeValue = new TextValue(
                             supportedColorModes.stream().map(LightColorMode::serializedName).toArray(String[]::new));
-                    buildChannel(COLOR_MODE_CHANNEL_ID, ComponentChannelType.STRING, colorModeValue, "Color Mode", this)
+                    buildChannel(newStyleChannels ? COLOR_MODE_CHANNEL_ID : COLOR_MODE_CHANNEL_ID_DEPRECATED,
+                            ComponentChannelType.STRING, colorModeValue, "Color Mode", this)
                             .withAutoUpdatePolicy(autoUpdatePolicy).isAdvanced(true).build();
 
                 }
@@ -115,9 +117,9 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
                     "Brightness", this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand)
                     .withAutoUpdatePolicy(autoUpdatePolicy).build();
         } else {
-            onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, ComponentChannelType.SWITCH, onOffValue, "On/Off State",
-                    this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(this::handleCommand)
-                    .withAutoUpdatePolicy(autoUpdatePolicy).build();
+            onOffChannel = buildChannel(newStyleChannels ? SWITCH_CHANNEL_ID : SWITCH_CHANNEL_ID_DEPRECATED,
+                    ComponentChannelType.SWITCH, onOffValue, "On/Off State", this).commandTopic(DUMMY_TOPIC, true, 1)
+                    .commandFilter(this::handleCommand).withAutoUpdatePolicy(autoUpdatePolicy).build();
         }
 
         if (effectValue != null) {
@@ -312,7 +314,8 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
                         } else {
                             colorTempValue
                                     .update(new QuantityType(Objects.requireNonNull(jsonState.colorTemp), Units.MIRED));
-                            listener.updateChannelState(buildChannelUID(COLOR_TEMP_CHANNEL_ID),
+                            listener.updateChannelState(buildChannelUID(
+                                    newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED),
                                     colorTempValue.getChannelState());
 
                             // Populate the color channel (if there is one) to match the color temperature.
@@ -339,7 +342,8 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
                             if (colorTempChannel != null) {
                                 double kelvin = ColorUtil.xyToKelvin(xy);
                                 colorTempValue.update(new QuantityType(kelvin, Units.KELVIN));
-                                listener.updateChannelState(buildChannelUID(COLOR_TEMP_CHANNEL_ID),
+                                listener.updateChannelState(buildChannelUID(
+                                        newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED),
                                         colorTempValue.getChannelState());
                             }
                         }
@@ -374,7 +378,9 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
                     final double[] xy = ColorUtil.hsbToXY(colorState);
                     double kelvin = ColorUtil.xyToKelvin(new double[] { xy[0], xy[1] });
                     colorTempValue.update(new QuantityType(kelvin, Units.KELVIN));
-                    listener.updateChannelState(buildChannelUID(COLOR_TEMP_CHANNEL_ID),
+                    listener.updateChannelState(
+                            buildChannelUID(
+                                    newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED),
                             colorTempValue.getChannelState());
                 }
 
@@ -383,7 +389,9 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
                 // https://github.com/home-assistant/core/blob/4f965f0eca09f0d12ae1c98c6786054063a36b44/homeassistant/components/mqtt/light/schema_json.py#L258
                 if (jsonState.colorTemp != null) {
                     colorTempValue.update(new QuantityType(Objects.requireNonNull(jsonState.colorTemp), Units.MIRED));
-                    listener.updateChannelState(buildChannelUID(COLOR_TEMP_CHANNEL_ID),
+                    listener.updateChannelState(
+                            buildChannelUID(
+                                    newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED),
                             colorTempValue.getChannelState());
 
                     colorModeValue.update(new StringType(LightColorMode.COLOR_MODE_COLOR_TEMP.serializedName()));
@@ -411,7 +419,9 @@ public class JSONSchemaLight extends AbstractRawSchemaLight {
             logger.warn("Invalid color value for {}", getHaID());
         }
 
-        listener.updateChannelState(buildChannelUID(COLOR_MODE_CHANNEL_ID), colorModeValue.getChannelState());
+        listener.updateChannelState(
+                buildChannelUID(newStyleChannels ? COLOR_MODE_CHANNEL_ID : COLOR_MODE_CHANNEL_ID_DEPRECATED),
+                colorModeValue.getChannelState());
 
         if (localColorChannel != null) {
             listener.updateChannelState(localColorChannel.getChannel().getUID(), colorValue.getChannelState());

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Light.java
@@ -55,10 +55,13 @@ public abstract class Light extends AbstractComponent<Light.ChannelConfiguration
     protected static final String TEMPLATE_SCHEMA = "template";
 
     protected static final String STATE_CHANNEL_ID = "state";
-    protected static final String ON_OFF_CHANNEL_ID = "on_off";
+    protected static final String SWITCH_CHANNEL_ID = "switch";
+    protected static final String SWITCH_CHANNEL_ID_DEPRECATED = "on_off";
     protected static final String BRIGHTNESS_CHANNEL_ID = "brightness";
-    protected static final String COLOR_MODE_CHANNEL_ID = "color_mode";
-    protected static final String COLOR_TEMP_CHANNEL_ID = "color_temp";
+    protected static final String COLOR_MODE_CHANNEL_ID = "color-mode";
+    protected static final String COLOR_MODE_CHANNEL_ID_DEPRECATED = "color_mode";
+    protected static final String COLOR_TEMP_CHANNEL_ID = "color-temp";
+    protected static final String COLOR_TEMP_CHANNEL_ID_DEPRECATED = "color_temp";
     protected static final String EFFECT_CHANNEL_ID = "effect";
     // This channel is a synthetic channel that may send to other channels
     // underneath

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/TemplateSchemaLight.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/TemplateSchemaLight.java
@@ -96,13 +96,14 @@ public class TemplateSchemaLight extends AbstractRawSchemaLight {
                     "Brightness", this).commandTopic(DUMMY_TOPIC, true, 1)
                     .commandFilter(command -> handleCommand(command)).withAutoUpdatePolicy(autoUpdatePolicy).build();
         } else {
-            onOffChannel = buildChannel(ON_OFF_CHANNEL_ID, ComponentChannelType.SWITCH, onOffValue, "On/Off State",
-                    this).commandTopic(DUMMY_TOPIC, true, 1).commandFilter(command -> handleCommand(command))
-                    .withAutoUpdatePolicy(autoUpdatePolicy).build();
+            onOffChannel = buildChannel(newStyleChannels ? SWITCH_CHANNEL_ID : SWITCH_CHANNEL_ID_DEPRECATED,
+                    ComponentChannelType.SWITCH, onOffValue, "On/Off State", this).commandTopic(DUMMY_TOPIC, true, 1)
+                    .commandFilter(command -> handleCommand(command)).withAutoUpdatePolicy(autoUpdatePolicy).build();
         }
 
         if (channelConfiguration.colorTempTemplate != null) {
-            buildChannel(COLOR_TEMP_CHANNEL_ID, ComponentChannelType.NUMBER, colorTempValue, "Color Temperature", this)
+            buildChannel(newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED,
+                    ComponentChannelType.NUMBER, colorTempValue, "Color Temperature", this)
                     .commandTopic(DUMMY_TOPIC, true, 1).commandFilter(command -> handleColorTempCommand(command))
                     .withAutoUpdatePolicy(autoUpdatePolicy).build();
         }
@@ -284,7 +285,9 @@ public class TemplateSchemaLight extends AbstractRawSchemaLight {
             } else {
                 colorTempValue.update(new QuantityType(mireds, Units.MIRED));
             }
-            listener.updateChannelState(buildChannelUID(COLOR_TEMP_CHANNEL_ID), colorTempValue.getChannelState());
+            listener.updateChannelState(
+                    buildChannelUID(newStyleChannels ? COLOR_TEMP_CHANNEL_ID : COLOR_TEMP_CHANNEL_ID_DEPRECATED),
+                    colorTempValue.getChannelState());
         }
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Update.java
@@ -43,7 +43,7 @@ import com.google.gson.annotations.SerializedName;
 @NonNullByDefault
 public class Update extends AbstractComponent<Update.ChannelConfiguration> implements ChannelStateUpdateListener {
     public static final String UPDATE_CHANNEL_ID = "update";
-    public static final String LATEST_VERSION_CHANNEL_ID = "latestVersion";
+    public static final String LATEST_VERSION_CHANNEL_ID = "latest-version";
 
     /**
      * Configuration class for MQTT component

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Vacuum.java
@@ -71,14 +71,18 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
     public static final String STATE_ERROR = "error";
 
     public static final String COMMAND_CH_ID = "command";
-    public static final String FAN_SPEED_CH_ID = "fanSpeed";
-    public static final String CUSTOM_COMMAND_CH_ID = "customCommand";
-    public static final String BATTERY_LEVEL_CH_ID = "batteryLevel";
+    public static final String FAN_SPEED_CH_ID = "fan-speed";
+    public static final String FAN_SPEED_CH_ID_DEPRECATED = "fanSpeed";
+    public static final String CUSTOM_COMMAND_CH_ID = "custom-command";
+    public static final String CUSTOM_COMMAND_CH_ID_DEPRECATED = "customCommand";
+    public static final String BATTERY_LEVEL_CH_ID = "battery-level";
+    public static final String BATTERY_LEVEL_CH_ID_DEPRECATED = "batteryLevel";
     public static final String CHARGING_CH_ID = "charging";
     public static final String CLEANING_CH_ID = "cleaning";
     public static final String DOCKED_CH_ID = "docked";
     public static final String ERROR_CH_ID = "error";
-    public static final String JSON_ATTRIBUTES_CH_ID = "jsonAttributes";
+    public static final String JSON_ATTRIBUTES_CH_ID = "json-attributes";
+    public static final String JSON_ATTRIBUTES_CH_ID_DEPRECATED = "jsonAttributes";
     public static final String STATE_CH_ID = "state";
 
     public static final List<String> LEGACY_DEFAULT_FEATURES = List.of(FEATURE_TURN_ON, FEATURE_TURN_OFF, FEATURE_STOP,
@@ -237,28 +241,33 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             }
             var fanSpeedValue = new TextValue(fanSpeedList.toArray(new String[0]));
             if (channelConfiguration.schema == Schema.LEGACY) {
-                buildOptionalChannel(FAN_SPEED_CH_ID, ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
+                buildOptionalChannel(newStyleChannels ? FAN_SPEED_CH_ID : FAN_SPEED_CH_ID_DEPRECATED,
+                        ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
                         channelConfiguration.setFanSpeedTopic, channelConfiguration.fanSpeedTemplate,
                         channelConfiguration.fanSpeedTopic);
             } else if (deviceSupportedFeatures.contains(FEATURE_STATUS)) {
-                buildOptionalChannel(FAN_SPEED_CH_ID, ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
+                buildOptionalChannel(newStyleChannels ? FAN_SPEED_CH_ID : FAN_SPEED_CH_ID_DEPRECATED,
+                        ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
                         channelConfiguration.setFanSpeedTopic, "{{ value_json.fan_speed }}",
                         channelConfiguration.stateTopic);
             } else {
                 LOGGER.info("Status feature is disabled, unable to get fan speed.");
-                buildOptionalChannel(FAN_SPEED_CH_ID, ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
+                buildOptionalChannel(newStyleChannels ? FAN_SPEED_CH_ID : FAN_SPEED_CH_ID_DEPRECATED,
+                        ComponentChannelType.STRING, fanSpeedValue, updateListener, null,
                         channelConfiguration.setFanSpeedTopic, null, null);
             }
         }
 
         if (deviceSupportedFeatures.contains(FEATURE_SEND_COMMAND)) {
-            buildOptionalChannel(CUSTOM_COMMAND_CH_ID, ComponentChannelType.STRING, new TextValue(), updateListener,
-                    null, channelConfiguration.sendCommandTopic, null, null);
+            buildOptionalChannel(newStyleChannels ? CUSTOM_COMMAND_CH_ID : CUSTOM_COMMAND_CH_ID_DEPRECATED,
+                    ComponentChannelType.STRING, new TextValue(), updateListener, null,
+                    channelConfiguration.sendCommandTopic, null, null);
         }
 
         if (channelConfiguration.schema == Schema.LEGACY) {
             // I assume, that if these topics defined in config, then we don't need to check features
-            buildOptionalChannel(BATTERY_LEVEL_CH_ID, ComponentChannelType.DIMMER,
+            buildOptionalChannel(newStyleChannels ? BATTERY_LEVEL_CH_ID : BATTERY_LEVEL_CH_ID_DEPRECATED,
+                    ComponentChannelType.DIMMER,
                     new PercentageValue(BigDecimal.ZERO, BigDecimal.valueOf(100), BigDecimal.ONE, null, null),
                     updateListener, null, null, channelConfiguration.batteryLevelTemplate,
                     channelConfiguration.batteryLevelTopic);
@@ -280,7 +289,8 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
                                 STATE_RETURNING, STATE_ERROR }),
                         updateListener, null, null, "{{ value_json.state }}", channelConfiguration.stateTopic);
                 if (deviceSupportedFeatures.contains(FEATURE_BATTERY)) {
-                    buildOptionalChannel(BATTERY_LEVEL_CH_ID, ComponentChannelType.DIMMER,
+                    buildOptionalChannel(newStyleChannels ? BATTERY_LEVEL_CH_ID : BATTERY_LEVEL_CH_ID_DEPRECATED,
+                            ComponentChannelType.DIMMER,
                             new PercentageValue(BigDecimal.ZERO, BigDecimal.valueOf(100), BigDecimal.ONE, null, null),
                             updateListener, null, null, "{{ value_json.battery_level }}",
                             channelConfiguration.stateTopic);
@@ -288,8 +298,9 @@ public class Vacuum extends AbstractComponent<Vacuum.ChannelConfiguration> {
             }
         }
 
-        buildOptionalChannel(JSON_ATTRIBUTES_CH_ID, ComponentChannelType.STRING, new TextValue(), updateListener, null,
-                null, channelConfiguration.jsonAttributesTemplate, channelConfiguration.jsonAttributesTopic);
+        buildOptionalChannel(newStyleChannels ? JSON_ATTRIBUTES_CH_ID : JSON_ATTRIBUTES_CH_ID_DEPRECATED,
+                ComponentChannelType.STRING, new TextValue(), updateListener, null, null,
+                channelConfiguration.jsonAttributesTemplate, channelConfiguration.jsonAttributesTopic);
         finalizeChannels();
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/ClimateTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/ClimateTests.java
@@ -74,9 +74,10 @@ public class ClimateTests extends AbstractComponentTests {
         assertThat(component.getName(), is("th1"));
 
         assertChannel(component, Climate.ACTION_CH_ID, "zigbee2mqtt/th1", "", "th1", TextValue.class);
-        assertChannel(component, Climate.AWAY_MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/away_mode", "th1",
-                OnOffValue.class);
-        assertChannel(component, Climate.CURRENT_TEMPERATURE_CH_ID, "zigbee2mqtt/th1", "", "th1", NumberValue.class);
+        assertChannel(component, Climate.AWAY_MODE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/away_mode",
+                "th1", OnOffValue.class);
+        assertChannel(component, Climate.CURRENT_TEMPERATURE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "", "th1",
+                NumberValue.class);
         assertChannel(component, Climate.HOLD_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/preset", "th1",
                 TextValue.class);
         assertChannel(component, Climate.MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/system_mode", "th1",
@@ -90,13 +91,13 @@ public class ClimateTests extends AbstractComponentTests {
                 "current_heating_setpoint": "24"}\
                 """);
         assertState(component, Climate.ACTION_CH_ID, new StringType("off"));
-        assertState(component, Climate.AWAY_MODE_CH_ID, OnOffType.ON);
-        assertState(component, Climate.CURRENT_TEMPERATURE_CH_ID, new QuantityType<>(22.2, SIUnits.CELSIUS));
+        assertState(component, Climate.AWAY_MODE_CH_ID_DEPRECATED, OnOffType.ON);
+        assertState(component, Climate.CURRENT_TEMPERATURE_CH_ID_DEPRECATED, new QuantityType<>(22.2, SIUnits.CELSIUS));
         assertState(component, Climate.HOLD_CH_ID, new StringType("schedule"));
         assertState(component, Climate.MODE_CH_ID, new StringType("heat"));
         assertState(component, Climate.TEMPERATURE_CH_ID, new QuantityType<>(24, SIUnits.CELSIUS));
 
-        component.getChannel(Climate.AWAY_MODE_CH_ID).getState().publishValue(OnOffType.OFF);
+        component.getChannel(Climate.AWAY_MODE_CH_ID_DEPRECATED).getState().publishValue(OnOffType.OFF);
         assertPublished("zigbee2mqtt/th1/set/away_mode", "OFF");
         component.getChannel(Climate.HOLD_CH_ID).getState().publishValue(new StringType("eco"));
         assertPublished("zigbee2mqtt/th1/set/preset", "eco");
@@ -143,9 +144,10 @@ public class ClimateTests extends AbstractComponentTests {
         assertThat(component.getName(), is("th1"));
 
         assertChannel(component, Climate.ACTION_CH_ID, "zigbee2mqtt/th1", "", "th1", TextValue.class);
-        assertChannel(component, Climate.AWAY_MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/away_mode", "th1",
-                OnOffValue.class);
-        assertChannel(component, Climate.CURRENT_TEMPERATURE_CH_ID, "zigbee2mqtt/th1", "", "th1", NumberValue.class);
+        assertChannel(component, Climate.AWAY_MODE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/away_mode",
+                "th1", OnOffValue.class);
+        assertChannel(component, Climate.CURRENT_TEMPERATURE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "", "th1",
+                NumberValue.class);
         assertChannel(component, Climate.HOLD_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/preset", "th1",
                 TextValue.class);
         assertChannel(component, Climate.MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/set/system_mode", "th1",
@@ -159,14 +161,14 @@ public class ClimateTests extends AbstractComponentTests {
                 "current_heating_setpoint": "24"}\
                 """);
         assertState(component, Climate.ACTION_CH_ID, new StringType("off"));
-        assertState(component, Climate.AWAY_MODE_CH_ID, OnOffType.ON);
-        assertState(component, Climate.CURRENT_TEMPERATURE_CH_ID, new QuantityType<>(22.2, SIUnits.CELSIUS));
+        assertState(component, Climate.AWAY_MODE_CH_ID_DEPRECATED, OnOffType.ON);
+        assertState(component, Climate.CURRENT_TEMPERATURE_CH_ID_DEPRECATED, new QuantityType<>(22.2, SIUnits.CELSIUS));
         assertState(component, Climate.HOLD_CH_ID, new StringType("schedule"));
         assertState(component, Climate.MODE_CH_ID, new StringType("heat"));
         assertState(component, Climate.TEMPERATURE_CH_ID, new QuantityType<>(24, SIUnits.CELSIUS));
 
         // Climate is in OFF state
-        component.getChannel(Climate.AWAY_MODE_CH_ID).getState().publishValue(OnOffType.OFF);
+        component.getChannel(Climate.AWAY_MODE_CH_ID_DEPRECATED).getState().publishValue(OnOffType.OFF);
         assertNotPublished("zigbee2mqtt/th1/set/away_mode", "OFF");
         component.getChannel(Climate.HOLD_CH_ID).getState().publishValue(new StringType("eco"));
         assertNotPublished("zigbee2mqtt/th1/set/preset", "eco");
@@ -185,7 +187,7 @@ public class ClimateTests extends AbstractComponentTests {
                 """);
 
         // Climate is in ON state
-        component.getChannel(Climate.AWAY_MODE_CH_ID).getState().publishValue(OnOffType.OFF);
+        component.getChannel(Climate.AWAY_MODE_CH_ID_DEPRECATED).getState().publishValue(OnOffType.OFF);
         assertPublished("zigbee2mqtt/th1/set/away_mode", "OFF");
         component.getChannel(Climate.HOLD_CH_ID).getState().publishValue(new StringType("eco"));
         assertPublished("zigbee2mqtt/th1/set/preset", "eco");
@@ -248,12 +250,12 @@ public class ClimateTests extends AbstractComponentTests {
         assertChannel(component, Climate.ACTION_CH_ID, "zigbee2mqtt/th1", "", "MQTT HVAC", TextValue.class);
         assertChannel(component, Climate.AUX_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/aux", "MQTT HVAC",
                 OnOffValue.class);
-        assertChannel(component, Climate.AWAY_MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/away_mode", "MQTT HVAC",
-                OnOffValue.class);
-        assertChannel(component, Climate.CURRENT_TEMPERATURE_CH_ID, "zigbee2mqtt/th1", "", "MQTT HVAC",
+        assertChannel(component, Climate.AWAY_MODE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "zigbee2mqtt/th1/away_mode",
+                "MQTT HVAC", OnOffValue.class);
+        assertChannel(component, Climate.CURRENT_TEMPERATURE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "", "MQTT HVAC",
                 NumberValue.class);
-        assertChannel(component, Climate.FAN_MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/fan_mode", "MQTT HVAC",
-                TextValue.class);
+        assertChannel(component, Climate.FAN_MODE_CH_ID_DEPRECATED, "zigbee2mqtt/th1", "zigbee2mqtt/th1/fan_mode",
+                "MQTT HVAC", TextValue.class);
         assertChannel(component, Climate.HOLD_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/hold", "MQTT HVAC",
                 TextValue.class);
         assertChannel(component, Climate.MODE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/mode", "MQTT HVAC",
@@ -262,10 +264,10 @@ public class ClimateTests extends AbstractComponentTests {
                 TextValue.class);
         assertChannel(component, Climate.TEMPERATURE_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/temperature",
                 "MQTT HVAC", NumberValue.class);
-        assertChannel(component, Climate.TEMPERATURE_HIGH_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/temperature_high",
-                "MQTT HVAC", NumberValue.class);
-        assertChannel(component, Climate.TEMPERATURE_LOW_CH_ID, "zigbee2mqtt/th1", "zigbee2mqtt/th1/temperature_low",
-                "MQTT HVAC", NumberValue.class);
+        assertChannel(component, Climate.TEMPERATURE_HIGH_CH_ID_DEPRECATED, "zigbee2mqtt/th1",
+                "zigbee2mqtt/th1/temperature_high", "MQTT HVAC", NumberValue.class);
+        assertChannel(component, Climate.TEMPERATURE_LOW_CH_ID_DEPRECATED, "zigbee2mqtt/th1",
+                "zigbee2mqtt/th1/temperature_low", "MQTT HVAC", NumberValue.class);
         assertChannel(component, Climate.POWER_CH_ID, "", "zigbee2mqtt/th1/power", "MQTT HVAC", OnOffValue.class);
 
         publishMessage("zigbee2mqtt/th1", """
@@ -277,21 +279,24 @@ public class ClimateTests extends AbstractComponentTests {
 
         assertState(component, Climate.ACTION_CH_ID, new StringType("fan"));
         assertState(component, Climate.AUX_CH_ID, OnOffType.ON);
-        assertState(component, Climate.AWAY_MODE_CH_ID, OnOffType.OFF);
-        assertState(component, Climate.CURRENT_TEMPERATURE_CH_ID, new QuantityType<>(35.5, ImperialUnits.FAHRENHEIT));
-        assertState(component, Climate.FAN_MODE_CH_ID, new StringType("p2"));
+        assertState(component, Climate.AWAY_MODE_CH_ID_DEPRECATED, OnOffType.OFF);
+        assertState(component, Climate.CURRENT_TEMPERATURE_CH_ID_DEPRECATED,
+                new QuantityType<>(35.5, ImperialUnits.FAHRENHEIT));
+        assertState(component, Climate.FAN_MODE_CH_ID_DEPRECATED, new StringType("p2"));
         assertState(component, Climate.HOLD_CH_ID, new StringType("u2"));
         assertState(component, Climate.MODE_CH_ID, new StringType("B1"));
         assertState(component, Climate.SWING_CH_ID, new StringType("G1"));
         assertState(component, Climate.TEMPERATURE_CH_ID, new QuantityType<>(30, ImperialUnits.FAHRENHEIT));
-        assertState(component, Climate.TEMPERATURE_HIGH_CH_ID, new QuantityType<>(37, ImperialUnits.FAHRENHEIT));
-        assertState(component, Climate.TEMPERATURE_LOW_CH_ID, new QuantityType<>(20, ImperialUnits.FAHRENHEIT));
+        assertState(component, Climate.TEMPERATURE_HIGH_CH_ID_DEPRECATED,
+                new QuantityType<>(37, ImperialUnits.FAHRENHEIT));
+        assertState(component, Climate.TEMPERATURE_LOW_CH_ID_DEPRECATED,
+                new QuantityType<>(20, ImperialUnits.FAHRENHEIT));
 
         component.getChannel(Climate.AUX_CH_ID).getState().publishValue(OnOffType.OFF);
         assertPublished("zigbee2mqtt/th1/aux", "OFF");
-        component.getChannel(Climate.AWAY_MODE_CH_ID).getState().publishValue(OnOffType.ON);
+        component.getChannel(Climate.AWAY_MODE_CH_ID_DEPRECATED).getState().publishValue(OnOffType.ON);
         assertPublished("zigbee2mqtt/th1/away_mode", "ON");
-        component.getChannel(Climate.FAN_MODE_CH_ID).getState().publishValue(new StringType("p1"));
+        component.getChannel(Climate.FAN_MODE_CH_ID_DEPRECATED).getState().publishValue(new StringType("p1"));
         assertPublished("zigbee2mqtt/th1/fan_mode", "fan_mode=p1");
         component.getChannel(Climate.HOLD_CH_ID).getState().publishValue(new StringType("u3"));
         assertPublished("zigbee2mqtt/th1/hold", "hold=u3");
@@ -301,9 +306,9 @@ public class ClimateTests extends AbstractComponentTests {
         assertPublished("zigbee2mqtt/th1/swing", "swing=G2");
         component.getChannel(Climate.TEMPERATURE_CH_ID).getState().publishValue(new DecimalType(30.5));
         assertPublished("zigbee2mqtt/th1/temperature", "temperature=30.5");
-        component.getChannel(Climate.TEMPERATURE_HIGH_CH_ID).getState().publishValue(new DecimalType(39.5));
+        component.getChannel(Climate.TEMPERATURE_HIGH_CH_ID_DEPRECATED).getState().publishValue(new DecimalType(39.5));
         assertPublished("zigbee2mqtt/th1/temperature_high", "temperature_high=39.5");
-        component.getChannel(Climate.TEMPERATURE_LOW_CH_ID).getState().publishValue(new DecimalType(19.5));
+        component.getChannel(Climate.TEMPERATURE_LOW_CH_ID_DEPRECATED).getState().publishValue(new DecimalType(19.5));
         assertPublished("zigbee2mqtt/th1/temperature_low", "temperature_low=19.5");
         component.getChannel(Climate.POWER_CH_ID).getState().publishValue(OnOffType.OFF);
         assertPublished("zigbee2mqtt/th1/power", "OFF");

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/DefaultSchemaLightTests.java
@@ -274,16 +274,16 @@ public class DefaultSchemaLightTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("light"));
 
-        assertChannel(component, Light.ON_OFF_CHANNEL_ID, "zigbee2mqtt/light/state", "zigbee2mqtt/light/set/state",
-                "On/Off State", OnOffValue.class);
+        assertChannel(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, "zigbee2mqtt/light/state",
+                "zigbee2mqtt/light/set/state", "On/Off State", OnOffValue.class);
         assertThat(component.brightnessChannel, is(nullValue()));
 
         publishMessage("zigbee2mqtt/light/state", "{\"power\": \"ON_\"}");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.ON);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.ON);
         publishMessage("zigbee2mqtt/light/state", "{\"power\": \"OFF_\"}");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
 
-        sendCommand(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        sendCommand(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
         assertPublished("zigbee2mqtt/light/set/state", "OFF_");
     }
 
@@ -305,17 +305,17 @@ public class DefaultSchemaLightTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(2));
         assertThat(component.getName(), is("light"));
 
-        assertChannel(component, Light.ON_OFF_CHANNEL_ID, "zigbee2mqtt/light/state", "zigbee2mqtt/light/set/state",
-                "On/Off State", OnOffValue.class);
+        assertChannel(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, "zigbee2mqtt/light/state",
+                "zigbee2mqtt/light/set/state", "On/Off State", OnOffValue.class);
         assertChannel(component, Light.EFFECT_CHANNEL_ID, "zigbee2mqtt/light/effect", "zigbee2mqtt/light/set/effect",
                 "Lighting Effect", TextValue.class);
 
         publishMessage("zigbee2mqtt/light/state", "{\"power\": \"ON\"}");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.ON);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.ON);
         publishMessage("zigbee2mqtt/light/effect", "party");
         assertState(component, Light.EFFECT_CHANNEL_ID, new StringType("party"));
         publishMessage("zigbee2mqtt/light/state", "{\"power\": \"OFF\"}");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
 
         sendCommand(component, Light.EFFECT_CHANNEL_ID, new StringType("rainbow"));
         assertPublished("zigbee2mqtt/light/set/effect", "rainbow");

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/JSONSchemaLightTests.java
@@ -203,16 +203,16 @@ public class JSONSchemaLightTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("light"));
 
-        assertChannel(component, Light.ON_OFF_CHANNEL_ID, "", "dummy", "On/Off State", OnOffValue.class);
+        assertChannel(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, "", "dummy", "On/Off State", OnOffValue.class);
 
         publishMessage("zigbee2mqtt/light/state", "{ \"state\": \"ON\" }");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.ON);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.ON);
         publishMessage("zigbee2mqtt/light/state", "{ \"state\": \"OFF\" }");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
 
-        sendCommand(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        sendCommand(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
         assertPublished("zigbee2mqtt/light/set/state", "{\"state\":\"OFF\"}");
-        sendCommand(component, Light.ON_OFF_CHANNEL_ID, OnOffType.ON);
+        sendCommand(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.ON);
         assertPublished("zigbee2mqtt/light/set/state", "{\"state\":\"ON\"}");
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/TemplateSchemaLightTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/TemplateSchemaLightTests.java
@@ -151,11 +151,12 @@ public class TemplateSchemaLightTests extends AbstractComponentTests {
         assertThat(component.getName(), is("Bulb-white"));
 
         assertChannel(component, Light.BRIGHTNESS_CHANNEL_ID, "", "dummy", "Brightness", PercentageValue.class);
-        assertChannel(component, Light.COLOR_TEMP_CHANNEL_ID, "", "dummy", "Color Temperature", NumberValue.class);
+        assertChannel(component, Light.COLOR_TEMP_CHANNEL_ID_DEPRECATED, "", "dummy", "Color Temperature",
+                NumberValue.class);
 
         publishMessage("shellies/bulb/color/0/status", "{ \"state\": \"on\", \"brightness\": 100 }");
         assertState(component, Light.BRIGHTNESS_CHANNEL_ID, PercentType.HUNDRED);
-        assertState(component, Light.COLOR_TEMP_CHANNEL_ID, UnDefType.NULL);
+        assertState(component, Light.COLOR_TEMP_CHANNEL_ID_DEPRECATED, UnDefType.NULL);
 
         sendCommand(component, Light.BRIGHTNESS_CHANNEL_ID, PercentType.HUNDRED);
         assertPublished("shellies/bulb/color/0/set", "{\"turn\": \"on\", \"mode\": \"white\", \"brightness\": 100}");
@@ -163,7 +164,7 @@ public class TemplateSchemaLightTests extends AbstractComponentTests {
         sendCommand(component, Light.BRIGHTNESS_CHANNEL_ID, OnOffType.OFF);
         assertPublished("shellies/bulb/color/0/set", "{\"turn\":\"off\", \"mode\": \"white\"}");
 
-        sendCommand(component, Light.COLOR_TEMP_CHANNEL_ID, new QuantityType(200, Units.MIRED));
+        sendCommand(component, Light.COLOR_TEMP_CHANNEL_ID_DEPRECATED, new QuantityType(200, Units.MIRED));
         assertPublished("shellies/bulb/color/0/set", "{\"turn\": \"on\", \"mode\": \"white\", \"temp\": 5000}");
     }
 
@@ -184,16 +185,16 @@ public class TemplateSchemaLightTests extends AbstractComponentTests {
         assertThat(component.channels.size(), is(1));
         assertThat(component.getName(), is("light"));
 
-        assertChannel(component, Light.ON_OFF_CHANNEL_ID, "", "dummy", "On/Off State", OnOffValue.class);
+        assertChannel(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, "", "dummy", "On/Off State", OnOffValue.class);
 
         publishMessage("zigbee2mqtt/light/state", "{\"power\": \"on\"}");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.ON);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.ON);
         publishMessage("zigbee2mqtt/light/state", "{\"power\": \"off\"}");
-        assertState(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        assertState(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
 
-        sendCommand(component, Light.ON_OFF_CHANNEL_ID, OnOffType.OFF);
+        sendCommand(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.OFF);
         assertPublished("zigbee2mqtt/light/set/state", "off");
-        sendCommand(component, Light.ON_OFF_CHANNEL_ID, OnOffType.ON);
+        sendCommand(component, Light.SWITCH_CHANNEL_ID_DEPRECATED, OnOffType.ON);
         assertPublished("zigbee2mqtt/light/set/state", "on");
     }
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/VacuumTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/VacuumTests.java
@@ -68,19 +68,19 @@ public class VacuumTests extends AbstractComponentTests {
         assertThat(component.getName(), is("Rockrobo"));
         assertChannel(component, Vacuum.COMMAND_CH_ID, "", "valetudo/rockrobo/command", "Rockrobo", TextValue.class);
         assertChannel(component, Vacuum.STATE_CH_ID, "valetudo/rockrobo/state", "", "Rockrobo", TextValue.class);
-        assertChannel(component, Vacuum.FAN_SPEED_CH_ID, "valetudo/rockrobo/state", "valetudo/rockrobo/set_fan_speed",
+        assertChannel(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, "valetudo/rockrobo/state",
+                "valetudo/rockrobo/set_fan_speed", "Rockrobo", TextValue.class);
+        assertChannel(component, Vacuum.CUSTOM_COMMAND_CH_ID_DEPRECATED, "", "valetudo/rockrobo/custom_command",
                 "Rockrobo", TextValue.class);
-        assertChannel(component, Vacuum.CUSTOM_COMMAND_CH_ID, "", "valetudo/rockrobo/custom_command", "Rockrobo",
-                TextValue.class);
-        assertChannel(component, Vacuum.BATTERY_LEVEL_CH_ID, "valetudo/rockrobo/state", "", "Rockrobo",
+        assertChannel(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, "valetudo/rockrobo/state", "", "Rockrobo",
                 PercentageValue.class);
-        assertChannel(component, Vacuum.JSON_ATTRIBUTES_CH_ID, "valetudo/rockrobo/attributes", "", "Rockrobo",
-                TextValue.class);
+        assertChannel(component, Vacuum.JSON_ATTRIBUTES_CH_ID_DEPRECATED, "valetudo/rockrobo/attributes", "",
+                "Rockrobo", TextValue.class);
 
         assertState(component, Vacuum.STATE_CH_ID, UnDefType.UNDEF);
-        assertState(component, Vacuum.FAN_SPEED_CH_ID, UnDefType.UNDEF);
-        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID, UnDefType.UNDEF);
-        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID, UnDefType.UNDEF);
+        assertState(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, UnDefType.UNDEF);
+        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, UnDefType.UNDEF);
+        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID_DEPRECATED, UnDefType.UNDEF);
 
         // @formatter:off
         String jsonValue;
@@ -126,9 +126,9 @@ public class VacuumTests extends AbstractComponentTests {
         // @formatter:on
 
         assertState(component, Vacuum.STATE_CH_ID, new StringType(Vacuum.STATE_DOCKED));
-        assertState(component, Vacuum.FAN_SPEED_CH_ID, new StringType("max"));
-        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID, new PercentType(100));
-        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID, new StringType(jsonValue));
+        assertState(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, new StringType("max"));
+        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, new PercentType(100));
+        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID_DEPRECATED, new StringType(jsonValue));
 
         component.getChannel(Vacuum.COMMAND_CH_ID).getState().publishValue(new StringType("start"));
         assertPublished("valetudo/rockrobo/command", "start");
@@ -144,11 +144,11 @@ public class VacuumTests extends AbstractComponentTests {
         // @formatter:on
 
         assertState(component, Vacuum.STATE_CH_ID, new StringType(Vacuum.STATE_CLEANING));
-        assertState(component, Vacuum.FAN_SPEED_CH_ID, new StringType("max"));
-        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID, new PercentType(99));
-        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID, new StringType(jsonValue));
+        assertState(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, new StringType("max"));
+        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, new PercentType(99));
+        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID_DEPRECATED, new StringType(jsonValue));
 
-        component.getChannel(Vacuum.FAN_SPEED_CH_ID).getState().publishValue(new StringType("medium"));
+        component.getChannel(Vacuum.FAN_SPEED_CH_ID_DEPRECATED).getState().publishValue(new StringType("medium"));
         assertPublished("valetudo/rockrobo/set_fan_speed", "medium");
 
         // @formatter:off
@@ -162,9 +162,9 @@ public class VacuumTests extends AbstractComponentTests {
         // @formatter:on
 
         assertState(component, Vacuum.STATE_CH_ID, new StringType(Vacuum.STATE_RETURNING));
-        assertState(component, Vacuum.FAN_SPEED_CH_ID, new StringType("medium"));
-        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID, new PercentType(80));
-        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID, new StringType(jsonValue));
+        assertState(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, new StringType("medium"));
+        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, new PercentType(80));
+        assertState(component, Vacuum.JSON_ATTRIBUTES_CH_ID_DEPRECATED, new StringType(jsonValue));
     }
 
     @SuppressWarnings("null")
@@ -208,14 +208,16 @@ public class VacuumTests extends AbstractComponentTests {
         // fan speed, send command
         assertThat(component.getName(), is("Rockrobo"));
         assertChannel(component, Vacuum.COMMAND_CH_ID, "", "vacuum/command", "Rockrobo", TextValue.class);
-        assertChannel(component, Vacuum.BATTERY_LEVEL_CH_ID, "vacuum/state", "", "Rockrobo", PercentageValue.class);
+        assertChannel(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, "vacuum/state", "", "Rockrobo",
+                PercentageValue.class);
         assertChannel(component, Vacuum.CHARGING_CH_ID, "vacuum/state", "", "Rockrobo", OnOffValue.class);
         assertChannel(component, Vacuum.CLEANING_CH_ID, "vacuum/state", "", "Rockrobo", OnOffValue.class);
         assertChannel(component, Vacuum.DOCKED_CH_ID, "vacuum/state", "", "Rockrobo", OnOffValue.class);
         assertChannel(component, Vacuum.ERROR_CH_ID, "vacuum/state", "", "Rockrobo", TextValue.class);
-        assertChannel(component, Vacuum.FAN_SPEED_CH_ID, "vacuum/state", "vacuum/set_fan_speed", "Rockrobo",
+        assertChannel(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, "vacuum/state", "vacuum/set_fan_speed", "Rockrobo",
                 TextValue.class);
-        assertChannel(component, Vacuum.CUSTOM_COMMAND_CH_ID, "", "vacuum/send_command", "Rockrobo", TextValue.class);
+        assertChannel(component, Vacuum.CUSTOM_COMMAND_CH_ID_DEPRECATED, "", "vacuum/send_command", "Rockrobo",
+                TextValue.class);
 
         // @formatter:off
         publishMessage("vacuum/state", """
@@ -230,11 +232,11 @@ public class VacuumTests extends AbstractComponentTests {
                 """);
         // @formatter:on
 
-        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID, new PercentType(61));
+        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, new PercentType(61));
         assertState(component, Vacuum.DOCKED_CH_ID, OnOffType.ON);
         assertState(component, Vacuum.CLEANING_CH_ID, OnOffType.OFF);
         assertState(component, Vacuum.CHARGING_CH_ID, OnOffType.ON);
-        assertState(component, Vacuum.FAN_SPEED_CH_ID, new StringType("off"));
+        assertState(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, new StringType("off"));
         assertState(component, Vacuum.ERROR_CH_ID, new StringType("Error message"));
 
         component.getChannel(Vacuum.COMMAND_CH_ID).getState().publishValue(new StringType("turn_on"));
@@ -253,17 +255,18 @@ public class VacuumTests extends AbstractComponentTests {
                 """);
         // @formatter:on
 
-        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID, new PercentType(55));
+        assertState(component, Vacuum.BATTERY_LEVEL_CH_ID_DEPRECATED, new PercentType(55));
         assertState(component, Vacuum.DOCKED_CH_ID, OnOffType.OFF);
         assertState(component, Vacuum.CLEANING_CH_ID, OnOffType.ON);
         assertState(component, Vacuum.CHARGING_CH_ID, OnOffType.OFF);
-        assertState(component, Vacuum.FAN_SPEED_CH_ID, new StringType("medium"));
+        assertState(component, Vacuum.FAN_SPEED_CH_ID_DEPRECATED, new StringType("medium"));
         assertState(component, Vacuum.ERROR_CH_ID, new StringType(""));
 
-        component.getChannel(Vacuum.FAN_SPEED_CH_ID).getState().publishValue(new StringType("high"));
+        component.getChannel(Vacuum.FAN_SPEED_CH_ID_DEPRECATED).getState().publishValue(new StringType("high"));
         assertPublished("vacuum/set_fan_speed", "high");
 
-        component.getChannel(Vacuum.CUSTOM_COMMAND_CH_ID).getState().publishValue(new StringType("custom_command"));
+        component.getChannel(Vacuum.CUSTOM_COMMAND_CH_ID_DEPRECATED).getState()
+                .publishValue(new StringType("custom_command"));
         assertPublished("vacuum/send_command", "custom_command");
     }
 


### PR DESCRIPTION
but only for newStyleChannels, which is already a breaking change of most channels getting renamed for 4.3 anyway
