### PR TITLE
[mqtt.homeassistant] bring AlarmControlPanel in line with current documentation

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -20,7 +20,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
-import org.openhab.core.thing.type.AutoUpdatePolicy;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -37,7 +36,6 @@ import com.google.gson.annotations.SerializedName;
 public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.ChannelConfiguration> {
     public static final String STATE_CHANNEL_ID = "state";
     public static final String STATE_CHANNEL_ID_DEPRECATED = "alarm";
-    public static final String JSON_ATTRIBUTES_CHANNEL_ID = "json-attributes";
     public static final String SWITCH_DISARM_CHANNEL_ID = "disarm";
     public static final String SWITCH_ARM_HOME_CHANNEL_ID = "armhome";
     public static final String SWITCH_ARM_AWAY_CHANNEL_ID = "armaway";
@@ -93,11 +91,6 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
         @SerializedName("supported_features")
         protected List<String> supportedFeatures = List.of(FEATURE_ARM_HOME, FEATURE_ARM_AWAY, FEATURE_ARM_NIGHT,
                 FEATURE_ARM_VACATION, FEATURE_ARM_CUSTOM_BYPASS, FEATURE_TRIGGER);
-
-        @SerializedName("json_attributes_template")
-        protected @Nullable String jsonAttributesTemplate;
-        @SerializedName("json_attributes_topic")
-        protected @Nullable String jsonAttributesTopic;
     }
 
     public AlarmControlPanel(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
@@ -158,13 +151,6 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
                     new TextValue(new String[] { channelConfiguration.payloadArmAway }), getName(),
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
-        }
-
-        if (channelConfiguration.jsonAttributesTopic != null) {
-            buildChannel(JSON_ATTRIBUTES_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(), "JSON Attributes",
-                    componentConfiguration.getUpdateListener())
-                    .stateTopic(channelConfiguration.jsonAttributesTopic, channelConfiguration.jsonAttributesTemplate)
-                    .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
         }
 
         finalizeChannels();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanel.java
@@ -12,11 +12,15 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal.component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.homeassistant.internal.ComponentChannelType;
 import org.openhab.binding.mqtt.homeassistant.internal.config.dto.AbstractChannelConfiguration;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -31,10 +35,30 @@ import com.google.gson.annotations.SerializedName;
  */
 @NonNullByDefault
 public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.ChannelConfiguration> {
-    public static final String STATE_CHANNEL_ID = "alarm"; // Randomly chosen channel "ID"
-    public static final String SWITCH_DISARM_CHANNEL_ID = "disarm"; // Randomly chosen channel "ID"
-    public static final String SWITCH_ARM_HOME_CHANNEL_ID = "armhome"; // Randomly chosen channel "ID"
-    public static final String SWITCH_ARM_AWAY_CHANNEL_ID = "armaway"; // Randomly chosen channel "ID"
+    public static final String STATE_CHANNEL_ID = "state";
+    public static final String STATE_CHANNEL_ID_DEPRECATED = "alarm";
+    public static final String JSON_ATTRIBUTES_CHANNEL_ID = "json-attributes";
+    public static final String SWITCH_DISARM_CHANNEL_ID = "disarm";
+    public static final String SWITCH_ARM_HOME_CHANNEL_ID = "armhome";
+    public static final String SWITCH_ARM_AWAY_CHANNEL_ID = "armaway";
+
+    public static final String FEATURE_ARM_HOME = "arm_home";
+    public static final String FEATURE_ARM_AWAY = "arm_away";
+    public static final String FEATURE_ARM_NIGHT = "arm_night";
+    public static final String FEATURE_ARM_VACATION = "arm_vacation";
+    public static final String FEATURE_ARM_CUSTOM_BYPASS = "arm_custom_bypass";
+    public static final String FEATURE_TRIGGER = "trigger";
+
+    public static final String STATE_ARMED_AWAY = "armed_away";
+    public static final String STATE_ARMED_CUSTOM_BYPASS = "armed_custom_bypass";
+    public static final String STATE_ARMED_HOME = "armed_home";
+    public static final String STATE_ARMED_NIGHT = "armed_night";
+    public static final String STATE_ARMED_VACATION = "armed_vacation";
+    public static final String STATE_ARMING = "arming";
+    public static final String STATE_DISARMED = "disarmed";
+    public static final String STATE_DISARMING = "disarming";
+    public static final String STATE_PENDING = "pending";
+    public static final String STATE_TRIGGERED = "triggered";
 
     /**
      * Configuration class for MQTT component
@@ -48,40 +72,78 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
 
         @SerializedName("state_topic")
         protected String stateTopic = "";
-        @SerializedName("state_disarmed")
-        protected String stateDisarmed = "disarmed";
-        @SerializedName("state_armed_home")
-        protected String stateArmedHome = "armed_home";
-        @SerializedName("state_armed_away")
-        protected String stateArmedAway = "armed_away";
-        @SerializedName("state_pending")
-        protected String statePending = "pending";
-        @SerializedName("state_triggered")
-        protected String stateTriggered = "triggered";
 
         @SerializedName("command_topic")
         protected @Nullable String commandTopic;
-        @SerializedName("payload_disarm")
-        protected String payloadDisarm = "DISARM";
-        @SerializedName("payload_arm_home")
-        protected String payloadArmHome = "ARM_HOME";
         @SerializedName("payload_arm_away")
         protected String payloadArmAway = "ARM_AWAY";
+        @SerializedName("payload_arm_home")
+        protected String payloadArmHome = "ARM_HOME";
+        @SerializedName("payload_arm_night")
+        protected String payloadArmNight = "ARM_NIGHT";
+        @SerializedName("payload_arm_vacation")
+        protected String payloadArmVacation = "ARM_VACATION";
+        @SerializedName("payload_arm_custom_bypass")
+        protected String payloadArmCustomBypass = "ARM_CUSTOM_BYPASS";
+        @SerializedName("payload_disarm")
+        protected String payloadDisarm = "DISARM";
+        @SerializedName("payload_trigger")
+        protected String payloadTrigger = "TRIGGER";
+
+        @SerializedName("supported_features")
+        protected List<String> supportedFeatures = List.of(FEATURE_ARM_HOME, FEATURE_ARM_AWAY, FEATURE_ARM_NIGHT,
+                FEATURE_ARM_VACATION, FEATURE_ARM_CUSTOM_BYPASS, FEATURE_TRIGGER);
+
+        @SerializedName("json_attributes_template")
+        protected @Nullable String jsonAttributesTemplate;
+        @SerializedName("json_attributes_topic")
+        protected @Nullable String jsonAttributesTopic;
     }
 
     public AlarmControlPanel(ComponentFactory.ComponentConfiguration componentConfiguration, boolean newStyleChannels) {
         super(componentConfiguration, ChannelConfiguration.class, newStyleChannels);
 
-        final String[] stateEnum = { channelConfiguration.stateDisarmed, channelConfiguration.stateArmedHome,
-                channelConfiguration.stateArmedAway, channelConfiguration.statePending,
-                channelConfiguration.stateTriggered };
-        buildChannel(STATE_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(stateEnum), getName(),
-                componentConfiguration.getUpdateListener())
-                .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate())//
-                .build();
+        List<String> stateEnum = new ArrayList(List.of(STATE_DISARMED, STATE_TRIGGERED, STATE_ARMING, STATE_DISARMING,
+                STATE_PENDING, STATE_TRIGGERED));
+        List<String> commandEnum = new ArrayList(List.of(channelConfiguration.payloadDisarm));
+        if (channelConfiguration.supportedFeatures.contains(FEATURE_ARM_HOME)) {
+            stateEnum.add(STATE_ARMED_HOME);
+            commandEnum.add(channelConfiguration.payloadArmHome);
+        }
+        if (channelConfiguration.supportedFeatures.contains(FEATURE_ARM_AWAY)) {
+            stateEnum.add(STATE_ARMED_AWAY);
+            commandEnum.add(channelConfiguration.payloadArmAway);
+        }
+        if (channelConfiguration.supportedFeatures.contains(FEATURE_ARM_NIGHT)) {
+            stateEnum.add(STATE_ARMED_NIGHT);
+            commandEnum.add(channelConfiguration.payloadArmNight);
+        }
+        if (channelConfiguration.supportedFeatures.contains(FEATURE_ARM_VACATION)) {
+            stateEnum.add(STATE_ARMED_VACATION);
+            commandEnum.add(channelConfiguration.payloadArmVacation);
+        }
+        if (channelConfiguration.supportedFeatures.contains(FEATURE_ARM_CUSTOM_BYPASS)) {
+            stateEnum.add(STATE_ARMED_CUSTOM_BYPASS);
+            commandEnum.add(channelConfiguration.payloadArmCustomBypass);
+        }
+        if (channelConfiguration.supportedFeatures.contains(FEATURE_TRIGGER)) {
+            commandEnum.add(channelConfiguration.payloadTrigger);
+        }
 
         String commandTopic = channelConfiguration.commandTopic;
-        if (commandTopic != null) {
+        TextValue value = (newStyleChannels && commandTopic != null)
+                ? new TextValue(stateEnum.toArray(new String[0]), commandEnum.toArray(new String[0]))
+                : new TextValue(stateEnum.toArray(new String[0]));
+        var builder = buildChannel(newStyleChannels ? STATE_CHANNEL_ID : STATE_CHANNEL_ID_DEPRECATED,
+                ComponentChannelType.STRING, value, getName(), componentConfiguration.getUpdateListener())
+                .stateTopic(channelConfiguration.stateTopic, channelConfiguration.getValueTemplate());
+
+        if (newStyleChannels && commandTopic != null) {
+            builder.commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos());
+        }
+        builder.build();
+
+        if (!newStyleChannels && commandTopic != null) {
             buildChannel(SWITCH_DISARM_CHANNEL_ID, ComponentChannelType.STRING,
                     new TextValue(new String[] { channelConfiguration.payloadDisarm }), getName(),
                     componentConfiguration.getUpdateListener())
@@ -97,6 +159,14 @@ public class AlarmControlPanel extends AbstractComponent<AlarmControlPanel.Chann
                     componentConfiguration.getUpdateListener())
                     .commandTopic(commandTopic, channelConfiguration.isRetain(), channelConfiguration.getQos()).build();
         }
+
+        if (channelConfiguration.jsonAttributesTopic != null) {
+            buildChannel(JSON_ATTRIBUTES_CHANNEL_ID, ComponentChannelType.STRING, new TextValue(), "JSON Attributes",
+                    componentConfiguration.getUpdateListener())
+                    .stateTopic(channelConfiguration.jsonAttributesTopic, channelConfiguration.jsonAttributesTemplate)
+                    .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+        }
+
         finalizeChannels();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanelDeprecatedTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/AlarmControlPanelDeprecatedTests.java
@@ -28,7 +28,7 @@ import org.openhab.core.library.types.StringType;
  * @author Anton Kharuzhy - Initial contribution
  */
 @NonNullByDefault
-public class AlarmControlPanelTests extends AbstractComponentTests {
+public class AlarmControlPanelDeprecatedTests extends AbstractComponentTests {
     public static final String CONFIG_TOPIC = "alarm_control_panel/0x0000000000000000_alarm_control_panel_zigbee2mqtt";
 
     @SuppressWarnings("null")
@@ -65,32 +65,36 @@ public class AlarmControlPanelTests extends AbstractComponentTests {
                 """);
         // @formatter:on
 
-        assertThat(component.channels.size(), is(1));
+        assertThat(component.channels.size(), is(4));
         assertThat(component.getName(), is("alarm"));
 
-        assertChannel(component, AlarmControlPanel.STATE_CHANNEL_ID, "zigbee2mqtt/alarm/state",
-                "zigbee2mqtt/alarm/set/state", "alarm", TextValue.class);
+        assertChannel(component, AlarmControlPanel.STATE_CHANNEL_ID_DEPRECATED, "zigbee2mqtt/alarm/state", "", "alarm",
+                TextValue.class);
+        assertChannel(component, AlarmControlPanel.SWITCH_DISARM_CHANNEL_ID, "", "zigbee2mqtt/alarm/set/state", "alarm",
+                TextValue.class);
+        assertChannel(component, AlarmControlPanel.SWITCH_ARM_AWAY_CHANNEL_ID, "", "zigbee2mqtt/alarm/set/state",
+                "alarm", TextValue.class);
+        assertChannel(component, AlarmControlPanel.SWITCH_ARM_HOME_CHANNEL_ID, "", "zigbee2mqtt/alarm/set/state",
+                "alarm", TextValue.class);
 
         publishMessage("zigbee2mqtt/alarm/state", "armed_home");
-        assertState(component, AlarmControlPanel.STATE_CHANNEL_ID, new StringType("armed_home"));
+        assertState(component, AlarmControlPanel.STATE_CHANNEL_ID_DEPRECATED, new StringType("armed_home"));
         publishMessage("zigbee2mqtt/alarm/state", "armed_away");
-        assertState(component, AlarmControlPanel.STATE_CHANNEL_ID, new StringType("armed_away"));
+        assertState(component, AlarmControlPanel.STATE_CHANNEL_ID_DEPRECATED, new StringType("armed_away"));
 
-        component.getChannel(AlarmControlPanel.STATE_CHANNEL_ID).getState().publishValue(new StringType("DISARM_"));
+        component.getChannel(AlarmControlPanel.SWITCH_DISARM_CHANNEL_ID).getState()
+                .publishValue(new StringType("DISARM_"));
         assertPublished("zigbee2mqtt/alarm/set/state", "DISARM_");
-        component.getChannel(AlarmControlPanel.STATE_CHANNEL_ID).getState().publishValue(new StringType("ARM_AWAY_"));
+        component.getChannel(AlarmControlPanel.SWITCH_ARM_AWAY_CHANNEL_ID).getState()
+                .publishValue(new StringType("ARM_AWAY_"));
         assertPublished("zigbee2mqtt/alarm/set/state", "ARM_AWAY_");
-        component.getChannel(AlarmControlPanel.STATE_CHANNEL_ID).getState().publishValue(new StringType("ARM_HOME_"));
+        component.getChannel(AlarmControlPanel.SWITCH_ARM_HOME_CHANNEL_ID).getState()
+                .publishValue(new StringType("ARM_HOME_"));
         assertPublished("zigbee2mqtt/alarm/set/state", "ARM_HOME_");
     }
 
     @Override
     protected Set<String> getConfigTopics() {
         return Set.of(CONFIG_TOPIC);
-    }
-
-    @Override
-    protected boolean useNewStyleChannels() {
-        return true;
     }
 }


### PR DESCRIPTION
 * state values aren't configurable
 * there are several more arming types. instead of using a channel for each, use a single channel for both states and commands, with separate state and command descriptions (as first used in the Lock component)
 * use the (new?) supported_features config option to limit the list of available states and commands

as usual, removal of old channels is dependent on newStyleChannels flag
