### PR TITLE
[entsoe] Refactor HTTP error handling

### DIFF
--- a/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/EntsoeHandlerFactory.java
+++ b/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/EntsoeHandlerFactory.java
@@ -16,12 +16,17 @@ import static org.openhab.binding.entsoe.internal.EntsoeBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link EntsoeHandlerFactory} is responsible for creating things and thing
@@ -33,6 +38,15 @@ import org.osgi.service.component.annotations.Component;
 @Component(configurationPid = "binding.entsoe", service = ThingHandlerFactory.class)
 public class EntsoeHandlerFactory extends BaseThingHandlerFactory {
 
+    private final HttpClient httpClient;
+
+    @Activate
+    public EntsoeHandlerFactory(final @Reference HttpClientFactory httpClientFactory,
+            ComponentContext componentContext) {
+        super.activate(componentContext);
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPE_UIDS.contains(thingTypeUID);
@@ -43,7 +57,7 @@ public class EntsoeHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (THING_TYPE_DAY_AHEAD.equals(thingTypeUID)) {
-            return new EntsoeHandler(thing);
+            return new EntsoeHandler(thing, httpClient);
         }
 
         return null;

--- a/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/client/Client.java
+++ b/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/client/Client.java
@@ -84,7 +84,7 @@ public class Client {
                 throw new EntsoeConfigurationException("Authentication failed. Please check your security token");
             }
             if (!HttpStatus.isSuccess(status)) {
-                throw new EntsoeResponseException("The request failed with HTTP error ");
+                throw new EntsoeResponseException("The request failed with HTTP error " + status);
             }
 
             String responseContent = response.getContentAsString();

--- a/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/client/Client.java
+++ b/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/client/Client.java
@@ -21,15 +21,25 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpResponseException;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.binding.entsoe.internal.exception.EntsoeConfigurationException;
 import org.openhab.binding.entsoe.internal.exception.EntsoeResponseException;
-import org.openhab.core.io.net.http.HttpUtil;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -46,27 +56,59 @@ import org.xml.sax.SAXException;
 @NonNullByDefault
 public class Client {
     private final Logger logger = LoggerFactory.getLogger(Client.class);
+    private final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+    private final HttpClient httpClient;
+    private final String userAgent;
 
-    private DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+    public Client(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        userAgent = "openHAB/" + FrameworkUtil.getBundle(this.getClass()).getVersion().toString();
+    }
 
-    public Map<Instant, SpotPrice> doGetRequest(Request request, int timeout, String configResolution)
-            throws EntsoeResponseException, EntsoeConfigurationException {
+    public Map<Instant, SpotPrice> doGetRequest(EntsoeRequest entsoeRequest, int timeout, String configResolution)
+            throws EntsoeResponseException, EntsoeConfigurationException, InterruptedException {
+        String url = entsoeRequest.toUrl();
+        Request request = httpClient.newRequest(url) //
+                .timeout(timeout, TimeUnit.SECONDS) //
+                .agent(userAgent) //
+                .method(HttpMethod.GET);
+
         try {
-            logger.debug("Sending GET request with parameters: {}", request);
-            String url = request.toUrl();
-            String responseText = HttpUtil.executeUrl("GET", url, timeout);
-            if (responseText == null) {
-                throw new EntsoeResponseException("Request failed");
-            }
-            logger.trace("Response: {}", responseText);
-            return parseXmlResponse(responseText, configResolution);
-        } catch (IOException e) {
-            String message = e.getMessage();
-            if (message != null && message.contains("Authentication challenge without WWW-Authenticate header")) {
+            logger.debug("Sending GET request with parameters: {}", entsoeRequest);
+
+            ContentResponse response = request.send();
+
+            int status = response.getStatus();
+            if (status == HttpStatus.UNAUTHORIZED_401) {
+                // This will currently not happen because "WWW-Authenticate" header is missing; see below.
                 throw new EntsoeConfigurationException("Authentication failed. Please check your security token");
             }
+            if (!HttpStatus.isSuccess(status)) {
+                throw new EntsoeResponseException("The request failed with HTTP error ");
+            }
+
+            String responseContent = response.getContentAsString();
+            if (responseContent == null) {
+                throw new EntsoeResponseException("Request failed");
+            }
+            logger.trace("Response: {}", responseContent);
+
+            return parseXmlResponse(responseContent, configResolution);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause != null && cause instanceof HttpResponseException httpResponseException) {
+                Response response = httpResponseException.getResponse();
+                if (response.getStatus() == HttpStatus.UNAUTHORIZED_401) {
+                    /*
+                     * The service may respond with HTTP code 401 without any "WWW-Authenticate"
+                     * header, violating RFC 7235. Jetty will then throw HttpResponseException.
+                     * We need to handle this in order to attempt reauthentication.
+                     */
+                    throw new EntsoeConfigurationException("Authentication failed. Please check your security token");
+                }
+            }
             throw new EntsoeResponseException(e);
-        } catch (ParserConfigurationException | SAXException e) {
+        } catch (IOException | TimeoutException | ParserConfigurationException | SAXException e) {
             throw new EntsoeResponseException(e);
         }
     }

--- a/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/client/EntsoeRequest.java
+++ b/bundles/org.openhab.binding.entsoe/src/main/java/org/openhab/binding/entsoe/internal/client/EntsoeRequest.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  *
  */
 @NonNullByDefault
-public class Request {
+public class EntsoeRequest {
 
     private static DateTimeFormatter requestFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
@@ -35,7 +35,7 @@ public class Request {
     private final Instant periodStart;
     private final Instant periodEnd;
 
-    public Request(String securityToken, String area, Instant periodStart, Instant periodEnd) {
+    public EntsoeRequest(String securityToken, String area, Instant periodStart, Instant periodEnd) {
         this.securityToken = securityToken;
         this.area = area;
         this.periodStart = periodStart;


### PR DESCRIPTION
The primary objective of this pull request is to improve handling of HTTP error code 401 ("Unauthorized") by eliminating exception message string comparison - see https://github.com/openhab/openhab-addons/pull/17416#discussion_r1759837495.

Additionally, we will now provide "openHAB" with version number in the `User-Agent` header. This will make it possible to reach out to us in case of any issues.

And last, but not least, `InterruptedException` will no longer be swallowed by `HttpUtil` and rethrown as `IOException`. This allows us rethrow `InterruptedException` all the way up the call chain. This will ensure that the thread interruption request is respected immediately, rather than masking the exception by catching it prematurely.