### PR TITLE
Multiple line break fixes in documentation

### DIFF
--- a/bundles/org.openhab.binding.cm11a/README.md
+++ b/bundles/org.openhab.binding.cm11a/README.md
@@ -18,7 +18,7 @@ In addition to controlling X10 modules the cm11a listens on the powerline and re
 
 The binding opens the serial port when it starts and keeps it open until the binding is terminated.
 If the serial port is disconnected a reconnect will be attempted the next time it is needed.
-Therefore, other applications should not attempt to use the port when OpneHAB is running.
+Therefore, other applications should not attempt to use the port when openHAB is running.
 However, another program could load macros into the cm11a before openHAB starts.
 
 ### cm11a macros

--- a/bundles/org.openhab.binding.hccrubbishcollection/README.md
+++ b/bundles/org.openhab.binding.hccrubbishcollection/README.md
@@ -9,7 +9,7 @@ A single supported thing called `collection`.
 
 ## Thing Configuration
 
-The thing supports one setting labelled `address` which is your street number and name as it appears on Google.
+The thing supports one setting labelled `address` which is your street number and name as it appears on Google.<br>
 _For Example:
 1 Victoria Street_
 

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -181,8 +181,7 @@ For a CCU2, the value may need to be increased to 180s.
 Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)
 
 - **unpairOnDeletion**
-If set to true, devices are automatically unpaired from the gateway when their corresponding things are deleted.
-
+If set to true, devices are automatically unpaired from the gateway when their corresponding things are deleted.<br>
 **Warning:** The option "factoryResetOnDeletion" also unpairs a device, so in order to avoid unpairing on deletion completely, both options need to be set to false! (default = false)
 
 - **factoryResetOnDeletion**

--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -182,6 +182,7 @@ Time in seconds that the controller will be in install mode when a device discov
 
 - **unpairOnDeletion**
 If set to true, devices are automatically unpaired from the gateway when their corresponding things are deleted.
+
 **Warning:** The option "factoryResetOnDeletion" also unpairs a device, so in order to avoid unpairing on deletion completely, both options need to be set to false! (default = false)
 
 - **factoryResetOnDeletion**

--- a/bundles/org.openhab.binding.hpprinter/README.md
+++ b/bundles/org.openhab.binding.hpprinter/README.md
@@ -112,8 +112,7 @@ Black Ink displayed as a whole percentage - `60 %`
 Text item=hpprinter_printer_djprinter_ink_blackLevel label="Black [%.0f %unit%]"
 ```
 
-Black Marker displayed in millilitres - `21 ml`
-_Default_
+Black Marker displayed in millilitres - `21 ml` _Default_
 
 ```perl
 Text item=hpprinter_printer_djprinter_usage_blackMarker label="Black Marker [%.0f %unit%]"

--- a/bundles/org.openhab.binding.hydrawise/README.md
+++ b/bundles/org.openhab.binding.hydrawise/README.md
@@ -34,7 +34,8 @@ Controller Things require a parent [Account Bridge](#account-bridge-thing)
 
 ### Local Thing
 
-The Local Thing type uses an undocumented API that allows direct HTTP access to an irrigation controller on the user's network. This provides a subset of features compared to the Cloud Thing type limited to basic zone control.<br>
+The Local Thing type uses an undocumented API that allows direct HTTP access to an irrigation controller on the user's network.
+This provides a subset of features compared to the Cloud Thing type limited to basic zone control.
 Controlling zones through the local API will not be reported back to the cloud service or the Hydrawise mobile/web applications, and reporting functionality will not reflect the locally controlled state.
 
 Local control may not be available on later Hydrawise controller firmware versions.

--- a/bundles/org.openhab.binding.hydrawise/README.md
+++ b/bundles/org.openhab.binding.hydrawise/README.md
@@ -17,7 +17,7 @@ An account must be manually added and configured.
 Controller Things are automatically discovered once an [Account Bridge](#account-bridge-thing) has be properly configured.
 
 The Controller Thing type is the primary way most users will control and monitor their irrigation system.
-This allows full control over zones, sensors and weather forecasts.
+This allows full control over zones, sensors and weather forecasts.<br>
 Changes made through this Thing type will be reflected in the Hydrawise mobile and web applications as well as in their reporting modules.
 
 Controller Things require a parent [Account Bridge](#account-bridge-thing)
@@ -34,8 +34,7 @@ Controller Things require a parent [Account Bridge](#account-bridge-thing)
 
 ### Local Thing
 
-The Local Thing type uses an undocumented API that allows direct HTTP access to an irrigation controller on the user's network.
-This provides a subset of features compared to the Cloud Thing type limited to basic zone control.
+The Local Thing type uses an undocumented API that allows direct HTTP access to an irrigation controller on the user's network. This provides a subset of features compared to the Cloud Thing type limited to basic zone control.<br>
 Controlling zones through the local API will not be reported back to the cloud service or the Hydrawise mobile/web applications, and reporting functionality will not reflect the locally controlled state.
 
 Local control may not be available on later Hydrawise controller firmware versions.

--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -15,7 +15,7 @@ It is absolutely recommended to configure static IP addresses for both, the open
 ### Nuki Bridge Callback
 
 The Nuki Binding will manage the required callback from the Nuki Bridge to the openHAB server if _manageCallbacks_ is set to `true`.
-If _manageCallbacks_ is not set it will default to `true`.
+If _manageCallbacks_ is not set it will default to `true`.<br>
 Make sure that you've selected the correct primary address in the [network settings](https://www.openhab.org/docs/settings/services_system.html#network-settings).
 
 If you want to manage the callbacks from the Nuki Bridge to the openHAB server by yourself, you need to set _manageCallbacks_ to `false`.

--- a/bundles/org.openhab.binding.prowl/README.md
+++ b/bundles/org.openhab.binding.prowl/README.md
@@ -10,10 +10,9 @@ The binding does not require any manual configuration on the binding level.
 
 ## Thing Configuration
 
-This binding has only one thing called _Broker_. If you want to use this binding, just add a broker instance and configure the API key, which you can generate on the Prowl website.
+This binding has only one thing called _Broker_. If you want to use this binding, just add a broker instance and configure the API key, which you can generate on the Prowl website.<br>
 You can also modify the _application_ property, which identifies the originator of these push messages.
-If you want to have specific refresh time for the remaining free push messages channel, you can edit the _refresh_ property.
-Anyway beware - every check consumes one free push message you can send in an hour.
+If you want to have specific refresh time for the remaining free push messages channel, you can edit the _refresh_ property. Anyway beware - every check consumes one free push message you can send in an hour.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.prowl/README.md
+++ b/bundles/org.openhab.binding.prowl/README.md
@@ -10,9 +10,11 @@ The binding does not require any manual configuration on the binding level.
 
 ## Thing Configuration
 
-This binding has only one thing called _Broker_. If you want to use this binding, just add a broker instance and configure the API key, which you can generate on the Prowl website.<br>
+This binding has only one thing called _Broker_.
+If you want to use this binding, just add a broker instance and configure the API key, which you can generate on the Prowl website.
 You can also modify the _application_ property, which identifies the originator of these push messages.
-If you want to have specific refresh time for the remaining free push messages channel, you can edit the _refresh_ property. Anyway beware - every check consumes one free push message you can send in an hour.
+If you want to have specific refresh time for the remaining free push messages channel, you can edit the _refresh_ property.
+Anyway beware - every check consumes one free push message you can send in an hour.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -38,10 +38,14 @@ binding.pulseaudio:sourceOutput=false
 
 ## Thing Configuration
 
-The Pulseaudio bridge requires the host (ip address or a hostname) and a port (default: 4712) as a configuration value in order for the binding to know where to access it.
+The Pulseaudio bridge requires the host (ip address or a hostname) and a port (default: 4712) as a configuration value in order for the binding to know where to access it.<br>
 A Pulseaudio device requires at least an identifier. For sinks and sources, you can use the name or the description. For sink inputs and source outputs, you can use the name or the application name.
 To know without hesitation the correct value to use, you should use the command line utility `pactl`. For example, to find the name of a sink:
+
+```bash
 `pactl -s <ip-address|hostname> list sinks | grep "name:"`
+```
+
 If you need to narrow the identification of a device (in case name or description are not consistent and sufficient), you can use the `additionalFilters` parameter (optional/advanced parameter), in the form of one or several (separator '###') regular expression(s), each one matching a property value of the pulseaudio device. You can use every properties listed with `pactl`.
 
 ## Channels

--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -38,8 +38,7 @@ binding.pulseaudio:sourceOutput=false
 
 ## Thing Configuration
 
-The Pulseaudio bridge requires the host (ip address or a hostname) and a port (default: 4712) as a configuration value in order for the binding to know where to access it.<br>
-A Pulseaudio device requires at least an identifier. For sinks and sources, you can use the name or the description. For sink inputs and source outputs, you can use the name or the application name.
+The Pulseaudio bridge requires the host (ip address or a hostname) and a port (default: 4712) as a configuration value in order for the binding to know where to access it. A Pulseaudio device requires at least an identifier. For sinks and sources, you can use the name or the description. For sink inputs and source outputs, you can use the name or the application name.
 To know without hesitation the correct value to use, you should use the command line utility `pactl`. For example, to find the name of a sink:
 
 ```bash

--- a/bundles/org.openhab.binding.samsungtv/README.md
+++ b/bundles/org.openhab.binding.samsungtv/README.md
@@ -45,8 +45,8 @@ Thing samsungtv:tv:livingroom [ hostName="192.168.1.10", port=55000, macAddress=
 
 Different ports are used on different models. It may be 55000, 8001 or 8002.
 
-If you have a <2016 TV, the interface will be *Legacy*, and the port is likely 55000.
-If you have a >2016 TV, the interface will be either *websocket* on port 8001, or *websocketsecure* on port 8002.
+If you have a <2016 TV, the interface will be *Legacy*, and the port is likely 55000.<br>
+If you have a >2016 TV, the interface will be either *websocket* on port 8001, or *websocketsecure* on port 8002.<br>
 If your TV supports *websocketsecure*, you **MUST** use it, otherwise the `keyCode` and all dependent channels will not work.
 
 In order for the binding to control your TV, you will be asked to accept the remote connection (from openHAB) on your TV. You have 30 seconds to accept the connection. If you fail to accept it, then most channels will not work.
@@ -58,6 +58,7 @@ You can set the connection to `Allow` on the TV, or delete the openHAB entry, an
 The binding will try to automatically discover the correct protocol for your TV, so **don't change it** unless you know it is wrong.
 
 Under `advanced`, you can enter a Smartthings PAT, and Device Id. This enables more channels via the Smartthings cloud. This is only for TV's that support Smartthings. No hub is required. The binding will attempt to discover the device ID for your TV automatically, you can enter it manually if automatic detection fails.
+
 Also under `advanced`, you have the ability to turn on *"Subscribe to UPnP events"*. This is off by default. This option reduces (but does not eliminate) the polling of UPnP services. You can enable it if you want to test it out. If you disable this setting (after testing), you should power cycle your TV to remove the old subscriptions.
 
 For >2019 TV's, there is an app workaround, see [App Discovery](#app-discovery) for details.
@@ -93,7 +94,7 @@ TVs support the following channels:
 | artColorTemperature | Number   | RW         | ArtMode Color temperature Minnimum value is -5 and maximum 5                                            |
 | artOrientation      | Switch   | RW         | TV orientation, Landscape (OFF) or Portrait (ON)                                                        |
 
-**NOTE:** channels: brightness, contrast, sharpness, colorTemperature don't work on newer TV's.
+**NOTE:** channels: brightness, contrast, sharpness, colorTemperature don't work on newer TV's.<br>
 **NOTE:** channels: sourceName, sourceId, programTitle, channelName and stopBrowser may need additional configuration.
 
 Some channels do not work on some TV's. It depends on the age of your TV, and what kind of interface it has. Only link channels that work on your TV, polling channels that your TV doesn't have may cause errors, and other problems. see [Tested TV Models](#tested-tv-models).
@@ -103,7 +104,7 @@ Some channels do not work on some TV's. It depends on the age of your TV, and wh
 `keyCode` is a String channel, that emulates a remote control. it allows you to send keys to the TV, as if they were from the remote control, hence it is send only.
 
 This is one of the more useful channels, and several new features have been added in this binding.
-Now all keyCode channel sends are queued, so they don’t overlap each other. You can also now use in line delays, and keypresses (in mS). for example:
+Now all keyCode channel sends are queued, so they don’t overlap each other. You can also now use in line delays, and keypresses (in mS). For example:<br>
 sending:
 `"KEY_MENU, 1000, KEY_DOWN, KEY_DOWN, KEY_ENTER, 2000, KEY_EXIT"`
 
@@ -310,7 +311,7 @@ Setpoint item=TV_ArtColorTemperature minValue=-5 maxValue=5 step=1 visibility=[T
 
 ### artOrientation
 
-`artOrientation` is a Switch channel, it reports the current orientation of the TV, OFF for Landscape, and ON for Portrait. This channel is polled. If you send an ON or OFF command to this channel, then the binding will send a long (4s) press of the key defined in the configuration for orientationKey.  
+`artOrientation` is a Switch channel, it reports the current orientation of the TV, OFF for Landscape, and ON for Portrait. This channel is polled. If you send an ON or OFF command to this channel, then the binding will send a long (4s) press of the key defined in the configuration for orientationKey.<br>
 For 2023- TV's `orientationKey` should be KEY_MULTI_VIEW (default), for 2024+ TV's this should be KEY_HOME.
 
 ```java

--- a/bundles/org.openhab.binding.solaredge/README.md
+++ b/bundles/org.openhab.binding.solaredge/README.md
@@ -32,10 +32,10 @@ It is called "SPRING_SECURITY_REMEMBER_ME_COOKIE".
 When using this token, see also `usePrivateApi` and `meterInstalled`.
 E.g. for Firefox, use the built-in [Storage Inspector](https://developer.mozilla.org/en-US/docs/Tools/Storage_Inspector) to retrieve the token.
 
-- **solarId** (required)
+- **solarId** (required)<br>
 Id of your inverter at SolarEdge (can be found in the URL after successful login: <https://monitoring.solaredge.com/solaredge-web/p/site/> **&lt;solarId&gt;** /#/dashboard)
 
-- **usePrivateApi** (optional)
+- **usePrivateApi** (optional)<br>
 can be set to true to use the private API.
 Private API has no limit regarding query frequency but is less stable.
 Private API will only gather live data if a meter is available.
@@ -43,17 +43,17 @@ The official public API has a limit of 300 queries per day but should be much mo
 Set this to true when using token retrieved from browser in `tokenOrApiKey`.
 See also `meterInstalled`. (default = false)
 
-- **meterInstalled** (optional)
+- **meterInstalled** (optional)<br>
 can be set to true for setups that contain a meter which is connected to the inverter.
 A meter allows more detailed data retrieval.
 This must be set to true when using token retrieved from browser in `tokenOrApiKey`.
 This can be set either to true or false when using the API key. (default = false)
 
-- **liveDataPollingInterval** (optional)
+- **liveDataPollingInterval** (optional)<br>
 interval (minutes) in which live data values are retrieved from Solaredge.
 Setting less than 10 minutes is only allowed when using private API. (default = 10)
 
-- **aggregateDataPollingInterval** (optional)
+- **aggregateDataPollingInterval** (optional)<br>
   interval (minutes) in which aggregate data values are retrieved from Solaredge.
   Setting less than 60 is only allowed when using private API. (default = 60)
 

--- a/bundles/org.openhab.binding.webexteams/README.md
+++ b/bundles/org.openhab.binding.webexteams/README.md
@@ -83,5 +83,5 @@ This binding includes these rule actions for sending messages:
 - `var success = botActions.sendPersonMessage(String personEmail, String markdown, String attach)` - Send a direct message to a person, with attachment.
 
 Sending messages for bot or person accounts works exactly the same.
-Attachments must be URLs.
+Attachments must be URLs.<br>
 Sending local files is not supported at this moment.


### PR DESCRIPTION
As part of the large documentation cleanup, some regressions occured. double spaces are interpreted as linebreaks. Some where fixed in #17619. This PR fixes the remaining ones.