### PR TITLE
[transform.vat] Add support for VAT rate periodization

### DIFF
--- a/bundles/org.openhab.transform.vat/README.md
+++ b/bundles/org.openhab.transform.vat/README.md
@@ -53,6 +53,9 @@ logger.info "Price incl. VAT: #{price_incl_vat}"
 
 The functionality of this `TransformationService` can also be used in a `Profile` on an `ItemChannelLink`.
 This is the most powerful usage since VAT will be added without providing any explicit country code, percentage or configuration.
+Time series are supported when using this Profile, including applying VAT rates accurately based on the specific date and time of each state, even as new VAT rates come into effect.
+This ensures that the correct VAT rate is applied for historical, current, or future data points, reflecting any changes in VAT regulations that occur over time.
+
 To use this, an `.items` file can be configured as follows:
 
 ```java

--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/RateProvider.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/RateProvider.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.vat.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.transform.vat.internal.model.VATCountry;
+import org.openhab.transform.vat.internal.model.VATPeriod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * The {@link RateProvider} class provides VAT rates for different
+ * countries in different periods of time.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class RateProvider {
+    private static final String RESOURCE_NAME = "/vat_rates.yaml";
+
+    private final Logger logger = LoggerFactory.getLogger(RateProvider.class);
+    private final Map<String, List<VATPeriod>> rateMap = getMap();
+
+    public @Nullable BigDecimal getPercentage(String country) {
+        return getPercentage(country, Instant.now());
+    }
+
+    public @Nullable BigDecimal getPercentage(String country, Instant time) {
+        List<VATPeriod> vatPeriods = rateMap.get(country);
+        if (vatPeriods == null) {
+            return null;
+        }
+        for (VATPeriod vatPeriod : vatPeriods) {
+            if (!time.isBefore(vatPeriod.start()) && time.isBefore(vatPeriod.end())) {
+                return vatPeriod.percentage();
+            }
+        }
+
+        logger.warn("No VAT rate for country {} valid at {}. This is a bug, please report", country, time);
+
+        return null;
+    }
+
+    private Map<String, List<VATPeriod>> getMap() {
+        HashMap<String, List<VATPeriod>> rateMap = new HashMap<>();
+        Collection<VATCountry> rates = parseResource();
+        for (VATCountry rate : rates) {
+            rateMap.put(rate.country(), rate.vatPeriod());
+        }
+        return rateMap;
+    }
+
+    private Collection<VATCountry> parseResource() {
+        try (InputStream inputStream = RateProvider.class.getResourceAsStream(RESOURCE_NAME)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("VAT resource not found");
+            }
+
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            mapper.registerModule(new JavaTimeModule());
+
+            return mapper.readValue(inputStream,
+                    mapper.getTypeFactory().constructCollectionType(List.class, VATCountry.class));
+        } catch (IOException e) {
+            throw new IllegalStateException("VAT resource could not be read and parsed", e);
+        }
+    }
+}

--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/VATTransformationService.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/VATTransformationService.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.transform.vat.internal;
 
-import static org.openhab.transform.vat.internal.VATTransformationConstants.*;
-
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -36,6 +34,7 @@ import org.slf4j.LoggerFactory;
 public class VATTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(VATTransformationService.class);
+    private final RateProvider rateProvider = new RateProvider();
 
     @Override
     public @Nullable String transform(String valueString, String sourceString) throws TransformationException {
@@ -53,12 +52,11 @@ public class VATTransformationService implements TransformationService {
         try {
             value = new BigDecimal(valueString);
         } catch (NumberFormatException e) {
-            String rate = RATES.get(valueString);
-            if (rate == null) {
+            value = rateProvider.getPercentage(valueString);
+            if (value == null) {
                 logger.warn("Input value '{}' could not be converted to a valid number or country code", valueString);
                 throw new TransformationException("VAT Transformation can only be used with numeric inputs", e);
             }
-            value = new BigDecimal(rate);
         }
 
         return addVAT(source, value).toString();

--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/model/VATCountry.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/model/VATCountry.java
@@ -10,21 +10,23 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.transform.vat.internal;
+package org.openhab.transform.vat.internal.model;
+
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.thing.profiles.ProfileTypeUID;
-import org.openhab.core.transform.TransformationService;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * The {@link VATTransformationConstants} class defines constants
- * used across the whole profile.
+ * DTO representing a country with VAT rates in different validity periods.
  *
  * @author Jacob Laursen - Initial contribution
  */
 @NonNullByDefault
-public class VATTransformationConstants {
-
-    public static final ProfileTypeUID PROFILE_TYPE_UID = new ProfileTypeUID(
-            TransformationService.TRANSFORM_PROFILE_SCOPE, "VAT");
+public record VATCountry(String country, @JsonProperty("vatPeriod") List<VATPeriod> vatPeriod) {
+    @Override
+    public String toString() {
+        return "CountryVAT{country='" + country + "', period=" + vatPeriod + '}';
+    }
 }

--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/model/VATPeriod.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/model/VATPeriod.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.vat.internal.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * DTO representing a VAT rate in a specific validity period.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public record VATPeriod(Instant start, Instant end, BigDecimal percentage) {
+
+    @Override
+    public Instant start() {
+        return Objects.isNull(start) ? Instant.MIN : start;
+    }
+
+    @Override
+    public Instant end() {
+        return Objects.isNull(end) ? Instant.MAX : end;
+    }
+
+    @Override
+    public String toString() {
+        return "VATPeriod{start='" + start() + "', end='" + end() + "', percentage=" + percentage + '}';
+    }
+}

--- a/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/profile/VATTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.vat/src/main/java/org/openhab/transform/vat/internal/profile/VATTransformationProfileFactory.java
@@ -37,6 +37,7 @@ import org.openhab.core.thing.profiles.ProfileTypeUID;
 import org.openhab.core.thing.profiles.i18n.ProfileTypeI18nLocalizationService;
 import org.openhab.core.transform.TransformationService;
 import org.openhab.core.util.BundleResolver;
+import org.openhab.transform.vat.internal.RateProvider;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -52,6 +53,7 @@ import org.osgi.service.component.annotations.Reference;
 public class VATTransformationProfileFactory implements ProfileFactory, ProfileTypeProvider {
 
     private final LocaleProvider localeProvider;
+    private final RateProvider rateProvider = new RateProvider();
     private final ProfileTypeI18nLocalizationService profileTypeI18nLocalizationService;
     private final Map<LocalizedKey, ProfileType> localizedProfileTypeCache = new ConcurrentHashMap<>();
     private final Bundle bundle;
@@ -76,7 +78,8 @@ public class VATTransformationProfileFactory implements ProfileFactory, ProfileT
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
-        return new VATTransformationProfile(callback, transformationService, profileContext, localeProvider);
+        return new VATTransformationProfile(callback, transformationService, profileContext, localeProvider,
+                rateProvider);
     }
 
     private ProfileType createLocalizedProfileType(ProfileType profileType, @Nullable Locale locale) {
@@ -101,11 +104,11 @@ public class VATTransformationProfileFactory implements ProfileFactory, ProfileT
     }
 
     @Reference(target = "(openhab.transform=VAT)")
-    public void addTransformationService(TransformationService service) {
-        this.transformationService = service;
+    public void addTransformationService(TransformationService transformationService) {
+        this.transformationService = transformationService;
     }
 
-    public void removeTransformationService(TransformationService service) {
+    public void removeTransformationService(TransformationService transformationService) {
         this.transformationService = null;
     }
 }

--- a/bundles/org.openhab.transform.vat/src/main/resources/vat_rates.yaml
+++ b/bundles/org.openhab.transform.vat/src/main/resources/vat_rates.yaml
@@ -1,0 +1,680 @@
+# European Union countries
+# Austria
+- country: "AT"
+  vatPeriod:
+    - percentage: 20
+# Belgium
+- country: "BE"
+  vatPeriod:
+    - percentage: 21
+# Bulgaria
+- country: "BG"
+  vatPeriod:
+    - percentage: 20
+# Croatia
+- country: "HR"
+  vatPeriod:
+    - percentage: 25
+# Cyprus
+- country: "CY"
+  vatPeriod:
+    - percentage: 19
+# Czech Republic
+- country: "CZ"
+  vatPeriod:
+    - percentage: 21
+# Denmark
+- country: "DK"
+  vatPeriod:
+    - percentage: 25
+# Estonia
+- country: "EE"
+  vatPeriod:
+    - percentage: 20
+# Finland
+- country: "FI"
+  vatPeriod:
+    - percentage: 24
+# France
+- country: "FR"
+  vatPeriod:
+    - percentage: 20
+# Germany
+- country: "DE"
+  vatPeriod:
+    - percentage: 19
+# Greece
+- country: "GR"
+  vatPeriod:
+    - percentage: 24
+# Hungary
+- country: "HU"
+  vatPeriod:
+    - percentage: 27
+# Ireland
+- country: "IE"
+  vatPeriod:
+    - percentage: 23
+# Italy
+- country: "IT"
+  vatPeriod:
+    - percentage: 22
+# Latvia
+- country: "LV"
+  vatPeriod:
+    - percentage: 21
+# Lithuania
+- country: "LT"
+  vatPeriod:
+    - percentage: 21
+# Luxembourg
+- country: "LU"
+  vatPeriod:
+    - percentage: 17
+# Malta
+- country: "MT"
+  vatPeriod:
+    - percentage: 18
+# Netherlands
+- country: "NL"
+  vatPeriod:
+    - percentage: 21
+# Poland
+- country: "PL"
+  vatPeriod:
+    - percentage: 23
+# Portugal
+- country: "PT"
+  vatPeriod:
+    - percentage: 23
+# Romania
+- country: "RO"
+  vatPeriod:
+    - percentage: 19
+# Slovakia
+- country: "SK"
+  vatPeriod:
+    - percentage: 20
+# Slovenia
+- country: "SI"
+  vatPeriod:
+    - percentage: 22
+# Spain
+- country: "ES"
+  vatPeriod:
+    - percentage: 21
+# Sweden
+- country: "SE"
+  vatPeriod:
+    - percentage: 25
+# Non-European Union countries
+# Albania
+- country: "AL"
+  vatPeriod:
+    - percentage: 20
+# Algeria
+- country: "DZ"
+  vatPeriod:
+    - percentage: 19
+# Andorra
+- country: "AD"
+  vatPeriod:
+    - percentage: 4.5
+# Angola
+- country: "AO"
+  vatPeriod:
+    - percentage: 14
+# Antigua and Barbuda
+- country: "AG"
+  vatPeriod:
+    - percentage: 15
+# Argentina
+- country: "AR"
+  vatPeriod:
+    - percentage: 21
+# Armenia
+- country: "AM"
+  vatPeriod:
+    - percentage: 20
+# Australia
+- country: "AU"
+  vatPeriod:
+    - percentage: 10
+# Azerbaijan
+- country: "AZ"
+  vatPeriod:
+    - percentage: 18
+# Bahamas
+- country: "BS"
+  vatPeriod:
+    - percentage: 12
+# Bahrain
+- country: "BH"
+  vatPeriod:
+    - percentage: 10
+# Bangladesh
+- country: "BD"
+  vatPeriod:
+    - percentage: 15
+# Barbados
+- country: "BB"
+  vatPeriod:
+    - percentage: 17.5
+# Belarus
+- country: "BY"
+  vatPeriod:
+    - percentage: 20
+# Belize
+- country: "BZ"
+  vatPeriod:
+    - percentage: 12.5
+# Benin
+- country: "BJ"
+  vatPeriod:
+    - percentage: 18
+# Bolivia
+- country: "BO"
+  vatPeriod:
+    - percentage: 13
+# Bosnia and Herzegovina
+- country: "BA"
+  vatPeriod:
+    - percentage: 17
+# Botswana
+- country: "BW"
+  vatPeriod:
+    - percentage: 12
+# Brazil
+- country: "BR"
+  vatPeriod:
+    - percentage: 20
+# Burkina Faso
+- country: "BF"
+  vatPeriod:
+    - percentage: 18
+# Burundi
+- country: "BI"
+  vatPeriod:
+    - percentage: 18
+# Cambodia
+- country: "KH"
+  vatPeriod:
+    - percentage: 10
+# Cameroon
+- country: "CM"
+  vatPeriod:
+    - percentage: 19.25
+# Canada
+- country: "CA"
+  vatPeriod:
+    - percentage: 5
+# Cape Verde
+- country: "CV"
+  vatPeriod:
+    - percentage: 15
+# Central African Republic
+- country: "CF"
+  vatPeriod:
+    - percentage: 19
+# Chad
+- country: "TD"
+  vatPeriod:
+    - percentage: 18
+# Chile
+- country: "CL"
+  vatPeriod:
+    - percentage: 19
+# China
+- country: "CN"
+  vatPeriod:
+    - percentage: 13
+# Colombia
+- country: "CO"
+  vatPeriod:
+    - percentage: 19
+# Costa Rica
+- country: "CR"
+  vatPeriod:
+    - percentage: 13
+# Democratic Republic of the Congo
+- country: "CD"
+  vatPeriod:
+    - percentage: 16
+# Dominica
+- country: "DM"
+  vatPeriod:
+    - percentage: 15
+# Dominican Republic
+- country: "DO"
+  vatPeriod:
+    - percentage: 18
+# Ecuador
+- country: "EC"
+  vatPeriod:
+    - percentage: 12
+# Egypt
+- country: "EG"
+  vatPeriod:
+    - percentage: 14
+# El Salvador
+- country: "SV"
+  vatPeriod:
+    - percentage: 13
+# Equatorial Guinea
+- country: "GQ"
+  vatPeriod:
+    - percentage: 15
+# Ethiopia
+- country: "ET"
+  vatPeriod:
+    - percentage: 15
+# Faroe Islands
+- country: "FO"
+  vatPeriod:
+    - percentage: 25
+# Fiji
+- country: "FJ"
+  vatPeriod:
+    - percentage: 15
+# Gabon
+- country: "GA"
+  vatPeriod:
+    - percentage: 18
+# Gambia
+- country: "GM"
+  vatPeriod:
+    - percentage: 15
+# Georgia
+- country: "GE"
+  vatPeriod:
+    - percentage: 18
+# Ghana
+- country: "GH"
+  vatPeriod:
+    - percentage: 15
+# Grenada
+- country: "GD"
+  vatPeriod:
+    - percentage: 15
+# Guatemala
+- country: "GT"
+  vatPeriod:
+    - percentage: 12
+# Guinea
+- country: "GN"
+  vatPeriod:
+    - percentage: 18
+# Guinea-Bissau
+- country: "GW"
+  vatPeriod:
+    - percentage: 15
+# Guyana
+- country: "GY"
+  vatPeriod:
+    - percentage: 16
+# Haiti
+- country: "HT"
+  vatPeriod:
+    - percentage: 10
+# Honduras
+- country: "HN"
+  vatPeriod:
+    - percentage: 15
+# Iceland
+- country: "IS"
+  vatPeriod:
+    - percentage: 24
+# India
+- country: "IN"
+  vatPeriod:
+    - percentage: 5.5
+# Indonesia
+- country: "ID"
+  vatPeriod:
+    - start: null
+      end: 2024-12-31T17:00:00Z
+      percentage: 11
+    - start: 2024-12-31T17:00:00Z
+      end: null
+      percentage: 12
+# Iran
+- country: "IR"
+  vatPeriod:
+    - percentage: 9
+# Isle of Man
+- country: "IM"
+  vatPeriod:
+    - percentage: 20
+# Israel
+- country: "IL"
+  vatPeriod:
+    - start: null
+      end: 2024-12-31T22:00:00Z
+      percentage: 17
+    - start: 2024-12-31T22:00:00Z
+      end: null
+      percentage: 18
+# Ivory Coast
+- country: "CI"
+  vatPeriod:
+    - percentage: 18
+# Jamaica
+- country: "JM"
+  vatPeriod:
+    - percentage: 12.5
+# Japan
+- country: "JP"
+  vatPeriod:
+    - percentage: 10
+# Jersey
+- country: "JE"
+  vatPeriod:
+    - percentage: 5
+# Jordan
+- country: "JO"
+  vatPeriod:
+    - percentage: 16
+# Kazakhstan
+- country: "KZ"
+  vatPeriod:
+    - percentage: 12
+# Kenya
+- country: "KE"
+  vatPeriod:
+    - percentage: 16
+# Kyrgyzstan
+- country: "KG"
+  vatPeriod:
+    - percentage: 20
+# Laos
+- country: "LA"
+  vatPeriod:
+    - percentage: 10
+# Lebanon
+- country: "LB"
+  vatPeriod:
+    - percentage: 11
+# Lesotho
+- country: "LS"
+  vatPeriod:
+    - percentage: 14
+# Liechtenstein
+- country: "LI"
+  vatPeriod:
+    - percentage: 7.7
+# Madagascar
+- country: "MG"
+  vatPeriod:
+    - percentage: 20
+# Malawi
+- country: "MW"
+  vatPeriod:
+    - percentage: 16.5
+# Malaysia
+- country: "MY"
+  vatPeriod:
+    - percentage: 6
+# Maldives
+- country: "MV"
+  vatPeriod:
+    - percentage: 6
+# Mali
+- country: "ML"
+  vatPeriod:
+    - percentage: 18
+# Mauritania
+- country: "MR"
+  vatPeriod:
+    - percentage: 14
+# Mauritius
+- country: "MU"
+  vatPeriod:
+    - percentage: 15
+# Mexico
+- country: "MX"
+  vatPeriod:
+    - percentage: 16
+# Moldova
+- country: "MD"
+  vatPeriod:
+    - percentage: 20
+# Monaco
+- country: "MC"
+  vatPeriod:
+    - percentage: 19.6
+# Mongolia
+- country: "MN"
+  vatPeriod:
+    - percentage: 10
+# Montenegro
+- country: "ME"
+  vatPeriod:
+    - percentage: 21
+# Morocco
+- country: "MA"
+  vatPeriod:
+    - percentage: 20
+# Mozambique
+- country: "MZ"
+  vatPeriod:
+    - percentage: 17
+# Namibia
+- country: "NA"
+  vatPeriod:
+    - percentage: 15
+# Nepal
+- country: "NP"
+  vatPeriod:
+    - percentage: 13
+# New Zealand
+- country: "NZ"
+  vatPeriod:
+    - percentage: 15
+# Nicaragua
+- country: "NI"
+  vatPeriod:
+    - percentage: 15
+# Niger
+- country: "NE"
+  vatPeriod:
+    - percentage: 19
+# Nigeria
+- country: "NG"
+  vatPeriod:
+    - percentage: 7.5
+# Niue
+- country: "NU"
+  vatPeriod:
+    - percentage: 5
+# North Macedonia
+- country: "MK"
+  vatPeriod:
+    - percentage: 18
+# Norway
+- country: "NO"
+  vatPeriod:
+    - percentage: 25
+# Pakistan
+- country: "PK"
+  vatPeriod:
+    - percentage: 17
+# Palau
+- country: "PW"
+  vatPeriod:
+    - percentage: 10
+# Palestine
+- country: "PS"
+  vatPeriod:
+    - percentage: 16
+# Panama
+- country: "PA"
+  vatPeriod:
+    - percentage: 7
+# Papua New Guinea
+- country: "PG"
+  vatPeriod:
+    - percentage: 10
+# Paraguay
+- country: "PY"
+  vatPeriod:
+    - percentage: 10
+# Peru
+- country: "PE"
+  vatPeriod:
+    - percentage: 18
+# Philippines
+- country: "PH"
+  vatPeriod:
+    - percentage: 12
+# Republic of Congo
+- country: "CG"
+  vatPeriod:
+    - percentage: 16
+# Russia
+- country: "RU"
+  vatPeriod:
+    - percentage: 20
+# Rwanda
+- country: "RW"
+  vatPeriod:
+    - percentage: 18
+# Saint Kitts and Nevis
+- country: "KN"
+  vatPeriod:
+    - percentage: 17
+# Saint Vincent and the Grenadines
+- country: "VC"
+  vatPeriod:
+    - percentage: 15
+# Samoa
+- country: "WS"
+  vatPeriod:
+    - percentage: 15
+# Saudi Arabia
+- country: "SA"
+  vatPeriod:
+    - percentage: 15
+# Senegal
+- country: "SN"
+  vatPeriod:
+    - percentage: 18
+# Serbia
+- country: "RS"
+  vatPeriod:
+    - percentage: 20
+# Seychelles
+- country: "SC"
+  vatPeriod:
+    - percentage: 15
+# Sierra Leone
+- country: "SL"
+  vatPeriod:
+    - percentage: 15
+# Singapore
+- country: "SG"
+  vatPeriod:
+    - percentage: 8
+# South Africa
+- country: "ZA"
+  vatPeriod:
+    - percentage: 15
+# South Korea
+- country: "KR"
+  vatPeriod:
+    - percentage: 10
+# Sri Lanka
+- country: "LK"
+  vatPeriod:
+    - percentage: 12
+# Sudan
+- country: "SD"
+  vatPeriod:
+    - percentage: 17
+# Switzerland
+- country: "CH"
+  vatPeriod:
+    - percentage: 7.7
+# Taiwan
+- country: "TW"
+  vatPeriod:
+    - percentage: 5
+# Tajikistan
+- country: "TJ"
+  vatPeriod:
+    - percentage: 20
+# Tanzania
+- country: "TZ"
+  vatPeriod:
+    - percentage: 18
+# Thailand
+- country: "TH"
+  vatPeriod:
+    - percentage: 10
+# Togo
+- country: "TG"
+  vatPeriod:
+    - percentage: 18
+# Tonga
+- country: "TO"
+  vatPeriod:
+    - percentage: 15
+# Trinidad and Tobago
+- country: "TT"
+  vatPeriod:
+    - percentage: 12.5
+# Tunisia
+- country: "TN"
+  vatPeriod:
+    - percentage: 18
+# Turkey
+- country: "TR"
+  vatPeriod:
+    - percentage: 18
+# Turkmenistan
+- country: "TM"
+  vatPeriod:
+    - percentage: 15
+# Uganda
+- country: "UG"
+  vatPeriod:
+    - percentage: 18
+# Ukraine
+- country: "UA"
+  vatPeriod:
+    - percentage: 20
+# United Arab Emirates
+- country: "AE"
+  vatPeriod:
+    - percentage: 5
+# United Kingdom
+- country: "GB"
+  vatPeriod:
+    - percentage: 20
+# Uruguay
+- country: "UY"
+  vatPeriod:
+    - percentage: 22
+# Uzbekistan
+- country: "UZ"
+  vatPeriod:
+    - percentage: 12
+# Vanuatu
+- country: "VU"
+  vatPeriod:
+    - percentage: 13
+# Vietnam
+- country: "VN"
+  vatPeriod:
+    - percentage: 10
+# Venezuela
+- country: "VE"
+  vatPeriod:
+    - percentage: 12
+# Zambia
+- country: "ZM"
+  vatPeriod:
+    - percentage: 16
+# Zimbabwe
+- country: "ZW"
+  vatPeriod:
+    - percentage: 15

--- a/bundles/org.openhab.transform.vat/src/test/java/org/openhab/transform/vat/internal/RateProviderTest.java
+++ b/bundles/org.openhab.transform.vat/src/test/java/org/openhab/transform/vat/internal/RateProviderTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.transform.vat.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link RateProvider}.
+ * 
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public class RateProviderTest {
+
+    @Test
+    void getPercentageWhenNoPeriods() {
+        RateProvider rateProvider = new RateProvider();
+        Instant time = LocalDateTime.of(2024, 10, 27, 22, 5, 0).atZone(ZoneId.of("Europe/Copenhagen")).toInstant();
+        @Nullable
+        BigDecimal actual = rateProvider.getPercentage("DK", time);
+        assertThat(actual, is(equalTo(new BigDecimal(25))));
+    }
+
+    @Test
+    void getPercentageJustBeforeNewRateComesIntoEffect() {
+        RateProvider rateProvider = new RateProvider();
+        Instant time = LocalDateTime.of(2025, 1, 1, 0, 0, 0).minusNanos(1).atZone(ZoneId.of("Asia/Jerusalem"))
+                .toInstant();
+        @Nullable
+        BigDecimal actual = rateProvider.getPercentage("IL", time);
+        assertThat(actual, is(equalTo(new BigDecimal(17))));
+    }
+
+    @Test
+    void getPercentageAtMomentOfNewRateComingIntoEffect() {
+        RateProvider rateProvider = new RateProvider();
+        Instant time = LocalDateTime.of(2025, 1, 1, 0, 0, 0).atZone(ZoneId.of("Asia/Jerusalem")).toInstant();
+        @Nullable
+        BigDecimal actual = rateProvider.getPercentage("IL", time);
+        assertThat(actual, is(equalTo(new BigDecimal(18))));
+    }
+}


### PR DESCRIPTION
VAT rates are now read from a YAML resource rather than a simple `Map` of countries. The format now also allows defining multiple validity periods for VAT rates in a given country, making it possible to prepare future changes so that they come into effect when they should.

Included rate changes:
- Uruguay now has correct rate; it was previously missing.
- Israel has a new rate with effect January 1st 2025.
- Indonesia has a new rate with effect January 1st 2025. Time-zone with 60% of the population selected (see below).

There is a small remaining issue for countries having multiple time-zones. I don't know if the change will come into effect at local midnight in each of the time-zones, but this is anyhow not supported. I thought about using local dates and applying openHAB's configured time-zone, but this would assume that openHAB is running in the same time-zone as the VAT rates of interest. Either way, I think this shortcoming is negligible.

For reference, I converted the rates into YAML by using a Python script I had ChatGTP generate for me and then running it on https://python-fiddle.com/:
```python
# Input as a single string in the given format
input_string = """
Map.entry("AT", "20"), // Austria
"""

# Parse the input string to extract country codes, VAT rates, and country names
rates = {}
for line in input_string.strip().splitlines():
    if 'Map.entry(' in line:
        parts = line.split('"')
        country_code = parts[1]
        vat_rate = parts[3]
        # Extract country name as a comment
        comment = line.split("//")[-1].strip() if "//" in line else ""
        rates[country_code] = (vat_rate, comment)

# Generate the YAML-like output as plain text
yaml_output = ""
for country_code, (rate, comment) in rates.items():
    # Use int if rate is a whole number, otherwise use float
    percentage = float(rate) if "." in rate else int(rate)
    yaml_output += f"# {comment}\n"  # Add comment with country name
    yaml_output += f"- country: \"{country_code}\"\n"
    yaml_output += f"  vatPeriod:\n"
    yaml_output += f"    - percentage: {percentage}\n"

# Print the output
print(yaml_output)
```