### PR TITLE
[sonos] Reduce log level

### DIFF
--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -3268,13 +3268,13 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     @Override
     public void onStatusChanged(boolean status) {
         if (status) {
-            logger.info("UPnP device {} is present (thing {})", getUDN(), getThing().getUID());
+            logger.debug("UPnP device {} is present (thing {})", getUDN(), getThing().getUID());
             if (getThing().getStatus() != ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.ONLINE);
                 scheduler.execute(this::poll);
             }
         } else {
-            logger.info("UPnP device {} is absent (thing {})", getUDN(), getThing().getUID());
+            logger.debug("UPnP device {} is absent (thing {})", getUDN(), getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR);
         }
     }


### PR DESCRIPTION
Partial fix for: https://github.com/openhab/openhab-addons/issues/17646

As the Thing handler state is allready set, there is no need to also log it to the `info` level.