### PR TITLE
Fix binding name in first README lines

### DIFF
--- a/bundles/org.openhab.binding.freeathome/README.md
+++ b/bundles/org.openhab.binding.freeathome/README.md
@@ -1,4 +1,4 @@
-# ABB/Busch-free@home Smart Home binding
+# ABB/Busch-free@home Smart Home Binding
 
 openHAB ABB/Busch-free@home binding based on the offical free@home local API.
 

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -1,4 +1,4 @@
-# LG TV control using serial protocol
+# LG TV Serial Binding
 
 This binding can send some commands typically used by LG LCD TVs (and some used by projectors).
 

--- a/bundles/org.openhab.binding.paradoxalarm/README.md
+++ b/bundles/org.openhab.binding.paradoxalarm/README.md
@@ -1,4 +1,4 @@
-# Paradox Alarm System binding
+# Paradox Alarm System Binding
 
 This binding is intended to provide basic support for Paradox Alarm system.
 

--- a/bundles/org.openhab.binding.pentair/README.md
+++ b/bundles/org.openhab.binding.pentair/README.md
@@ -1,4 +1,4 @@
-# Pentair Pool
+# Pentair Binding
 
 This is an openHAB binding for a Pentair Pool System.
 It is based on combined efforts of many on the Internet in reverse-engineering the proprietary Pentair protocol (see References section).

--- a/bundles/org.openhab.binding.velux/README.md
+++ b/bundles/org.openhab.binding.velux/README.md
@@ -1,4 +1,3 @@
-
 # Velux Binding
 
 This binding integrates the <B>Velux</B> devices with help of a gateway, the <B>Velux Bridge KLF200</B>, which is able to control 200 actuators.


### PR DESCRIPTION
I found some irregularities in the [list of addons](https://www.openhab.org/addons/), for example:

![image](https://github.com/user-attachments/assets/e6064c0d-512c-4e8f-8062-bd8863263070)
![image](https://github.com/user-attachments/assets/1fcbb35d-1f82-4ad5-a60d-c49fcb57a6ba)
![image](https://github.com/user-attachments/assets/d3be4838-b5b0-45e4-95ed-ec476753fc2f)

The only thing I could find within these bindings being different from other bindings was the first heading in the README not ending in "Binding" (case sensitive):

```bash
$ find ./bundles/org.openhab.binding.* -maxdepth 1 -type f -name "README.md" -exec sh -c 'head -n 1 "$1" | grep -P -qv "Binding\r?$" && echo "$1"' _ {} \;
./bundles/org.openhab.binding.bluetooth.airthings/README.md
./bundles/org.openhab.binding.bluetooth.am43/README.md
./bundles/org.openhab.binding.bluetooth.bluegiga/README.md
./bundles/org.openhab.binding.bluetooth.bluez/README.md
./bundles/org.openhab.binding.bluetooth.blukii/README.md
./bundles/org.openhab.binding.bluetooth.daikinmadoka/README.md
./bundles/org.openhab.binding.bluetooth.generic/README.md
./bundles/org.openhab.binding.bluetooth.govee/README.md
./bundles/org.openhab.binding.bluetooth.hdpowerview/README.md
./bundles/org.openhab.binding.bluetooth.radoneye/README.md
./bundles/org.openhab.binding.bluetooth.roaming/README.md
./bundles/org.openhab.binding.bluetooth.ruuvitag/README.md
./bundles/org.openhab.binding.freeathome/README.md
./bundles/org.openhab.binding.lgtvserial/README.md
./bundles/org.openhab.binding.modbus.e3dc/README.md
./bundles/org.openhab.binding.modbus.helioseasycontrols/README.md
./bundles/org.openhab.binding.modbus.stiebeleltron/README.md
./bundles/org.openhab.binding.modbus.studer/README.md
./bundles/org.openhab.binding.modbus.sunspec/README.md
./bundles/org.openhab.binding.paradoxalarm/README.md
./bundles/org.openhab.binding.pentair/README.md
./bundles/org.openhab.binding.velux/README.md
```

Therefore I have fixed these headings to be consistent with others.