### PR TITLE
[plugwiseha] Improve connection stability

### DIFF
--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAControllerRequest.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAControllerRequest.java
@@ -72,6 +72,7 @@ public class PlugwiseHAControllerRequest<T> {
     private static final String CONTENT_TYPE_TEXT_XML = MimeTypes.Type.TEXT_XML_8859_1.toString();
     private static final long TIMEOUT_SECONDS = 5;
     private static final int REQUEST_MAX_RETRY_COUNT = 3;
+    private static final int RETRY_DELAY_TIMOUT = 3000;
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseHAControllerRequest.class);
     private final XStream xStream;
@@ -252,6 +253,12 @@ public class PlugwiseHAControllerRequest<T> {
         } catch (TimeoutException e) {
             if (retries > 0) {
                 this.logger.debug("TimeoutException occured, remaining retries {}", retries - 1);
+                try {
+                    Thread.sleep(RETRY_DELAY_TIMOUT);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new PlugwiseHATimeoutException(ie);
+                }
                 return getContentResponse(retries - 1);
             } else {
                 throw new PlugwiseHATimeoutException(e);

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/converter/DateTimeConverter.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/converter/DateTimeConverter.java
@@ -38,10 +38,7 @@ public class DateTimeConverter extends AbstractSingleValueConverter {
 
     @Override
     public boolean canConvert(@Nullable @SuppressWarnings("rawtypes") Class type) {
-        if (type == null) {
-            return false;
-        }
-        return ZonedDateTime.class.isAssignableFrom(type);
+        return (type == null) ? false : ZonedDateTime.class.isAssignableFrom(type);
     }
 
     @Override

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/ActuatorFunctionalityThermostat.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/ActuatorFunctionalityThermostat.java
@@ -24,15 +24,12 @@ public class ActuatorFunctionalityThermostat extends ActuatorFunctionality {
     @SuppressWarnings("unused")
     private Double setpoint;
 
-    @SuppressWarnings("unused")
     @XStreamAlias("preheating_allowed")
     private Boolean preheatingAllowed;
 
-    @SuppressWarnings("unused")
     @XStreamAlias("cooling_allowed")
     private Boolean coolingAllowed;
 
-    @SuppressWarnings("unused")
     @XStreamAlias("regulation_control")
     private String regulationControl;
 

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/DomainObjects.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/DomainObjects.java
@@ -30,7 +30,6 @@ public class DomainObjects {
     @XStreamImplicit(itemFieldName = "location", keyFieldName = "id")
     private Locations locations = new Locations();
 
-    @SuppressWarnings("unused")
     @XStreamImplicit(itemFieldName = "module", keyFieldName = "id")
     private Modules modules = new Modules();
 

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/DomainObjects.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/DomainObjects.java
@@ -46,7 +46,9 @@ public class DomainObjects {
     }
 
     public Appliances mergeAppliances(Appliances updatedAppliances) {
-        if (updatedAppliances != null) {
+        if (appliances == null) {
+            this.appliances = updatedAppliances;
+        } else if (updatedAppliances != null) {
             this.appliances.merge(updatedAppliances);
         }
 
@@ -54,7 +56,9 @@ public class DomainObjects {
     }
 
     public Locations mergeLocations(Locations updatedLocations) {
-        if (updatedLocations != null) {
+        if (locations == null) {
+            this.locations = updatedLocations;
+        } else if (updatedLocations != null) {
             this.locations.merge(updatedLocations);
         }
 

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Log.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Log.java
@@ -76,7 +76,7 @@ public class Log extends PlugwiseBaseModel implements PlugwiseComparableDate<Log
     }
 
     public Optional<String> getMeasurementUnit() {
-        return Optional.ofNullable(unit);
+        return Optional.ofNullable(unit != null && !unit.isBlank() ? unit : null);
     }
 
     public ZonedDateTime getMeasurementDate() {

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Module.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Module.java
@@ -30,7 +30,6 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("module")
 public class Module extends PlugwiseBaseModel implements PlugwiseComparableDate<Module> {
 
-    @SuppressWarnings("unused")
     @XStreamImplicit(itemFieldName = "service", keyFieldName = "id")
     private Services services;
 

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Service.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/dto/Service.java
@@ -20,11 +20,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("service")
 public class Service extends PlugwiseBaseModel {
 
-    @SuppressWarnings("unused")
     @XStreamAlias("log_type")
     private String logType;
 
-    @SuppressWarnings("unused")
     @XStreamAlias("point_log")
     private String pointLogId;
 }

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/discovery/PlugwiseHADiscoveryService.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/discovery/PlugwiseHADiscoveryService.java
@@ -99,7 +99,7 @@ public class PlugwiseHADiscoveryService extends AbstractThingHandlerDiscoverySer
         PlugwiseHAController controller = thingHandler.getController();
 
         if (controller != null) {
-            DomainObjects domainObjects = controller.getDomainObjects();
+            DomainObjects domainObjects = controller.getAndMergeDomainObjects();
 
             if (domainObjects != null) {
                 for (Location location : domainObjects.getLocations().values()) {

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHAApplianceHandler.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHAApplianceHandler.java
@@ -146,10 +146,8 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 }
                 break;
             case APPLIANCE_OFFSET_CHANNEL:
-                if (command instanceof QuantityType quantityCommand) {
-                    Unit<Temperature> unit = entity.getOffsetTemperatureUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                if (command instanceof QuantityType<?> quantityCommand) {
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     QuantityType<?> state = quantityCommand.toUnit(unit);
 
                     if (state != null) {
@@ -172,9 +170,8 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 }
                 break;
             case APPLIANCE_SETPOINT_CHANNEL:
-                if (command instanceof QuantityType quantityCommand) {
-                    Unit<Temperature> unit = entity.getSetpointTemperatureUnit().orElse(UNIT_CELSIUS)
-                            .equals(UNIT_CELSIUS) ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT;
+                if (command instanceof QuantityType<?> quantityCommand) {
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     QuantityType<?> state = quantityCommand.toUnit(unit);
 
                     if (state != null) {
@@ -226,6 +223,11 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 break;
         }
         return state;
+    }
+
+    private Unit<Temperature> getRemoteTemperatureUnit(Appliance entity) {
+        return UNIT_CELSIUS.equals(entity.getDHWTempUnit().orElse(UNIT_CELSIUS)) ? SIUnits.CELSIUS
+                : ImperialUnits.FAHRENHEIT;
     }
 
     @Override
@@ -280,9 +282,7 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 break;
             case APPLIANCE_OFFSET_CHANNEL:
                 if (entity.getOffsetTemperature().isPresent()) {
-                    Unit<Temperature> unit = entity.getOffsetTemperatureUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getOffsetTemperature().get(), unit);
                 }
                 break;
@@ -298,16 +298,13 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 break;
             case APPLIANCE_SETPOINT_CHANNEL:
                 if (entity.getSetpointTemperature().isPresent()) {
-                    Unit<Temperature> unit = entity.getSetpointTemperatureUnit().orElse(UNIT_CELSIUS)
-                            .equals(UNIT_CELSIUS) ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getSetpointTemperature().get(), unit);
                 }
                 break;
             case APPLIANCE_TEMPERATURE_CHANNEL:
                 if (entity.getTemperature().isPresent()) {
-                    Unit<Temperature> unit = entity.getTemperatureUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getTemperature().get(), unit);
                 }
                 break;
@@ -330,8 +327,7 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 break;
             case APPLIANCE_INTENDEDBOILERTEMP_CHANNEL:
                 if (entity.getIntendedBoilerTemp().isPresent()) {
-                    Unit<Temperature> unit = entity.getIntendedBoilerTempUnit().orElse(UNIT_CELSIUS)
-                            .equals(UNIT_CELSIUS) ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getIntendedBoilerTemp().get(), unit);
                 }
                 break;
@@ -358,17 +354,13 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 break;
             case APPLIANCE_RETURNWATERTEMPERATURE_CHANNEL:
                 if (entity.getBoilerTemp().isPresent()) {
-                    Unit<Temperature> unit = entity.getReturnWaterTempUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getReturnWaterTemp().get(), unit);
                 }
                 break;
             case APPLIANCE_DHWTEMPERATURE_CHANNEL:
                 if (entity.getDHWTemp().isPresent()) {
-                    Unit<Temperature> unit = entity.getDHWTempUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getDHWTemp().get(), unit);
                 }
                 break;
@@ -379,25 +371,19 @@ public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance,
                 break;
             case APPLIANCE_BOILERTEMPERATURE_CHANNEL:
                 if (entity.getBoilerTemp().isPresent()) {
-                    Unit<Temperature> unit = entity.getBoilerTempUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getBoilerTemp().get(), unit);
                 }
                 break;
             case APPLIANCE_DHWSETPOINT_CHANNEL:
                 if (entity.getDHTSetpoint().isPresent()) {
-                    Unit<Temperature> unit = entity.getDHTSetpointUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getDHTSetpoint().get(), unit);
                 }
                 break;
             case APPLIANCE_MAXBOILERTEMPERATURE_CHANNEL:
                 if (entity.getMaxBoilerTemp().isPresent()) {
-                    Unit<Temperature> unit = entity.getMaxBoilerTempUnit().orElse(UNIT_CELSIUS).equals(UNIT_CELSIUS)
-                            ? SIUnits.CELSIUS
-                            : ImperialUnits.FAHRENHEIT;
+                    Unit<Temperature> unit = getRemoteTemperatureUnit(entity);
                     state = new QuantityType<>(entity.getMaxBoilerTemp().get(), unit);
                 }
                 break;

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/OH-INF/config/config.xml
@@ -23,11 +23,11 @@
 			<label>Smile ID</label>
 			<description>The Smile ID is the 8 letter code on the sticker on the back of the Adam boiler gateway</description>
 		</parameter>
-		<parameter name="refresh" type="integer" min="1" max="120" required="true" unit="s">
+		<parameter name="refresh" type="integer" min="3" max="300" required="true" unit="s">
 			<label>Refresh Interval</label>
 			<unitLabel>seconds</unitLabel>
 			<description>Refresh interval in seconds</description>
-			<default>5</default>
+			<default>15</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>


### PR DESCRIPTION
This PR mainly improves the handling of the connection to the Adam device, but also has other improvements:
- Whenever a timeout occurs, a 3 second delay is added to give the device some time to catch up.
- Improved locking to prevent multiple parallel calls to the device
- When a zone temperature set command is performed it now also accepts a DecimalType.
- Various minor fixes like javadoc, method modifiers and others.
- Solve compile warnings
- Adjust refresh interval to match both config and readme