### PR TITLE
[network] Modify iOS port knock to use a valid mDNS packet

### DIFF
--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -446,7 +446,8 @@ public class NetworkUtils {
     public void wakeUpIOS(InetAddress address) throws IOException {
         int port = 5353;
         try (DatagramSocket s = new DatagramSocket()) {
-            byte[] buffer = new byte[0];
+            // Send a valid mDNS packet (12 bytes of zeroes)
+            byte[] buffer = new byte[12];
             s.send(new DatagramPacket(buffer, buffer.length, address, port));
             logger.trace("Sent packet to {}:{} to wake up iOS device", address, port);
         } catch (PortUnreachableException e) {


### PR DESCRIPTION
The network binding has functionality that assumes, by default, that a device is an iOS device, and should be woken up by sending a packet to port 5353 (mDNS). The code sends a packet with an empty UDP payload, which is not a valid mDNS packet. 

If the device is not an iOS device, but is instead a Windows device running the Apple Bonjour Service, the Bonjour Service will add an entry to the application event log for each "malformed" packet received. While this feature can now be disabled (since #16259 was merged), I believe it would be a simple (and non-breaking) change to send a 12-byte packet of zeroes instead. This *is* a valid mDNS packet (representing a query with 0 questions and 0 answers) so doesn't trigger the error logging in Bonjour for Windows.

There is also a possibility that the malformed packets may trip some firewalls, but I do not have any evidence that this is happening.

<!--
# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
