### PR TITLE
[shelly] Fix suggestion finder

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/addon/addon.xml
@@ -44,7 +44,7 @@
 			<match-properties>
 				<match-property>
 					<name>name</name>
-					<regex>.*Shelly.*</regex>
+					<regex>(?i).*SHELLY.*</regex>
 				</match-property>
 			</match-properties>
 		</discovery-method>


### PR DESCRIPTION
My PM Mini is discovered as name starting with "shelly" (lowercase):
![image](https://github.com/user-attachments/assets/3027f3a2-8cb1-4382-9de7-2da97c1bfbe2)

Making the matching case-insensitive is consistent with the logic in code:
https://github.com/openhab/openhab-addons/blob/18862d3e28d1061b1daca5a54f547236bbf7df10/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyDiscoveryParticipant.java#L95-L99

Regression of #15817