### PR TITLE
[ism8] Improve debug logging

### DIFF
--- a/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/internal/Ism8Handler.java
+++ b/bundles/org.openhab.binding.ism8/src/main/java/org/openhab/binding/ism8/internal/Ism8Handler.java
@@ -177,7 +177,7 @@ public class Ism8Handler extends BaseThingHandler implements IDataPointChangeLis
                     return true;
                 }
             } else {
-                logger.debug("Ism8 channel: {} and DataPoint do not have a matching Id: {} vs {}", channel.getUID(), id,
+                logger.trace("Ism8 channel: {} and DataPoint do not have a matching Id: {} vs {}", channel.getUID(), id,
                         dataPoint.getId());
             }
         } catch (NumberFormatException e) {
@@ -193,7 +193,7 @@ public class Ism8Handler extends BaseThingHandler implements IDataPointChangeLis
         for (Channel channel : getThing().getChannels()) {
             if (channel.getConfiguration().containsKey(CHANNEL_CONFIG_ID)) {
                 if (updateChannel(channel, dataPoint)) {
-                    break;
+                    return;
                 }
             }
         }

--- a/bundles/org.openhab.binding.ism8/src/test/java/org/openhab/binding/ism8/internal/util/Ism8DomainMapTest.java
+++ b/bundles/org.openhab.binding.ism8/src/test/java/org/openhab/binding/ism8/internal/util/Ism8DomainMapTest.java
@@ -37,8 +37,6 @@ import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.util.HexUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -48,7 +46,6 @@ import org.slf4j.LoggerFactory;
 @ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class Ism8DomainMapTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Ism8DomainMap.class);
 
     @BeforeEach
     public void initialize() {


### PR DESCRIPTION
When ISM8 add-on is set to DEBUG logging, the output is currently as follows:

```
[DEBUG] [g.openhab.binding.ism8.server.Server] - CHA Heizleistung 8300.00
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8: dataPointChanged DataPoint 178=8300.00
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId053 and DataPoint do not have a matching Id: 53 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId054 and DataPoint do not have a matching Id: 54 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId194 and DataPoint do not have a matching Id: 194 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId056 and DataPoint do not have a matching Id: 56 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId057 and DataPoint do not have a matching Id: 57 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId058 and DataPoint do not have a matching Id: 58 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId059 and DataPoint do not have a matching Id: 59 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId060 and DataPoint do not have a matching Id: 60 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId061 and DataPoint do not have a matching Id: 61 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId062 and DataPoint do not have a matching Id: 62 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId063 and DataPoint do not have a matching Id: 63 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId064 and DataPoint do not have a matching Id: 64 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId065 and DataPoint do not have a matching Id: 65 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId066 and DataPoint do not have a matching Id: 66 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId068 and DataPoint do not have a matching Id: 68 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId069 and DataPoint do not have a matching Id: 69 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId070 and DataPoint do not have a matching Id: 70 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId071 and DataPoint do not have a matching Id: 71 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId072 and DataPoint do not have a matching Id: 72 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId073 and DataPoint do not have a matching Id: 73 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId074 and DataPoint do not have a matching Id: 74 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId075 and DataPoint do not have a matching Id: 75 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId076 and DataPoint do not have a matching Id: 76 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId077 and DataPoint do not have a matching Id: 77 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId078 and DataPoint do not have a matching Id: 78 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId079 and DataPoint do not have a matching Id: 79 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId114 and DataPoint do not have a matching Id: 114 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId115 and DataPoint do not have a matching Id: 115 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId116 and DataPoint do not have a matching Id: 116 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId117 and DataPoint do not have a matching Id: 117 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId135 and DataPoint do not have a matching Id: 135 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId136 and DataPoint do not have a matching Id: 136 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId137 and DataPoint do not have a matching Id: 137 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId141 and DataPoint do not have a matching Id: 141 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId146 and DataPoint do not have a matching Id: 146 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId147 and DataPoint do not have a matching Id: 147 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId195 and DataPoint do not have a matching Id: 195 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId196 and DataPoint do not have a matching Id: 196 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId176 and DataPoint do not have a matching Id: 176 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8 channel: ism8:device:wolf:DpId177 and DataPoint do not have a matching Id: 177 vs 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8: updating channel ism8:device:wolf:DpId178 with datapoint: 178
[DEBUG] [ab.binding.ism8.internal.Ism8Handler] - Ism8: no channel was found for DataPoint id: 178
```

First thing, when updating a channel with new data, all channels are traversed to find the one with the matching ID. This causes a lot of debug output, which is not helpful.
The PR sets this message to TRACE. Maybe removing it would be fine as well.

Second, after the correct channel has been updated, a message is issued, saying that no channel was found.
This is fixed by this PR.


In addition, an unused logger is removed from the tests to avoid warnings - regression from #17688.