### PR TITLE
[chromecast] Assign unique id to thing actions

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/action/ChromecastActions.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/action/ChromecastActions.java
@@ -57,7 +57,7 @@ public class ChromecastActions implements ThingActions {
         }
     }
 
-    @RuleAction(label = "@text/playURLTypeActionLabel", description = "@text/playURLTypeActionDescription")
+    @RuleAction(label = "@text/playURLTypeActionLabel", description = "@text/playURLTypeActionDescription", id = "playURLWithMediaType")
     public @ActionOutput(name = "result", label = "Success", type = "java.lang.Boolean") Boolean playURL(
             @ActionInput(name = "url") @Nullable String url,
             @ActionInput(name = "mediaType") @Nullable String mediaType) {


### PR DESCRIPTION
Related to #17707

Depends on openhab/openhab-core#4438
