### PR TITLE
[samsungtv] Fix for incorrect PowerState

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
@@ -120,13 +120,13 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
     @NonNullByDefault({})
     public class TVProperties {
         class Device {
-            boolean frameTVSupport;
-            boolean gamePadSupport;
-            boolean imeSyncedSupport;
-            String oS;
-            String powerState;
-            boolean tokenAuthSupport;
-            boolean voiceSupport;
+            boolean FrameTVSupport;
+            boolean GamePadSupport;
+            boolean ImeSyncedSupport;
+            String OS;
+            String PowerState;
+            boolean TokenAuthSupport;
+            boolean VoiceSupport;
             String countryCode;
             String description;
             String firmwareVersion;
@@ -143,22 +143,22 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
         String isSupport;
 
         public boolean getFrameTVSupport() {
-            return Optional.ofNullable(device).map(a -> a.frameTVSupport).orElse(false);
+            return Optional.ofNullable(device).map(a -> a.FrameTVSupport).orElse(false);
         }
 
         public boolean getTokenAuthSupport() {
-            return Optional.ofNullable(device).map(a -> a.tokenAuthSupport).orElse(false);
+            return Optional.ofNullable(device).map(a -> a.TokenAuthSupport).orElse(false);
         }
 
         public String getPowerState() {
             if (!getOS().isBlank()) {
-                return Optional.ofNullable(device).map(a -> a.powerState).orElse("on");
+                return Optional.ofNullable(device).map(a -> a.PowerState).orElse("on");
             }
             return "off";
         }
 
         public String getOS() {
-            return Optional.ofNullable(device).map(a -> a.oS).orElse("");
+            return Optional.ofNullable(device).map(a -> a.OS).orElse("");
         }
 
         public String getWifiMac() {


### PR DESCRIPTION
Bugfix for #17542

On some TV's, sending ON to turn the TV on, would result in the TV immediately turning OFF a few seconds later.

This was caused by the POJO which is used for decoding the json from the TV being changed to camelCase (don't know when this happened). Some of the json values are in UpperCamelCase though, so were not being decoded, specifically OS and PowerState.

This bug fix changes the POJO back to match the received json, and should resolve a number of similar issues.