### PR TITLE
[jsscripting] Upgrade GraalJS from 22.0.0.2 to 24.1.1

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -23,7 +23,7 @@
       !jdk.vm.ci.services
     </bnd.importpackage>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
-    <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
+    <graal.version>23.0.6</graal.version>
     <oh.version>${project.version}</oh.version>
     <ohjs.version>openhab@5.8.1</ohjs.version>
   </properties>
@@ -156,6 +156,11 @@
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
       <version>${graal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>76.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -23,25 +23,37 @@
       !jdk.vm.ci.services
     </bnd.importpackage>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
-    <graal.version>23.0.6</graal.version>
+    <graaljs.version>24.1.1</graaljs.version>
     <oh.version>${project.version}</oh.version>
     <ohjs.version>openhab@5.8.1</ohjs.version>
   </properties>
 
   <build>
     <plugins>
-      <!-- exclude META-INF/services/com.oracle.truffle.api.TruffleLanguage$Provider when unpacking dependencies -->
+      <!-- bundle the modular dependencies into an uber-JAR -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
         <executions>
           <execution>
-            <id>embed-dependencies</id>
+            <phase>package</phase>
             <goals>
-              <goal>unpack-dependencies</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <excludes>META-INF/services/com.oracle.truffle.api.TruffleLanguage$Provider</excludes> <!-- we'll provide this -->
+              <artifactSet>
+                <excludes>
+                  <exclude>org.lastnpe.eea:eea-all</exclude>
+                  <exclude>org.apache.karaf.features:framework</exclude>
+                </excludes>
+              </artifactSet>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <!-- Transformer to merge module-info.class files, if needed -->
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
             </configuration>
           </execution>
         </executions>
@@ -130,37 +142,29 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.graalvm.sdk</groupId>
-      <artifactId>graal-sdk</artifactId>
-      <version>${graal.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.graalvm.truffle</groupId>
-      <artifactId>truffle-api</artifactId>
-      <version>${graal.version}</version>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>polyglot</artifactId>
+      <version>${graaljs.version}</version>
     </dependency>
     <!-- Graal JavaScript ScriptEngine JSR 223 support -->
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
-      <version>${graal.version}</version>
+      <version>${graaljs.version}</version>
     </dependency>
     <!-- Graal TRegex engine (internally used by Graal JavaScript engine) -->
     <dependency>
       <groupId>org.graalvm.regex</groupId>
       <artifactId>regex</artifactId>
-      <version>${graal.version}</version>
+      <version>${graaljs.version}</version>
     </dependency>
     <!-- Graal JavaScript engine (depends on Graal TRegex engine, must be added after it) -->
     <dependency>
-      <groupId>org.graalvm.js</groupId>
-      <artifactId>js</artifactId>
-      <version>${graal.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.icu</groupId>
-      <artifactId>icu4j</artifactId>
-      <version>76.1</version>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>js-community</artifactId>
+      <version>${graaljs.version}</version>
+      <type>pom</type>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -163,8 +163,8 @@ public class OpenhabGraalJSScriptEngine
                         .option("js.nashorn-compat", "true") // Enable Nashorn compat mode as openhab-js relies on
                                                              // accessors, see
                                                              // https://github.com/oracle/graaljs/blob/master/docs/user/NashornMigrationGuide.md#accessors
-                        .option("js.ecmascript-version", "2022") // If Nashorn compat is enabled, it will enforce ES5
-                                                                 // compatibility, we want ECMA2022
+                        .option("js.ecmascript-version", "2024") // If Nashorn compat is enabled, it will enforce ES5
+                                                                 // compatibility, we want ECMA2024
                         .option("js.commonjs-require", "true") // Enable CommonJS module support
                         .hostClassLoader(getClass().getClassLoader())
                         .fileSystem(new DelegatingFileSystem(FileSystems.getDefault().provider()) {

--- a/bundles/org.openhab.automation.jsscripting/src/main/resources/META-INF/services/com.oracle.truffle.api.TruffleLanguage$Provider
+++ b/bundles/org.openhab.automation.jsscripting/src/main/resources/META-INF/services/com.oracle.truffle.api.TruffleLanguage$Provider
@@ -1,2 +1,0 @@
-com.oracle.truffle.regex.RegexLanguageProvider
-com.oracle.truffle.js.lang.JavaScriptLanguageProvider


### PR DESCRIPTION
Changelog: https://github.com/oracle/graaljs/blob/master/CHANGELOG.md#version-2410

FYI I wondered if we could OSGi-ify org.graalvm.polglot:polyglot and possibly other dependencies and what would be the benefit of this.
This is tested on my dev system running 5.0.0 snapshot.