### PR TITLE
[lutron] Added device discovery for DivaSmartDimmer and PaddleSwitchPico

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
@@ -88,6 +88,7 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                         case "SunnataDimmer":
                         case "WallDimmer":
                         case "PlugInDimmer":
+                        case "DivaSmartDimmer":
                             notifyDiscovery(THING_TYPE_DIMMER, deviceId, label);
                             break;
                         case "WallSwitch":
@@ -99,6 +100,7 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                             notifyDiscovery(THING_TYPE_FAN, deviceId, label);
                             break;
                         case "Pico2Button":
+                        case "PaddleSwitchPico":
                             notifyDiscovery(THING_TYPE_PICO, deviceId, label, "model", "2B");
                             break;
                         case "Pico2ButtonRaiseLower":
@@ -118,7 +120,7 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                             // Don't discover sensors. Using occupancy groups instead.
                             break;
                         default:
-                            logger.info("Unrecognized device type: {}", device.deviceType);
+                            logger.info("Unrecognized device type: {} ({})", device.deviceType, deviceId);
                             break;
                     }
                 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
@@ -120,7 +120,7 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                             // Don't discover sensors. Using occupancy groups instead.
                             break;
                         default:
-                            logger.info("Unrecognized device type: {} ({})", device.deviceType, deviceId);
+                            logger.info("Unrecognized device type: {} id: {}", device.deviceType, deviceId);
                             break;
                     }
                 }


### PR DESCRIPTION
# [lutron] Added device discovery for DivaSmartDimmer and PaddleSwitchPico

# Description

Added discovery of  DivaSmartDimmer and PaddleSwitchPico device types and mapped to creation of appropriate device.
Also, added the deviceId to the "Unrecognized" device log so that users can manually add new devices in the future.