### PR TITLE
[nanoleaf] Suppress ipv6 addr in controller discovery

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/README.md
+++ b/bundles/org.openhab.binding.nanoleaf/README.md
@@ -40,6 +40,8 @@ You can set the **color** for each panel and in the case of a Nanoleaf Canvas or
 
 ## Discovery
 
+Note that the discovery is based upon IP V4 addresses as the binding does not support IP V6 addresses.
+
 ### Adding the Controller as a Thing
 
 To add a nanoleaf controller, go to your inbox and start a scan.

--- a/bundles/org.openhab.binding.nanoleaf/README.md
+++ b/bundles/org.openhab.binding.nanoleaf/README.md
@@ -40,8 +40,6 @@ You can set the **color** for each panel and in the case of a Nanoleaf Canvas or
 
 ## Discovery
 
-Note that the discovery is based upon IP V4 addresses as the binding does not support IP V6 addresses.
-
 ### Adding the Controller as a Thing
 
 To add a nanoleaf controller, go to your inbox and start a scan.
@@ -134,22 +132,8 @@ The controller thing has the following parameters:
 **Important note on the topic of IPV6 ip addresses:**
 
 With firmware version 8.5.2 or newer, panels may change between being OFFLINE and ONLINE.
-This is due to the fact that if they are discovered with IPv6 addresses, the binding is not able to correctly send API requests to the devices.
-It is therefore recommended to disable IPv6 on the openHAB server.
-
-This can e.g. be achieved on openHABian the following way:
-
-```shell
-sudo nano /etc/sysctl.conf`
-```
-
-Add the following at the bottom of the file:
-
-```ini
-net.ipv6.conf.all.disable_ipv6 = 1
-net.ipv6.conf.default.disable_ipv6 = 1
-net.ipv6.conf.lo.disable_ipv6 = 1
-```
+This is because if they are discovered with IPv6 addresses, the binding is not able to correctly send API requests to the devices which leads to an unstable behaviour.
+To avoid this, the binding will only discover devices based on their IPv4 address.
 
 Reboot your server after the change.
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
@@ -74,7 +74,7 @@ public class NanoleafMDNSDiscoveryParticipant implements MDNSDiscoveryParticipan
                 return null;
             }
         } catch (UnknownHostException e) {
-            logger.error("Error while checking IP address for nanoleaf controller: {}", host);
+            logger.warn("Error while checking IP address for nanoleaf controller: {}", host);
             return null;
         }
         properties.put(CONFIG_ADDRESS, host);

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
@@ -14,6 +14,8 @@ package org.openhab.binding.nanoleaf.internal.discovery;
 
 import static org.openhab.binding.nanoleaf.internal.NanoleafBindingConstants.*;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -66,6 +68,15 @@ public class NanoleafMDNSDiscoveryParticipant implements MDNSDiscoveryParticipan
         }
         final Map<String, Object> properties = new HashMap<>(2);
         String host = service.getHostAddresses()[0];
+        try {
+            if (InetAddress.getByName(host).getAddress().length != 4) {
+                logger.info("Ignoring IPv6 address for nanoleaf controllers: {}", host);
+                return null;
+            }
+        } catch (UnknownHostException e) {
+            logger.error("Error while checking IP address for nanoleaf controller: {}", host);
+            return null;
+        }
         properties.put(CONFIG_ADDRESS, host);
         int port = service.getPort();
         properties.put(CONFIG_PORT, port);

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
@@ -70,7 +70,7 @@ public class NanoleafMDNSDiscoveryParticipant implements MDNSDiscoveryParticipan
         String host = service.getHostAddresses()[0];
         try {
             if (InetAddress.getByName(host).getAddress().length != 4) {
-                logger.info("Ignoring IPv6 address for nanoleaf controllers: {}", host);
+                logger.debug("Ignoring IPv6 address for nanoleaf controllers: {}", host);
                 return null;
             }
         } catch (UnknownHostException e) {


### PR DESCRIPTION
The nanoleaf binding becomes very unstable when run in an ipv6 environment (though ipv6 is required when using matter). This simple change ignores the (additional) ipv6 announcement of the nanoleaf controller which fixes online/offline flapping of the nanoleaf thing.

Also see https://community.openhab.org/t/nanoleaf-binding-may-fail-when-upgrading-to-the-latest-nanoleaf-firmware-because-of-ipv6/148152