### PR TITLE
[AmazonEchoControl] Unifiy error messages

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
@@ -184,7 +184,7 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
         AccountHandler accountHandler = getAccountHandler();
         SmartHomeBaseDevice smartHomeBaseDevice = this.smartHomeBaseDevice;
         if (smartHomeBaseDevice == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Can't find smarthomeBaseDevice!");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Can't find smarthomeBaseDevice");
             return;
         }
 


### PR DESCRIPTION
Just a small typo I noticed while using the binding
```
20:46:29 (14. 11.)    Thing 'amazonechocontrol:smartHomeDeviceGroup:Amazon_System_Konto:Multimedia_Kueche_Echo_Geraet' changed from OFFLINE: Can't find smarthomeBaseDevice! to OFFLINE: Can't find smarthomeBaseDevice
20:46:37 (14. 11.)    Thing 'amazonechocontrol:smartHomeDeviceGroup:Amazon_System_Konto:Multimedia_Kueche_Echo_Geraet' changed from OFFLINE: Can't find smarthomeBaseDevice to OFFLINE: Can't find smarthomeBaseDevice!
```