### PR TITLE
[mercedesme] Add vin automatically to discovered vehicle

### DIFF
--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/discovery/MercedesMeDiscoveryService.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/discovery/MercedesMeDiscoveryService.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Component;
  * associated vehicles and provides DiscoveryResults
  *
  * @author Bernd Weymann - Initial Contribution
+ * @author Bernd Weymann - Add vin as representation property
  */
 @NonNullByDefault
 @Component(service = DiscoveryService.class, configurationPid = "discovery.mercedesme")
@@ -56,8 +57,9 @@ public class MercedesMeDiscoveryService extends AbstractDiscoveryService {
                 break;
         }
         if (ttuid != null) {
+            properties.put("vin", vin);
             thingDiscovered(DiscoveryResultBuilder.create(new ThingUID(ttuid, ac.getThing().getUID(), vin))
-                    .withBridge(ac.getThing().getUID()).withProperties(properties)
+                    .withBridge(ac.getThing().getUID()).withProperties(properties).withRepresentationProperty("vin")
                     .withLabel("Mercedes Benz " + ttuid.getId().toUpperCase()).build());
         }
     }

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
@@ -324,7 +324,9 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
         } else {
             if (!capabilitiesMap.containsKey(vin)) {
                 // only report new discovery if capabilities aren't discovered yet
-                discoveryService.vehicleDiscovered(this, vin, getCapabilities(vin));
+                Map<String, Object> discoveryProperties = getCapabilities(vin);
+                discoveryProperties.put("vin", vin);
+                discoveryService.vehicleDiscovered(this, vin, discoveryProperties);
             }
         }
     }


### PR DESCRIPTION
Bugfix: Discovered things are not working immediately because `vin` configuration was missing. Added vin now as representation property.
