### PR TITLE
[mercedesme] Websocket decoupling

### DIFF
--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
@@ -203,12 +203,12 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
             server = Optional.empty();
             Utils.removePort(config.get().callbackPort);
         }
-        ws.interrupt();
         scheduledFuture.ifPresent(schedule -> {
             if (!schedule.isCancelled()) {
                 schedule.cancel(true);
             }
         });
+        ws.interrupt();
     }
 
     /**

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
@@ -376,7 +376,7 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
         } catch (IOException e) {
             logger.trace("IOException decoding message {}", e.getMessage());
         } catch (Error err) {
-            logger.trace("Error caught {}", err.getMessage());
+            logger.debug("Error caught {}", err.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
@@ -219,6 +219,7 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
             }
         });
         ws.interrupt();
+        eventQueue.clear();
     }
 
     /**
@@ -313,6 +314,8 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
                     eventQueue.wait();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    eventQueue.clear();
+                    return;
                 }
             }
             if (!eventQueue.isEmpty()) {

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/AccountHandler.java
@@ -79,7 +79,6 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
     private final Map<String, VehicleHandler> activeVehicleHandlerMap = new HashMap<>();
     private final Map<String, VEPUpdate> vepUpdateMap = new HashMap<>();
     private final Map<String, Map<String, Object>> capabilitiesMap = new HashMap<>();
-    private final List<Map<String, VEPUpdate>> eventQueue = new ArrayList<>();
 
     private Optional<AuthServer> server = Optional.empty();
     private Optional<AuthService> authService = Optional.empty();
@@ -88,7 +87,6 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
     private String capabilitiesEndpoint = "/v1/vehicle/%s/capabilities";
     private String commandCapabilitiesEndpoint = "/v1/vehicle/%s/capabilities/commands";
     private String poiEndpoint = "/v1/vehicle/%s/route";
-    private boolean updateRunning = false;
 
     final MBWebsocket ws;
     Optional<AccountConfiguration> config = Optional.empty();
@@ -290,7 +288,9 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
         List<String> notFoundList = new ArrayList<>();
         map.forEach((key, value) -> {
             VehicleHandler h = activeVehicleHandlerMap.get(key);
-            if (h == null) {
+            if (h != null) {
+                h.distributeContent(value);
+            } else {
                 if (value.getFullUpdate()) {
                     vepUpdateMap.put(key, value);
                 }
@@ -298,50 +298,9 @@ public class AccountHandler extends BaseBridgeHandler implements AccessTokenRefr
             }
         });
         notFoundList.forEach(vin -> {
-            map.remove(vin);
             logger.trace("No VehicleHandler available for VIN {}", vin);
         });
-        if (!map.isEmpty()) {
-            synchronized (eventQueue) {
-                eventQueue.add(map);
-                scheduler.execute(this::doDdistributeVepUpdates);
-            }
-        }
         return notFoundList.isEmpty();
-    }
-
-    public void doDdistributeVepUpdates() {
-        Map<String, VEPUpdate> map;
-        synchronized (eventQueue) {
-            while (updateRunning) {
-                try {
-                    eventQueue.wait();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-            if (!eventQueue.isEmpty()) {
-                map = eventQueue.remove(0);
-            } else {
-                return;
-            }
-            updateRunning = true;
-        }
-        try {
-            map.forEach((key, value) -> {
-                VehicleHandler h = activeVehicleHandlerMap.get(key);
-                if (h != null) {
-                    h.distributeContent(value);
-                }
-            });
-        } catch (Throwable t) {
-            logger.info("Exception during update {}", t.getMessage());
-            // ensure every possible throwable is catched to ensure running queue
-        }
-        synchronized (eventQueue) {
-            updateRunning = false;
-            eventQueue.notifyAll();
-        }
     }
 
     public void commandStatusUpdate(Map<String, AppTwinCommandStatusUpdatesByPID> updatesByVinMap) {

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandler.java
@@ -181,9 +181,11 @@ public class VehicleHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
+        //
         accountHandler.ifPresent(ah -> {
             ah.unregisterVin(config.get().vin);
         });
+        eventQueue.clear();
         super.dispose();
     }
 
@@ -604,6 +606,8 @@ public class VehicleHandler extends BaseThingHandler {
                     eventQueue.wait();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    eventQueue.clear();
+                    return;
                 }
             }
             if (!eventQueue.isEmpty()) {

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandler.java
@@ -181,7 +181,6 @@ public class VehicleHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
-        //
         accountHandler.ifPresent(ah -> {
             ah.unregisterVin(config.get().vin);
         });

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -169,10 +169,6 @@ public class MBWebsocket {
         }
     }
 
-    public boolean isRunning() {
-        return running;
-    }
-
     public void interrupt() {
         synchronized (this) {
             runTill = Instant.MIN;
@@ -202,6 +198,7 @@ public class MBWebsocket {
     @OnWebSocketMessage
     public void onBytes(InputStream is) {
         try {
+            byte[] array = is.readAllBytes();
             PushMessage pm = VehicleEvents.PushMessage.parseFrom(is);
             if (pm.hasVepUpdates()) {
                 boolean distributed = accountHandler.distributeVepUpdates(pm.getVepUpdates().getUpdatesMap());

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -205,7 +205,7 @@ public class MBWebsocket {
              * 3. VehicleHandler responsible to update channels
              */
         } catch (IOException e) {
-            logger.trace("IOException reading input stream {}", e.getMessage());
+            logger.debug("IOException reading input stream {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -194,7 +194,7 @@ public class MBWebsocket {
         try {
             byte[] array = is.readAllBytes();
             is.close();
-            accountHandler.onMessage(array);
+            accountHandler.enqueueMessage(array);
         } catch (IOException e) {
             logger.trace("IOException reading input stream {}", e.getMessage());
         }

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -195,6 +195,12 @@ public class MBWebsocket {
             byte[] array = is.readAllBytes();
             is.close();
             accountHandler.enqueueMessage(array);
+            /**
+             * 1. Websocket thread responsible for reading stream in bytes and enqueue for AccountHandler.
+             * 2. AccountHamdler thread responsible for encoding proto message. In case of update enqueue proto message
+             * at VehicleHandöer
+             * 3. VehicleHandler responsible to update channels
+             */
         } catch (IOException e) {
             logger.trace("IOException reading input stream {}", e.getMessage());
         }

--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -196,6 +196,9 @@ public class MBWebsocket {
             is.close();
             accountHandler.enqueueMessage(array);
             /**
+             * https://community.openhab.org/t/mercedes-me/136866/12
+             * Release Websocket thread as early as possible to avoid execeptions
+             *
              * 1. Websocket thread responsible for reading stream in bytes and enqueue for AccountHandler.
              * 2. AccountHamdler thread responsible for encoding proto message. In case of update enqueue proto message
              * at VehicleHandöer

--- a/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandlerTest.java
+++ b/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandlerTest.java
@@ -116,6 +116,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
         assertEquals(10, updateListener.getUpdatesForGroup("doors"), "Doors Update Count");
@@ -152,6 +153,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-ImperialUnits.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
         assertEquals(10, updateListener.getUpdatesForGroup("doors"), "Doors Update Count");
@@ -188,6 +190,8 @@ class VehicleHandlerTest {
         json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
+
         assertEquals("%.1f °C", patternMock.patternMap.get("test::bev:hvac#temperature"), "Temperature Pattern");
         commandOptionMock.getCommandList("test::bev:hvac#temperature").forEach(cmd -> {
             assertTrue(cmd.getCommand().endsWith(" °C"), "Command Option Celsius Unit");
@@ -210,6 +214,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
         assertEquals(10, updateListener.getUpdatesForGroup("doors"), "Doors Update Count");
@@ -247,12 +252,16 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA-Charging-Weekday.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
+
         assertEquals("2023-09-09 13:54", ((DateTimeType) updateListener.getResponse("test::bev:charge#end-time"))
                 .format("%1$tY-%1$tm-%1$td %1$tH:%1$tM"), "End of Charge Time");
 
         json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA-Charging-Weekday-Underrun.json");
         update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
+
         assertEquals("2023-09-11 13:55", ((DateTimeType) updateListener.getResponse("test::bev:charge#end-time"))
                 .format("%1$tY-%1$tm-%1$td %1$tH:%1$tM"), "End of Charge Time");
     }
@@ -273,6 +282,8 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/PartialUpdate-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, false);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
+
         assertEquals(2, updateListener.updatesReceived.size(), "Update Count");
         assertEquals("2023-09-19 20:45", ((DateTimeType) updateListener.getResponse("test::bev:charge#end-time"))
                 .format("%1$tY-%1$tm-%1$td %1$tH:%1$tM"), "End of Charge Time");
@@ -295,6 +306,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/PartialUpdate-GPS.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, false);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
         assertEquals(3, updateListener.updatesReceived.size(), "Update Count");
         assertEquals("1.23,4.56", updateListener.getResponse("test::bev:position#gps").toFullString(), "GPS update");
         assertEquals("41.9 °", updateListener.getResponse("test::bev:position#heading").toFullString(),
@@ -317,6 +329,8 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/PartialUpdate-Range.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, false);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
+
         assertEquals(3, updateListener.updatesReceived.size(), "Update Count");
         assertEquals("15017 km", updateListener.getResponse("test::bev:range#mileage").toFullString(),
                 "Mileage Update");
@@ -342,6 +356,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Hybrid-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
         assertEquals(10, updateListener.getUpdatesForGroup("doors"), "Doors Update Count");
@@ -375,6 +390,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Hybrid-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         // Test charged / uncharged battery and filled / unfilled tank volume
         assertEquals("5.800000190734863 kWh", updateListener.getResponse("test::hybrid:range#charged").toFullString(),
@@ -404,6 +420,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
         assertEquals(10, updateListener.getUpdatesForGroup("doors"), "Doors Update Count");
@@ -451,11 +468,13 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
         assertFalse(updateListener.updatesReceived.containsKey("test::bev:vehicle#proto-update"),
                 "Proto Channel not updated");
 
         updateListener.linked = true;
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
         assertTrue(updateListener.updatesReceived.containsKey("test::bev:vehicle#proto-update"),
                 "Proto Channel not updated");
     }
@@ -478,6 +497,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Unknown.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
         assertEquals("22 °C", updateListener.getResponse("test::bev:hvac#temperature").toFullString(),
                 "Temperature Point One Updated");
 
@@ -509,6 +529,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Unknown.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         ChannelUID cuid = new ChannelUID(thingMock.getUID(), Constants.GROUP_HVAC, "temperature");
         updateListener = new ThingCallbackListener();
@@ -539,6 +560,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vh.distributeContent(update);
+        updateListener.waitForUpdates();
 
         ChannelUID cuid = new ChannelUID(thingMock.getUID(), Constants.GROUP_CHARGE, "max-soc");
         vh.handleCommand(cuid, QuantityType.valueOf("90 %"));
@@ -587,6 +609,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vHandler.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(POSITIONING_UPDATE_COUNT, updateListener.getUpdatesForGroup("position"), "Position Update Count");
         assertEquals("1.23,4.56", updateListener.getResponse("test::bev:position#gps").toFullString(),
@@ -609,6 +632,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vHandler.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals(HVAC_UPDATE_COUNT, updateListener.getUpdatesForGroup("hvac"), "HVAC Update Count");
         assertEquals(0, ((DecimalType) updateListener.getResponse("test::bev:hvac#ac-status")).intValue(),
@@ -628,6 +652,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vHandler.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals("72 %", updateListener.getResponse("test::bev:eco#accel").toFullString(), "Eco Acceleration");
         assertEquals("81 %", updateListener.getResponse("test::bev:eco#coasting").toFullString(), "Eco Coasting");
@@ -648,6 +673,7 @@ class VehicleHandlerTest {
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Combustion.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
         vHandler.distributeContent(update);
+        updateListener.waitForUpdates();
 
         assertEquals("29 %", updateListener.getResponse("test::combustion:range#adblue-level").toFullString(),
                 "AdBlue Tank Level");

--- a/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandlerTest.java
+++ b/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/internal/handler/VehicleHandlerTest.java
@@ -115,7 +115,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
@@ -152,7 +152,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-ImperialUnits.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
@@ -189,7 +189,7 @@ class VehicleHandlerTest {
         // overwrite with EU Units
         json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals("%.1f °C", patternMock.patternMap.get("test::bev:hvac#temperature"), "Temperature Pattern");
@@ -213,7 +213,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
@@ -251,7 +251,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA-Charging-Weekday.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals("2023-09-09 13:54", ((DateTimeType) updateListener.getResponse("test::bev:charge#end-time"))
@@ -259,7 +259,7 @@ class VehicleHandlerTest {
 
         json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA-Charging-Weekday-Underrun.json");
         update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals("2023-09-11 13:55", ((DateTimeType) updateListener.getResponse("test::bev:charge#end-time"))
@@ -281,7 +281,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/PartialUpdate-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, false);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(2, updateListener.updatesReceived.size(), "Update Count");
@@ -305,7 +305,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/PartialUpdate-GPS.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, false);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
         assertEquals(3, updateListener.updatesReceived.size(), "Update Count");
         assertEquals("1.23,4.56", updateListener.getResponse("test::bev:position#gps").toFullString(), "GPS update");
@@ -328,7 +328,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/PartialUpdate-Range.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, false);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(3, updateListener.updatesReceived.size(), "Update Count");
@@ -355,7 +355,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Hybrid-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
@@ -389,7 +389,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Hybrid-Charging.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         // Test charged / uncharged battery and filled / unfilled tank volume
@@ -419,7 +419,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(GROUP_COUNT, updateListener.updatesPerGroupMap.size(), "Group Update Count");
@@ -467,13 +467,13 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
         assertFalse(updateListener.updatesReceived.containsKey("test::bev:vehicle#proto-update"),
                 "Proto Channel not updated");
 
         updateListener.linked = true;
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
         assertTrue(updateListener.updatesReceived.containsKey("test::bev:vehicle#proto-update"),
                 "Proto Channel not updated");
@@ -496,7 +496,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Unknown.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
         assertEquals("22 °C", updateListener.getResponse("test::bev:hvac#temperature").toFullString(),
                 "Temperature Point One Updated");
@@ -528,7 +528,7 @@ class VehicleHandlerTest {
         vh.setCallback(updateListener);
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Unknown.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         ChannelUID cuid = new ChannelUID(thingMock.getUID(), Constants.GROUP_HVAC, "temperature");
@@ -559,7 +559,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vh.distributeContent(update);
+        vh.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         ChannelUID cuid = new ChannelUID(thingMock.getUID(), Constants.GROUP_CHARGE, "max-soc");
@@ -608,7 +608,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vHandler.distributeContent(update);
+        vHandler.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(POSITIONING_UPDATE_COUNT, updateListener.getUpdatesForGroup("position"), "Position Update Count");
@@ -631,7 +631,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vHandler.distributeContent(update);
+        vHandler.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals(HVAC_UPDATE_COUNT, updateListener.getUpdatesForGroup("hvac"), "HVAC Update Count");
@@ -651,7 +651,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-BEV-EQA.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vHandler.distributeContent(update);
+        vHandler.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals("72 %", updateListener.getResponse("test::bev:eco#accel").toFullString(), "Eco Acceleration");
@@ -672,7 +672,7 @@ class VehicleHandlerTest {
 
         String json = FileReader.readFileInString("src/test/resources/proto-json/MB-Combustion.json");
         VEPUpdate update = ProtoConverter.json2Proto(json, true);
-        vHandler.distributeContent(update);
+        vHandler.enqueueUpdate(update);
         updateListener.waitForUpdates();
 
         assertEquals("29 %", updateListener.getResponse("test::combustion:range#adblue-level").toFullString(),


### PR DESCRIPTION
Warnings from MercedesMe websocket reported in [community](https://community.openhab.org/t/mercedes-me/136866/12), After analysis design flaw in current binding needs to solved:
Websocket thread is performing the complete chain from reading bytestream up to channel updates. While this other messages  are dismissed 
Structural change to free websocket thread as early as possible:

1. Websocket thread responsible for reading stream in bytes and enqueue for AccountHandler.
2. AccountHamdler thread responsible for encoding proto message. In case of update enqueue proto message at VehicleHandöer
4. VehicleHandler responsible to update channels
