### PR TITLE
Fix `DateTimeType` tests

### DIFF
--- a/bundles/org.openhab.binding.dbquery/src/test/java/org/openhab/binding/dbquery/internal/Value2StateConverterTest.java
+++ b/bundles/org.openhab.binding.dbquery/src/test/java/org/openhab/binding/dbquery/internal/Value2StateConverterTest.java
@@ -21,7 +21,6 @@ import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Base64;
 import java.util.Date;
 import java.util.stream.Stream;
@@ -119,8 +118,7 @@ class Value2StateConverterTest {
         var instant = Instant.now();
         var converted = instance.convertValue(instant, DateTimeType.class);
         assertThat(converted, instanceOf(DateTimeType.class));
-        assertThat(((DateTimeType) converted).getZonedDateTime(),
-                is(ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).withFixedOffsetZone()));
+        assertThat(((DateTimeType) converted).getInstant(), is(instant));
     }
 
     @Test
@@ -128,16 +126,15 @@ class Value2StateConverterTest {
         var date = new Date();
         var converted = instance.convertValue(date, DateTimeType.class);
         assertThat(converted, instanceOf(DateTimeType.class));
-        assertThat(((DateTimeType) converted).getZonedDateTime(),
-                is(ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).withFixedOffsetZone()));
+        assertThat(((DateTimeType) converted).getInstant(), is(date.toInstant()));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "2019-10-12T07:20:50.52Z", "2019-10-12" })
+    @ValueSource(strings = { "2019-10-12T07:20:50.52", "2019-10-12" })
     void givenValidStringDateAndDatetimeTargetReturnDatetype(String date) {
         var converted = instance.convertValue(date, DateTimeType.class);
         assertThat(converted, instanceOf(DateTimeType.class));
-        var convertedDateTime = ((DateTimeType) converted).getZonedDateTime();
+        var convertedDateTime = ((DateTimeType) converted).getInstant().atZone(ZoneId.systemDefault());
         assertThat(convertedDateTime.getYear(), is(2019));
         assertThat(convertedDateTime.getMonthValue(), is(10));
         assertThat(convertedDateTime.getDayOfMonth(), is(12));

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/FineOffsetDataParserTest.java
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/test/java/org/openhab/binding/fineoffsetweatherstation/internal/service/FineOffsetDataParserTest.java
@@ -24,6 +24,7 @@ import org.openhab.binding.fineoffsetweatherstation.internal.domain.ConversionCo
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.DebugDetails;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.Protocol;
 import org.openhab.binding.fineoffsetweatherstation.internal.domain.response.MeasuredValue;
+import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.util.HexUtils;
 
 /**
@@ -101,7 +102,10 @@ class FineOffsetDataParserTest {
         List<MeasuredValue> data = new FineOffsetDataParser(Protocol.DEFAULT).getMeasuredValues(bytes,
                 new ConversionContext(ZoneOffset.UTC), debugDetails);
         Assertions.assertThat(data)
-                .extracting(MeasuredValue::getChannelId, measuredValue -> measuredValue.getState().toString())
+                .extracting(MeasuredValue::getChannelId,
+                        measuredValue -> measuredValue.getState() instanceof DateTimeType dateTimeState
+                                ? dateTimeState.getInstant().toString()
+                                : measuredValue.getState().toString())
                 .containsExactly(new Tuple("temperature-indoor", "20.2 °C"), new Tuple("humidity-indoor", "62 %"),
                         new Tuple("pressure-absolute", "996.4 hPa"), new Tuple("pressure-relative", "996.4 hPa"),
                         new Tuple("temperature-outdoor", "12.2 °C"), new Tuple("humidity-outdoor", "76 %"),
@@ -110,8 +114,7 @@ class FineOffsetDataParserTest {
                         new Tuple("irradiation-uv", "0 mW/m²"), new Tuple("uv-index", "0"),
                         new Tuple("temperature-channel-1", "13.4 °C"), new Tuple("humidity-channel-1", "85 %"),
                         new Tuple("water-leak-channel-1", "OFF"), new Tuple("water-leak-channel-3", "OFF"),
-                        new Tuple("lightning-counter", "6"),
-                        new Tuple("lightning-time", "2023-11-07T15:42:41.000+0000"),
+                        new Tuple("lightning-counter", "6"), new Tuple("lightning-time", "2023-11-07T15:42:41Z"),
                         new Tuple("lightning-distance", "27 km"), new Tuple("wind-max-day", "3.8 m/s"),
                         new Tuple("temperature-external-channel-1", "13.6 °C"),
                         new Tuple("sensor-co2-temperature", "20.6 °C"), new Tuple("sensor-co2-humidity", "63 %"),

--- a/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/dpt/DPTTest.java
+++ b/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/dpt/DPTTest.java
@@ -201,13 +201,13 @@ class DPTTest {
     @Test
     void testToDPT10ValueFromQuantityType() {
         // DateTimeType, not QuantityType
-        assertEquals("Wed, 17:30:00", ValueEncoder.encode(new DateTimeType("2019-06-12T17:30:00Z"), "10.001"));
+        assertEquals("Wed, 17:30:00", ValueEncoder.encode(new DateTimeType("2019-06-12T17:30:00"), "10.001"));
     }
 
     @Test
     void testToDPT11ValueFromQuantityType() {
         // DateTimeType, not QuantityType
-        assertEquals("2019-06-12", ValueEncoder.encode(new DateTimeType("2019-06-12T17:30:00Z"), "11.001"));
+        assertEquals("2019-06-12", ValueEncoder.encode(new DateTimeType("2019-06-12T17:30:00"), "11.001"));
     }
 
     @Test
@@ -337,7 +337,7 @@ class DPTTest {
     @Test
     void testToDPT19ValueFromQuantityType() {
         // DateTimeType, not QuantityType
-        assertEquals("2019-06-12 17:30:00", ValueEncoder.encode(new DateTimeType("2019-06-12T17:30:00Z"), "19.001"));
+        assertEquals("2019-06-12 17:30:00", ValueEncoder.encode(new DateTimeType("2019-06-12T17:30:00"), "19.001"));
         // special: clock fault
         assertNull(ValueDecoder.decode("19.001", new byte[] { (byte) (2019 - 1900), 1, 15, 17, 30, 0, (byte) 0x80, 0 },
                 DateTimeType.class));

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/vehicle/VehicleStateContainerTest.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/vehicle/VehicleStateContainerTest.java
@@ -48,10 +48,10 @@ public class VehicleStateContainerTest {
         VehicleStateContainer vehicleStateContainer = JsonStringDeserializer.getVehicleState(vehicleStateJson);
 
         assertNotNull(vehicleStateContainer);
-        assertEquals("2024-06-01T00:00",
+        assertEquals("2024-06-01T00:00:00Z",
                 ((DateTimeType) VehicleStatusUtils
-                        .getNextServiceDate(vehicleStateContainer.getState().getRequiredServices())).getZonedDateTime()
-                        .toLocalDateTime().toString(),
+                        .getNextServiceDate(vehicleStateContainer.getState().getRequiredServices())).getInstant()
+                        .toString(),
                 "Service Date");
 
         assertEquals("2022-12-21T15:41:23Z", vehicleStateContainer.getState().getLastUpdatedAt(), "Last update time");


### PR DESCRIPTION
This refactors a few tests that assume the time-zone being put into a `DateTimeType` will be the same as returned from `getZonedDateTime()` or used by `format()`. Also fixes a few tests mixing UTC and system time-zone.

These assumptions are still valid now, but if openhab/openhab-core#3583 is merged, they no longer will be. Therefore, this PR needs to be merged at latest at the same time to not break the build, but **can be merged already now**. Verifying these assumptions in addon tests provide no real value - this belongs to the core tests related to `DateTimeType`.

Prerequisite for openhab/openhab-core#3583
Also related to #17725 which simplifies `DateTimeType` logic if openhab/openhab-core#3583 is merged