### PR TITLE
[oppo] Add missing input option and enable translations

### DIFF
--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoHandlerFactory.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/OppoHandlerFactory.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.oppo.internal.handler.OppoHandler;
+import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -41,14 +43,19 @@ public class OppoHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_PLAYER);
 
     private final SerialPortManager serialPortManager;
+    private final TranslationProvider translationProvider;
+    private final LocaleProvider localeProvider;
 
     private final OppoStateDescriptionOptionProvider stateDescriptionProvider;
 
     @Activate
     public OppoHandlerFactory(final @Reference OppoStateDescriptionOptionProvider provider,
-            final @Reference SerialPortManager serialPortManager) {
+            final @Reference SerialPortManager serialPortManager, @Reference TranslationProvider translationProvider,
+            @Reference LocaleProvider localeProvider) {
         this.stateDescriptionProvider = provider;
         this.serialPortManager = serialPortManager;
+        this.translationProvider = translationProvider;
+        this.localeProvider = localeProvider;
     }
 
     @Override
@@ -61,7 +68,8 @@ public class OppoHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
-            return new OppoHandler(thing, stateDescriptionProvider, serialPortManager);
+            return new OppoHandler(thing, stateDescriptionProvider, serialPortManager, translationProvider,
+                    localeProvider);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/handler/OppoHandler.java
@@ -36,6 +36,8 @@ import org.openhab.binding.oppo.internal.communication.OppoMessageEventListener;
 import org.openhab.binding.oppo.internal.communication.OppoSerialConnector;
 import org.openhab.binding.oppo.internal.communication.OppoStatusCodes;
 import org.openhab.binding.oppo.internal.configuration.OppoThingConfiguration;
+import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.NextPreviousType;
@@ -56,6 +58,9 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +90,10 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
     private SerialPortManager serialPortManager;
     private OppoConnector connector = new OppoDefaultConnector();
 
+    private final TranslationProvider translationProvider;
+    private final LocaleProvider localeProvider;
+    private final @Nullable Bundle bundle;
+
     private List<StateOption> inputSourceOptions = new ArrayList<>();
     private List<StateOption> hdmiModeOptions = new ArrayList<>();
 
@@ -105,10 +114,14 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
      * Constructor
      */
     public OppoHandler(Thing thing, OppoStateDescriptionOptionProvider stateDescriptionProvider,
-            SerialPortManager serialPortManager) {
+            SerialPortManager serialPortManager, @Reference TranslationProvider translationProvider,
+            @Reference LocaleProvider localeProvider) {
         super(thing);
         this.stateDescriptionProvider = stateDescriptionProvider;
         this.serialPortManager = serialPortManager;
+        this.translationProvider = translationProvider;
+        this.localeProvider = localeProvider;
+        this.bundle = FrameworkUtil.getBundle(OppoHandler.class);
     }
 
     @Override
@@ -842,9 +855,12 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
     }
 
     private void buildOptionDropdowns(int model) {
+        hdmiModeOptions.clear();
+        inputSourceOptions.clear();
+
         if (model == MODEL83 || model == MODEL103 || model == MODEL105) {
-            hdmiModeOptions.add(new StateOption("AUTO", "Auto"));
-            hdmiModeOptions.add(new StateOption("SRC", "Source Direct"));
+            hdmiModeOptions.add(new StateOption("AUTO", getString("auto", "Auto")));
+            hdmiModeOptions.add(new StateOption("SRC", getString("direct", "Source Direct")));
             if (model != MODEL83) {
                 hdmiModeOptions.add(new StateOption("4K2K", "4K*2K"));
             }
@@ -856,26 +872,27 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
         }
 
         if (model == MODEL103 || model == MODEL105) {
-            inputSourceOptions.add(new StateOption("0", "Blu-Ray Player"));
-            inputSourceOptions.add(new StateOption("1", "HDMI/MHL IN-Front"));
-            inputSourceOptions.add(new StateOption("2", "HDMI IN-Back"));
-            inputSourceOptions.add(new StateOption("3", "ARC"));
+            inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
+            inputSourceOptions.add(new StateOption("1", getString("hdmi_in_front", "HDMI/MHL In-Front")));
+            inputSourceOptions.add(new StateOption("2", getString("hdmi_in_back", "HDMI In-Back")));
+            inputSourceOptions.add(new StateOption("3", getString("arc1", "ARC 1")));
+            inputSourceOptions.add(new StateOption("4", getString("arc2", "ARC 2")));
 
             if (model == MODEL105) {
-                inputSourceOptions.add(new StateOption("4", "Optical In"));
-                inputSourceOptions.add(new StateOption("5", "Coaxial In"));
-                inputSourceOptions.add(new StateOption("6", "USB Audio In"));
+                inputSourceOptions.add(new StateOption("5", getString("optical", "Optical In")));
+                inputSourceOptions.add(new StateOption("6", getString("coaxial", "Coaxial In")));
+                inputSourceOptions.add(new StateOption("7", getString("usb", "USB Audio In")));
             }
         }
 
         if (model == MODEL203 || model == MODEL205) {
-            hdmiModeOptions.add(new StateOption("AUTO", "Auto"));
-            hdmiModeOptions.add(new StateOption("SRC", "Source Direct"));
-            hdmiModeOptions.add(new StateOption("UHD_AUTO", "UHD Auto"));
+            hdmiModeOptions.add(new StateOption("AUTO", getString("auto", "Auto")));
+            hdmiModeOptions.add(new StateOption("SRC", getString("direct", "Source Direct")));
+            hdmiModeOptions.add(new StateOption("UHD_AUTO", getString("auto_uhd", "UHD Auto")));
             hdmiModeOptions.add(new StateOption("UHD24", "UHD24"));
             hdmiModeOptions.add(new StateOption("UHD50", "UHD50"));
             hdmiModeOptions.add(new StateOption("UHD60", "UHD60"));
-            hdmiModeOptions.add(new StateOption("1080P_AUTO", "1080P Auto"));
+            hdmiModeOptions.add(new StateOption("1080P_AUTO", getString("auto_1080p", "1080P Auto")));
             hdmiModeOptions.add(new StateOption("1080P24", "1080P24"));
             hdmiModeOptions.add(new StateOption("1080P50", "1080P50"));
             hdmiModeOptions.add(new StateOption("1080P60", "1080P60"));
@@ -888,16 +905,20 @@ public class OppoHandler extends BaseThingHandler implements OppoMessageEventLis
             hdmiModeOptions.add(new StateOption("480P", "480P"));
             hdmiModeOptions.add(new StateOption("480I", "480I"));
 
-            inputSourceOptions.add(new StateOption("0", "Blu-Ray Player"));
-            inputSourceOptions.add(new StateOption("1", "HDMI IN"));
-            inputSourceOptions.add(new StateOption("2", "ARC"));
+            inputSourceOptions.add(new StateOption("0", getString("blu_ray", "Blu-ray Player")));
+            inputSourceOptions.add(new StateOption("1", getString("hdmi_in", "HDMI In")));
+            inputSourceOptions.add(new StateOption("2", getString("arc", "ARC")));
 
             if (model == MODEL205) {
-                inputSourceOptions.add(new StateOption("3", "Optical In"));
-                inputSourceOptions.add(new StateOption("4", "Coaxial In"));
-                inputSourceOptions.add(new StateOption("5", "USB Audio In"));
+                inputSourceOptions.add(new StateOption("3", getString("optical", "Optical In")));
+                inputSourceOptions.add(new StateOption("4", getString("coaxial", "Coaxial In")));
+                inputSourceOptions.add(new StateOption("5", getString("usb", "USB Audio In")));
             }
         }
+    }
+
+    private @Nullable String getString(String i18nKey, String defaultStr) {
+        return translationProvider.getText(bundle, "option." + i18nKey, defaultStr, localeProvider.getLocale());
     }
 
     private void handleHdmiModeUpdate(String updateData) {

--- a/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/i18n/oppo.properties
+++ b/bundles/org.openhab.binding.oppo/src/main/resources/OH-INF/i18n/oppo.properties
@@ -163,3 +163,20 @@ channel-type.oppo.zoom_mode.state.option.09 = 4x
 channel-type.oppo.zoom_mode.state.option.10 = 1/2
 channel-type.oppo.zoom_mode.state.option.11 = 1/3
 channel-type.oppo.zoom_mode.state.option.12 = 1/4
+
+# selectable player option descriptions
+
+option.arc = ARC
+option.arc1 = ARC 1
+option.arc2 = ARC 2
+option.auto = Auto
+option.auto_1080p = 1080P Auto
+option.auto_uhd = UHD Auto
+option.blu_ray = Blu-ray Player
+option.coaxial = Coaxial In
+option.direct = Source Direct
+option.hdmi_in = HDMI In
+option.hdmi_in_back = HDMI In-Back
+option.hdmi_in_front = HDMI/MHL In-Front
+option.optical = Optical In
+option.usb = USB Audio In


### PR DESCRIPTION
Add the missing `ARC 2` option for the Source Input channel of the BDP-103/BDP-105.
![image](https://github.com/user-attachments/assets/e5117087-925d-4791-bbd3-6b304bfda345)


Also enable translation of all of the various models' selectable option labels.