### PR TITLE
[deconz] Distinguish thing action scope across the binding

### DIFF
--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -228,17 +228,17 @@ Thing actions can be used to manage the network and its content.
 
 The `deconz` thing supports a thing action to allow new devices to join the network:
 
-| Action name            | Input Value          | Return Value | Description                                                                                                    |
-| ---------------------- | -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------- |
-| `permitJoin(duration)` | `duration` (Integer) | -            | allows new devices to join for `duration` seconds. Allowed values are 1-240, default is 120 if no value given. |
+| Scope          | Action name            | Input Value          | Return Value | Description                                                                                                    |
+| -------------- | ---------------------- | -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------- |
+| deconz-bridge  | `permitJoin(duration)` | `duration` (Integer) | -            | allows new devices to join for `duration` seconds. Allowed values are 1-240, default is 120 if no value given. |
 
 The `lightgroup` thing supports thing actions for managing scenes:
 
-| Action name         | Input Value     | Return Value | Description                                                                               |
-| ------------------- | --------------- | ------------ | ----------------------------------------------------------------------------------------- |
-| `createScene(name)` | `name` (String) | `newSceneId` | Creates a new scene with the name `name` and returns the new scene's id (if successfull). |
-| `deleteScene(id)`   | `id` (Integer)  | -            | Deletes the scene with the given id.                                                      |
-| `storeScene(id)`    | `id` (Integer)  | -            | Store the current group's state as scene with the given id.                               |
+| Scope   | Action name         | Input Value     | Return Value | Description                                                                               |
+| ------- | ------------------- | --------------- | ------------ | ----------------------------------------------------------------------------------------- |
+| deconz  | `createScene(name)` | `name` (String) | `newSceneId` | Creates a new scene with the name `name` and returns the new scene's id (if successfull). |
+| deconz  | `deleteScene(id)`   | `id` (Integer)  | -            | Deletes the scene with the given id.                                                      |
+| deconz  | `storeScene(id)`    | `id` (Integer)  | -            | Store the current group's state as scene with the given id.                               |
 
 The return value refers to a key of the given name within the returned Map. See [example](#thing-actions-example).
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/action/BridgeActions.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/action/BridgeActions.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Jan N. Klug - Initial contribution
  */
 @Component(scope = ServiceScope.PROTOTYPE, service = BridgeActions.class)
-@ThingActionsScope(name = "deconz")
+@ThingActionsScope(name = "deconz-bridge")
 @NonNullByDefault
 public class BridgeActions implements ThingActions {
     private final Logger logger = LoggerFactory.getLogger(BridgeActions.class);

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/action/GroupActions.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/action/GroupActions.java
@@ -47,7 +47,7 @@ import com.google.gson.reflect.TypeToken;
  * @author Jan N. Klug - Initial contribution
  */
 @Component(scope = ServiceScope.PROTOTYPE, service = GroupActions.class)
-@ThingActionsScope(name = "deconz")
+@ThingActionsScope(name = "deconz-group")
 @NonNullByDefault
 public class GroupActions implements ThingActions {
     private static final String NEW_SCENE_ID_OUTPUT = "newSceneId";

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/action/GroupActions.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/action/GroupActions.java
@@ -47,7 +47,7 @@ import com.google.gson.reflect.TypeToken;
  * @author Jan N. Klug - Initial contribution
  */
 @Component(scope = ServiceScope.PROTOTYPE, service = GroupActions.class)
-@ThingActionsScope(name = "deconz-group")
+@ThingActionsScope(name = "deconz")
 @NonNullByDefault
 public class GroupActions implements ThingActions {
     private static final String NEW_SCENE_ID_OUTPUT = "newSceneId";


### PR DESCRIPTION
In response to issue https://github.com/openhab/openhab-addons/issues/17785