### PR TITLE
[telegram] Add action that supports various options

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -2,7 +2,7 @@
 
 The Telegram binding allows sending and receiving messages to and from Telegram clients (<https://telegram.org>), by using the Telegram Bot API.
 
-# Prerequisites
+## Prerequisites
 
 As described in the Telegram Bot API (<https://core.telegram.org/bots#6-botfather>), this is the manual procedure needed in order to get the necessary information.
 
@@ -59,15 +59,15 @@ In order to send a message, an action must be used instead.
 
 **telegramBot** parameters:
 
-| Property | Default | Required | Description |
-|-|-|-|-|
-| `chatIds` | | Yes | A list of chatIds that are entered one per line in the UI, or are comma separated values when using textual config. |
-| `botToken` | | Yes | Authentication token that looks like 1122334455:AABBCCDDEEFFGG1122334455667788 |
-| `parseMode` |  None   | No | Support for formatted messages, values: Markdown or HTML. |
-| `proxyHost` |  None   | No | Proxy host for telegram binding. |
-| `proxyPort` |  None   | No | Proxy port for telegram binding. |
-| `proxyType` |  SOCKS5 | No | Type of proxy server for telegram binding (SOCKS5 or HTTP). |
-| `longPollingTime` | 25 | No | Timespan in seconds for long polling the telegram API. |
+| Property          | Default | Required | Description                                                                                                         |
+|-------------------|---------|----------|---------------------------------------------------------------------------------------------------------------------|
+| `chatIds`         |         | Yes      | A list of chatIds that are entered one per line in the UI, or are comma separated values when using textual config. |
+| `botToken`        |         | Yes      | Authentication token that looks like 1122334455:AABBCCDDEEFFGG1122334455667788                                      |
+| `parseMode`       | None    | No       | Support for formatted messages, values: Markdown or HTML.                                                           |
+| `proxyHost`       | None    | No       | Proxy host for telegram binding.                                                                                    |
+| `proxyPort`       | None    | No       | Proxy port for telegram binding.                                                                                    |
+| `proxyType`       | SOCKS5  | No       | Type of proxy server for telegram binding (SOCKS5 or HTTP).                                                         |
+| `longPollingTime` | 25      | No       | Timespan in seconds for long polling the telegram API.                                                              |
 
 By default chat ids are bi-directionally, i.e. they can send and receive messages.
 They can be prefixed with an access modifier:
@@ -193,17 +193,18 @@ Each of the actions returns true on success or false on failure.
 
 These actions will send a message to all chat ids configured for this bot.
 
-| Action                     | Description  |
-|----------------------------|--------------|
-| sendTelegram(String message) | Sends a message. |
-| sendTelegram(String format, Object... args)          | Sends a formatted message (See <https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html> for more information).
-| sendTelegramQuery(String message, String replyId, String... buttons) | Sends a question to the user that can be answered via the defined buttons. The replyId can be freely choosen and is sent back with the answer. Then, the id is required to identify what question has been answered (e.g. in case of multiple open questions). The final result looks like this: ![Telegram Inline Keyboard](doc/queryExample.png) |
-| sendTelegramAnswer(String replyId, String message) | Sends a message after the user has answered a question. You should _always_ call this method after you received an answer. It will remove buttons from the specific question and will also stop the progress bar displayed at the client side. If no message is necessary, just pass `null` here. |
-| deleteTelegramQuery(String replyId) | Deletes a question in the chat. The replyId must be the same as used for the corresponding sendTelegramQuery() action. |
-| sendTelegramPhoto(String photoURL, String caption) | Sends a picture. Can be one of the URL formats, see the Note below, or a base64 encoded image (simple base64 data or data URI scheme). |
-| sendTelegramPhoto(String photoURL, String caption, String username, String password) | Sends a picture which is downloaded from a username/password protected http/https address. |
-| sendTelegramAnimation(String animationURL, String caption) | Send animation files either GIF or H.264/MPEG-4 AVC video without sound. |
-| sendTelegramVideo(String videoURL, String caption) | Send MP4 video files up to 50MB. |
+| Action                                                                                                                         | Description                                                                                                                                                                                                                                                                                                                                        |
+|--------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| sendTelegram(String message)                                                                                                   | Sends a message.                                                                                                                                                                                                                                                                                                                                   |
+| sendTelegram(String format, Object... args)                                                                                    | Sends a formatted message (See <https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html> for more information)                                                                                                                                                                                                       |
+| sendTelegramTo(Long[] chatIds, String message, Integer replyMessageId,Boolean silent, Integer messageThreadId, Object... args) | Sends a message with various options                                                                                                                                                                                                                                                                                                               |
+| sendTelegramQuery(String message, String replyId, String... buttons)                                                           | Sends a question to the user that can be answered via the defined buttons. The replyId can be freely choosen and is sent back with the answer. Then, the id is required to identify what question has been answered (e.g. in case of multiple open questions). The final result looks like this: ![Telegram Inline Keyboard](doc/queryExample.png) |
+| sendTelegramAnswer(String replyId, String message)                                                                             | Sends a message after the user has answered a question. You should _always_ call this method after you received an answer. It will remove buttons from the specific question and will also stop the progress bar displayed at the client side. If no message is necessary, just pass `null` here.                                                  |
+| deleteTelegramQuery(String replyId)                                                                                            | Deletes a question in the chat. The replyId must be the same as used for the corresponding sendTelegramQuery() action.                                                                                                                                                                                                                             |
+| sendTelegramPhoto(String photoURL, String caption)                                                                             | Sends a picture. Can be one of the URL formats, see the Note below, or a base64 encoded image (simple base64 data or data URI scheme).                                                                                                                                                                                                             |
+| sendTelegramPhoto(String photoURL, String caption, String username, String password)                                           | Sends a picture which is downloaded from a username/password protected http/https address.                                                                                                                                                                                                                                                         |
+| sendTelegramAnimation(String animationURL, String caption)                                                                     | Send animation files either GIF or H.264/MPEG-4 AVC video without sound.                                                                                                                                                                                                                                                                           |
+| sendTelegramVideo(String videoURL, String caption)                                   | Send MP4 video files up to 50MB.                                                                                                                                                                                                                                                                                                                   |
 
 **Note:** In actions that require a file URL, the following formats are acceptable:
 

--- a/bundles/org.openhab.binding.telegram/pom.xml
+++ b/bundles/org.openhab.binding.telegram/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.github.pengrad</groupId>
       <artifactId>java-telegram-bot-api</artifactId>
-      <version>7.1.0</version>
+      <version>7.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -233,6 +233,12 @@ public class TelegramHandler extends BaseThingHandler {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                                 "Unauthorized attempt to connect to the Telegram server, please check if the bot token is valid");
                         return;
+                    case 429:
+                        cancelThingOnlineStatusJob();
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                "Too Many Requests, temporary delaying");
+                        delayThingOnlineStatus();
+                        return;
                     case 502:
                         cancelThingOnlineStatusJob();
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -391,26 +391,26 @@ public class TelegramHandler extends BaseThingHandler {
                         lastMessageUsername = message.from().username();
                     }
                 }
-            } else if (callbackQuery != null && callbackQuery.message() != null
-                    && callbackQuery.message().text() != null) {
+            } else if (callbackQuery != null && callbackQuery.maybeInaccessibleMessage() instanceof Message cbMessage
+                    && cbMessage.text() != null) {
                 String[] callbackData = callbackQuery.data().split(" ", 2);
 
                 if (callbackData.length == 2) {
                     replyId = callbackData[0];
                     lastMessageText = callbackData[1];
-                    lastMessageDate = callbackQuery.message().date();
+                    lastMessageDate = cbMessage.date();
                     lastMessageFirstName = callbackQuery.from().firstName();
                     lastMessageLastName = callbackQuery.from().lastName();
                     lastMessageUsername = callbackQuery.from().username();
-                    chatId = callbackQuery.message().chat().id();
+                    chatId = cbMessage.chat().id();
                     replyIdToCallbackId.put(new ReplyKey(chatId, replyId), callbackQuery.id());
 
                     // build and publish callbackEvent trigger channel payload
                     JsonObject callbackRaw = JsonParser.parseString(gson.toJson(callbackQuery)).getAsJsonObject();
                     JsonObject callbackPayload = new JsonObject();
-                    callbackPayload.addProperty("message_id", callbackQuery.message().messageId());
+                    callbackPayload.addProperty("message_id", cbMessage.messageId());
                     callbackPayload.addProperty("from", lastMessageFirstName + " " + lastMessageLastName);
-                    callbackPayload.addProperty("chat_id", callbackQuery.message().chat().id());
+                    callbackPayload.addProperty("chat_id", cbMessage.chat().id());
                     callbackPayload.addProperty("callback_id", callbackQuery.id());
                     callbackPayload.addProperty("reply_id", callbackData[0]);
                     callbackPayload.addProperty("text", callbackData[1]);

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -195,7 +196,7 @@ public class TelegramActions implements ThingActions {
     public @ActionOutput(label = "Success", type = "java.lang.Boolean") boolean sendTelegram(
             @ActionInput(name = "chatId") @Nullable Long chatId,
             @ActionInput(name = "message") @Nullable String message) {
-        return sendTelegramGeneral(chatId, message, (String) null);
+        return sendTelegramGeneral(chatId, message, (String) null, null, null, null);
     }
 
     @RuleAction(label = "send a message", description = "Send a Telegram message using the Telegram API.")
@@ -218,7 +219,7 @@ public class TelegramActions implements ThingActions {
             @ActionInput(name = "message") @Nullable String message,
             @ActionInput(name = "replyId") @Nullable String replyId,
             @ActionInput(name = "buttons") @Nullable String... buttons) {
-        return sendTelegramGeneral(chatId, message, replyId, buttons);
+        return sendTelegramGeneral(chatId, message, replyId, null, null, null, buttons);
     }
 
     @RuleAction(label = "send a query", description = "Send a Telegram Query using the Telegram API.")
@@ -238,7 +239,8 @@ public class TelegramActions implements ThingActions {
     }
 
     private boolean sendTelegramGeneral(@Nullable Long chatId, @Nullable String message, @Nullable String replyId,
-            @Nullable String... buttons) {
+            @Nullable Integer replyToMessageId, @Nullable Boolean disableNotification,
+            @Nullable Integer messageThreadId, @Nullable String... buttons) {
         if (message == null) {
             logger.warn("Message not defined; action skipped.");
             return false;
@@ -250,6 +252,15 @@ public class TelegramActions implements ThingActions {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
             SendMessage sendMessage = new SendMessage(chatId, message);
+            if (replyToMessageId != null) {
+                sendMessage.replyToMessageId(replyToMessageId);
+            }
+            if (disableNotification != null) {
+                sendMessage.disableNotification(disableNotification);
+            }
+            if (messageThreadId != null) {
+                sendMessage.messageThreadId(messageThreadId);
+            }
             if (localHandler.getParseMode() != null) {
                 sendMessage.parseMode(localHandler.getParseMode());
             }
@@ -350,6 +361,37 @@ public class TelegramActions implements ThingActions {
             }
         }
         return true;
+    }
+
+    @RuleAction(label = "send a message", description = "Send a Telegram using the Telegram API.")
+    public @ActionOutput(label = "Success", type = "java.lang.Boolean") boolean sendTelegramTo(
+            @ActionInput(name = "chatId") @Nullable Long @Nullable [] chatIds,
+            @ActionInput(name = "message") @Nullable String message,
+            @ActionInput(name = "replyMessageId") @Nullable Integer replyMessageId,
+            @ActionInput(name = "silent") @Nullable Boolean silent,
+            @ActionInput(name = "messageThreadId") @Nullable Integer messageThreadId,
+            @ActionInput(name = "args") @Nullable Object... args) {
+        if (message == null) {
+            return false;
+        }
+        TelegramHandler localHandler = handler;
+        List<Long> chatIdentifiers = List.of();
+        if (chatIds != null) {
+            Long[] chatIdentifiersArray = chatIds; // compiler vs null annotation fix
+            chatIdentifiers = List.of(chatIdentifiersArray);
+        } else if (localHandler != null) {
+            chatIdentifiers = localHandler.getReceiverChatIds();
+        }
+
+        boolean successful = true;
+        for (Long chatId : chatIdentifiers) {
+
+            // supports both with and without args
+            successful = successful == sendTelegramGeneral(chatId, String.format(message, args), (String) null,
+                    replyMessageId, silent, messageThreadId);
+        }
+
+        return successful;
     }
 
     @RuleAction(label = "send a photo", description = "Send a picture using the Telegram API.")
@@ -702,6 +744,13 @@ public class TelegramActions implements ThingActions {
     public static boolean sendTelegram(ThingActions actions, @Nullable Long chatId, @Nullable String format,
             @Nullable Object... args) {
         return ((TelegramActions) actions).sendTelegram(chatId, format, args);
+    }
+
+    public static boolean sendTelegramTo(ThingActions actions, @Nullable Long @Nullable [] chatIds,
+            @Nullable String message, @Nullable Integer replyMessageId, @Nullable Boolean silent,
+            @Nullable Integer messageThreadId, @Nullable Object... args) {
+        return ((TelegramActions) actions).sendTelegramTo(chatIds, message, replyMessageId, silent, messageThreadId,
+                args);
     }
 
     public static boolean sendTelegramQuery(ThingActions actions, @Nullable Long chatId, @Nullable String message,

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <netty.version>4.1.104.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <okio.version>3.9.0</okio.version>
-    <gson.version>2.9.1</gson.version>
+    <gson.version>2.10.1</gson.version>
     <kotlin.version>1.9.23</kotlin.version>
     <sat.version>0.16.0</sat.version>
     <slf4j.version>2.0.12</slf4j.version>


### PR DESCRIPTION
Unfortunately the support for method overloads is limited in java. That together with the existing action methods makes it hard to add additional features to the action methods.

For instance, adding silent mode would add a double set of action methods. My proposal is to have one 'fat' method that     had all possible combinations. Wether an option is used or not depends on the nullness.

Fixes: https://github.com/openhab/openhab-addons/issues/8018 (Send message to multiple chats)
Fixes: https://github.com/openhab/openhab-addons/issues/8487 (Send message without notification)
Fixes: https://github.com/openhab/openhab-addons/issues/15040 (Send message with thread id)
Fixes: https://github.com/openhab/openhab-addons/issues/15069 (Send message as reply to an existing message)

A test jar is here: https://1drv.ms/u/s!AnMcxmvEeupwjvsHyGFM4f3IfgiI-g?e=68LyRl

I would like to get feedback on:
1. Should the parameter ChatIds be an array or string (comma seperated). The first is the best type but not supported by main UI. So maybe the string is the best user friendly one?
2. Does the 'fat' method support enough option, or should we add more? 
3. Should we add some placeholders parameters to the method signature to create future compatiblity?