### PR TITLE
[metOfficeDataHub] Readme adjustment for accuracy

### DIFF
--- a/bundles/org.openhab.binding.metofficedatahub/README.md
+++ b/bundles/org.openhab.binding.metofficedatahub/README.md
@@ -14,8 +14,8 @@ A possible use case could be to pull forecast data, for the next day to determin
 ## Prerequisite
 
 In order to use this binding, you will need a Met Office Data Hub account.
-Once created you will need to create a plan for access to the "Site Specific" subscriptions.
-This will give you the client id and secret required for the bridge.
+Once created you will need to create a plan for access to the "Site Specific" Global Spot subscriptions.
+This will give you the API key required for the bridge.
 
 ## Supported Things
 


### PR DESCRIPTION
A very minor readme adjustment I missed, when sorting out the formatting, and a few unit ref's.

This clarifies the specific variant of the "Site Specific" API, a key should be obtained for.

References to the older version of the API that had 2 parameters client id and secret have been removed, and replaced by API key for the newer version of the API that this is was updated and merged against.