### PR TITLE
Provide unit hints for RSSI channel types

### DIFF
--- a/bundles/org.openhab.binding.easee/src/main/resources/OH-INF/thing/easee-readonly-channel-types.xml
+++ b/bundles/org.openhab.binding.easee/src/main/resources/OH-INF/thing/easee-readonly-channel-types.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 	<channel-type id="type-rssi">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Received Signal Strength Indicator</label>
 		<category>QualityOfService</category>
 		<state pattern="%d %unit%" readOnly="true">

--- a/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecovacs/src/main/resources/OH-INF/thing/thing-types.xml
@@ -296,7 +296,7 @@
 	</channel-type>
 
 	<channel-type id="wifi-rssi" advanced="true">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Wi-Fi Signal Strength</label>
 		<description>Received signal strength indicator for Wi-Fi</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.freeboxos/src/main/resources/OH-INF/thing/channel-types.xml
@@ -27,7 +27,7 @@
 	</channel-type>
 
 	<channel-type id="rssi">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI</label>
 		<description>Received signal strength indicator</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/channels.xml
@@ -67,7 +67,7 @@
 	</channel-type>
 
 	<channel-type id="rssi" advanced="true">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI</label>
 		<description>Received Signal Strength Indicator</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/thing/channels.xml
@@ -507,7 +507,7 @@
 	</channel-type>
 
 	<channel-type id="rssi" advanced="true">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal</label>
 		<description>Signal strength indicator.</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/channels.xml
@@ -51,7 +51,7 @@
 
 	<!-- Misc Channel types -->
 	<channel-type id="rssi" advanced="true">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal</label>
 		<description>Wi-Fi signal strength indicator.</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/thing/thing-types.xml
@@ -362,7 +362,7 @@
 	</channel-type>
 
 	<channel-type id="rssi">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Received Signal Strength Indicator</label>
 		<description>Received Signal Strength Indicator (RSSI) of the wireless client</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.wlanthermo/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.wlanthermo/src/main/resources/OH-INF/thing/channel-types.xml
@@ -251,7 +251,7 @@
 	</channel-type>
 
 	<channel-type id="rssi" advanced="true">
-		<item-type>Number:Power</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI in dBm</label>
 		<category>Number</category>
 		<state readOnly="true"/>


### PR DESCRIPTION
Based on this search:
```bash
grep -R "<item-type>Number:Power</item-type>" -B 1 | grep -i rssi | sort
```

Without this hint, **W** will be defaulted as unit.