### PR TITLE
[jrubyscripting] Upgrade to JRuby 9.4.9.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -15,8 +15,8 @@
   <name>openHAB Add-ons :: Bundles :: Automation :: JRuby Scripting</name>
 
   <properties>
-    <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.4.8.0</jruby.version>
+    <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional,jdk.crac.management;resolution:=optional</bnd.importpackage>
+    <jruby.version>9.4.9.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
https://www.jruby.org/2024/11/04/jruby-9-4-9-0.html
There are no major changes, just bug fixes. Notable fix include:

> REXML was updated to 3.3.9 to get recent fixes and to address [CVE-2024-49761](https://github.com/advisories/GHSA-2rxp-v6pw-ch6m), a ReDOS vulnerability. Only users parsing unsanitized XML with REXML are affected. [#8396](https://github.com/jruby/jruby/pull/8396)

This version passed the helper library's ci: https://github.com/openhab/openhab-jruby/pull/363

