### PR TITLE
[vesync] Core 300S Updates

### DIFF
--- a/bundles/org.openhab.binding.vesync/README.md
+++ b/bundles/org.openhab.binding.vesync/README.md
@@ -71,7 +71,7 @@ Channel names in **bold** are read/write, everything else is read-only
 | **enabled**          | Switch               | Whether the hardware device is enabled (Switched on)       | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S | [ON, OFF]                  |       |
 | **childLock**        | Switch               | Whether the child lock (display lock is enabled)           | 600S, 400S, 300S, Vital 100S, Vital 200S       | [ON, OFF]                  |       |
 | **display**          | Switch               | Whether the display is enabled (display is shown)          | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S | [ON, OFF]                  |       |
-| **fanMode**          | String               | The operation mode of the fan                              | 131S, 600S, 300S, 400S, Vital 100S             | [auto, manual, sleep]      |       |
+| **fanMode**          | String               | The operation mode of the fan                              | 131S, 600S, 400S, 300S, Vital 100S             | [auto, manual, sleep]      |       |
 | **fanMode**          | String               | The operation mode of the fan                              | 200S,                                          | [manual, sleep]            |       |
 | **fanMode**          | String               | The operation mode of the fan                              | Vital 200S                                     | [auto, manual, sleep, pet] |       |
 | **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 600S, 400S                                     | [1...4]                    |       |

--- a/bundles/org.openhab.binding.vesync/README.md
+++ b/bundles/org.openhab.binding.vesync/README.md
@@ -71,12 +71,12 @@ Channel names in **bold** are read/write, everything else is read-only
 | **enabled**          | Switch               | Whether the hardware device is enabled (Switched on)       | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S | [ON, OFF]                  |       |
 | **childLock**        | Switch               | Whether the child lock (display lock is enabled)           | 600S, 400S, 300S, Vital 100S, Vital 200S       | [ON, OFF]                  |       |
 | **display**          | Switch               | Whether the display is enabled (display is shown)          | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S | [ON, OFF]                  |       |
-| **fanMode**          | String               | The operation mode of the fan                              | 131S, 600S, 400S, Vital 100S                   | [auto, manual, sleep]      |       |
-| **fanMode**          | String               | The operation mode of the fan                              | 200S, 300S,                                    | [manual, sleep]            |       |
+| **fanMode**          | String               | The operation mode of the fan                              | 131S, 600S, 300S, 400S, Vital 100S             | [auto, manual, sleep]      |       |
+| **fanMode**          | String               | The operation mode of the fan                              | 200S,                                          | [manual, sleep]            |       |
 | **fanMode**          | String               | The operation mode of the fan                              | Vital 200S                                     | [auto, manual, sleep, pet] |       |
 | **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 600S, 400S                                     | [1...4]                    |       |
-| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 131S, 300S                                     | [1...3]                    |       |
-| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | Vital 100S,Vital 200S                          | [1...5]                    |       |
+| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 131S,                                          | [1...3]                    |       |
+| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 300S, Vital 100S,Vital 200S                    | [1...5]                    |       |
 | **nightLightMode**   | String               | The night lights mode                                      | 200S, 300S                                     | [on, dim, off]             |       |
 | filterLifePercentage | Number:Dimensionless | The remaining filter life as a percentage                  | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S |                            |       |
 | airQuality           | Number:Dimensionless | The air quality as represented by the Core200S / Core300S  | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S |                            |       |

--- a/bundles/org.openhab.binding.vesync/README.md
+++ b/bundles/org.openhab.binding.vesync/README.md
@@ -75,8 +75,8 @@ Channel names in **bold** are read/write, everything else is read-only
 | **fanMode**          | String               | The operation mode of the fan                              | 200S,                                          | [manual, sleep]            |       |
 | **fanMode**          | String               | The operation mode of the fan                              | Vital 200S                                     | [auto, manual, sleep, pet] |       |
 | **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 600S, 400S                                     | [1...4]                    |       |
-| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 131S,                                          | [1...3]                    |       |
-| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 300S, Vital 100S,Vital 200S                    | [1...5]                    |       |
+| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | 131S, 300S                                     | [1...3]                    |       |
+| **manualFanSpeed**   | Number:Dimensionless | The speed of the fan when in manual mode                   | Vital 100S,Vital 200S                          | [1...5]                    |       |
 | **nightLightMode**   | String               | The night lights mode                                      | 200S, 300S                                     | [on, dim, off]             |       |
 | filterLifePercentage | Number:Dimensionless | The remaining filter life as a percentage                  | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S |                            |       |
 | airQuality           | Number:Dimensionless | The air quality as represented by the Core200S / Core300S  | 131S, 600S, 400S, 300S, Vital 100S, Vital 200S |                            |       |

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
@@ -97,7 +97,7 @@ public class VeSyncDeviceAirPurifierHandler extends VeSyncBaseDeviceHandler {
             NIGHT_LIGHTS);
 
     public static final VeSyncDevicePurifierMetadata CORE300S = new VeSyncDevicePurifierMetadata(1,
-            DEV_FAMILY_CORE_300S, List.of("C301S", "C302S"), List.of("Core300S"), FAN_MODES_MAN_SLEEP, 1, 3,
+            DEV_FAMILY_CORE_300S, List.of("C301S", "C302S"), List.of("Core300S"), FAN_MODES_NO_PET, 1, 5,
             NIGHT_LIGHTS);
 
     public static final VeSyncDevicePurifierMetadata CORE400S = new VeSyncDevicePurifierMetadata(1,

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
@@ -97,7 +97,7 @@ public class VeSyncDeviceAirPurifierHandler extends VeSyncBaseDeviceHandler {
             NIGHT_LIGHTS);
 
     public static final VeSyncDevicePurifierMetadata CORE300S = new VeSyncDevicePurifierMetadata(1,
-            DEV_FAMILY_CORE_300S, List.of("C301S", "C302S"), List.of("Core300S"), FAN_MODES_NO_PET, 1, 5, NIGHT_LIGHTS);
+            DEV_FAMILY_CORE_300S, List.of("C301S", "C302S"), List.of("Core300S"), FAN_MODES_NO_PET, 1, 3, NIGHT_LIGHTS);
 
     public static final VeSyncDevicePurifierMetadata CORE400S = new VeSyncDevicePurifierMetadata(1,
             DEV_FAMILY_CORE_400S, List.of("C401S"), List.of("Core400S"), FAN_MODES_NO_PET, 1, 4, NO_NIGHT_LIGHTS);

--- a/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
+++ b/bundles/org.openhab.binding.vesync/src/main/java/org/openhab/binding/vesync/internal/handlers/VeSyncDeviceAirPurifierHandler.java
@@ -97,8 +97,7 @@ public class VeSyncDeviceAirPurifierHandler extends VeSyncBaseDeviceHandler {
             NIGHT_LIGHTS);
 
     public static final VeSyncDevicePurifierMetadata CORE300S = new VeSyncDevicePurifierMetadata(1,
-            DEV_FAMILY_CORE_300S, List.of("C301S", "C302S"), List.of("Core300S"), FAN_MODES_NO_PET, 1, 5,
-            NIGHT_LIGHTS);
+            DEV_FAMILY_CORE_300S, List.of("C301S", "C302S"), List.of("Core300S"), FAN_MODES_NO_PET, 1, 5, NIGHT_LIGHTS);
 
     public static final VeSyncDevicePurifierMetadata CORE400S = new VeSyncDevicePurifierMetadata(1,
             DEV_FAMILY_CORE_400S, List.of("C401S"), List.of("Core400S"), FAN_MODES_NO_PET, 1, 4, NO_NIGHT_LIGHTS);


### PR DESCRIPTION
[vesync] Core 300S Updates

This updates the device profile for the core 300S. This adds the auto mode to the fan modes for its profile. It looks like since the initial ports the modes specified for the device have been updated.

This change adds the auto mode as a valid payload for the protocol to allow for this device.

This relates to OpenHab issue: [#16456] (https://github.com/openhab/openhab-addons/issues/16456).

The changes have been confirmed as working as expected.
