### PR TITLE
Add UoM support for RSSI channels

### DIFF
--- a/bundles/org.openhab.binding.airgradient/README.md
+++ b/bundles/org.openhab.binding.airgradient/README.md
@@ -77,7 +77,7 @@ For more information about the data in the channels, please refer to the models 
 | tvoc               | Number:Density       | Read       | Total Volatile Organic Compounds                                                 |
 | atmp               | Number:Temperature   | Read       | Ambient Temperature                                                              |
 | rhum               | Number:Dimensionless | Read       | Relative Humidity Percentage                                                     |
-| wifi               | Number               | Read       | Received signal strength indicator                                               |
+| wifi               | Number:Power         | Read       | Received signal strength indicator                                               |
 | uploads-since-boot | Number:Dimensionless | Read       | Number of measure uploads since last reboot (boot)                               |
 | leds               | String               | Read/Write | Sets the leds mode (off/co2/pm)                                                  |
 | calibration        | String               | Write      | Triggers co2 calibration on the device                                           |

--- a/bundles/org.openhab.binding.airgradient/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.airgradient/src/main/resources/OH-INF/thing/thing-types.xml
@@ -72,6 +72,7 @@
 			<property name="firmwareVersion"/>
 			<property name="serialNumber"/>
 			<property name="modelId"/>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 		<representation-property>serialNumber</representation-property>
 
@@ -121,6 +122,7 @@
 			<property name="firmwareVersion"/>
 			<property name="serialNumber"/>
 			<property name="modelId"/>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 		<representation-property>location</representation-property>
 
@@ -161,7 +163,7 @@
 	</channel-type>
 
 	<channel-type id="wifi">
-		<item-type>Number</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI</label>
 		<description>Received signal strength indicator</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.airgradient/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.airgradient/src/main/resources/OH-INF/update/update.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="airgradient:airgradient-local">
+		<instruction-set targetVersion="1">
+			<update-channel id="wifi">
+				<type>airgradient:wifi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="airgradient:airgradient-location">
+		<instruction-set targetVersion="1">
+			<update-channel id="wifi">
+				<type>airgradient:wifi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>

--- a/bundles/org.openhab.binding.bluetooth/README.md
+++ b/bundles/org.openhab.binding.bluetooth/README.md
@@ -54,7 +54,7 @@ bluetooth:beacon:hci0:b1  "BLE Beacon" (bluetooth:bluez:hci0) [ address="68:64:4
 demo.items:
 
 ```java
-Number Beacon_RSSI "My Beacon [%.0f]" { channel="bluetooth:beacon:hci0:b1:rssi" }
+Number:Power Beacon_RSSI "My Beacon [%.0f %unit%]" { unit="dBm", channel="bluetooth:beacon:hci0:b1:rssi" }
 ```
 
 demo.sitemap:

--- a/bundles/org.openhab.binding.bluetooth/README.md
+++ b/bundles/org.openhab.binding.bluetooth/README.md
@@ -39,9 +39,9 @@ Other configuration parameters may be required depending on the bluetooth thing 
 
 Every Bluetooth thing has the following channel:
 
-| Channel ID | Item Type | Description                                                                                         |
-|------------|-----------|-----------------------------------------------------------------------------------------------------|
-| rssi       | Number    | The "Received Signal Strength Indicator", the [RSSI](https://blog.bluetooth.com/proximity-and-rssi) |
+| Channel ID | Item Type    | Description                                                                                         |
+|------------|--------------|-----------------------------------------------------------------------------------------------------|
+| rssi       | Number:Power | The "Received Signal Strength Indicator", the [RSSI](https://blog.bluetooth.com/proximity-and-rssi) |
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/channels.xml
@@ -9,7 +9,7 @@
 		<label>RSSI</label>
 		<description>Received signal strength indicator</description>
 		<category>QualityOfService</category>
-		<state readOnly="true" pattern="%d dBm"/>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
 	<channel-type id="adapter-uid">

--- a/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/channels.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<channel-type id="rssi">
-		<item-type>Number</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI</label>
 		<description>Received signal strength indicator</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/thing/thing-types.xml
@@ -17,6 +17,10 @@
 			<channel id="rssi" typeId="rssi"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
 		<config-description>
 			<parameter name="address" type="text">
 				<label>Address</label>

--- a/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.bluetooth/src/main/resources/OH-INF/update/update.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="bluetooth:beacon">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>bluetooth:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>

--- a/bundles/org.openhab.binding.draytonwiser/README.md
+++ b/bundles/org.openhab.binding.draytonwiser/README.md
@@ -52,7 +52,7 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 | `heatChannel1DemandState`    | Switch               | Is channel 1 calling the boiler for heat                 |
 | `heatChannel2Demand`         | Number:Dimensionless | Current demand level of heating channel 2                |
 | `heatChannel2DemandState`    | Switch               | Is channel 2 calling the boiler for heat                 |
-| `currentSignalRSSI`          | Number               | Relative Signal Strength Indicator                       |
+| `currentSignalRSSI`          | Number:Power         | Relative Signal Strength Indicator                       |
 | `currentWiserSignalStrength` | String               | Human readable signal strength                           |
 | `currentSignalStrength`      | Number               | Signal strength value that maps to qualityofservice icon |
 
@@ -87,7 +87,7 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 | `currentBatteryVoltage`      | Number:ElectricPotential | Currently reported battery voltage                       |
 | `currentWiserBatteryLevel`   | String                   | Human readable battery level                             |
 | `currentBatteryLevel`        | Number                   | Battery level in percent                                 |
-| `currentSignalRSSI`          | Number                   | Relative Signal Strength Indicator                       |
+| `currentSignalRSSI`          | Number:Power             | Relative Signal Strength Indicator                       |
 | `currentSignalLQI`           | Number                   | Link Quality Indicator                                   |
 | `currentWiserSignalStrength` | String                   | Human readable signal strength                           |
 | `currentSignalStrength`      | Number                   | Signal strength value that maps to qualityofservice icon |
@@ -103,7 +103,7 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 | `currentBatteryVoltage`      | Number:ElectricPotential | Currently reported battery voltage                       |
 | `currentWiserBatteryLevel`   | String                   | Human readable battery level                             |
 | `currentBatteryLevel`        | Number                   | Battery level in percent                                 |
-| `currentSignalRSSI`          | Number                   | Relative Signal Strength Indicator                       |
+| `currentSignalRSSI`          | Number:Power             | Relative Signal Strength Indicator                       |
 | `currentSignalLQI`           | Number                   | Link Quality Indicator                                   |
 | `currentWiserSignalStrength` | String                   | Human readable signal strength                           |
 | `currentSignalStrength`      | Number                   | Signal strength value that maps to qualityofservice icon |
@@ -113,7 +113,7 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 
 | Channel                  | Item Type     | Description                                |
 |--------------------------|---------------|--------------------------------------------|
-| `currentSignalRSSI`      | Number        | Relative Signal Strength Indicator         |
+| `currentSignalRSSI`      | Number:Power  | Relative Signal Strength Indicator         |
 | `currentSignalLQI`       | Number        | Link Quality Indicator                     |
 | `zigbeeConnected`        | Switch        | Is the TRV joined to network               |
 | `plugInstantaneousPower` | Number:Power  | Current Power being drawn through the plug |

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
@@ -65,6 +65,9 @@
 			<channel id="comfortModeState" typeId="comfortModeState-channel"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>id</representation-property>
 	</thing-type>
 
@@ -158,6 +161,9 @@
 			<channel id="deviceLocked" typeId="deviceLocked-channel"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>serialNumber</representation-property>
 
 		<config-description>
@@ -192,6 +198,9 @@
 			<channel id="deviceLocked" typeId="deviceLocked-channel"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>serialNumber</representation-property>
 
 		<config-description>
@@ -223,6 +232,9 @@
 			<channel id="plugEnergyDelivered" typeId="plugEnergyDelivered-channel"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>serialNumber</representation-property>
 
 		<config-description>
@@ -294,10 +306,10 @@
 	</channel-type>
 
 	<channel-type id="signalRSSI-channel" advanced="true">
-		<item-type>Number</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal RSSI</label>
 		<description>The reported network signal RSSI</description>
-		<state readOnly="true"/>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
 	<channel-type id="signalLQI-channel" advanced="true">

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/update/update.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="draytonwiser:boiler-controller">
+		<instruction-set targetVersion="1">
+			<update-channel id="currentSignalRSSI">
+				<type>draytonwiser:signalRSSI-channel</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="draytonwiser:roomstat">
+		<instruction-set targetVersion="1">
+			<update-channel id="currentSignalRSSI">
+				<type>draytonwiser:signalRSSI-channel</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="draytonwiser:itrv">
+		<instruction-set targetVersion="1">
+			<update-channel id="currentSignalRSSI">
+				<type>draytonwiser:signalRSSI-channel</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="draytonwiser:smart-plug">
+		<instruction-set targetVersion="1">
+			<update-channel id="currentSignalRSSI">
+				<type>draytonwiser:signalRSSI-channel</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>

--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/README.md
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/README.md
@@ -48,7 +48,7 @@ For users that prefer manual configuration, we list here the configurable parame
 | dataFormat                | Number                   | Data format version                                                      |
 | measurementSequenceNumber | Number:Dimensionless     | Measurement sequence number                                              |
 | movementCounter           | Number:Dimensionless     | Movement counter                                                         |
-| rssi                      | Number                   | Received signal (between the Gateway and the sensor) strength indicator  |
+| rssi                      | Number:Power             | Received signal (between the Gateway and the sensor) strength indicator  |
 | ts                        | DateTime                 | Timestamp when the message from Bluetooth-sensor was received by Gateway |
 | gwts                      | DateTime                 | Timestamp when the message from Bluetooth-sensor was relayed by Gateway  |
 | gwmac                     | String                   | MAC-address of Ruuvi Gateway                                             |

--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/resources/OH-INF/thing/thing-types.xml
@@ -30,6 +30,10 @@
 			<channel id="txPower" typeId="ruuvitag_txPower"/>
 		</channels>
 
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
 		<config-description>
 			<parameter name="topic" type="text">
 				<label>MQTT Topic</label>
@@ -40,11 +44,11 @@
 	</thing-type>
 
 	<channel-type id="ruuvitag_rssi">
-		<item-type>Number</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI</label>
 		<description>Received signal strength indicator</description>
 		<category>QualityOfService</category>
-		<state readOnly="true" pattern="%d dBm"/>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	<channel-type id="ruuvitag_ts">
 		<item-type>DateTime</item-type>

--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/src/main/resources/OH-INF/update/update.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="mqtt:ruuvitag_beacon">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>mqtt:ruuvitag_rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>

--- a/bundles/org.openhab.binding.surepetcare/README.md
+++ b/bundles/org.openhab.binding.surepetcare/README.md
@@ -75,53 +75,53 @@ Channel names in **bold** are read/write, everything else is read-only
 
 ### Flap Device Thing (Cat or Pet Flap)
 
-| Channel               | Type     | Description                                                           |
-|-----------------------|----------|-----------------------------------------------------------------------|
-| id                    | Number   | A unique id assigned by the Sure Petcare API                          |
-| name                  | Text     | The name of the flap                                                  |
-| product               | Text     | The type of product (3=pet flap, 6=cat flap)                          |
-| curfewEnabled1        | Switch   | Indicator if curfew #1 configuration is enabled                       |
-| curfewLockTime1       | Text     | The curfew #1 locking time (HH:MM)                                    |
-| curfewUnlockTime1     | Text     | The curfew #1 unlocking time (HH:MM)                                  |
-| curfewEnabled2        | Switch   | Indicator if curfew #2 configuration is enabled                       |
-| curfewLockTime2       | Text     | The curfew #2 locking time (HH:MM)                                    |
-| curfewUnlockTime2     | Text     | The curfew #2 unlocking time (HH:MM)                                  |
-| curfewEnabled3        | Switch   | Indicator if curfew #3 configuration is enabled                       |
-| curfewLockTime3       | Text     | The curfew #3 locking time (HH:MM)                                    |
-| curfewUnlockTime3     | Text     | The curfew #3 unlocking time (HH:MM)                                  |
-| curfewEnabled4        | Switch   | Indicator if curfew #4 configuration is enabled                       |
-| curfewLockTime4       | Text     | The curfew #4 locking time (HH:MM)                                    |
-| curfewUnlockTime4     | Text     | The curfew #4 unlocking time (HH:MM)                                  |
-| lockingMode           | Text     | The locking mode (e.g. in/out, in-only, out-only etc.)                |
-| online                | Switch   | Indicator if the flap is connected to the hub                         |
-| lowBattery            | Switch   | Indicator if the battery voltage is low                               |
-| batteryLevel          | Number   | The battery voltage percentage                                        |
-| batteryVoltage        | Number   | The absolute battery voltage measurement                              |
-| deviceRSSI            | Number   | The received device signal strength in dB                             |
-| hubRSSI               | Number   | The received hub signal strength in dB                                |
+| Channel            | Type         | Description                                                |
+|--------------------|--------------|------------------------------------------------------------|
+| id                 | Number       | A unique id assigned by the Sure Petcare API               |
+| name               | Text         | The name of the flap                                       |
+| product            | Text         | The type of product (3=pet flap, 6=cat flap)               |
+| curfewEnabled1     | Switch       | Indicator if curfew #1 configuration is enabled            |
+| curfewLockTime1    | Text         | The curfew #1 locking time (HH:MM)                         |
+| curfewUnlockTime1  | Text         | The curfew #1 unlocking time (HH:MM)                       |
+| curfewEnabled2     | Switch       | Indicator if curfew #2 configuration is enabled            |
+| curfewLockTime2    | Text         | The curfew #2 locking time (HH:MM)                         |
+| curfewUnlockTime2  | Text         | The curfew #2 unlocking time (HH:MM)                       |
+| curfewEnabled3     | Switch       | Indicator if curfew #3 configuration is enabled            |
+| curfewLockTime3    | Text         | The curfew #3 locking time (HH:MM)                         |
+| curfewUnlockTime3  | Text         | The curfew #3 unlocking time (HH:MM)                       |
+| curfewEnabled4     | Switch       | Indicator if curfew #4 configuration is enabled            |
+| curfewLockTime4    | Text         | The curfew #4 locking time (HH:MM)                         |
+| curfewUnlockTime4  | Text         | The curfew #4 unlocking time (HH:MM)                       |
+| lockingMode        | Text         | The locking mode (e.g. in/out, in-only, out-only etc.)     |
+| online             | Switch       | Indicator if the flap is connected to the hub              |
+| lowBattery         | Switch       | Indicator if the battery voltage is low                    |
+| batteryLevel       | Number       | The battery voltage percentage                             |
+| batteryVoltage     | Number       | The absolute battery voltage measurement                   |
+| deviceRSSI         | Number:Power | The received device signal strength in dB                  |
+| hubRSSI            | Number:Power | The received hub signal strength in dB                     |
 
 ### Feeder Device Thing
 
-| Channel           | Type        | Description                                                                                     |
-|-------------------|-------------|-------------------------------------------------------------------------------------------------|
-| id                | Number      | A unique id assigned by the Sure Petcare API                                                    |
-| name              | Text        | The name of the feeder                                                                          |
-| product           | Text        | The type of product                                                                             |
-| online            | Switch      | Indicator if the feeder is connected to the hub                                                 |
-| lowBattery        | Switch      | Indicator if the battery voltage is low                                                         |
-| batteryLevel      | Number      | The battery voltage percentage                                                                  |
-| batteryVoltage    | Number      | The absolute battery voltage measurement                                                        |
-| deviceRSSI        | Number      | The received device signal strength in dB                                                       |
-| hubRSSI           | Number      | The received hub signal strength in dB                                                          |
-| bowls             | Text        | The feeder bowls type (1 big bowl or 2 half bowls)                                              |
-| bowlsFood         | Text        | The feeder big bowl food type (wet food, dry food or both)                                      |
-| bowlsTarget       | Number:Mass | The feeder big bowl target weight in gram (even if user setting is oz, API stores this in gram) |
-| bowlsFoodLeft     | Text        | The feeder left half bowl food type (wet food, dry food or both)                                |
-| bowlsTargetLeft   | Number:Mass | The feeder left half bowl target weight                                                         |
-| bowlsFoodRight    | Text        | The feeder right half bowl food type (wet food, dry food or both)                               |
-| bowlsTargetRight  | Number:Mass | The feeder right half bowl target weight                                                        |
-| bowlsCloseDelay   | Text        | The feeder lid close delay (fast, normal, slow)                                                 |
-| bowlsTrainingMode | Text        | The feeder training mode (off, full open, almost full open, half closed, almost closed)         |
+| Channel           | Type         | Description                                                                                     |
+|-------------------|--------------|-------------------------------------------------------------------------------------------------|
+| id                | Number       | A unique id assigned by the Sure Petcare API                                                    |
+| name              | Text         | The name of the feeder                                                                          |
+| product           | Text         | The type of product                                                                             |
+| online            | Switch       | Indicator if the feeder is connected to the hub                                                 |
+| lowBattery        | Switch       | Indicator if the battery voltage is low                                                         |
+| batteryLevel      | Number       | The battery voltage percentage                                                                  |
+| batteryVoltage    | Number       | The absolute battery voltage measurement                                                        |
+| deviceRSSI        | Number:Power | The received device signal strength in dB                                                       |
+| hubRSSI           | Number:Power | The received hub signal strength in dB                                                          |
+| bowls             | Text         | The feeder bowls type (1 big bowl or 2 half bowls)                                              |
+| bowlsFood         | Text         | The feeder big bowl food type (wet food, dry food or both)                                      |
+| bowlsTarget       | Number:Mass  | The feeder big bowl target weight in gram (even if user setting is oz, API stores this in gram) |
+| bowlsFoodLeft     | Text         | The feeder left half bowl food type (wet food, dry food or both)                                |
+| bowlsTargetLeft   | Number:Mass  | The feeder left half bowl target weight                                                         |
+| bowlsFoodRight    | Text         | The feeder right half bowl food type (wet food, dry food or both)                               |
+| bowlsTargetRight  | Number:Mass  | The feeder right half bowl target weight                                                        |
+| bowlsCloseDelay   | Text         | The feeder lid close delay (fast, normal, slow)                                                 |
+| bowlsTrainingMode | Text         | The feeder training mode (off, full open, almost full open, half closed, almost closed)         |
 
 ### Pet Thing
 

--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
@@ -31,6 +31,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -138,8 +139,10 @@ public class SurePetcareDeviceHandler extends SurePetcareBaseObjectHandler {
                         (batVol - BATTERY_EMPTY_VOLTAGE) / (BATTERY_FULL_VOLTAGE - BATTERY_EMPTY_VOLTAGE) * 100.0f,
                         100.0f)));
                 updateState(DEVICE_CHANNEL_LOW_BATTERY, OnOffType.from(batVol < LOW_BATTERY_THRESHOLD));
-                updateState(DEVICE_CHANNEL_DEVICE_RSSI, new DecimalType(device.status.signal.deviceRssi));
-                updateState(DEVICE_CHANNEL_HUB_RSSI, new DecimalType(device.status.signal.hubRssi));
+                updateState(DEVICE_CHANNEL_DEVICE_RSSI,
+                        QuantityType.valueOf(device.status.signal.deviceRssi, Units.DECIBEL_MILLIWATTS));
+                updateState(DEVICE_CHANNEL_HUB_RSSI,
+                        QuantityType.valueOf(device.status.signal.hubRssi, Units.DECIBEL_MILLIWATTS));
 
                 if (thing.getThingTypeUID().equals(THING_TYPE_FLAP_DEVICE)) {
                     updateThingCurfews(device);

--- a/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/thing/things.xml
+++ b/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/thing/things.xml
@@ -144,6 +144,7 @@
 			<property name="productType"/>
 			<property name="productName"/>
 			<property name="pairingAt"/>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 		<representation-property>id</representation-property>
 	</thing-type>
@@ -186,6 +187,7 @@
 			<property name="productType"/>
 			<property name="productName"/>
 			<property name="pairingAt"/>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 		<representation-property>id</representation-property>
 	</thing-type>
@@ -548,17 +550,17 @@
 	</channel-type>
 
 	<channel-type id="rssiDeviceType" advanced="true">
-		<item-type>Number</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal Strength Device (RSSI)</label>
 		<description>The received device signal strength (RSSI).</description>
-		<state readOnly="true" pattern="%.2f dB"/>
+		<state readOnly="true" pattern="%.2f dBm"/>
 	</channel-type>
 
 	<channel-type id="rssiHubType" advanced="true">
-		<item-type>Number</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal Strength Hub (RSSI)</label>
 		<description>The received hub signal strength (RSSI).</description>
-		<state readOnly="true" pattern="%.2f dB"/>
+		<state readOnly="true" pattern="%.2f dBm"/>
 	</channel-type>
 
 	<channel-type id="bowlsFoodType">

--- a/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/thing/things.xml
+++ b/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/thing/things.xml
@@ -553,14 +553,14 @@
 		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal Strength Device (RSSI)</label>
 		<description>The received device signal strength (RSSI).</description>
-		<state readOnly="true" pattern="%.2f dBm"/>
+		<state readOnly="true" pattern="%.2f %unit%"/>
 	</channel-type>
 
 	<channel-type id="rssiHubType" advanced="true">
 		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>Signal Strength Hub (RSSI)</label>
 		<description>The received hub signal strength (RSSI).</description>
-		<state readOnly="true" pattern="%.2f dBm"/>
+		<state readOnly="true" pattern="%.2f %unit%"/>
 	</channel-type>
 
 	<channel-type id="bowlsFoodType">

--- a/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/update/update.xml
+++ b/bundles/org.openhab.binding.surepetcare/src/main/resources/OH-INF/update/update.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="surepetcare:feederDevice">
+		<instruction-set targetVersion="1">
+			<update-channel id="deviceRSSI">
+				<type>surepetcare:rssiDeviceType</type>
+			</update-channel>
+			<update-channel id="hubRSSI">
+				<type>surepetcare:rssiHubType</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="surepetcare:flapDevice">
+		<instruction-set targetVersion="1">
+			<update-channel id="deviceRSSI">
+				<type>surepetcare:rssiDeviceType</type>
+			</update-channel>
+			<update-channel id="hubRSSI">
+				<type>surepetcare:rssiHubType</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>

--- a/itests/org.openhab.binding.mqtt.ruuvigateway.tests/src/main/java/org/openhab/binding/mqtt/ruuvigateway/RuuviGatewayTest.java
+++ b/itests/org.openhab.binding.mqtt.ruuvigateway.tests/src/main/java/org/openhab/binding/mqtt/ruuvigateway/RuuviGatewayTest.java
@@ -193,6 +193,13 @@ public class RuuviGatewayTest extends MqttOSGiTest {
             thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(thingUID, channelId)).build());
         });
 
+        /*
+         * Since we now have an 'upgrade/instructions.xml' file the {@link ManagedThingProvider} is now obliged to apply
+         * those instructions to this test thing. And if the test thing is undergoing such an upgrade, the tests beyond
+         * this line will fail. So we add a 'thingTypeVersion' property to prevent such update process.
+         */
+        thingBuilder.withProperty("thingTypeVersion", "1");
+
         Thing thing = thingBuilder.build();
         thingProvider.add(thing);
         waitForAssert(() -> assertNotNull(thing.getHandler()));


### PR DESCRIPTION
As mentioned in #17826 there are some bindings having a received signal strength indication channel -- **_where there is at least a strong suspicion_** -- that the UoM unit is `dBm` .. but where the thing type is currently not fully specified to reflect that.

This PR seeks to improve the thing type xml specification of those channels, and provide update instructions for existing things.

Clues leading to my suspicion that the unit is `dBm` are as follows:
- bluetooth binding(s): the channel type has a state description pattern `dBm` 
- airgradient binding: the channel type has a state description pattern `dBm` 
- surepetcare binding: the channel type has a state description pattern `dB`
- mqtt.ruuvitag binding: channel provides a `Units.DECIBEL_MILLIWATTS` QuantityType
- draytonwiser binding: channel provides a `Units.DECIBEL_MILLIWATTS` QuantityType

Note in #17826 I mentioned some other bindings that use received signal strength indication channels that could potentially have the same treatment as in this PR. HOWEVER I have decided not to address those since there are no direct clues that the unit could be `dBm`.

Signed-off-by: AndrewFG <software@whitebear.ch>
