### PR TITLE
[mqtt.homeassistant] Update Jinjava to 2.7.4

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>com.hubspot.jinjava.jinjava</artifactId>
-      <version>2.7.3</version>
+      <version>2.7.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/feature/feature.xml
@@ -6,7 +6,7 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-mqtt</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.3</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.4</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
 		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>

--- a/bundles/org.openhab.transform.jinja/pom.xml
+++ b/bundles/org.openhab.transform.jinja/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>com.hubspot.jinjava.jinjava</artifactId>
-      <version>2.7.3</version>
+      <version>2.7.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-transformation-jinja" description="Jinja Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.3</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.4</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
 		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -23,7 +23,7 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-mqtt</feature>
 		<feature dependency="true">openhab.tp-commons-net</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.3</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.4</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
 		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -123,7 +123,7 @@ Import-Package: \
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.17.1,2.17.2)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
 	com.google.re2j.re2j;version='[1.2.0,1.2.1)',\
-	com.hubspot.jinjava.jinjava;version='[2.7.3,2.7.4)',\
+	com.hubspot.jinjava.jinjava;version='[2.7.4,2.7.5)',\
 	javassist;version='[3.29.2,3.29.3)',\
 	org.apache.commons.commons-net;version='[3.9.0,3.9.1)',\
 	org.apache.commons.lang3;version='[3.14.0,3.14.1)',\


### PR DESCRIPTION
Which includes support for break/continue, which is what Zigbee2MQTT's new event component uses in their template.
