### PR TITLE
[groovyscripting] Prevent CNFE for scoped classes unavailable to the class loader

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -51,7 +51,15 @@ public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
         ImportCustomizer importCustomizer = new ImportCustomizer();
         for (Map.Entry<String, Object> entry : scopeValues.entrySet()) {
             if (entry.getValue() instanceof Class<?> clazz) {
-                importCustomizer.addImport(entry.getKey(), clazz.getCanonicalName());
+                String canonicalName = clazz.getCanonicalName();
+                try {
+                    // Only add imports for classes that are available to the classloader
+                    getClass().getClassLoader().loadClass(canonicalName);
+                    importCustomizer.addImport(entry.getKey(), canonicalName);
+                    logger.debug("Added import for {} as {}", entry.getKey(), canonicalName);
+                } catch (ClassNotFoundException e) {
+                    logger.debug("Unable to add import for {} as {}", entry.getKey(), canonicalName, e);
+                }
             } else {
                 scriptEngine.put(entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
Fixes the `ClassNotFoundException` when using Thing actions caused by #17383. The `GroovyClassLoader` loads classes by name however the Thing actions classes cannot be loaded by name because they are internal classes.

Fixes #17683

--- 

In the future we could probably also modify the `CustomizableGroovyClassLoader` to return the `Class` instances provided by the `scopeValues` call to prevent class loader issues.