### PR TITLE
[wiz] Correct units for RSSI

### DIFF
--- a/bundles/org.openhab.binding.wiz/src/main/java/org/openhab/binding/wiz/internal/handler/WizHandler.java
+++ b/bundles/org.openhab.binding.wiz/src/main/java/org/openhab/binding/wiz/internal/handler/WizHandler.java
@@ -592,7 +592,7 @@ public class WizHandler extends BaseThingHandler {
                 strength = 4;
             }
             updateDeviceState(CHANNEL_SIGNAL_STRENGTH, new DecimalType(strength));
-            updateDeviceState(CHANNEL_RSSI, new QuantityType<>(receivedParam.rssi, Units.DECIBEL));
+            updateDeviceState(CHANNEL_RSSI, new QuantityType<>(receivedParam.rssi, Units.DECIBEL_MILLIWATTS));
         }
     }
 

--- a/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -17,6 +17,9 @@
 			<channel id="last-update" typeId="last-update"/>
 			<channel id="rssi" typeId="rssi"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description-ref uri="thing-type:wiz:device"/>
 	</thing-type>
 
@@ -34,6 +37,9 @@
 			<channel id="last-update" typeId="last-update"/>
 			<channel id="rssi" typeId="rssi"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description-ref uri="thing-type:wiz:device"/>
 	</thing-type>
 
@@ -49,6 +55,9 @@
 			<channel id="last-update" typeId="last-update"/>
 			<channel id="rssi" typeId="rssi"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description-ref uri="thing-type:wiz:device"/>
 	</thing-type>
 
@@ -62,6 +71,9 @@
 			<channel id="last-update" typeId="last-update"/>
 			<channel id="rssi" typeId="rssi"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description-ref uri="thing-type:wiz:device"/>
 	</thing-type>
 
@@ -78,6 +90,9 @@
 			<channel id="last-update" typeId="last-update"/>
 			<channel id="rssi" typeId="rssi"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description-ref uri="thing-type:wiz:device"/>
 	</thing-type>
 
@@ -90,6 +105,9 @@
 			<channel-group id="light" typeId="dimmable-light"/>
 			<channel-group id="fan" typeId="fan-group"/>
 		</channel-groups>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<config-description-ref uri="thing-type:wiz:device"/>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -185,7 +185,7 @@
 	</channel-type>
 
 	<channel-type id="rssi" advanced="true">
-		<item-type unitHint="dB">Number:Dimensionless</item-type>
+		<item-type unitHint="dBm">Number:Power</item-type>
 		<label>RSSI</label>
 		<description>WiFi Received Signal Strength Indicator</description>
 		<category>QualityOfService</category>

--- a/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="wiz:color-bulb">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>wiz:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="wiz:tunable-bulb">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>wiz:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="wiz:dimmable-bulb">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>wiz:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="wiz:plug">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>wiz:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="wiz:fan">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>wiz:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+	<thing-type uid="wiz:fan-with-dimmable-bulb">
+		<instruction-set targetVersion="1">
+			<update-channel id="rssi">
+				<type>wiz:rssi</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+
+</update:update-descriptions>


### PR DESCRIPTION
Number:Power of dBm, instead of Number:Dimensionless of dB.

See discussion in #17826
