### PR TITLE
[ntp] Remove obsoleted integration tests

### DIFF
--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.openhab.binding.ntp.internal.NtpBindingConstants;
@@ -210,35 +208,6 @@ public class NtpOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testDateTimeChannelTimeZoneUpdate() {
-        Configuration configuration = new Configuration();
-        configuration.put(NtpBindingConstants.PROPERTY_TIMEZONE, TEST_TIME_ZONE_ID);
-        initialize(configuration, NtpBindingConstants.CHANNEL_DATE_TIME, ACCEPTED_ITEM_TYPE_DATE_TIME, null, null);
-
-        String testItemState = getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME).toString();
-        assertFormat(testItemState, DateTimeType.DATE_PATTERN_WITH_TZ_AND_MS);
-        ZonedDateTime timeZoneFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
-                .getZonedDateTime();
-
-        ZoneOffset expectedOffset = ZoneId.of(TEST_TIME_ZONE_ID).getRules()
-                .getOffset(timeZoneFromItemRegistry.toInstant());
-        assertEquals(expectedOffset, timeZoneFromItemRegistry.getOffset());
-    }
-
-    @Test
-    public void testDateTimeChannelCalendarTimeZoneUpdate() {
-        Configuration configuration = new Configuration();
-        configuration.put(NtpBindingConstants.PROPERTY_TIMEZONE, TEST_TIME_ZONE_ID);
-        initialize(configuration, NtpBindingConstants.CHANNEL_DATE_TIME, ACCEPTED_ITEM_TYPE_DATE_TIME, null, null);
-        ZonedDateTime timeZoneIdFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
-                .getZonedDateTime();
-
-        ZoneOffset expectedOffset = ZoneId.of(TEST_TIME_ZONE_ID).getRules()
-                .getOffset(timeZoneIdFromItemRegistry.toInstant());
-        assertEquals(expectedOffset, timeZoneIdFromItemRegistry.getOffset());
-    }
-
-    @Test
     public void testStringChannelDefaultTimeZoneUpdate() {
         final String expectedTimeZoneEEST = "EEST";
         final String expectedTimeZoneEET = "EET";
@@ -257,36 +226,6 @@ public class NtpOSGiTest extends JavaOSGiTest {
         String timeZoneFromItemRegistry = getStringChannelTimeZoneFromItemRegistry();
 
         assertThat(timeZoneFromItemRegistry, is(anyOf(equalTo(expectedTimeZoneEEST), equalTo(expectedTimeZoneEET))));
-    }
-
-    @Test
-    public void testDateTimeChannelDefaultTimeZoneUpdate() {
-        ZonedDateTime zoned = ZonedDateTime.now();
-
-        ZoneOffset expectedTimeZone = zoned.getOffset();
-        Configuration configuration = new Configuration();
-        // Initialize with configuration with no time zone property set.
-        initialize(configuration, NtpBindingConstants.CHANNEL_DATE_TIME, ACCEPTED_ITEM_TYPE_DATE_TIME, null, null);
-
-        String testItemState = getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME).toString();
-        assertFormat(testItemState, DateTimeType.DATE_PATTERN_WITH_TZ_AND_MS);
-        ZoneOffset timeZoneFromItemRegistry = new DateTimeType(testItemState).getZonedDateTime().getOffset();
-
-        assertEquals(expectedTimeZone, timeZoneFromItemRegistry);
-    }
-
-    @Test
-    @Disabled("https://github.com/eclipse/smarthome/issues/5224")
-    public void testDateTimeChannelCalendarDefaultTimeZoneUpdate() {
-        Configuration configuration = new Configuration();
-        // Initialize with configuration with no time zone property set.
-        initialize(configuration, NtpBindingConstants.CHANNEL_DATE_TIME, ACCEPTED_ITEM_TYPE_DATE_TIME, null, null);
-
-        ZonedDateTime timeZoneIdFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
-                .getZonedDateTime();
-
-        ZoneOffset expectedOffset = ZoneId.systemDefault().getRules().getOffset(timeZoneIdFromItemRegistry.toInstant());
-        assertEquals(expectedOffset, timeZoneIdFromItemRegistry.getOffset());
     }
 
     @Test


### PR DESCRIPTION
These tests are no longer relevant since `DateTimeType` is now "zone-less". They are currently failing.

Related to openhab/openhab-core#3583