### PR TITLE
[robonect] Simplify `DateTimeType` handling

### DIFF
--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -18,7 +18,6 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
@@ -304,9 +303,7 @@ public class RobonectHandler extends BaseThingHandler {
         long adjustedTime = rawInstant.getEpochSecond() - offsetToConfiguredZone.getTotalSeconds();
         Instant adjustedInstant = Instant.ofEpochMilli(adjustedTime * 1000);
 
-        // we provide the time in the format as configured in the openHAB settings
-        ZonedDateTime zdt = adjustedInstant.atZone(timeZoneProvider.getTimeZone());
-        return new DateTimeType(zdt);
+        return new DateTimeType(adjustedInstant);
     }
 
     private void refreshVersionInfo() {

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
@@ -64,20 +64,22 @@ import org.openhab.core.types.UnDefType;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class RobonectHandlerTest {
 
+    private static final ZoneId TIME_ZONE = ZoneId.of("Europe/Berlin");
+
     private RobonectHandler subject;
 
     private @Mock Thing robonectThingMock;
     private @Mock RobonectClient robonectClientMock;
     private @Mock ThingHandlerCallback callbackMock;
     private @Mock HttpClientFactory httpClientFactoryMock;
-    private @Mock TimeZoneProvider timezoneProvider;
+    private @Mock TimeZoneProvider timeZoneProvider;
 
     @BeforeEach
     public void setUp() {
         Mockito.when(robonectThingMock.getUID()).thenReturn(new ThingUID("1:2:3"));
-        Mockito.when(timezoneProvider.getTimeZone()).thenReturn(ZoneId.of("Europe/Berlin"));
+        Mockito.when(timeZoneProvider.getTimeZone()).thenReturn(TIME_ZONE);
 
-        subject = new RobonectHandler(robonectThingMock, httpClientFactoryMock, timezoneProvider);
+        subject = new RobonectHandler(robonectThingMock, httpClientFactoryMock, timeZoneProvider);
         subject.setCallback(callbackMock);
         subject.setRobonectClient(robonectClientMock);
     }
@@ -110,7 +112,7 @@ public class RobonectHandlerTest {
         State value = stateCaptor.getValue();
         assertTrue(value instanceof DateTimeType);
 
-        ZonedDateTime zdt = ((DateTimeType) value).getZonedDateTime();
+        ZonedDateTime zdt = ((DateTimeType) value).getZonedDateTime(TIME_ZONE);
         assertEquals(1, zdt.getDayOfMonth());
         assertEquals(2017, zdt.getYear());
         assertEquals(Month.MAY, zdt.getMonth());
@@ -159,7 +161,7 @@ public class RobonectHandlerTest {
         State errorDate = errorDateCaptor.getValue();
         assertTrue(errorDate instanceof DateTimeType);
 
-        ZonedDateTime zdt = ((DateTimeType) errorDate).getZonedDateTime();
+        ZonedDateTime zdt = ((DateTimeType) errorDate).getZonedDateTime(TIME_ZONE);
         assertEquals(1, zdt.getDayOfMonth());
         assertEquals(2017, zdt.getYear());
         assertEquals(Month.MAY, zdt.getMonth());


### PR DESCRIPTION
This fixes a test that fails when being run on a system in another time-zone than CET (i.e. CI builds):
https://github.com/jlaur/openhab-addons/actions/runs/12244010700

The commit has been cherry-picked from #17725
Related to openhab/openhab-core#3583