### PR TITLE
[boschshc] Update location properties when initializing things

### DIFF
--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCBindingConstants.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCBindingConstants.java
@@ -134,4 +134,8 @@ public class BoschSHCBindingConstants {
 
     // static device/service names
     public static final String SERVICE_INTRUSION_DETECTION = "intrusionDetectionSystem";
+
+    // thing properties
+    public static final String PROPERTY_LOCATION_LEGACY = "Location";
+    public static final String PROPERTY_LOCATION = "location";
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCDeviceHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCDeviceHandler.java
@@ -12,6 +12,10 @@
  */
 package org.openhab.binding.boschshc.internal.devices;
 
+import static org.openhab.binding.boschshc.internal.devices.BoschSHCBindingConstants.PROPERTY_LOCATION;
+import static org.openhab.binding.boschshc.internal.devices.BoschSHCBindingConstants.PROPERTY_LOCATION_LEGACY;
+
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -83,7 +87,42 @@ public abstract class BoschSHCDeviceHandler extends BoschSHCHandler {
      *         otherwise
      */
     protected boolean processDeviceInfo(Device deviceInfo) {
+        try {
+            updateLocationPropertiesIfApplicable(deviceInfo);
+        } catch (Exception e) {
+            logger.warn("Error while updating location properties for thing {}.", getThing().getUID(), e);
+        }
+        // do not cancel thing initialization if location properties cannot be updated
         return true;
+    }
+
+    private void updateLocationPropertiesIfApplicable(Device deviceInfo) throws BoschSHCException {
+        Map<String, String> thingProperties = getThing().getProperties();
+        removeLegacyLocationPropertyIfApplicable(thingProperties);
+        updateLocationPropertyIfApplicable(thingProperties, deviceInfo);
+    }
+
+    private void updateLocationPropertyIfApplicable(Map<String, String> thingProperties, Device deviceInfo)
+            throws BoschSHCException {
+        @Nullable
+        String roomName = getBridgeHandler().resolveRoomId(deviceInfo.roomId);
+        if (roomName != null) {
+            @Nullable
+            String currentLocation = thingProperties.get(PROPERTY_LOCATION);
+            if (currentLocation == null || !currentLocation.equals(roomName)) {
+                logger.debug("Updating property '{}' of thing {} to '{}'.", PROPERTY_LOCATION, getThing().getUID(),
+                        roomName);
+                updateProperty(PROPERTY_LOCATION, roomName);
+            }
+        }
+    }
+
+    private void removeLegacyLocationPropertyIfApplicable(Map<String, String> thingProperties) {
+        if (thingProperties.containsKey(PROPERTY_LOCATION_LEGACY)) {
+            logger.debug("Removing legacy property '{}' from thing {}.", PROPERTY_LOCATION_LEGACY, getThing().getUID());
+            // null value indicates that the property should be removed
+            updateProperty(PROPERTY_LOCATION_LEGACY, null);
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCDeviceHandler.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/devices/BoschSHCDeviceHandler.java
@@ -89,7 +89,7 @@ public abstract class BoschSHCDeviceHandler extends BoschSHCHandler {
     protected boolean processDeviceInfo(Device deviceInfo) {
         try {
             updateLocationPropertiesIfApplicable(deviceInfo);
-        } catch (Exception e) {
+        } catch (BoschSHCException e) {
             logger.warn("Error while updating location properties for thing {}.", getThing().getUID(), e);
         }
         // do not cancel thing initialization if location properties cannot be updated
@@ -104,12 +104,10 @@ public abstract class BoschSHCDeviceHandler extends BoschSHCHandler {
 
     private void updateLocationPropertyIfApplicable(Map<String, String> thingProperties, Device deviceInfo)
             throws BoschSHCException {
-        @Nullable
         String roomName = getBridgeHandler().resolveRoomId(deviceInfo.roomId);
         if (roomName != null) {
-            @Nullable
             String currentLocation = thingProperties.get(PROPERTY_LOCATION);
-            if (currentLocation == null || !currentLocation.equals(roomName)) {
+            if (!roomName.equals(currentLocation)) {
                 logger.debug("Updating property '{}' of thing {} to '{}'.", PROPERTY_LOCATION, getThing().getUID(),
                         roomName);
                 updateProperty(PROPERTY_LOCATION, roomName);

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryService.java
@@ -243,7 +243,7 @@ public class ThingDiscoveryService extends AbstractThingHandlerDiscoveryService<
         discoveryResult.withBridge(thingHandler.getThing().getUID());
 
         if (!roomName.isEmpty()) {
-            discoveryResult.withProperty("Location", roomName);
+            discoveryResult.withProperty(BoschSHCBindingConstants.PROPERTY_LOCATION, roomName);
         }
         thingDiscovered(discoveryResult.build());
 

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/bridge/BridgeHandlerTest.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.boschshc.internal.devices.bridge;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1125,5 +1127,34 @@ class BridgeHandlerTest {
 
         verify(httpClient).createRequest(any(), same(HttpMethod.GET));
         verify(httpClient).sendRequest(any(), same(PublicInformation.class), any(), isNull());
+    }
+
+    @Test
+    void resolveRoomId() throws InterruptedException, TimeoutException, ExecutionException {
+        Request request = mock(Request.class);
+        when(httpClient.createRequest(any(), eq(HttpMethod.GET))).thenReturn(request);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(200);
+        String roomsJson = """
+                [
+                    {
+                        "@type": "room",
+                        "id": "hz_1",
+                        "iconId": "icon_room_living_room",
+                        "name": "Living Room"
+                    },
+                    {
+                        "@type": "room",
+                        "id": "hz_2",
+                        "iconId": "icon_room_dining_room",
+                        "name": "Dining Room"
+                    }
+                ]
+                """;
+        when(contentResponse.getContentAsString()).thenReturn(roomsJson);
+        assertThat(fixture.resolveRoomId("hz_1"), is("Living Room"));
+        assertThat(fixture.resolveRoomId("hz_2"), is("Dining Room"));
+        assertThat(fixture.resolveRoomId(null), is(nullValue()));
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/relay/RelayHandlerTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/devices/relay/RelayHandlerTest.java
@@ -12,8 +12,11 @@
  */
 package org.openhab.binding.boschshc.internal.devices.relay;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -375,5 +378,56 @@ class RelayHandlerTest extends AbstractPowerSwitchHandlerTest<RelayHandler> {
     void testUpdateModePropertyIfApplicableImpulseSwitchMode() {
         verify(getCallback(), times(2)).thingUpdated(argThat(t -> ImpulseSwitchService.IMPULSE_SWITCH_SERVICE_NAME
                 .equals(t.getProperties().get(RelayHandler.PROPERTY_MODE))));
+    }
+
+    /**
+     * This has to be tested differently for the RelayHandler because the thing mock
+     * will be replaced by a real thing during the first initialization, which
+     * modifies the channels.
+     */
+    @Test
+    @Tag(TAG_LEGACY_LOCATION_PROPERTY)
+    @Override
+    protected void deleteLegacyLocationProperty() {
+        ArgumentCaptor<Thing> thingCaptor = ArgumentCaptor.forClass(Thing.class);
+        verify(getCallback(), times(3)).thingUpdated(thingCaptor.capture());
+        List<Thing> allValues = thingCaptor.getAllValues();
+        assertThat(allValues, hasSize(3));
+        assertThat(allValues.get(2).getProperties(), not(hasKey(BoschSHCBindingConstants.PROPERTY_LOCATION_LEGACY)));
+    }
+
+    /**
+     * This has to be tested differently for the RelayHandler because the thing mock
+     * will be replaced by a real thing during the first initialization, which
+     * modifies the channels.
+     */
+    @Test
+    @Tag(TAG_LOCATION_PROPERTY)
+    @Override
+    protected void locationPropertyDidNotChange() {
+        // re-initialize
+        getFixture().initialize();
+
+        verify(getCallback(), times(3)).thingUpdated(
+                argThat(t -> t.getProperties().get(BoschSHCBindingConstants.PROPERTY_LOCATION).equals("Kitchen")));
+    }
+
+    /**
+     * This has to be tested differently for the RelayHandler because the thing mock
+     * will be replaced by a real thing during the first initialization, which
+     * modifies the channels.
+     */
+    @Test
+    @Tag(TAG_LOCATION_PROPERTY)
+    @Override
+    protected void locationPropertyDidChange() {
+        getDevice().roomId = "hz_2";
+        when(getBridgeHandler().resolveRoomId("hz_2")).thenReturn("Dining Room");
+
+        // re-initialize
+        getFixture().initialize();
+
+        verify(getCallback(), times(4)).thingUpdated(
+                argThat(t -> t.getProperties().get(BoschSHCBindingConstants.PROPERTY_LOCATION).equals("Dining Room")));
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.boschshc/src/test/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryServiceTest.java
@@ -194,7 +194,8 @@ class ThingDiscoveryServiceTest {
         assertThat(result.getThingUID().getId(), is("testDevice_ID"));
         assertThat(result.getBridgeUID().getId(), is("testSHC"));
         assertThat(result.getLabel(), is("Test Name"));
-        assertThat(String.valueOf(result.getProperties().get("Location")), is("TestRoom"));
+        assertThat(String.valueOf(result.getProperties().get(BoschSHCBindingConstants.PROPERTY_LOCATION)),
+                is("TestRoom"));
     }
 
     @Test


### PR DESCRIPTION
When a device is initialized, an attempt is made to look up the room name for the room id specified for the device and to store the room name in a thing property. This property is also updated if a room change is detected.

The legacy property `Location` is removed if present. From now on the property `location` (with proper lower case spelling) is used.

* add constants for location properties
* implement location updates in abstract device handler
* extend bridge handler to provide a cached list of rooms
* add unit tests

closes #16599