### PR TITLE
[broadlinkthermostat] Fix binding name

### DIFF
--- a/bundles/org.openhab.binding.broadlinkthermostat/README.md
+++ b/bundles/org.openhab.binding.broadlinkthermostat/README.md
@@ -1,4 +1,4 @@
-# Broadlink Binding
+# Broadlink Thermostat Binding
 
 The binding integrates devices based on broadlink controllers.
 As the binding uses the [broadlink-java-api](https://github.com/mob41/broadlink-java-api), theoretically all devices supported by the api can be integrated with this binding.

--- a/bundles/org.openhab.binding.broadlinkthermostat/pom.xml
+++ b/bundles/org.openhab.binding.broadlinkthermostat/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.binding.broadlinkthermostat</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: Broadlink Binding</name>
+  <name>openHAB Add-ons :: Bundles :: Broadlink Thermostat Binding</name>
 
   <dependencies>
     <dependency>

--- a/bundles/org.openhab.binding.broadlinkthermostat/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.broadlinkthermostat/src/main/resources/OH-INF/addon/addon.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>Broadlinkthermostat Binding</name>
-	<description>This is the binding for Broadlinkthermostat devices.</description>
+	<name>Broadlink Thermostat Binding</name>
+	<description>This is the binding for Broadlink thermostat devices.</description>
 	<connection>local</connection>
 </addon:addon>

--- a/bundles/org.openhab.binding.broadlinkthermostat/src/main/resources/OH-INF/i18n/broadlinkthermostat.properties
+++ b/bundles/org.openhab.binding.broadlinkthermostat/src/main/resources/OH-INF/i18n/broadlinkthermostat.properties
@@ -1,7 +1,7 @@
 # add-on
 
-addon.broadlinkthermostat.name = Broadlink Binding
-addon.broadlinkthermostat.description = This is the binding for Broadlink devices.
+addon.broadlinkthermostat.name = Broadlink Thermostat Binding
+addon.broadlinkthermostat.description = This is the binding for Broadlink thermostat devices.
 
 # thing types
 


### PR DESCRIPTION
With the new broadlink binding, we now have two bindings with the same name:

![image](https://github.com/user-attachments/assets/a2d8a2e6-01f3-42e8-963f-752fbdd5f3f6)

See also https://community.openhab.org/t/broadlink-binding-4-1-0-4-3-0/154734/151