### PR TITLE
Resolve runbundles for reverting LinkedTransferQueue high CPU usage workaround

### DIFF
--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -19,7 +19,7 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 -runsystempackages: sun.reflect
 
 -runfw: org.eclipse.osgi
--runee: JavaSE-17
+-runee: JavaSE-21
 
 # An unused random HTTP port is used during tests to prevent resource conflicts
 # This property is set by the build-helper-maven-plugin in the itests pom.xml

--- a/itests/org.openhab.automation.groovyscripting.tests/itest.bndrun
+++ b/itests/org.openhab.automation.groovyscripting.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.automation.groovyscripting
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.automation.jsscriptingnashorn.tests/itest.bndrun
+++ b/itests/org.openhab.automation.jsscriptingnashorn.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.automation.jsscriptingnashorn
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -25,7 +25,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -31,7 +31,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -35,7 +35,6 @@ Fragment-Host: org.openhab.binding.hue
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.binding.max
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mielecloud.tests/itest.bndrun
@@ -32,7 +32,6 @@ Fragment-Host: org.openhab.binding.mielecloud
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -35,7 +35,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -53,7 +53,6 @@ Import-Package: \
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -53,7 +53,6 @@ Import-Package: \
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.mqtt.ruuvigateway.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.ruuvigateway.tests/itest.bndrun
@@ -53,7 +53,6 @@ Import-Package: \
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -33,7 +33,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -35,7 +35,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -38,7 +38,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -35,7 +35,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\


### PR DESCRIPTION
Related to openhab/openhab-core#4499