### PR TITLE
[insteon] Replace deprecated datetimetype method

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageHandler.java
@@ -18,8 +18,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Set;
 
@@ -601,18 +599,12 @@ public abstract class MessageHandler extends BaseFeatureHandler {
 
         @Override
         public void handleMessage(byte cmd1, Msg msg) {
-            Instant instant = Instant.ofEpochMilli(msg.getTimestamp());
-            ZonedDateTime timestamp = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
-            ZonedDateTime lastTimestamp = getLastTimestamp();
-            // set last time if not defined yet or message timestamp is greater than last value
-            if (lastTimestamp == null || timestamp.compareTo(lastTimestamp) > 0) {
+            Instant timestamp = Instant.ofEpochMilli(msg.getTimestamp());
+            Instant lastTimestamp = feature.getState() instanceof DateTimeType datetime ? datetime.getInstant() : null;
+            // update state if not defined or is older than message timestamp
+            if (lastTimestamp == null || lastTimestamp.isBefore(timestamp)) {
                 feature.updateState(new DateTimeType(timestamp));
             }
-        }
-
-        private @Nullable ZonedDateTime getLastTimestamp() {
-            State state = feature.getState();
-            return state instanceof DateTimeType datetime ? datetime.getZonedDateTime() : null;
         }
     }
 


### PR DESCRIPTION
Replaced deprecated `DateTimeType.getZonedDateTime()` method with directly using `Instant` objects.

I did run a successful test in my environment of this change.