### PR TITLE
[bondhome] Catch null host exception in discovery service

### DIFF
--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -244,7 +244,7 @@ public class BondHttpApi {
 
                 logger.debug("HTTP response from request to {}: {}", uri, httpResponse);
                 return httpResponse;
-            } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            } catch (InterruptedException | TimeoutException | ExecutionException | IllegalArgumentException e) {
                 logger.debug("Last request to Bond Bridge failed; {} retries remaining: {}", numRetriesRemaining,
                         e.getMessage());
                 numRetriesRemaining--;


### PR DESCRIPTION
Upon upgrading to OH-4.3.0, I am seeing this error at startup or anytime the bond bridge is disabled and re-enabled. The issue appears to be a race condition where the discovery service attempts to start calling request() before bridgeHandler.getBridgeIpAddress() can provide the IP address of the bridge. By catching the IllegalArgumentException , the service will continue and is able to discover devices in subsequent scans.

![image](https://github.com/user-attachments/assets/238bf6c5-e2d3-4c56-903f-924aeb0e896f)
 