### PR TITLE
[tado.doc] Updated tado binding documentation for tado X

### DIFF
--- a/bundles/org.openhab.binding.tado/README.md
+++ b/bundles/org.openhab.binding.tado/README.md
@@ -5,6 +5,8 @@ The tado° binding integrates devices from [tado°](https://www.tado.com).
 It requires a fully functional tado° installation.
 You can then monitor and control all zone types (Heating, AC, Hot Water) as well as retrieve the HOME/AWAY status of mobile devices, and setting the HOME/AWAY status of your home.
 
+**WARNING**: This binding doesn't work together with new tado X radiator thermostats, as they are using a different API (see [here](https://app.swaggerhub.com/apis/JPlenert/TadoX/0.8.0) ).
+
 ## `home` Thing (the Bridge)
 
 The `home` thing serves as bridge to the tado° cloud services.


### PR DESCRIPTION
Updated the documentation of the tado binding, as the current binding is not compatible to the new tado X devices.
Inserted a swagger link to updated API for the new devices.