### PR TITLE
[pulseaudio] Markdown documentation fixes

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -71,7 +71,7 @@ This requires the module **module-simple-protocol-tcp** to be present on the ser
 ### Thing Configuration
 
 | Config Name                 | Item Type   | Description                                                                                       |
-|-----------------------------|-----------------------------------------------------------------------------------------------------------------|
+|-----------------------------|-------------|---------------------------------------------------------------------------------------------------|
 | name                        | text        | The name of one specific device. You can also use the description                                 |
 | activateSimpleProtocolSink  | boolean     | Activation of a corresponding sink in openHAB                                                     |
 | additionalFilters           | text        | Additional filters to select the proper device on the pulseaudio server, in case of ambiguity     |
@@ -90,7 +90,7 @@ This requires the module **module-simple-protocol-tcp** to be present on the tar
 ### Thing Configuration
 
 | Config ID                    | Item Type   | Description                                                                                       |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------|
+|------------------------------|-------------|---------------------------------------------------------------------------------------------------|
 | name                         | text        | The name of one specific device. You can also use the description                                 |
 | activateSimpleProtocolSource | boolean     | Activation of a corresponding sink in openHAB                                                     |
 | additionalFilters            | text        | Additional filters to select the proper device on the pulseaudio server, in case of ambiguity     |
@@ -119,7 +119,9 @@ Bridge pulseaudio:bridge:<bridgname> "<Bridge Label>" @ "<Room>" [ host="<ipAddr
 
 <!--
 ### pulseaudio.items
+
 ```
 
 ```
+
 -->


### PR DESCRIPTION
Two tables were rendered incorrectly due to missing pipes, see https://www.openhab.org/addons/bindings/pulseaudio/

Further markdownlint fixes.