### PR TITLE
[upnpcontrol] Fix `IllegalArgumentException` when downloading album art

### DIFF
--- a/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/handler/UpnpRendererHandler.java
+++ b/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/handler/UpnpRendererHandler.java
@@ -1653,7 +1653,7 @@ public class UpnpRendererHandler extends UpnpHandler {
             } else {
                 State albumArt = null;
                 try {
-                    albumArt = HttpUtil.downloadImage(media.getAlbumArtUri());
+                    albumArt = HttpUtil.downloadImage(media.getAlbumArtUri().trim());
                 } catch (IllegalArgumentException e) {
                     logger.debug("Invalid album art URI: {}", media.getAlbumArtUri(), e);
                 }

--- a/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/handler/UpnpRendererHandler.java
+++ b/bundles/org.openhab.binding.upnpcontrol/src/main/java/org/openhab/binding/upnpcontrol/internal/handler/UpnpRendererHandler.java
@@ -1648,7 +1648,7 @@ public class UpnpRendererHandler extends UpnpHandler {
         }
         if (!(isCurrent
                 && (media.getAlbumArtUri().isEmpty() || media.getAlbumArtUri().contains("DefaultAlbumCover")))) {
-            if (media.getAlbumArtUri().isEmpty() || media.getAlbumArtUri().contains("DefaultAlbumCover")) {
+            if (media.getAlbumArtUri().isBlank() || media.getAlbumArtUri().contains("DefaultAlbumCover")) {
                 updateState(ALBUM_ART, UnDefType.UNDEF);
             } else {
                 State albumArt = null;


### PR DESCRIPTION
Artwork was failing to download on my new WiiM pro streamers due to whitespace in the URI.

```
2024-12-23 11:33:55.964 [DEBUG] [internal.handler.UpnpRendererHandler] - Invalid album art URI: http://mediaserver-cont-usc-mp1-1-v4v6.pandora.com/images/
88/0c/ed/6e/d48642d08e076af31fc3dd51/1080W_1080H.jpg
java.lang.IllegalArgumentException: Illegal character in path at index 110: http://mediaserver-cont-usc-mp1-1-v4v6.pandora.com/images/88/0c/ed/6e/d48642d0
8e076af31fc3dd51/1080W_1080H.jpg
        at java.net.URI.create(URI.java:906) ~[?:?]
        at org.eclipse.jetty.client.HttpClient.newRequest(HttpClient.java:473) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.executeUrlAndGetReponse(HttpUtil.java:212) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadData(HttpUtil.java:443) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadImage(HttpUtil.java:406) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadImage(HttpUtil.java:377) ~[?:?]
        at org.openhab.core.io.net.http.HttpUtil.downloadImage(HttpUtil.java:363) ~[?:?]
```