### PR TITLE
[pihole] Fix enableBlocking action

### DIFF
--- a/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/JettyAdminService.java
+++ b/bundles/org.openhab.binding.pihole/src/main/java/org/openhab/binding/pihole/internal/rest/JettyAdminService.java
@@ -81,7 +81,7 @@ public class JettyAdminService implements AdminService {
     @Override
     public void enableBlocking() throws PiHoleException {
         logger.debug("Enabling blocking");
-        var url = baseUrl.resolve("/admin/api.php?disable&auth=%s".formatted(token));
+        var url = baseUrl.resolve("/admin/api.php?enable&auth=%s".formatted(token));
         var request = client.newRequest(url).timeout(TIMEOUT_SECONDS, SECONDS);
         send(request);
     }


### PR DESCRIPTION
The pihole thing action `enableBlocking` currently uses the wrong API endpoint and therefor disables the blocking instead of enabling it.

fixes #17966