### PR TITLE
[network] Fix last-seen channel being set to `UNDEF` at startup

### DIFF
--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -103,8 +103,6 @@ public class NetworkHandler extends BaseThingHandler
                 Instant lastSeen = presenceDetection.getLastSeen();
                 if (lastSeen != null) {
                     updateState(CHANNEL_LASTSEEN, new DateTimeType(lastSeen));
-                } else {
-                    updateState(CHANNEL_LASTSEEN, UnDefType.UNDEF);
                 }
                 break;
             default:
@@ -144,8 +142,6 @@ public class NetworkHandler extends BaseThingHandler
         Instant lastSeen = presenceDetection.getLastSeen();
         if (value.isReachable() && lastSeen != null) {
             updateState(CHANNEL_LASTSEEN, new DateTimeType(lastSeen));
-        } else if (!value.isReachable() && lastSeen == null) {
-            updateState(CHANNEL_LASTSEEN, UnDefType.UNDEF);
         }
 
         updateNetworkProperties();

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -100,6 +100,8 @@ public class NetworkHandler extends BaseThingHandler
                 });
                 break;
             case CHANNEL_LASTSEEN:
+                // We should not set the last seen state to UNDEF, it prevents restoreOnStartup from working
+                // For reference: https://github.com/openhab/openhab-addons/issues/17404
                 Instant lastSeen = presenceDetection.getLastSeen();
                 if (lastSeen != null) {
                     updateState(CHANNEL_LASTSEEN, new DateTimeType(lastSeen));
@@ -143,6 +145,8 @@ public class NetworkHandler extends BaseThingHandler
         if (value.isReachable() && lastSeen != null) {
             updateState(CHANNEL_LASTSEEN, new DateTimeType(lastSeen));
         }
+        // We should not set the last seen state to UNDEF, it prevents restoreOnStartup from working
+        // For reference: https://github.com/openhab/openhab-addons/issues/17404
 
         updateNetworkProperties();
     }


### PR DESCRIPTION
This fix makes it possible to use `restoreOnStartup` for the last-seen channel. When a device is not on the network and openHAB reboots, the last-seen channel is set to `UNDEF`. This renders the use of `restoreOnStartup` useless. 

If `restoreOnStartup` is not used, the channel remains `NULL` after startup. I think that is a fair trade-off compared to being set to `UNDEF`.

Fixes  https://github.com/openhab/openhab-addons/issues/17404