### PR TITLE
[network] Fix discovery performance causing a slow openHAB start

### DIFF
--- a/bundles/org.openhab.binding.network/README.md
+++ b/bundles/org.openhab.binding.network/README.md
@@ -14,7 +14,7 @@ The binding has the following configuration options:
 - **arpPingToolPath:** If the ARP ping tool is not called `arping` and cannot be found in the PATH environment variable, the absolute path can be configured here. Default is `arping`.
 - **cacheDeviceStateTimeInMS:** The result of a device presence detection is cached for a small amount of time. Set this time here in milliseconds. Be aware that no new pings will be issued within this time frame, even if explicitly requested. Default is 2000.
 - **preferResponseTimeAsLatency:** If enabled, an attempt will be made to extract the latency from the output of the ping command. If no such latency value is found in the ping command output, the time to execute the ping command is used as fallback latency. If disabled, the time to execute the ping command is always used as latency value. This is disabled by default to be backwards-compatible and to not break statistics and monitoring which existed before this feature.
-- **numberOfDiscoveryThreads:** Specifies the number of threads to be used during the discovery process. Increasing this value may speed up the discovery of devices on large networks but could also increase the load on the system. Default is `100`. _note:_The binding needs a restart for this configuration parameter to have effect.
+- **numberOfDiscoveryThreads:** Specifies the number of threads to be used during the discovery process. Increasing this value may speed up the discovery of devices on large networks but could also increase the load on the system. Default is `100`.
 
 Create a `<openHAB-conf>/services/network.cfg` file and use the above options like this:
 

--- a/bundles/org.openhab.binding.network/README.md
+++ b/bundles/org.openhab.binding.network/README.md
@@ -14,6 +14,7 @@ The binding has the following configuration options:
 - **arpPingToolPath:** If the ARP ping tool is not called `arping` and cannot be found in the PATH environment variable, the absolute path can be configured here. Default is `arping`.
 - **cacheDeviceStateTimeInMS:** The result of a device presence detection is cached for a small amount of time. Set this time here in milliseconds. Be aware that no new pings will be issued within this time frame, even if explicitly requested. Default is 2000.
 - **preferResponseTimeAsLatency:** If enabled, an attempt will be made to extract the latency from the output of the ping command. If no such latency value is found in the ping command output, the time to execute the ping command is used as fallback latency. If disabled, the time to execute the ping command is always used as latency value. This is disabled by default to be backwards-compatible and to not break statistics and monitoring which existed before this feature.
+- **numberOfDiscoveryThreads:** Specifies the number of threads to be used during the discovery process. Increasing this value may speed up the discovery of devices on large networks but could also increase the load on the system. Default is `100`. _note:_The binding needs a restart for this configuration parameter to have effect.
 
 Create a `<openHAB-conf>/services/network.cfg` file and use the above options like this:
 
@@ -22,6 +23,7 @@ binding.network:allowSystemPings=true
 binding.network:allowDHCPlisten=false
 binding.network:arpPingToolPath=arping
 binding.network:cacheDeviceStateTimeInMS=2000
+binding.network:numberOfDiscoveryThreads=100
 ```
 
 ## Supported Things

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
@@ -29,13 +29,17 @@ import org.openhab.binding.network.internal.utils.NetworkUtils.ArpPingUtilEnum;
 @NonNullByDefault
 public class NetworkBindingConfiguration {
 
+    public final static int DEFAULT_DISCOVERY_THREADS = 100;
+    public final static String DEFAULT_ARPING_TOOL_PATH = "arping";
+    public final static ArpPingUtilEnum DEFAULT_ARPING_METHOD = ArpPingUtilEnum.DISABLED;
     public boolean allowSystemPings = true;
     public boolean allowDHCPlisten = true;
     public BigDecimal cacheDeviceStateTimeInMS = BigDecimal.valueOf(2000);
-    public String arpPingToolPath = "arping";
-    public ArpPingUtilEnum arpPingUtilMethod = ArpPingUtilEnum.DISABLED;
+    public String arpPingToolPath = DEFAULT_ARPING_TOOL_PATH;
+    public ArpPingUtilEnum arpPingUtilMethod = DEFAULT_ARPING_METHOD;
     // For backwards compatibility reasons, the default is to use the ping method execution time as latency value
     public boolean preferResponseTimeAsLatency = false;
+    public int numberOfDiscoveryThreads = DEFAULT_DISCOVERY_THREADS;
 
     private List<NetworkBindingConfigurationListener> listeners = new ArrayList<>();
 
@@ -45,6 +49,7 @@ public class NetworkBindingConfiguration {
         this.cacheDeviceStateTimeInMS = newConfiguration.cacheDeviceStateTimeInMS;
         this.arpPingToolPath = newConfiguration.arpPingToolPath;
         this.preferResponseTimeAsLatency = newConfiguration.preferResponseTimeAsLatency;
+        this.numberOfDiscoveryThreads = newConfiguration.numberOfDiscoveryThreads;
 
         NetworkUtils networkUtils = new NetworkUtils();
         this.arpPingUtilMethod = networkUtils.determineNativeArpPingMethod(arpPingToolPath);
@@ -65,6 +70,6 @@ public class NetworkBindingConfiguration {
         return "NetworkBindingConfiguration{" + "allowSystemPings=" + allowSystemPings + ", allowDHCPlisten="
                 + allowDHCPlisten + ", cacheDeviceStateTimeInMS=" + cacheDeviceStateTimeInMS + ", arpPingToolPath='"
                 + arpPingToolPath + '\'' + ", arpPingUtilMethod=" + arpPingUtilMethod + ", preferResponseTimeAsLatency="
-                + preferResponseTimeAsLatency + '}';
+                + preferResponseTimeAsLatency + ", numberOfDiscoveryThreads=" + numberOfDiscoveryThreads + '}';
     }
 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConstants.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConstants.java
@@ -28,6 +28,7 @@ import org.openhab.core.thing.ThingTypeUID;
 public class NetworkBindingConstants {
 
     public static final String BINDING_ID = "network";
+    public static final String BINDING_CONFIGURATION_PID = "binding.network";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID BACKWARDS_COMPATIBLE_DEVICE = new ThingTypeUID(BINDING_ID, "device");

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.network.internal;
 
+import static org.openhab.binding.network.internal.NetworkBindingConstants.*;
+
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -41,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-@Component(service = ThingHandlerFactory.class, configurationPid = "binding.network")
+@Component(service = ThingHandlerFactory.class, configurationPid = BINDING_CONFIGURATION_PID)
 public class NetworkHandlerFactory extends BaseThingHandlerFactory {
     final NetworkBindingConfiguration configuration = new NetworkBindingConfiguration();
     private static final String NETWORK_HANDLER_THREADPOOL_NAME = "networkBinding";
@@ -51,7 +53,7 @@ public class NetworkHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
-        return NetworkBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
 
     // The activate component call is used to access the bindings configuration
@@ -80,12 +82,11 @@ public class NetworkHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(NetworkBindingConstants.PING_DEVICE)
-                || thingTypeUID.equals(NetworkBindingConstants.BACKWARDS_COMPATIBLE_DEVICE)) {
+        if (thingTypeUID.equals(PING_DEVICE) || thingTypeUID.equals(BACKWARDS_COMPATIBLE_DEVICE)) {
             return new NetworkHandler(thing, executor, false, configuration);
-        } else if (thingTypeUID.equals(NetworkBindingConstants.SERVICE_DEVICE)) {
+        } else if (thingTypeUID.equals(SERVICE_DEVICE)) {
             return new NetworkHandler(thing, executor, true, configuration);
-        } else if (thingTypeUID.equals(NetworkBindingConstants.SPEEDTEST_DEVICE)) {
+        } else if (thingTypeUID.equals(SPEEDTEST_DEVICE)) {
             return new SpeedTestHandler(thing);
         }
         return null;

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
@@ -13,11 +13,13 @@
 package org.openhab.binding.network.internal;
 
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.network.internal.handler.NetworkHandler;
 import org.openhab.binding.network.internal.handler.SpeedTestHandler;
+import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -42,8 +44,10 @@ import org.slf4j.LoggerFactory;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.network")
 public class NetworkHandlerFactory extends BaseThingHandlerFactory {
     final NetworkBindingConfiguration configuration = new NetworkBindingConfiguration();
-
+    private static final String NETWORK_HANDLER_THREADPOOL_NAME = "networkBinding";
     private final Logger logger = LoggerFactory.getLogger(NetworkHandlerFactory.class);
+    private final ScheduledExecutorService executor = ThreadPoolManager
+            .getScheduledPool(NETWORK_HANDLER_THREADPOOL_NAME);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -78,9 +82,9 @@ public class NetworkHandlerFactory extends BaseThingHandlerFactory {
 
         if (thingTypeUID.equals(NetworkBindingConstants.PING_DEVICE)
                 || thingTypeUID.equals(NetworkBindingConstants.BACKWARDS_COMPATIBLE_DEVICE)) {
-            return new NetworkHandler(thing, false, configuration);
+            return new NetworkHandler(thing, executor, false, configuration);
         } else if (thingTypeUID.equals(NetworkBindingConstants.SERVICE_DEVICE)) {
-            return new NetworkHandler(thing, true, configuration);
+            return new NetworkHandler(thing, executor, true, configuration);
         } else if (thingTypeUID.equals(NetworkBindingConstants.SPEEDTEST_DEVICE)) {
             return new SpeedTestHandler(thing);
         }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
@@ -435,7 +435,7 @@ public class PresenceDetection implements IPRequestReceivedCallback {
                 try {
                     completableFuture.join();
                 } catch (CancellationException | CompletionException e) {
-                    logger.debug("Detection future failed to complete", e);
+                    logger.debug("Detection future failed to complete {}", e.getMessage());
                 }
             });
             logger.debug("All {} detection futures for {} have completed", completableFutures.size(), hostname);

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
@@ -548,7 +548,8 @@ public class PresenceDetection implements IPRequestReceivedCallback {
                 } catch (IOException e) {
                     logger.trace("Failed to execute an ARP ping for {}", hostname, e);
                 } catch (InterruptedException e) {
-                    // This can be ignored, the thread will end anyway
+                    Thread.currentThread().interrupt();
+                    return;
                 }
             };
 
@@ -558,7 +559,8 @@ public class PresenceDetection implements IPRequestReceivedCallback {
                         networkUtils.wakeUpIOS(destinationAddress);
                         Thread.sleep(50);
                     } catch (InterruptedException e) {
-                        // Ignore, thread will end
+                        Thread.currentThread().interrupt();
+                        return;
                     } catch (IOException e) {
                         logger.trace("Failed to wake up iOS device for {}", hostname, e);
                     }
@@ -600,7 +602,8 @@ public class PresenceDetection implements IPRequestReceivedCallback {
             } catch (IOException e) {
                 logger.trace("Failed to execute a native ping for {}", hostname, e);
             } catch (InterruptedException e) {
-                // This can be ignored, the thread will end anyway
+                Thread.currentThread().interrupt();
+                return;
             }
         });
     }
@@ -622,8 +625,11 @@ public class PresenceDetection implements IPRequestReceivedCallback {
         try {
             logger.debug("Refreshing {} reachability state", hostname);
             getValue();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (ExecutionException e) {
             logger.debug("Failed to refresh {} presence detection", hostname, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
         }
     }
 

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetectionValue.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetectionValue.java
@@ -24,9 +24,10 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * Contains the result or partial result of a presence detection.
+ * Contains the result or partial result of a presence detection. This class is thread-safe.
  *
  * @author David Graeff - Initial contribution
+ * @author Ravi Nadahar - Made class thread-safe
  */
 @NonNullByDefault
 public class PresenceDetectionValue {
@@ -34,9 +35,14 @@ public class PresenceDetectionValue {
     public static final Duration UNREACHABLE = Duration.ofMillis(-1);
 
     private final String hostAddress;
+
+    /* All access must be guarded by "this" */
     private Duration latency;
 
+    /* All access must be guarded by "this" */
     private final Set<PresenceDetectionType> reachableDetectionTypes = new TreeSet<>();
+
+    /* All access must be guarded by "this" */
     private final List<Integer> reachableTcpPorts = new ArrayList<>();
 
     /**
@@ -61,14 +67,14 @@ public class PresenceDetectionValue {
      * Return the ping latency, {@value #UNREACHABLE} if not reachable. Can be 0 if
      * no specific latency is known but the device is still reachable.
      */
-    public Duration getLowestLatency() {
+    public synchronized Duration getLowestLatency() {
         return latency;
     }
 
     /**
      * Returns <code>true</code> if the target is reachable by any means.
      */
-    public boolean isReachable() {
+    public synchronized boolean isReachable() {
         return !UNREACHABLE.equals(latency);
     }
 
@@ -86,9 +92,13 @@ public class PresenceDetectionValue {
                     "Latency must be >=0. Create a new PresenceDetectionValue for a not reachable device!");
         } else if (newLatency.isZero()) {
             return false;
-        } else if (!isReachable() || latency.isZero() || newLatency.compareTo(latency) < 0) {
-            latency = newLatency;
-            return true;
+        } else {
+            synchronized (this) {
+                if (!isReachable() || latency.isZero() || newLatency.compareTo(latency) < 0) {
+                    latency = newLatency;
+                    return true;
+                }
+            }
         }
         return false;
     }
@@ -98,14 +108,14 @@ public class PresenceDetectionValue {
      *
      * @param type a {@link PresenceDetectionType}.
      */
-    void addReachableDetectionType(PresenceDetectionType type) {
+    synchronized void addReachableDetectionType(PresenceDetectionType type) {
         reachableDetectionTypes.add(type);
     }
 
     /**
      * Return true if the target can be reached by ICMP or ARP pings.
      */
-    public boolean isPingReachable() {
+    public synchronized boolean isPingReachable() {
         return reachableDetectionTypes.contains(PresenceDetectionType.ARP_PING)
                 || reachableDetectionTypes.contains(PresenceDetectionType.ICMP_PING);
     }
@@ -113,41 +123,37 @@ public class PresenceDetectionValue {
     /**
      * Return true if the target provides open TCP ports.
      */
-    public boolean isTcpServiceReachable() {
+    public synchronized boolean isTcpServiceReachable() {
         return reachableDetectionTypes.contains(PresenceDetectionType.TCP_CONNECTION);
     }
 
     /**
      * Return a string of comma-separated successful presence detection types.
      */
-    public String getSuccessfulDetectionTypes() {
+    public synchronized String getSuccessfulDetectionTypes() {
         return reachableDetectionTypes.stream().map(PresenceDetectionType::name).collect(Collectors.joining(", "));
     }
 
     /**
      * Return the reachable TCP ports of the presence detection value.
-     * Thread safe.
      */
-    public List<Integer> getReachableTcpPorts() {
-        synchronized (reachableTcpPorts) {
-            return new ArrayList<>(reachableTcpPorts);
-        }
+    public synchronized List<Integer> getReachableTcpPorts() {
+        return new ArrayList<>(reachableTcpPorts);
     }
 
     /**
      * Add a reachable TCP port to this presence detection result value object.
-     * Thread safe.
      */
-    void addReachableTcpPort(int tcpPort) {
-        synchronized (reachableTcpPorts) {
-            reachableTcpPorts.add(tcpPort);
-        }
+    synchronized void addReachableTcpPort(int tcpPort) {
+        reachableTcpPorts.add(tcpPort);
     }
 
     @Override
     public String toString() {
-        return "PresenceDetectionValue [hostAddress=" + hostAddress + ", latency=" + durationToMillis(latency)
-                + "ms, reachableDetectionTypes=" + reachableDetectionTypes + ", reachableTcpPorts=" + reachableTcpPorts
-                + "]";
+        synchronized (this) {
+            return "PresenceDetectionValue [hostAddress=" + hostAddress + ", latency=" + durationToMillis(latency)
+                    + "ms, reachableDetectionTypes=" + reachableDetectionTypes + ", reachableTcpPorts="
+                    + reachableTcpPorts + "]";
+        }
     }
 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/WakeOnLanPacketSender.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/WakeOnLanPacketSender.java
@@ -67,7 +67,7 @@ public class WakeOnLanPacketSender {
 
     public WakeOnLanPacketSender(String macAddress, @Nullable String hostname, @Nullable Integer port,
             Set<String> networkInterfaceNames) {
-        logger.debug("initialized WOL Packet Sender (mac: {}, hostname: {}, port: {}, networkInterfaceNames: {})",
+        logger.trace("initialized WOL Packet Sender (mac: {}, hostname: {}, port: {}, networkInterfaceNames: {})",
                 macAddress, hostname, port, networkInterfaceNames);
         this.macAddress = macAddress;
         this.hostname = hostname;

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -166,7 +166,7 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
             final AtomicInteger scannedIPcount = new AtomicInteger(0);
 
             for (String ip : networkIPs) {
-                final PresenceDetection pd = new PresenceDetection(this, Duration.ofSeconds(2));
+                final PresenceDetection pd = new PresenceDetection(this, Duration.ofSeconds(2), service);
                 pd.setHostname(ip);
                 pd.setIOSDevice(true);
                 pd.setUseDhcpSniffing(false);

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -12,7 +12,12 @@
  */
 package org.openhab.binding.network.internal.discovery;
 
-import static org.openhab.binding.network.internal.NetworkBindingConstants.*;
+import static org.openhab.binding.network.internal.NetworkBindingConstants.BINDING_CONFIGURATION_PID;
+import static org.openhab.binding.network.internal.NetworkBindingConstants.PARAMETER_HOSTNAME;
+import static org.openhab.binding.network.internal.NetworkBindingConstants.PARAMETER_PORT;
+import static org.openhab.binding.network.internal.NetworkBindingConstants.PING_DEVICE;
+import static org.openhab.binding.network.internal.NetworkBindingConstants.SERVICE_DEVICE;
+import static org.openhab.binding.network.internal.NetworkBindingConstants.SUPPORTED_THING_TYPES_UIDS;
 import static org.openhab.binding.network.internal.utils.NetworkUtils.durationToMillis;
 
 import java.io.IOException;
@@ -76,10 +81,10 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
     /* All access must be guarded by "this" */
     private @Nullable ExecutorService executorService;
     private final NetworkUtils networkUtils = new NetworkUtils();
-    private final @Nullable ConfigurationAdmin admin;
+    private final ConfigurationAdmin admin;
 
     @Activate
-    public NetworkDiscoveryService(@Reference @Nullable ConfigurationAdmin admin) {
+    public NetworkDiscoveryService(@Reference ConfigurationAdmin admin) {
         super(SUPPORTED_THING_TYPES_UIDS,
                 (int) Math.round(new NetworkUtils().getNetworkIPs(MAXIMUM_IPS_PER_INTERFACE).size()
                         * (durationToMillis(PING_TIMEOUT) / 1000.0)),
@@ -288,9 +293,6 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
 
     private @Nullable NetworkBindingConfiguration getConfig() {
         ConfigurationAdmin admin = this.admin;
-        if (admin == null) {
-            return null;
-        }
         try {
             Configuration configOnline = admin.getConfiguration(BINDING_CONFIGURATION_PID, null);
             if (configOnline != null) {

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -204,12 +204,15 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
             return;
         }
 
+        service.shutdown(); // initiate shutdown
         try {
-            service.awaitTermination(PING_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (!service.awaitTermination(PING_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                service.shutdownNow(); // force shutdown if still busy
+            }
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // Reset interrupt flag
+            service.shutdownNow();
+            Thread.currentThread().interrupt();
         }
-        service.shutdown();
         executorService = null;
     }
 

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -201,7 +201,7 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
     }
 
     private final ThreadLocal<PresenceDetection> presenceDetectorThreadLocal = ThreadLocal
-            .withInitial(() -> new PresenceDetection(this, scheduler, Duration.ofSeconds(2)));
+            .withInitial(() -> new PresenceDetection(this, Duration.ofSeconds(2)));
 
     @Override
     protected synchronized void stopScan() {

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -26,7 +26,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -154,13 +153,7 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
         removeOlderResults(getTimestampOfLastScan(), null);
         logger.debug("Starting Network Device Discovery");
 
-        Map<String, Set<CidrAddress>> discoveryList = networkUtils.getNetworkIPsPerInterface().entrySet().stream()
-                .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
-                .filter(e -> e.getValue().stream().noneMatch(addr -> {
-                    String hostAddress = addr.getAddress().getHostAddress();
-                    return hostAddress.startsWith("127.") // loopback 127.0.0.0/8
-                            || hostAddress.startsWith("169.254."); // link-local 169.254.0.0/16
-                })).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Set<CidrAddress>> discoveryList = networkUtils.getNetworkIPsPerInterface();
 
         // Track completion for all interfaces
         final int totalInterfaces = discoveryList.size();

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -188,9 +188,13 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
 
                     try {
                         pd.getValue();
-                    } catch (ExecutionException | InterruptedException e) {
+                    } catch (ExecutionException e) {
                         logger.warn("Error scanning IP {} on interface {}: {}", ip, networkInterface, e.getMessage());
                         // Do not stop the whole scan; just log and continue
+                    } catch (InterruptedException e1) {
+                        logger.trace("Scan interrupted for IP {} on interface {}", ip, networkInterface);
+                        Thread.currentThread().interrupt();
+                        return;
                     }
                     int count = scannedIPcount.incrementAndGet();
                     if (count == networkIPs.size()) {

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -253,6 +253,7 @@ public class NetworkHandler extends BaseThingHandler
     // Create a new network service and apply all configurations.
     @Override
     public void initialize() {
+        updateStatus(ThingStatus.UNKNOWN);
         executor.submit(() -> {
             initialize(new PresenceDetection(this, Duration.ofMillis(configuration.cacheDeviceStateTimeInMS.intValue()),
                     executor));

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -80,7 +80,7 @@ public class NetworkHandler extends BaseThingHandler
     private ScheduledExecutorService executor;
 
     /**
-     * Do not call this directly, but use the {@see NetworkHandlerBuilder} instead.
+     * Creates a new instance using the specified parameters.
      */
     public NetworkHandler(Thing thing, ScheduledExecutorService executor, boolean isTCPServiceDevice,
             NetworkBindingConfiguration configuration) {

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -76,12 +77,15 @@ public class NetworkHandler extends BaseThingHandler
     // Retry counter. Will be reset as soon as a device presence detection succeed.
     private int retryCounter = 0;
     private NetworkHandlerConfiguration handlerConfiguration = new NetworkHandlerConfiguration();
+    private ScheduledExecutorService executor;
 
     /**
      * Do not call this directly, but use the {@see NetworkHandlerBuilder} instead.
      */
-    public NetworkHandler(Thing thing, boolean isTCPServiceDevice, NetworkBindingConfiguration configuration) {
+    public NetworkHandler(Thing thing, ScheduledExecutorService executor, boolean isTCPServiceDevice,
+            NetworkBindingConfiguration configuration) {
         super(thing);
+        this.executor = executor;
         this.isTCPServiceDevice = isTCPServiceDevice;
         this.configuration = configuration;
         this.configuration.addNetworkBindingConfigurationListener(this);
@@ -202,7 +206,7 @@ public class NetworkHandler extends BaseThingHandler
         updateStatus(ThingStatus.ONLINE);
 
         if (handlerConfiguration.refreshInterval > 0) {
-            refreshJob = scheduler.scheduleWithFixedDelay(presenceDetection::refresh, 0,
+            refreshJob = executor.scheduleWithFixedDelay(presenceDetection::refresh, 0,
                     handlerConfiguration.refreshInterval, TimeUnit.MILLISECONDS);
         }
     }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -224,7 +224,8 @@ public class NetworkHandler extends BaseThingHandler
     // Create a new network service and apply all configurations.
     @Override
     public void initialize() {
-        initialize(new PresenceDetection(this, Duration.ofMillis(configuration.cacheDeviceStateTimeInMS.intValue())));
+        initialize(new PresenceDetection(this, Duration.ofMillis(configuration.cacheDeviceStateTimeInMS.intValue()),
+                executor));
     }
 
     /**

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -60,24 +60,30 @@ import org.slf4j.LoggerFactory;
  * @author Marc Mettke - Initial contribution
  * @author David Graeff - Rewritten
  * @author Wouter Born - Add Wake-on-LAN thing action support
+ * @author Ravi Nadahar - Made class thread-safe
  */
 @NonNullByDefault
 public class NetworkHandler extends BaseThingHandler
         implements PresenceDetectionListener, NetworkBindingConfigurationListener {
     private final Logger logger = LoggerFactory.getLogger(NetworkHandler.class);
-    private @NonNullByDefault({}) PresenceDetection presenceDetection;
-    private @Nullable ScheduledFuture<?> refreshJob;
-    private @NonNullByDefault({}) WakeOnLanPacketSender wakeOnLanPacketSender;
 
-    private boolean isTCPServiceDevice;
-    private NetworkBindingConfiguration configuration;
+    /* All access must be guarded by "this" */
+    private @Nullable PresenceDetection presenceDetection;
+
+    /* All access must be guarded by "this" */
+    private @Nullable ScheduledFuture<?> refreshJob;
+
+    /* All access must be guarded by "this" */
+    private @Nullable WakeOnLanPacketSender wakeOnLanPacketSender;
+
+    private final boolean isTCPServiceDevice;
+    private final NetworkBindingConfiguration configuration;
 
     // How many retries before a device is deemed offline
-    int retries;
+    volatile int retries;
     // Retry counter. Will be reset as soon as a device presence detection succeed.
-    private int retryCounter = 0;
-    private NetworkHandlerConfiguration handlerConfiguration = new NetworkHandlerConfiguration();
-    private ScheduledExecutorService executor;
+    private volatile int retryCounter = 0;
+    private final ScheduledExecutorService executor;
 
     /**
      * Creates a new instance using the specified parameters.
@@ -92,17 +98,23 @@ public class NetworkHandler extends BaseThingHandler
     }
 
     private void refreshValue(ChannelUID channelUID) {
+        PresenceDetection pd;
+        ScheduledFuture<?> rj;
+        synchronized (this) {
+            pd = presenceDetection;
+            rj = refreshJob;
+        }
         // We are not yet even initialized, don't do anything
-        if (presenceDetection == null || refreshJob == null) {
+        if (pd == null || rj == null) {
             return;
         }
 
         switch (channelUID.getId()) {
             case CHANNEL_ONLINE:
-                presenceDetection.getValue(value -> updateState(CHANNEL_ONLINE, OnOffType.from(value.isReachable())));
+                pd.getValue(value -> updateState(CHANNEL_ONLINE, OnOffType.from(value.isReachable())));
                 break;
             case CHANNEL_LATENCY:
-                presenceDetection.getValue(value -> {
+                pd.getValue(value -> {
                     double latencyMs = durationToMillis(value.getLowestLatency());
                     updateState(CHANNEL_LATENCY, new QuantityType<>(latencyMs, MetricPrefix.MILLI(Units.SECOND)));
                 });
@@ -110,7 +122,7 @@ public class NetworkHandler extends BaseThingHandler
             case CHANNEL_LASTSEEN:
                 // We should not set the last seen state to UNDEF, it prevents restoreOnStartup from working
                 // For reference: https://github.com/openhab/openhab-addons/issues/17404
-                Instant lastSeen = presenceDetection.getLastSeen();
+                Instant lastSeen = pd.getLastSeen();
                 if (lastSeen != null) {
                     updateState(CHANNEL_LASTSEEN, new DateTimeType(lastSeen));
                 }
@@ -141,7 +153,11 @@ public class NetworkHandler extends BaseThingHandler
     public void finalDetectionResult(PresenceDetectionValue value) {
         // We do not notify the framework immediately if a device presence detection failed and
         // the user configured retries to be > 1.
-        retryCounter = value.isReachable() ? 0 : retryCounter + 1;
+        if (value.isReachable()) {
+            retryCounter = 0;
+        } else {
+            retryCounter++;
+        }
 
         if (retryCounter >= retries) {
             updateState(CHANNEL_ONLINE, OnOffType.OFF);
@@ -149,7 +165,11 @@ public class NetworkHandler extends BaseThingHandler
             retryCounter = 0;
         }
 
-        Instant lastSeen = presenceDetection.getLastSeen();
+        PresenceDetection pd;
+        synchronized (this) {
+            pd = presenceDetection;
+        }
+        Instant lastSeen = pd == null ? null : pd.getLastSeen();
         if (value.isReachable() && lastSeen != null) {
             updateState(CHANNEL_LASTSEEN, new DateTimeType(lastSeen));
         }
@@ -161,12 +181,14 @@ public class NetworkHandler extends BaseThingHandler
 
     @Override
     public void dispose() {
-        ScheduledFuture<?> refreshJob = this.refreshJob;
-        if (refreshJob != null) {
-            refreshJob.cancel(true);
-            this.refreshJob = null;
+        synchronized (this) {
+            ScheduledFuture<?> refreshJob = this.refreshJob;
+            if (refreshJob != null) {
+                refreshJob.cancel(true);
+                this.refreshJob = null;
+            }
+            presenceDetection = null;
         }
-        presenceDetection = null;
     }
 
     /**
@@ -174,58 +196,67 @@ public class NetworkHandler extends BaseThingHandler
      * Used by testing for injecting.
      */
     void initialize(PresenceDetection presenceDetection) {
-        handlerConfiguration = getConfigAs(NetworkHandlerConfiguration.class);
+        NetworkHandlerConfiguration config = getConfigAs(NetworkHandlerConfiguration.class);
 
-        this.presenceDetection = presenceDetection;
-        presenceDetection.setHostname(handlerConfiguration.hostname);
-        presenceDetection.setNetworkInterfaceNames(handlerConfiguration.networkInterfaceNames);
+        presenceDetection.setHostname(config.hostname);
+        presenceDetection.setNetworkInterfaceNames(config.networkInterfaceNames);
         presenceDetection.setPreferResponseTimeAsLatency(configuration.preferResponseTimeAsLatency);
 
         if (isTCPServiceDevice) {
-            Integer port = handlerConfiguration.port;
+            Integer port = config.port;
             if (port == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No port configured!");
                 return;
             }
             presenceDetection.setServicePorts(Set.of(port));
         } else {
-            presenceDetection.setIOSDevice(handlerConfiguration.useIOSWakeUp);
+            presenceDetection.setIOSDevice(config.useIOSWakeUp);
             // Hand over binding configurations to the network service
             presenceDetection.setUseDhcpSniffing(configuration.allowDHCPlisten);
-            presenceDetection.setUseIcmpPing(handlerConfiguration.useIcmpPing ? configuration.allowSystemPings : null);
-            presenceDetection.setUseArpPing(handlerConfiguration.useArpPing, configuration.arpPingToolPath,
+            presenceDetection.setUseIcmpPing(config.useIcmpPing ? configuration.allowSystemPings : null);
+            presenceDetection.setUseArpPing(config.useArpPing, configuration.arpPingToolPath,
                     configuration.arpPingUtilMethod);
         }
 
-        this.retries = handlerConfiguration.retry.intValue();
-        presenceDetection.setTimeout(Duration.ofMillis(handlerConfiguration.timeout));
-
-        wakeOnLanPacketSender = new WakeOnLanPacketSender(handlerConfiguration.macAddress,
-                handlerConfiguration.hostname, handlerConfiguration.port, handlerConfiguration.networkInterfaceNames);
+        this.retries = config.retry.intValue();
+        presenceDetection.setTimeout(Duration.ofMillis(config.timeout));
+        synchronized (this) {
+            this.presenceDetection = presenceDetection;
+            wakeOnLanPacketSender = new WakeOnLanPacketSender(config.macAddress, config.hostname, config.port,
+                    config.networkInterfaceNames);
+            if (config.refreshInterval > 0) {
+                refreshJob = executor.scheduleWithFixedDelay(presenceDetection::refresh, 0, config.refreshInterval,
+                        TimeUnit.MILLISECONDS);
+            }
+        }
 
         updateStatus(ThingStatus.ONLINE);
-
-        if (handlerConfiguration.refreshInterval > 0) {
-            refreshJob = executor.scheduleWithFixedDelay(presenceDetection::refresh, 0,
-                    handlerConfiguration.refreshInterval, TimeUnit.MILLISECONDS);
-        }
     }
 
     private void updateNetworkProperties() {
         // Update properties (after startAutomaticRefresh, to get the correct dhcp state)
         Map<String, String> properties = editProperties();
-        properties.put(NetworkBindingConstants.PROPERTY_ARP_STATE, presenceDetection.getArpPingState());
-        properties.put(NetworkBindingConstants.PROPERTY_ICMP_STATE, presenceDetection.getIPPingState());
-        properties.put(NetworkBindingConstants.PROPERTY_PRESENCE_DETECTION_TYPE, "");
-        properties.put(NetworkBindingConstants.PROPERTY_DHCP_STATE, presenceDetection.getDhcpState());
+        synchronized (this) {
+            PresenceDetection pd = presenceDetection;
+            if (pd == null) {
+                logger.warn("Can't update network properties because presenceDetection is null");
+                return;
+            }
+            properties.put(NetworkBindingConstants.PROPERTY_ARP_STATE, pd.getArpPingState());
+            properties.put(NetworkBindingConstants.PROPERTY_ICMP_STATE, pd.getIPPingState());
+            properties.put(NetworkBindingConstants.PROPERTY_PRESENCE_DETECTION_TYPE, "");
+            properties.put(NetworkBindingConstants.PROPERTY_DHCP_STATE, pd.getDhcpState());
+        }
         updateProperties(properties);
     }
 
     // Create a new network service and apply all configurations.
     @Override
     public void initialize() {
-        initialize(new PresenceDetection(this, Duration.ofMillis(configuration.cacheDeviceStateTimeInMS.intValue()),
-                executor));
+        executor.submit(() -> {
+            initialize(new PresenceDetection(this, Duration.ofMillis(configuration.cacheDeviceStateTimeInMS.intValue()),
+                    executor));
+        });
     }
 
     /**
@@ -238,7 +269,12 @@ public class NetworkHandler extends BaseThingHandler
     @Override
     public void bindingConfigurationChanged() {
         // Make sure that changed binding configuration is reflected
-        presenceDetection.setPreferResponseTimeAsLatency(configuration.preferResponseTimeAsLatency);
+        synchronized (this) {
+            PresenceDetection pd = presenceDetection;
+            if (pd != null) {
+                pd.setPreferResponseTimeAsLatency(configuration.preferResponseTimeAsLatency);
+            }
+        }
     }
 
     @Override
@@ -247,15 +283,32 @@ public class NetworkHandler extends BaseThingHandler
     }
 
     public void sendWakeOnLanPacketViaIp() {
-        // Hostname can't be null
-        wakeOnLanPacketSender.sendWakeOnLanPacketViaIp();
+        WakeOnLanPacketSender sender;
+        synchronized (this) {
+            sender = wakeOnLanPacketSender;
+        }
+        if (sender != null) {
+            // Hostname can't be null
+            sender.sendWakeOnLanPacketViaIp();
+        } else {
+            logger.warn("Failed to send WoL packet via IP because sender is null");
+        }
     }
 
     public void sendWakeOnLanPacketViaMac() {
-        if (handlerConfiguration.macAddress.isEmpty()) {
+        NetworkHandlerConfiguration config = getConfigAs(NetworkHandlerConfiguration.class);
+        if (config.macAddress.isEmpty()) {
             throw new IllegalStateException(
                     "Cannot send WoL packet because the 'macAddress' is not configured for " + thing.getUID());
         }
-        wakeOnLanPacketSender.sendWakeOnLanPacketViaMac();
+        WakeOnLanPacketSender sender;
+        synchronized (this) {
+            sender = wakeOnLanPacketSender;
+        }
+        if (sender != null) {
+            sender.sendWakeOnLanPacketViaMac();
+        } else {
+            logger.warn("Failed to send WoL packet via MAC because sender is null");
+        }
     }
 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class LatencyParser {
 
-    private static final Pattern LATENCY_PATTERN = Pattern.compile(".*time=(.*) ?(u|m)s.*");
+    private static final Pattern LATENCY_PATTERN = Pattern.compile(".*time(?:=|<)(.*) ?(u|m)s.*");
     private final Logger logger = LoggerFactory.getLogger(LatencyParser.class);
 
     // This is how the input looks like on Mac and Linux:
@@ -60,7 +60,7 @@ public class LatencyParser {
      *         contain a latency value which matches the known patterns.
      */
     public @Nullable Duration parseLatency(String inputLine) {
-        logger.trace("Parsing latency from input {}", inputLine);
+        logger.trace("Parsing latency from input \"{}\"", inputLine);
 
         Matcher m = LATENCY_PATTERN.matcher(inputLine);
         if (m.find() && m.groupCount() >= 2) {

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
@@ -60,7 +60,7 @@ public class LatencyParser {
      *         contain a latency value which matches the known patterns.
      */
     public @Nullable Duration parseLatency(String inputLine) {
-        logger.debug("Parsing latency from input {}", inputLine);
+        logger.trace("Parsing latency from input {}", inputLine);
 
         Matcher m = LATENCY_PATTERN.matcher(inputLine);
         if (m.find() && m.groupCount() >= 2) {
@@ -69,8 +69,6 @@ public class LatencyParser {
             }
             return millisToDuration(Double.parseDouble(m.group(1).replace(",", ".")));
         }
-
-        logger.debug("Did not find a latency value");
         return null;
     }
 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
@@ -32,6 +32,12 @@ import org.slf4j.LoggerFactory;
 public class LatencyParser {
 
     private static final Pattern LATENCY_PATTERN = Pattern.compile(".*time(?:=|<)(.*) ?(u|m)s.*");
+    private static final Pattern THOMAS_HABERT_ARPING_PATTERN = Pattern
+            .compile("^[\\w ]+from[\\w:()\\.= ]+?time=([0-9,\\.]+)\\s?(m|u)sec$");
+    private static final Pattern IPUTILS_ARPING_PATTERN = Pattern
+            .compile("^Unicast[\\w ]+from[\\w:()\\.= \\[\\]]+?\\s*([0-9,\\.]+)\\s?(m|u)s$");
+    private static final Pattern ELI_FULKERSON_ARP_PING_PATTERN = Pattern
+            .compile("^Reply that[\\w:\\. ]+?\\sin\\s([0-9,\\.]+)\\s?(m|u)s$");
     private final Logger logger = LoggerFactory.getLogger(LatencyParser.class);
 
     // This is how the input looks like on Mac and Linux:
@@ -56,13 +62,34 @@ public class LatencyParser {
      * Examine a single ping or arping command output line and try to extract the latency value if it is contained.
      *
      * @param inputLine Single output line of the ping or arping command.
+     * @param type the syntax to expect. Use {@code null} for generic ping syntax.
      * @return Latency value provided by the ping or arping command. <code>null</code> if the provided line did not
      *         contain a latency value which matches the known patterns.
      */
-    public @Nullable Duration parseLatency(String inputLine) {
+    public @Nullable Duration parseLatency(String inputLine, @Nullable ArpPingUtilEnum type) {
         logger.trace("Parsing latency from input \"{}\"", inputLine);
 
-        Matcher m = LATENCY_PATTERN.matcher(inputLine);
+        Pattern pattern;
+        if (type == null) {
+            pattern = LATENCY_PATTERN;
+        } else {
+            switch (type) {
+                case ELI_FULKERSON_ARP_PING_FOR_WINDOWS:
+                    pattern = ELI_FULKERSON_ARP_PING_PATTERN;
+                    break;
+                case IPUTILS_ARPING:
+                    pattern = IPUTILS_ARPING_PATTERN;
+                    break;
+                case THOMAS_HABERT_ARPING:
+                case THOMAS_HABERT_ARPING_WITHOUT_TIMEOUT:
+                    pattern = THOMAS_HABERT_ARPING_PATTERN;
+                    break;
+                default:
+                    pattern = LATENCY_PATTERN;
+                    break;
+            }
+        }
+        Matcher m = pattern.matcher(inputLine);
         if (m.find() && m.groupCount() >= 2) {
             if ("u".equals(m.group(2))) {
                 return microsToDuration(Double.parseDouble(m.group(1).replace(",", ".")));

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -305,7 +305,7 @@ public class NetworkUtils {
         } catch (IOException e) {
             logger.trace("Native ping to 127.0.0.1 failed", e);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // Reset interrupt flag
+            Thread.currentThread().interrupt();
         }
         return IpPingMethodEnum.JAVA_PING;
     }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -261,7 +261,7 @@ public class NetworkUtils {
             socket.connect(new InetSocketAddress(host, port), (int) timeout.toMillis());
             success = true;
         } catch (ConnectException | SocketTimeoutException | NoRouteToHostException e) {
-            logger.trace("Could not connect to {}:{}", host, port, e);
+            logger.trace("Could not connect to {}:{} {}", host, port, e.getMessage());
         }
         return new PingResult(success, Duration.between(execStartTime, Instant.now()));
     }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -411,7 +411,7 @@ public class NetworkUtils {
             // this specific string is contained in the output
             if (line.contains("TTL=") || line.contains("ttl=")) {
                 PingResult pingResult = new PingResult(true, Duration.between(execStartTime, execStopTime));
-                pingResult.setResponseTime(latencyParser.parseLatency(line));
+                pingResult.setResponseTime(latencyParser.parseLatency(line, null));
                 return pingResult;
             }
         }
@@ -496,7 +496,7 @@ public class NetworkUtils {
         Duration responseTime;
         for (String line : output) {
             if (!line.isBlank()) {
-                responseTime = latencyParser.parseLatency(line);
+                responseTime = latencyParser.parseLatency(line, arpingTool);
                 if (responseTime != null) {
                     pingResult.setResponseTime(responseTime);
                     return pingResult;

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -151,7 +151,7 @@ public class NetworkUtils {
         try {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
                 NetworkInterface networkInterface = en.nextElement();
-                if (!networkInterface.isLoopback()) {
+                if (networkInterface.isUp() && !networkInterface.isLoopback()) {
                     result.add(networkInterface.getName());
                 }
             }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -176,7 +176,7 @@ public class NetworkUtils {
 
     /**
      * Retrieves a map of network interface names to their associated IP addresses.
-     * 
+     *
      * @return A map where the key is the name of the network interface and the value is a set of CidrAddress objects
      *         representing the IP addresses and network prefix lengths for that interface.
      */
@@ -185,7 +185,7 @@ public class NetworkUtils {
         try {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
                 NetworkInterface networkInterface = en.nextElement();
-                if (networkInterface.isUp() || !networkInterface.isLoopback()) {
+                if (!networkInterface.isUp() || networkInterface.isLoopback()) {
                     logger.trace("Network interface: {} is excluded in the search", networkInterface.getName());
                     continue;
                 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -186,10 +186,13 @@ public class NetworkUtils {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
                 NetworkInterface networkInterface = en.nextElement();
                 if (networkInterface.isUp() && !networkInterface.isLoopback()) {
+                    logger.trace("Network interface: {} is included in the", networkInterface.getName());
                     outputMap.put(networkInterface.getName(),
                             networkInterface.getInterfaceAddresses().stream()
                                     .map(m -> new CidrAddress(m.getAddress(), m.getNetworkPrefixLength()))
                                     .collect(Collectors.toSet()));
+                } else {
+                    logger.trace("Network interface: {} is excluded in the search", networkInterface.getName());
                 }
             }
         } catch (SocketException e) {

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -186,7 +186,7 @@ public class NetworkUtils {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
                 NetworkInterface networkInterface = en.nextElement();
                 if (networkInterface.isUp() && !networkInterface.isLoopback()) {
-                    logger.trace("Network interface: {} is included in the", networkInterface.getName());
+                    logger.trace("Network interface: {} is included in the search", networkInterface.getName());
                     outputMap.put(networkInterface.getName(),
                             networkInterface.getInterfaceAddresses().stream()
                                     .map(m -> new CidrAddress(m.getAddress(), m.getNetworkPrefixLength()))

--- a/bundles/org.openhab.binding.network/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.network/src/main/resources/OH-INF/addon/addon.xml
@@ -43,5 +43,12 @@
 				such latency value is found in the ping command output, the time to execute the ping command is used as fallback
 				latency. If disabled, the time to execute the ping command is always used as latency value.</description>
 		</parameter>
+		<parameter name="numberOfDiscoveryThreads" type="integer" min="0" step="10">
+			<default>100</default>
+			<label>Number of Discovery Threads</label>
+			<description>The number of threads to use when scanning for network devices. Fewer threads, results in lower memory
+				consumption but a slower operation. Use 0 for unlimited.</description>
+			<advanced>true</advanced>
+		</parameter>
 	</config-description>
 </addon:addon>

--- a/bundles/org.openhab.binding.network/src/main/resources/OH-INF/i18n/network.properties
+++ b/bundles/org.openhab.binding.network/src/main/resources/OH-INF/i18n/network.properties
@@ -13,6 +13,8 @@ addon.config.network.arpPingToolPath.label = ARP Ping Tool Path
 addon.config.network.arpPingToolPath.description = If your arp ping tool is not called arping and cannot be found in the PATH environment, you can configure the absolute path / tool name here.
 addon.config.network.cacheDeviceStateTimeInMS.label = Cache Time
 addon.config.network.cacheDeviceStateTimeInMS.description = The result of a device presence detection is cached for a small amount of time. Be aware that no new pings will be issued within this time frame, even if explicitly requested.
+addon.config.network.numberOfDiscoveryThreads.label = Number of Discovery Threads
+addon.config.network.numberOfDiscoveryThreads.description = The number of threads to use when scanning for network devices. Fewer threads, results in lower memory consumption but a slower operation. Use 0 for unlimited.
 addon.config.network.preferResponseTimeAsLatency.label = Use Response Time as Latency
 addon.config.network.preferResponseTimeAsLatency.description = If enabled, an attempt will be made to extract the latency from the output of the ping command. If no such latency value is found in the ping command output, the time to execute the ping command is used as fallback latency. If disabled, the time to execute the ping command is always used as latency value.
 

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
@@ -22,10 +22,12 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,6 +52,7 @@ import org.openhab.binding.network.internal.utils.PingResult;
 public class PresenceDetectionTest {
 
     private @NonNullByDefault({}) PresenceDetection subject;
+    private @NonNullByDefault({}) PresenceDetection asyncSubject;
 
     private @Mock @NonNullByDefault({}) Consumer<PresenceDetectionValue> callback;
     private @Mock @NonNullByDefault({}) ExecutorService detectionExecutorService;
@@ -78,36 +81,59 @@ public class PresenceDetectionTest {
         subject.setUseArpPing(true, "arping", ArpPingUtilEnum.IPUTILS_ARPING);
         subject.setUseIcmpPing(true);
 
+        asyncSubject = spy(new PresenceDetection(listener, Duration.ofSeconds(2), Executors.newSingleThreadExecutor()));
+
+        asyncSubject.networkUtils = networkUtils;
+        asyncSubject.setHostname("127.0.0.1");
+        asyncSubject.setTimeout(Duration.ofMillis(300));
+        asyncSubject.setUseDhcpSniffing(false);
+        asyncSubject.setIOSDevice(true);
+        asyncSubject.setServicePorts(Set.of(1010));
+        asyncSubject.setUseArpPing(true, "arping", ArpPingUtilEnum.IPUTILS_ARPING);
+        asyncSubject.setUseIcmpPing(true);
+
         assertThat(subject.pingMethod, is(IpPingMethodEnum.WINDOWS_PING));
     }
 
-    // Depending on the amount of test methods an according amount of threads is spawned.
-    // We will check if they spawn and return in time.
+    // Depending on the amount of test methods an according amount of threads is used.
     @Test
-    public void threadCountTest() {
-        assertNull(subject.detectionExecutorService);
+    public void usedThreadCountTest() {
+        // Custom executor to count submitted tasks
+        class CountingExecutor implements java.util.concurrent.Executor {
+            int count = 0;
+
+            @Override
+            public void execute(@Nullable Runnable command) {
+                count++;
+                if (command != null) {
+                    command.run();
+                }
+            }
+        }
+        CountingExecutor countingExecutor = new CountingExecutor();
+
+        // Create a new subject with the counting executor
+        subject = spy(new PresenceDetection(listener, Duration.ofSeconds(2), countingExecutor));
+        subject.networkUtils = networkUtils;
+        subject.setHostname("127.0.0.1");
+        subject.setTimeout(Duration.ofMillis(300));
+        subject.setUseDhcpSniffing(false);
+        subject.setIOSDevice(true);
+        subject.setServicePorts(Set.of(1010));
+        subject.setUseArpPing(true, "arping", ArpPingUtilEnum.IPUTILS_ARPING);
+        subject.setUseIcmpPing(true);
 
         doNothing().when(subject).performArpPing(any(), any());
         doNothing().when(subject).performJavaPing(any());
         doNothing().when(subject).performSystemPing(any());
         doNothing().when(subject).performServicePing(any(), anyInt());
 
-        doReturn(waitForResultExecutorService).when(subject).getThreadsFor(1);
-
         subject.getValue(callback -> {
+            // No-op callback
         });
 
-        // Thread count: ARP + ICMP + 1*TCP
-        assertThat(subject.detectionChecks, is(3));
-        assertNotNull(subject.detectionExecutorService);
-
-        // "Wait" for the presence detection to finish
-        ArgumentCaptor<Runnable> runnableCapture = ArgumentCaptor.forClass(Runnable.class);
-        verify(waitForResultExecutorService, times(1)).execute(runnableCapture.capture());
-        runnableCapture.getValue().run();
-
-        assertThat(subject.detectionChecks, is(0));
-        assertNull(subject.detectionExecutorService);
+        // Thread count: ARP + ICMP + 1*TCP + task completion watcher = 4
+        assertThat(countingExecutor.count, is(4));
     }
 
     @Test
@@ -118,27 +144,11 @@ public class PresenceDetectionTest {
                 anyString(), any(), any());
         doReturn(pingResult).when(networkUtils).servicePing(anyString(), anyInt(), any());
 
-        doReturn(detectionExecutorService).when(subject).getThreadsFor(3);
-        doReturn(waitForResultExecutorService).when(subject).getThreadsFor(1);
-
         subject.performPresenceDetection();
 
         assertThat(subject.detectionChecks, is(3));
 
-        // Perform the different presence detection threads now
-        ArgumentCaptor<Runnable> capture = ArgumentCaptor.forClass(Runnable.class);
-        verify(detectionExecutorService, times(3)).execute(capture.capture());
-        for (Runnable r : capture.getAllValues()) {
-            r.run();
-        }
-
-        // "Wait" for the presence detection to finish
-        ArgumentCaptor<Runnable> runnableCapture = ArgumentCaptor.forClass(Runnable.class);
-        verify(waitForResultExecutorService, times(1)).execute(runnableCapture.capture());
-        runnableCapture.getValue().run();
-
-        assertThat(subject.detectionChecks, is(0));
-
+        // All detection methods should be called (direct executor runs synchronously)
         verify(subject, times(0)).performJavaPing(any());
         verify(subject).performSystemPing(any());
         verify(subject).performArpPing(any(), any());
@@ -159,41 +169,22 @@ public class PresenceDetectionTest {
                 anyString(), any(), any());
         doReturn(pingResult).when(networkUtils).servicePing(anyString(), anyInt(), any());
 
-        doReturn(detectionExecutorService).when(subject).getThreadsFor(3);
-        doReturn(waitForResultExecutorService).when(subject).getThreadsFor(1);
-
         // We expect no valid value
-        assertTrue(subject.cache.isExpired());
+        assertTrue(asyncSubject.cache.isExpired());
         // Get value will issue a PresenceDetection internally.
-        subject.getValue(callback);
-        verify(subject).performPresenceDetection();
-        assertNotNull(subject.detectionExecutorService);
-        // There should be no straight callback yet
-        verify(callback, times(0)).accept(any());
-
-        // Perform the different presence detection threads now
-        ArgumentCaptor<Runnable> capture = ArgumentCaptor.forClass(Runnable.class);
-        verify(detectionExecutorService, times(3)).execute(capture.capture());
-        for (Runnable r : capture.getAllValues()) {
-            r.run();
-        }
-
-        // "Wait" for the presence detection to finish
-        capture = ArgumentCaptor.forClass(Runnable.class);
-        verify(waitForResultExecutorService, times(1)).execute(capture.capture());
-        capture.getValue().run();
-
-        // Although there are multiple partial results and a final result,
-        // the getValue() consumers get the fastest response possible, and only once.
+        asyncSubject.getValue(callback);
+        verify(asyncSubject).performPresenceDetection();
+        Thread.sleep(200); // give it some time to execute
+        // Callback should be called once with the result (since we use direct executor)
         verify(callback, times(1)).accept(any());
 
         // As long as the cache is valid, we can get the result back again
-        subject.getValue(callback);
+        asyncSubject.getValue(callback);
         verify(callback, times(2)).accept(any());
 
         // Invalidate value, we should not get a new callback immediately again
-        subject.cache.invalidateValue();
-        subject.getValue(callback);
+        asyncSubject.cache.invalidateValue();
+        asyncSubject.getValue(callback);
         verify(callback, times(2)).accept(any());
     }
 }

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
@@ -65,7 +65,8 @@ public class PresenceDetectionTest {
         doReturn(ArpPingUtilEnum.IPUTILS_ARPING).when(networkUtils).determineNativeArpPingMethod(anyString());
         doReturn(IpPingMethodEnum.WINDOWS_PING).when(networkUtils).determinePingMethod();
 
-        subject = spy(new PresenceDetection(listener, scheduledExecutorService, Duration.ofSeconds(2)));
+        // Inject a direct executor so async tasks run synchronously in tests
+        subject = spy(new PresenceDetection(listener, scheduledExecutorService, Duration.ofSeconds(2), Runnable::run));
         subject.networkUtils = networkUtils;
 
         // Set a useful configuration. The default presenceDetection is a no-op.

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
@@ -66,7 +66,7 @@ public class PresenceDetectionTest {
         doReturn(IpPingMethodEnum.WINDOWS_PING).when(networkUtils).determinePingMethod();
 
         // Inject a direct executor so async tasks run synchronously in tests
-        subject = spy(new PresenceDetection(listener, scheduledExecutorService, Duration.ofSeconds(2), Runnable::run));
+        subject = spy(new PresenceDetection(listener, Duration.ofSeconds(2), Runnable::run));
         subject.networkUtils = networkUtils;
 
         // Set a useful configuration. The default presenceDetection is a no-op.

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
@@ -57,7 +57,7 @@ public class DiscoveryTest {
     }
 
     @Test
-    public void pingDeviceDetected() {
+    public void pingDeviceDetected() throws InterruptedException {
         NetworkDiscoveryService d = new NetworkDiscoveryService();
         d.addDiscoveryListener(listener);
 
@@ -67,6 +67,7 @@ public class DiscoveryTest {
         when(value.isPingReachable()).thenReturn(true);
         when(value.isTcpServiceReachable()).thenReturn(false);
         d.partialDetectionResult(value);
+        Thread.sleep(200L);
         verify(listener).thingDiscovered(any(), result.capture());
         DiscoveryResult dresult = result.getValue();
         assertThat(dresult.getThingUID(), is(NetworkDiscoveryService.createPingUID(ip)));
@@ -74,7 +75,7 @@ public class DiscoveryTest {
     }
 
     @Test
-    public void tcpDeviceDetected() {
+    public void tcpDeviceDetected() throws InterruptedException {
         NetworkDiscoveryService d = new NetworkDiscoveryService();
         d.addDiscoveryListener(listener);
 
@@ -85,6 +86,7 @@ public class DiscoveryTest {
         when(value.isTcpServiceReachable()).thenReturn(true);
         when(value.getReachableTcpPorts()).thenReturn(List.of(1010));
         d.partialDetectionResult(value);
+        Thread.sleep(200L);
         verify(listener).thingDiscovered(any(), result.capture());
         DiscoveryResult dresult = result.getValue();
         assertThat(dresult.getThingUID(), is(NetworkDiscoveryService.createServiceUID(ip, 1010)));

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
@@ -58,7 +58,7 @@ public class DiscoveryTest {
 
     @Test
     public void pingDeviceDetected() throws InterruptedException {
-        NetworkDiscoveryService d = new NetworkDiscoveryService();
+        NetworkDiscoveryService d = new NetworkDiscoveryService(null);
         d.addDiscoveryListener(listener);
 
         ArgumentCaptor<DiscoveryResult> result = ArgumentCaptor.forClass(DiscoveryResult.class);
@@ -76,7 +76,7 @@ public class DiscoveryTest {
 
     @Test
     public void tcpDeviceDetected() throws InterruptedException {
-        NetworkDiscoveryService d = new NetworkDiscoveryService();
+        NetworkDiscoveryService d = new NetworkDiscoveryService(null);
         d.addDiscoveryListener(listener);
 
         ArgumentCaptor<DiscoveryResult> result = ArgumentCaptor.forClass(DiscoveryResult.class);

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
@@ -33,6 +33,7 @@ import org.openhab.binding.network.internal.NetworkBindingConstants;
 import org.openhab.binding.network.internal.PresenceDetectionValue;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * Tests cases for {@see PresenceDetectionValue}
@@ -58,7 +59,8 @@ public class DiscoveryTest {
 
     @Test
     public void pingDeviceDetected() throws InterruptedException {
-        NetworkDiscoveryService d = new NetworkDiscoveryService(null);
+        ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class);
+        NetworkDiscoveryService d = new NetworkDiscoveryService(configAdmin);
         d.addDiscoveryListener(listener);
 
         ArgumentCaptor<DiscoveryResult> result = ArgumentCaptor.forClass(DiscoveryResult.class);
@@ -76,7 +78,8 @@ public class DiscoveryTest {
 
     @Test
     public void tcpDeviceDetected() throws InterruptedException {
-        NetworkDiscoveryService d = new NetworkDiscoveryService(null);
+        ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class);
+        NetworkDiscoveryService d = new NetworkDiscoveryService(configAdmin);
         d.addDiscoveryListener(listener);
 
         ArgumentCaptor<DiscoveryResult> result = ArgumentCaptor.forClass(DiscoveryResult.class);

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
@@ -82,7 +82,8 @@ public class NetworkHandlerTest extends JavaTest {
             conf.put(NetworkBindingConstants.PARAMETER_TIMEOUT, 1234);
             return conf;
         });
-        PresenceDetection presenceDetection = spy(new PresenceDetection(handler, Duration.ofSeconds(2)));
+        PresenceDetection presenceDetection = spy(
+                new PresenceDetection(handler, Duration.ofSeconds(2), scheduledExecutorService));
 
         handler.initialize(presenceDetection);
         assertThat(handler.retries, is(10));
@@ -103,7 +104,7 @@ public class NetworkHandlerTest extends JavaTest {
             conf.put(NetworkBindingConstants.PARAMETER_HOSTNAME, "127.0.0.1");
             return conf;
         });
-        handler.initialize(new PresenceDetection(handler, Duration.ofSeconds(2)));
+        handler.initialize(new PresenceDetection(handler, Duration.ofSeconds(2), scheduledExecutorService));
         // Check that we are offline
         ArgumentCaptor<ThingStatusInfo> statusInfoCaptor = ArgumentCaptor.forClass(ThingStatusInfo.class);
         verify(callback).statusUpdated(eq(thing), statusInfoCaptor.capture());
@@ -123,7 +124,8 @@ public class NetworkHandlerTest extends JavaTest {
             conf.put(NetworkBindingConstants.PARAMETER_REFRESH_INTERVAL, 0); // disable auto refresh
             return conf;
         });
-        PresenceDetection presenceDetection = spy(new PresenceDetection(handler, Duration.ofSeconds(2)));
+        PresenceDetection presenceDetection = spy(
+                new PresenceDetection(handler, Duration.ofSeconds(2), scheduledExecutorService));
         doReturn(Instant.now()).when(presenceDetection).getLastSeen();
 
         handler.initialize(presenceDetection);

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
@@ -71,7 +71,7 @@ public class NetworkHandlerTest extends JavaTest {
     @Test
     public void checkAllConfigurations() {
         NetworkBindingConfiguration config = new NetworkBindingConfiguration();
-        NetworkHandler handler = spy(new NetworkHandler(thing, true, config));
+        NetworkHandler handler = spy(new NetworkHandler(thing, scheduledExecutorService, true, config));
         handler.setCallback(callback);
         // Provide all possible configuration
         when(thing.getConfiguration()).thenAnswer(a -> {
@@ -94,7 +94,7 @@ public class NetworkHandlerTest extends JavaTest {
     @Test
     public void tcpDeviceInitTests() {
         NetworkBindingConfiguration config = new NetworkBindingConfiguration();
-        NetworkHandler handler = spy(new NetworkHandler(thing, true, config));
+        NetworkHandler handler = spy(new NetworkHandler(thing, scheduledExecutorService, true, config));
         assertThat(handler.isTCPServiceDevice(), is(true));
         handler.setCallback(callback);
         // Port is missing, should make the device OFFLINE
@@ -114,7 +114,7 @@ public class NetworkHandlerTest extends JavaTest {
     @Test
     public void pingDeviceInitTests() {
         NetworkBindingConfiguration config = new NetworkBindingConfiguration();
-        NetworkHandler handler = spy(new NetworkHandler(thing, false, config));
+        NetworkHandler handler = spy(new NetworkHandler(thing, scheduledExecutorService, false, config));
         handler.setCallback(callback);
         // Provide minimal configuration
         when(thing.getConfiguration()).thenAnswer(a -> {

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
@@ -79,21 +79,15 @@ public class NetworkHandlerTest extends JavaTest {
             conf.put(NetworkBindingConstants.PARAMETER_RETRY, 10);
             conf.put(NetworkBindingConstants.PARAMETER_HOSTNAME, "127.0.0.1");
             conf.put(NetworkBindingConstants.PARAMETER_PORT, 8080);
-            conf.put(NetworkBindingConstants.PARAMETER_REFRESH_INTERVAL, 101010);
             conf.put(NetworkBindingConstants.PARAMETER_TIMEOUT, 1234);
             return conf;
         });
-        PresenceDetection presenceDetection = spy(
-                new PresenceDetection(handler, scheduledExecutorService, Duration.ofSeconds(2)));
-        // Mock start/stop automatic refresh
-        doNothing().when(presenceDetection).startAutomaticRefresh();
-        doNothing().when(presenceDetection).stopAutomaticRefresh();
+        PresenceDetection presenceDetection = spy(new PresenceDetection(handler, Duration.ofSeconds(2)));
 
         handler.initialize(presenceDetection);
         assertThat(handler.retries, is(10));
         assertThat(presenceDetection.getHostname(), is("127.0.0.1"));
         assertThat(presenceDetection.getServicePorts().iterator().next(), is(8080));
-        assertThat(presenceDetection.getRefreshInterval(), is(Duration.ofMillis(101010)));
         assertThat(presenceDetection.getTimeout(), is(Duration.ofMillis(1234)));
     }
 
@@ -109,7 +103,7 @@ public class NetworkHandlerTest extends JavaTest {
             conf.put(NetworkBindingConstants.PARAMETER_HOSTNAME, "127.0.0.1");
             return conf;
         });
-        handler.initialize(new PresenceDetection(handler, scheduledExecutorService, Duration.ofSeconds(2)));
+        handler.initialize(new PresenceDetection(handler, Duration.ofSeconds(2)));
         // Check that we are offline
         ArgumentCaptor<ThingStatusInfo> statusInfoCaptor = ArgumentCaptor.forClass(ThingStatusInfo.class);
         verify(callback).statusUpdated(eq(thing), statusInfoCaptor.capture());
@@ -126,13 +120,10 @@ public class NetworkHandlerTest extends JavaTest {
         when(thing.getConfiguration()).thenAnswer(a -> {
             Configuration conf = new Configuration();
             conf.put(NetworkBindingConstants.PARAMETER_HOSTNAME, "127.0.0.1");
+            conf.put(NetworkBindingConstants.PARAMETER_REFRESH_INTERVAL, 0); // disable auto refresh
             return conf;
         });
-        PresenceDetection presenceDetection = spy(
-                new PresenceDetection(handler, scheduledExecutorService, Duration.ofSeconds(2)));
-        // Mock start/stop automatic refresh
-        doNothing().when(presenceDetection).startAutomaticRefresh();
-        doNothing().when(presenceDetection).stopAutomaticRefresh();
+        PresenceDetection presenceDetection = spy(new PresenceDetection(handler, Duration.ofSeconds(2)));
         doReturn(Instant.now()).when(presenceDetection).getLastSeen();
 
         handler.initialize(presenceDetection);

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
@@ -35,7 +35,7 @@ public class LatencyParserTest {
         String input = "64 bytes from 192.168.1.1: icmp_seq=0 ttl=64 time=1.225 ms";
 
         // Act
-        Duration resultLatency = latencyParser.parseLatency(input);
+        Duration resultLatency = latencyParser.parseLatency(input, null);
 
         // Assert
         assertNotNull(resultLatency);
@@ -55,7 +55,7 @@ public class LatencyParserTest {
 
         for (String inputLine : inputLines) {
             // Act
-            Duration resultLatency = latencyParser.parseLatency(inputLine);
+            Duration resultLatency = latencyParser.parseLatency(inputLine, null);
 
             // Assert
             assertNull(resultLatency);
@@ -69,10 +69,15 @@ public class LatencyParserTest {
         String input = "Reply from 192.168.178.207: bytes=32 time=2ms TTL=64";
 
         // Act
-        Duration resultLatency = latencyParser.parseLatency(input);
+        Duration resultLatency = latencyParser.parseLatency(input, null);
 
         // Assert
         assertNotNull(resultLatency);
         assertEquals(2, durationToMillis(resultLatency), 0);
+
+        input = "Reply from 10.80.5.2: bytes=32 time<1ms TTL=64";
+        resultLatency = latencyParser.parseLatency(input, null);
+        assertNotNull(resultLatency);
+        assertEquals(1, durationToMillis(resultLatency), 0.0);
     }
 }


### PR DESCRIPTION
- Fixes: https://github.com/openhab/openhab-addons/issues/17956
- Fixes: https://github.com/openhab/openhab-addons/issues/16810
- Fixes: https://github.com/openhab/openhab-addons/issues/16262
- 
No breaking changes.
Improved logging
Improved separation of concerns
Improved parsing of ping results (<1ms)
Improved resource use (memory and threads)
Discovery takes binding configuration into consideration 

should be backported to 5.0.x and 4.3.x.

Testable jar 5.1.0 snapshot (2025-09-05) or later:  https://1drv.ms/u/c/70ea7ac46bc61c73/EegJadzMpp1IlQYIN5kMCfwBpyUEcQF8ReQZGRMTmTcllw?e=TQEpxt