### PR TITLE
[tellstick] Update async-http-client to version 2.12.4

### DIFF
--- a/bundles/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/org.openhab.binding.tellstick/pom.xml
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
-      <version>2.10.4</version>
+      <version>2.12.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client-netty-utils</artifactId>
-      <version>2.10.4</version>
+      <version>2.12.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes securrity issue: https://github.com/AsyncHttpClient/async-http-client/security/advisories/GHSA-mfj5-cf8g-g2fv
Supersedes: https://github.com/openhab/openhab-addons/pull/17897