### PR TITLE
[insteon] Fix led command stack overflow error

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/CommandHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/CommandHandler.java
@@ -1460,8 +1460,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
         }
 
         private void setLEDOnOff(InsteonChannelConfiguration config, Command cmd) {
-            State state = getInsteonDevice().getFeatureState(FEATURE_LED_ON_OFF);
-            if (!((State) cmd).equals(state)) {
+            DeviceFeature feature = getInsteonDevice().getFeature(FEATURE_LED_ON_OFF);
+            if (feature != null) {
                 feature.handleCommand(config, cmd);
             }
         }
@@ -2187,8 +2187,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
         }
 
         private void setLEDControl(InsteonChannelConfiguration config) {
-            State state = getInsteonModem().getFeatureState(FEATURE_LED_CONTROL);
-            if (!OnOffType.ON.equals(state)) {
+            DeviceFeature feature = getInsteonModem().getFeature(FEATURE_LED_CONTROL);
+            if (feature != null) {
                 feature.handleCommand(config, OnOffType.ON);
             }
         }


### PR DESCRIPTION
Instead of sending a command to a relevant feature, it sent it back to itself causing the stack overflow. Additionally, the command should be sent regardless of the current state since it may not be up to date at the time the command is received.

This bugfix should be included in 4.3.1.