### PR TITLE
[mqtt.generic] Fix ClassCastException when receiving ON/OFF on a dimmer channel

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -75,7 +75,7 @@ public class PercentageValue extends Value {
 
     @Override
     public Command parseCommand(Command command) throws IllegalArgumentException {
-        PercentType oldvalue = (state instanceof UnDefType) ? new PercentType() : (PercentType) state;
+        PercentType oldvalue = (state instanceof UnDefType) ? new PercentType() : state.as(PercentType.class);
         // Nothing do to -> We have received a percentage
         if (command instanceof PercentType percent) {
             return percent;

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -313,6 +313,8 @@ public class ValueTests {
         assertThat(v.parseCommand(new DecimalType(10.0)), is(PercentType.ZERO));
         assertThat(v.getMQTTpublishValue(PercentType.ZERO, null), is("10"));
 
+        v.update(OnOffType.OFF);
+
         assertThat(v.parseCommand(OnOffType.ON), is(OnOffType.ON));
         assertThat(v.getMQTTpublishValue(OnOffType.ON, null), is("110"));
         assertThat(v.parseCommand(OnOffType.OFF), is(OnOffType.OFF));


### PR DESCRIPTION
A dimmer channel used to be able to receive `ON` / `OFF` through MQTT in openHAB 4.2. This broke in 4.3.

Reported here: https://community.openhab.org/t/openhab-4-3-release-discussion/160888/192

This needs to be backported to 4.3.x

