### PR TITLE
[tesla] Fix `NumberFormatException`

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/protocol/dto/VehicleData.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/protocol/dto/VehicleData.java
@@ -27,7 +27,7 @@ public class VehicleData {
     @SerializedName("id")
     public Long id;
     @SerializedName("user_id")
-    public int userId;
+    public Long userId;
     @SerializedName("vehicle_id")
     public String vehicleId;
     @SerializedName("vin")


### PR DESCRIPTION
Fix NumberFormatException reported here: https://community.openhab.org/t/tesla-binding-exception-occurred-while-parsing-data/161012/5

Test jar should be usable in 4.3.0: https://1drv.ms/u/s!AnMcxmvEeupwj49RabXgS_bRX-8P4Q?e=dVZurL

Should be backported when confirmed as fix.