### PR TITLE
[insteon] Add led brightness on level channel parameter

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/config/config.xml
@@ -32,5 +32,12 @@
 			</options>
 		</parameter>
 	</config-description>
+	<config-description uri="channel-type:insteon:led-brightness">
+		<parameter name="onLevel" type="integer" min="0" max="100">
+			<label>On Level</label>
+			<description>LED brightness level to use when an ON command is received. Default to 50%.</description>
+			<default>50</default>
+		</parameter>
+	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/i18n/insteon.properties
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/i18n/insteon.properties
@@ -471,6 +471,8 @@ channel-type.config.insteon.dimmer.onLevel.label = On Level
 channel-type.config.insteon.dimmer.onLevel.description = Override the dimmer on level local setting.
 channel-type.config.insteon.dimmer.rampRate.label = Ramp Rate
 channel-type.config.insteon.dimmer.rampRate.description = Override the dimmer ramp rate local setting.
+channel-type.config.insteon.led-brightness.onLevel.label = On Level
+channel-type.config.insteon.led-brightness.onLevel.description = LED brightness level to use when an ON command is received. Default to 50%.
 
 channel-type.config.insteon.legacy-button.related.label = Related Devices
 channel-type.config.insteon.legacy-button.related.description = List of related Insteon devices separated by a '+' sign.

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/channels.xml
@@ -332,6 +332,8 @@
 		<item-type>Dimmer</item-type>
 		<label>LED Brightness Level</label>
 		<description>Set the device led(s) brightness level.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy> <!-- binding controls state updates -->
+		<config-description-ref uri="channel-type:insteon:led-brightness"/>
 	</channel-type>
 
 	<channel-type id="led-on-off" advanced="true">

--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-features.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-features.xml
@@ -180,7 +180,6 @@
 		<message-handler command="0x19">TriggerPollMsgHandler</message-handler> <!-- poll after cmd request reply ack -->
 		<message-handler command="0x2E" ext="1" cmd1="0x2E" cmd2="0x00" d2="0x01" field="userData8">CustomPercentMsgHandler</message-handler>
 		<message-handler default="true">NoOpMsgHandler</message-handler>
-		<command-handler command="OnOffType" ext="1" cmd1="0x2E" d2="0x06" field="userData3">CustomOnOffCommandHandler</command-handler>
 		<command-handler command="PercentType" ext="1" cmd1="0x2E" d2="0x06" field="userData3">CustomPercentCommandHandler</command-handler>
 		<command-handler command="RefreshType">RefreshCommandHandler</command-handler>
 		<poll-handler>NoPollHandler</poll-handler> <!-- polled by ExtDataGroup -->


### PR DESCRIPTION
This change adds a channel parameter to set the LED brightness level to use when an ON command is received. It now defaults to 50% in line with [standard behavior](https://www.insteon.com/support-knowledgebase/2016/8/15/change-led-brightness-levels-switchlincs).

This also includes removing `OnOffType` command support for the `on-level` channel since it should only be set to a percent value.