### PR TITLE
[pipertts] Fix library load on windows

### DIFF
--- a/bundles/org.openhab.voice.pipertts/README.md
+++ b/bundles/org.openhab.voice.pipertts/README.md
@@ -17,7 +17,7 @@ The add-on is compatible with the following platforms:
 
 The add-on will download the required dependencies at first activation.
 
-If your openHAB installation does not have access to the Internet, you need to download the [piper-jni jar file](https://repo1.maven.org/maven2/io/github/givimad/piper-jni/1.2.0-a0f09cd/piper-jni-1.2.0-a0f09cd.jar) and place it at '<OPENHAB_USERDATA>/piper/'.
+If your openHAB installation does not have access to the Internet, you need to download the [piper-jni jar file](https://repo1.maven.org/maven2/io/github/givimad/piper-jni/1.2.0-c0670df/piper-jni-1.2.0-c0670df.jar) and place it at '<OPENHAB_USERDATA>/piper/'.
 
 ### Downloading Voice Model Files
 

--- a/bundles/org.openhab.voice.pipertts/pom.xml
+++ b/bundles/org.openhab.voice.pipertts/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.github.givimad</groupId>
       <artifactId>piper-jni</artifactId>
-      <version>1.2.0-a0f09cd</version>
+      <version>1.2.0-c0670df</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.voice.pipertts/src/main/java/org/openhab/voice/pipertts/internal/PiperTTSService.java
+++ b/bundles/org.openhab.voice.pipertts/src/main/java/org/openhab/voice/pipertts/internal/PiperTTSService.java
@@ -87,7 +87,7 @@ import io.github.givimad.piperjni.PiperVoice;
         + " Text-to-Speech", description_uri = SERVICE_CATEGORY + ":" + SERVICE_ID)
 public class PiperTTSService extends AbstractCachedTTSService {
     // piper-jni version from pom.xml
-    private static final String PIPER_VERSION = "1.2.0-a0f09cd";
+    private static final String PIPER_VERSION = "1.2.0-c0670df";
     private static final Path PIPER_FOLDER = Path.of(OpenHAB.getUserDataFolder(), "piper");
     private static final Path LIB_FOLDER = PIPER_FOLDER.resolve("lib-" + PIPER_VERSION);
     private static final Path JAR_FILE = PIPER_FOLDER.resolve("piper-jni-" + PIPER_VERSION + ".jar");


### PR DESCRIPTION
The previous version of the library had an issue loading the library files from an external directory on windows, this version fixed it.