### PR TITLE
Added note about required yearly manual step

### DIFF
--- a/bundles/org.openhab.binding.tellstick/README.md
+++ b/bundles/org.openhab.binding.tellstick/README.md
@@ -130,6 +130,9 @@ Copy the 'token' returned in Step 3) and use that as accessToken in the local br
 Bridge tellstick:telldus-local:3 "Tellstick Local ZWave" [ipAddress="x.y.z.w" , accesToken= "XYZ...W"]
 ```
 
+**NOTE**: This binding does not automatically update the the token, even if 'Auto renew access' is chosen in step 2) above. This has to be done manually at least once a year, as described in the 'Refreshing a token' section in the above page.
+
+
 Required:
 
 - **ipAddress:** Local IP address of your Tellstick device

--- a/bundles/org.openhab.binding.tellstick/README.md
+++ b/bundles/org.openhab.binding.tellstick/README.md
@@ -132,7 +132,6 @@ Bridge tellstick:telldus-local:3 "Tellstick Local ZWave" [ipAddress="x.y.z.w" , 
 
 **NOTE**: This binding does not automatically update the the token, even if 'Auto renew access' is chosen in step 2) above. This has to be done manually at least once a year, as described in the 'Refreshing a token' section in the above page.
 
-
 Required:
 
 - **ipAddress:** Local IP address of your Tellstick device


### PR DESCRIPTION
It's currently not clear from the documentation that a yearly refresh of the access token is required, so I thought I'd contribute with this info