### PR TITLE
[insteon] Fix motion sensor device type config typo

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-types.xml
@@ -908,7 +908,7 @@
 		<feature name="daytime" group="2">WirelessSensorState</feature>
 		<feature name="lowBattery" group="3">WirelessSensorState</feature>
 		<feature name="heartbeat" group="4">HeartbeatMonitor</feature>
-		<feature-group name="extDataGroup" type="extDataGroup">
+		<feature-group name="extDataGroup" type="ExtDataGroup">
 			<feature name="batteryLevel">MotionSensorBatteryLevel</feature>
 			<feature name="lightLevel">MotionSensorLightLevel</feature>
 		</feature-group>


### PR DESCRIPTION
This change fixes a typo in the device types configuration for motion sensor.

This should be back ported since the motion sensor channels `battery-level` and `light-level` don't have any state for in the OH 4.3 release.