### PR TITLE
[benqprojector] Fix response processing for newer projectors

### DIFF
--- a/bundles/org.openhab.binding.benqprojector/README.md
+++ b/bundles/org.openhab.binding.benqprojector/README.md
@@ -98,7 +98,7 @@ sitemaps/benq.sitemap
 sitemap benq label="BenQ Projector" {
     Frame label="Controls" {
         Switch     item=benqPower  label="Power"
-        Selection  item=benqSource label="Source" mappings=["hdmi"="HDMI", "hdmi2"="HDMI2", "ypbr"="Component", "RGB"="Computer", "vid"="Video", "svid"="S-Video"]
+        Selection  item=benqSource label="Source" mappings=["hdmi"="HDMI", "hdmi2"="HDMI2", "usbreader"="USB Reader", "ypbr"="Component", "RGB"="Computer", "vid"="Video", "svid"="S-Video"]
         Selection  item=benqPictureMode label="Picture Mode"
         Selection  item=benqAspectRatio label="Aspect Ratio"
         Switch     item=benqFreeze label="Freeze"

--- a/bundles/org.openhab.binding.benqprojector/README.md
+++ b/bundles/org.openhab.binding.benqprojector/README.md
@@ -89,7 +89,7 @@ String benqAspectRatio  "Aspect Ratio [%s]"           { channel="benqprojector:p
 Switch benqFreeze                                     { channel="benqprojector:projector-serial:hometheater:freeze" }
 Switch benqBlank                                      { channel="benqprojector:projector-serial:hometheater:blank" }
 String benqDirect                                     { channel="benqprojector:projector-serial:hometheater:directcmd" }
-Number benqLampTime     "Lamp Time [%d h]"   <switch> { channel="benqprojector:projector-serial:hometheater:lamptime" }
+Number benqLampTime     "Lamp Time [%d h]"    <light> { channel="benqprojector:projector-serial:hometheater:lamptime" }
 ```
 
 sitemaps/benq.sitemap

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorBindingConstants.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorBindingConstants.java
@@ -42,4 +42,7 @@ public class BenqProjectorBindingConstants {
     // Config properties
     public static final String THING_PROPERTY_HOST = "host";
     public static final String THING_PROPERTY_PORT = "port";
+
+    // Unsupported item response
+    public static final String UNSUPPORTED_ITM = "Unsupported item";
 }

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.benqprojector.internal;
 
+import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingConstants.*;
+
 import java.time.Duration;
 import java.util.Locale;
 
@@ -34,10 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class BenqProjectorDevice {
-    private static final String UNSUPPORTED_ITM = "Unsupported item";
-    private static final String BLOCK_ITM = "Block item";
-    private static final String ILLEGAL_FMT = "Illegal format";
-
     private static final int LAMP_REFRESH_WAIT_MINUTES = 5;
 
     private ExpiringCache<Integer> cachedLampHours = new ExpiringCache<>(Duration.ofMinutes(LAMP_REFRESH_WAIT_MINUTES),
@@ -66,14 +64,6 @@ public class BenqProjectorDevice {
 
         if (response.contains(UNSUPPORTED_ITM)) {
             return "UNSUPPORTED";
-        }
-
-        if (response.contains(BLOCK_ITM)) {
-            throw new BenqProjectorCommandException("Block Item received for command: " + query);
-        }
-
-        if (response.contains(ILLEGAL_FMT)) {
-            throw new BenqProjectorCommandException("Illegal Format response received for command: " + query);
         }
 
         logger.debug("Response: '{}'", response);

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.benqprojector.internal;
 
 import java.time.Duration;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -122,7 +123,7 @@ public class BenqProjectorDevice {
      * Power
      */
     public Switch getPowerStatus() throws BenqProjectorCommandException, BenqProjectorException {
-        return (queryString("pow=?").contains("on") ? Switch.ON : Switch.OFF);
+        return (queryString("pow=?").toLowerCase(Locale.ENGLISH).contains("on") ? Switch.ON : Switch.OFF);
     }
 
     public void setPower(Switch value) throws BenqProjectorCommandException, BenqProjectorException {
@@ -172,7 +173,7 @@ public class BenqProjectorDevice {
      * Blank Screen
      */
     public Switch getBlank() throws BenqProjectorCommandException, BenqProjectorException {
-        return (queryString("blank=?").contains("on") ? Switch.ON : Switch.OFF);
+        return (queryString("blank=?").toLowerCase(Locale.ENGLISH).contains("on") ? Switch.ON : Switch.OFF);
     }
 
     public void setBlank(Switch value) throws BenqProjectorCommandException, BenqProjectorException {
@@ -183,7 +184,7 @@ public class BenqProjectorDevice {
      * Freeze
      */
     public Switch getFreeze() throws BenqProjectorCommandException, BenqProjectorException {
-        return (queryString("freeze=?").contains("on") ? Switch.ON : Switch.OFF);
+        return (queryString("freeze=?").toLowerCase(Locale.ENGLISH).contains("on") ? Switch.ON : Switch.OFF);
     }
 
     public void setFreeze(Switch value) throws BenqProjectorCommandException, BenqProjectorException {

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
@@ -126,10 +126,11 @@ public class BenqProjectorDevice {
     }
 
     public void setPower(Switch value) throws BenqProjectorCommandException, BenqProjectorException {
-        sendCommand(value == Switch.ON ? "pow=on" : "pow=off");
-
-        // some projectors need the off command twice to switch off
-        if (value == Switch.OFF) {
+        if (value == Switch.ON) {
+            sendCommand("pow=on");
+        } else {
+            // some projectors need the off command twice to switch off
+            sendCommand("pow=off");
             sendCommand("pow=off");
         }
     }

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorDevice.java
@@ -127,6 +127,11 @@ public class BenqProjectorDevice {
 
     public void setPower(Switch value) throws BenqProjectorCommandException, BenqProjectorException {
         sendCommand(value == Switch.ON ? "pow=on" : "pow=off");
+
+        // some projectors need the off command twice to switch off
+        if (value == Switch.OFF) {
+            sendCommand("pow=off");
+        }
     }
 
     /*

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -93,8 +92,7 @@ public interface BenqProjectorConnector {
                     // The response is fully received when the second '#' arrives
                     // example: *pow=?# *POW=ON#
                     if (resp.chars().filter(ch -> ch == '#').count() >= 2) {
-                        return resp.replaceAll("[\\s\\r\\n*#>]", BLANK).replace(data, BLANK)
-                                .toLowerCase(Locale.ENGLISH);
+                        return resp.replaceAll("[\\s\\r\\n*#>]", BLANK).replace(data, BLANK);
                     }
                 } else {
                     try {

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
@@ -37,8 +37,8 @@ public interface BenqProjectorConnector {
     static final String END = "#\r";
     static final String BLANK = "";
 
-    public static final String BLOCK_ITM = "Block item";
-    public static final String ILLEGAL_FMT = "Illegal format";
+    static final String BLOCK_ITM = "Block item";
+    static final String ILLEGAL_FMT = "Illegal format";
 
     /**
      * Procedure for connecting to projector.

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.benqprojector.internal.connector;
 
+import static org.openhab.binding.benqprojector.internal.BenqProjectorBindingConstants.*;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -19,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.benqprojector.internal.BenqProjectorCommandException;
 import org.openhab.binding.benqprojector.internal.BenqProjectorException;
 
 /**
@@ -33,6 +36,9 @@ public interface BenqProjectorConnector {
     static final String START = "\r*";
     static final String END = "#\r";
     static final String BLANK = "";
+
+    public static final String BLOCK_ITM = "Block item";
+    public static final String ILLEGAL_FMT = "Illegal format";
 
     /**
      * Procedure for connecting to projector.
@@ -55,8 +61,9 @@ public interface BenqProjectorConnector {
      *            Message to send.
      *
      * @throws BenqProjectorException
+     * @throws BenqProjectorCommandException
      */
-    String sendMessage(String data) throws BenqProjectorException;
+    String sendMessage(String data) throws BenqProjectorException, BenqProjectorCommandException;
 
     /**
      * Common method called by the Serial or Tcp connector to send the message to the projector, wait for a response and
@@ -70,9 +77,10 @@ public interface BenqProjectorConnector {
      *            The connector's output stream.
      *
      * @throws BenqProjectorException
+     * @throws BenqProjectorCommandException
      */
     default String sendMsgReadResp(String data, @Nullable InputStream in, @Nullable OutputStream out)
-            throws IOException, BenqProjectorException {
+            throws IOException, BenqProjectorException, BenqProjectorCommandException {
         String resp = BLANK;
 
         if (in != null && out != null) {
@@ -88,6 +96,19 @@ public interface BenqProjectorConnector {
                     byte[] tmpData = new byte[availableBytes];
                     int readBytes = in.read(tmpData, 0, availableBytes);
                     resp = resp.concat(new String(tmpData, 0, readBytes, StandardCharsets.US_ASCII));
+
+                    if (resp.contains(UNSUPPORTED_ITM)) {
+                        return resp;
+                    }
+
+                    if (resp.contains(BLOCK_ITM)) {
+                        throw new BenqProjectorCommandException("Block Item received for command: " + data);
+                    }
+
+                    if (resp.contains(ILLEGAL_FMT)) {
+                        throw new BenqProjectorCommandException(
+                                "Illegal Format response received for command: " + data);
+                    }
 
                     // The response is fully received when the second '#' arrives
                     // example: *pow=?# *POW=ON#

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorConnector.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -88,8 +89,12 @@ public interface BenqProjectorConnector {
                     byte[] tmpData = new byte[availableBytes];
                     int readBytes = in.read(tmpData, 0, availableBytes);
                     resp = resp.concat(new String(tmpData, 0, readBytes, StandardCharsets.US_ASCII));
-                    if (resp.contains(END)) {
-                        return resp.replaceAll("[\\r\\n*#>]", BLANK).replace(data, BLANK);
+
+                    // The response is fully received when the second '#' arrives
+                    // example: *pow=?# *POW=ON#
+                    if (resp.chars().filter(ch -> ch == '#').count() >= 2) {
+                        return resp.replaceAll("[\\s\\r\\n*#>]", BLANK).replace(data, BLANK)
+                                .toLowerCase(Locale.ENGLISH);
                     }
                 } else {
                     try {

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorSerialConnector.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorSerialConnector.java
@@ -18,6 +18,7 @@ import java.io.OutputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.benqprojector.internal.BenqProjectorCommandException;
 import org.openhab.binding.benqprojector.internal.BenqProjectorException;
 import org.openhab.core.io.transport.serial.PortInUseException;
 import org.openhab.core.io.transport.serial.SerialPort;
@@ -120,7 +121,7 @@ public class BenqProjectorSerialConnector implements BenqProjectorConnector, Ser
     }
 
     @Override
-    public String sendMessage(String data) throws BenqProjectorException {
+    public String sendMessage(String data) throws BenqProjectorException, BenqProjectorCommandException {
         InputStream in = this.in;
         OutputStream out = this.out;
 

--- a/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorTcpConnector.java
+++ b/bundles/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/connector/BenqProjectorTcpConnector.java
@@ -19,6 +19,7 @@ import java.net.Socket;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.benqprojector.internal.BenqProjectorCommandException;
 import org.openhab.binding.benqprojector.internal.BenqProjectorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +100,7 @@ public class BenqProjectorTcpConnector implements BenqProjectorConnector {
     }
 
     @Override
-    public String sendMessage(String data) throws BenqProjectorException {
+    public String sendMessage(String data) throws BenqProjectorException, BenqProjectorCommandException {
         InputStream in = this.in;
         OutputStream out = this.out;
 


### PR DESCRIPTION
Resolves #17996. The current implementation does not work at all with some newer projectors possibly due to an unexpected carriage return in the projector's response. This PR fixes the issue and also an issue where the off command needed to be sent twice to make the projector turn off.

Test build: https://github.com/mlobstein/openhab-addons/releases/download/v4.3.0-snapshot/org.openhab.binding.benqprojector-4.3.0-SNAPSHOT.jar