### PR TITLE
[netatmo] Remove space before colon

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/action/RoomActions.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/action/RoomActions.java
@@ -111,7 +111,7 @@ public class RoomActions implements ThingActions {
                 return;
             }
         } catch (IllegalArgumentException e) {
-            logger.info("Invalid mode passed : {} - {}", mode, e.getMessage());
+            logger.info("Invalid mode passed: {} - {}", mode, e.getMessage());
             return;
         }
 

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/AircareApi.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/AircareApi.java
@@ -55,6 +55,6 @@ public class AircareApi extends RestManager {
                 return station;
             }
         }
-        throw new NetatmoException("Unexpected answer querying device '%s' : not found.", deviceId);
+        throw new NetatmoException("Unexpected answer querying device '%s': not found.", deviceId);
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/RestManager.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/RestManager.java
@@ -65,14 +65,14 @@ public abstract class RestManager {
         URI uri = uriBuilder.build();
         T response = apiBridge.executeUri(uri, method, clazz, payload, contentType, 3);
         if (response instanceof ApiResponse.Ok apiResponseOk && apiResponseOk.failed()) {
-            throw new NetatmoException("Command failed : %s for uri : %s", response.getStatus(), uri.toString());
+            throw new NetatmoException("Command failed: %s for uri: %s", response.getStatus(), uri.toString());
         }
         return response;
     }
 
     private static UriBuilder appendParams(UriBuilder builder, @Nullable Object... params) {
         if (params.length % 2 != 0) {
-            throw new IllegalArgumentException("appendParams : params count must be even");
+            throw new IllegalArgumentException("appendParams: params count must be even");
         }
         for (int i = 0; i < params.length; i += 2) {
             Object param1 = params[i];
@@ -82,7 +82,7 @@ public abstract class RestManager {
                     builder.queryParam(query, param2);
                 }
             } else {
-                throw new IllegalArgumentException("appendParams : even parameters must be Strings");
+                throw new IllegalArgumentException("appendParams: even parameters must be Strings");
             }
         }
         return builder;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/SecurityApi.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/SecurityApi.java
@@ -112,7 +112,7 @@ public class SecurityApi extends RestManager {
         try {
             return get(uriBuilder, Ping.class).getStatus();
         } catch (NetatmoException e) {
-            logger.debug("Pinging {} failed : {}", vpnUrl, e.getMessage());
+            logger.debug("Pinging {} failed: {}", vpnUrl, e.getMessage());
             return null;
         }
     }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/WeatherApi.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/WeatherApi.java
@@ -77,7 +77,7 @@ public class WeatherApi extends RestManager {
                 return station;
             }
         }
-        throw new NetatmoException("Unexpected answer searching device '%s' : not found.", deviceId);
+        throw new NetatmoException("Unexpected answer searching device '%s': not found.", deviceId);
     }
 
     /**
@@ -98,7 +98,7 @@ public class WeatherApi extends RestManager {
                 return station;
             }
         }
-        throw new NetatmoException("Unexpected answer searching device '%s' : not found.", deviceId);
+        throw new NetatmoException("Unexpected answer searching device '%s': not found.", deviceId);
     }
 
     public Collection<NAMain> getFavoriteAndGuestStationsData() throws NetatmoException {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/NetatmoConstants.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/NetatmoConstants.java
@@ -248,8 +248,8 @@ public class NetatmoConstants {
     }
 
     // Radio signal quality thresholds
-    static final int[] WIFI_SIGNAL_LEVELS = new int[] { 99, 84, 69, 54 }; // Resp : bad, average, good, full
-    static final int[] RADIO_SIGNAL_LEVELS = new int[] { 90, 80, 70, 60 }; // Resp : low, medium, high, full
+    static final int[] WIFI_SIGNAL_LEVELS = new int[] { 99, 84, 69, 54 }; // Resp: bad, average, good, full
+    static final int[] RADIO_SIGNAL_LEVELS = new int[] { 90, 80, 70, 60 }; // Resp: low, medium, high, full
 
     // Thermostat definitions
     public enum SetpointMode {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/deserialization/NAPushTypeDeserializer.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/deserialization/NAPushTypeDeserializer.java
@@ -59,7 +59,7 @@ class NAPushTypeDeserializer implements JsonDeserializer<NAPushType> {
     }
 
     /**
-     * @param apiName : Netatmo Object name (NSD, NACamera...)
+     * @param apiName Netatmo Object name (NSD, NACamera...)
      * @return moduletype value if found, or else Unknown
      */
     public static ModuleType fromNetatmoObject(String apiName) {
@@ -68,7 +68,7 @@ class NAPushTypeDeserializer implements JsonDeserializer<NAPushType> {
     }
 
     /**
-     * @param apiName : Netatmo Event name (hush, off, on ...)
+     * @param apiName Netatmo Event name (hush, off, on ...)
      * @return eventType value if found, or else Unknown
      */
     public static EventType fromEvent(String apiName) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/EnergyCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/EnergyCapability.java
@@ -114,7 +114,7 @@ public class EnergyCapability extends RestCapability<EnergyApi> {
                 api.setThermpoint(energyId, roomId, mode, endtime, temp);
                 handler.expireData();
             } catch (NetatmoException e) {
-                logger.warn("Error setting room thermostat mode '{}' : {}", mode, e.getMessage());
+                logger.warn("Error setting room thermostat mode '{}': {}", mode, e.getMessage());
             }
         });
     }
@@ -154,7 +154,7 @@ public class EnergyCapability extends RestCapability<EnergyApi> {
                 }
                 handler.expireData();
             } catch (NetatmoException e) {
-                logger.warn("Error handling command '{}' : {}", command, e.getMessage());
+                logger.warn("Error handling command '{}': {}", command, e.getMessage());
             } catch (IllegalArgumentException e) {
                 logger.warn("Command '{}' sent to channel '{}' is not a valid setpoint mode.", command, channelName);
             }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/SecurityCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/SecurityCapability.java
@@ -133,7 +133,7 @@ class SecurityCapability extends RestCapability<SecurityApi> {
                 }
             });
         } catch (NetatmoException e) {
-            logger.warn("Error retrieving last events for home '{}' : {}", securityId, e.getMessage());
+            logger.warn("Error retrieving last events for home '{}': {}", securityId, e.getMessage());
         }
         return result;
     }
@@ -182,7 +182,7 @@ class SecurityCapability extends RestCapability<SecurityApi> {
             try {
                 return api.getDeviceEvents(securityId, moduleId, deviceType);
             } catch (NetatmoException e) {
-                logger.warn("Error retrieving last events of camera '{}' : {}", moduleId, e.getMessage());
+                logger.warn("Error retrieving last events of camera '{}': {}", moduleId, e.getMessage());
                 return null;
             }
         }).orElse(List.of()));
@@ -193,7 +193,7 @@ class SecurityCapability extends RestCapability<SecurityApi> {
             try {
                 return api.getPersonEvents(securityId, personId);
             } catch (NetatmoException e) {
-                logger.warn("Error retrieving last events of person '{}' : {}", personId, e.getMessage());
+                logger.warn("Error retrieving last events of person '{}': {}", personId, e.getMessage());
                 return null;
             }
         }).orElse(List.of()));
@@ -205,7 +205,7 @@ class SecurityCapability extends RestCapability<SecurityApi> {
                 api.setPersonAwayStatus(securityId, personId, away);
                 handler.expireData();
             } catch (NetatmoException e) {
-                logger.warn("Error setting person away/at home '{}' : {}", personId, e.getMessage());
+                logger.warn("Error setting person away/at home '{}': {}", personId, e.getMessage());
             }
         });
     }
@@ -224,7 +224,7 @@ class SecurityCapability extends RestCapability<SecurityApi> {
                 api.changeStatus(localURL, status);
                 handler.expireData();
             } catch (NetatmoException e) {
-                logger.warn("Error changing camera monitoring status '{}' : {}", status, e.getMessage());
+                logger.warn("Error changing camera monitoring status '{}': {}", status, e.getMessage());
             }
         });
     }
@@ -235,7 +235,7 @@ class SecurityCapability extends RestCapability<SecurityApi> {
                 api.changeFloodLightMode(securityId, cameraId, mode);
                 handler.expireData();
             } catch (NetatmoException e) {
-                logger.warn("Error changing Presence floodlight mode '{}' : {}", mode, e.getMessage());
+                logger.warn("Error changing Presence floodlight mode '{}': {}", mode, e.getMessage());
             }
         });
     }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/providers/NetatmoThingTypeProvider.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/providers/NetatmoThingTypeProvider.java
@@ -87,7 +87,7 @@ public class NetatmoThingTypeProvider implements ThingTypeProvider {
                 return localizationService.createLocalizedThingType(bundle,
                         moduleType.isABridge() ? thingTypeBuilder.buildBridge() : thingTypeBuilder.build(), locale);
             } catch (IllegalArgumentException e) {
-                logger.warn("Unable to define ModuleType for thingType {} : {}", thingTypeUID.getId(), e.getMessage());
+                logger.warn("Unable to define ModuleType for thingType {}: {}", thingTypeUID.getId(), e.getMessage());
             }
         }
         return null;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/GrantServlet.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/GrantServlet.java
@@ -93,7 +93,7 @@ public class GrantServlet extends NetatmoServlet {
             resp.getWriter().append(replaceKeysFromMap(accountTemplate, replaceMap));
             resp.getWriter().close();
         } else {
-            logger.warn("Unexpected : requestUrl is null");
+            logger.warn("Unexpected: requestUrl is null");
         }
     }
 

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/WebhookServlet.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/servlet/WebhookServlet.java
@@ -71,9 +71,9 @@ public class WebhookServlet extends NetatmoServlet {
             logger.info("Setting up WebHook at Netatmo to {}", uri.toString());
             hookSet = securityApi.addwebhook(uri);
         } catch (UriBuilderException e) {
-            logger.info("webhookUrl is not a valid URI '{}' : {}", uri, e.getMessage());
+            logger.info("webhookUrl is not a valid URI '{}': {}", uri, e.getMessage());
         } catch (NetatmoException e) {
-            logger.info("Error setting webhook : {}", e.getMessage());
+            logger.info("Error setting webhook: {}", e.getMessage());
         }
     }
 
@@ -85,7 +85,7 @@ public class WebhookServlet extends NetatmoServlet {
                 securityApi.dropWebhook();
                 hookSet = false;
             } catch (NetatmoException e) {
-                logger.warn("Error releasing webhook : {}", e.getMessage());
+                logger.warn("Error releasing webhook: {}", e.getMessage());
             }
         }
         super.dispose();
@@ -99,12 +99,12 @@ public class WebhookServlet extends NetatmoServlet {
 
     private void processEvent(String data) throws IOException {
         if (!data.isEmpty()) {
-            logger.debug("Event transmitted from restService : {}", data);
+            logger.debug("Event transmitted from restService: {}", data);
             try {
                 WebhookEvent event = deserializer.deserialize(WebhookEvent.class, data);
                 notifyListeners(event);
             } catch (NetatmoException e) {
-                logger.debug("Error deserializing webhook data received : {}. {}", data, e.getMessage());
+                logger.debug("Error deserializing webhook data received: {}. {}", data, e.getMessage());
             }
         }
     }


### PR DESCRIPTION
In French, there is a space before a colon, whereas in English, there is not.

This also fixes a few Javadoc issues.

See also #17483 for similar fix in all README's.