### PR TITLE
[insteon] Fix x10 device message handling

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
@@ -564,16 +564,10 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
     public void requestReplied(Msg msg) {
         DeviceFeature feature = getFeatureQueried();
         if (feature != null && feature.isMyReply(msg)) {
-            if (msg.isReplyAck()) {
-                // mark feature queried as acked
-                feature.setQueryStatus(QueryStatus.QUERY_ACKED);
-            } else {
-                logger.debug("got a reply nack msg: {}", msg);
-                // mark feature queried as processed and answered
-                setFeatureQueried(null);
-                feature.setQueryMessage(null);
-                feature.setQueryStatus(QueryStatus.QUERY_ANSWERED);
-            }
+            // mark feature queried as processed and answered
+            setFeatureQueried(null);
+            feature.setQueryMessage(null);
+            feature.setQueryStatus(QueryStatus.QUERY_ANSWERED);
         }
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
@@ -907,6 +907,25 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
     }
 
     /**
+     * Notifies that a message request was replied for this device
+     *
+     * @param msg the message received
+     */
+    @Override
+    public void requestReplied(Msg msg) {
+        DeviceFeature feature = getFeatureQueried();
+        if (feature != null && feature.isMyReply(msg)) {
+            if (msg.isReplyAck()) {
+                // mark feature queried as acked
+                feature.setQueryStatus(QueryStatus.QUERY_ACKED);
+            } else {
+                logger.debug("got a reply nack msg: {}", msg);
+                super.requestReplied(msg);
+            }
+        }
+    }
+
+    /**
      * Notifies that the link db has been updated for this device
      */
     public void linkDBUpdated() {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonModem.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonModem.java
@@ -448,9 +448,6 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
             if (address == null) {
                 return;
             }
-            if (msg.isX10()) {
-                lastX10Address = msg.isX10Address() ? (X10Address) address : null;
-            }
             long time = System.currentTimeMillis();
             Device device = getAddress().equals(address) ? this : getDevice(address);
             if (device != null) {
@@ -483,13 +480,12 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
     }
 
     private void handleX10Message(Msg msg) throws FieldException {
-        X10Address address = lastX10Address;
-        if (msg.isX10Address()) {
-            // store the x10 address to use with the next cmd
-            lastX10Address = msg.getX10Address();
-        } else if (address != null) {
+        X10Address address = msg.isX10Address() ? msg.getX10Address() : lastX10Address;
+        if (address != null) {
             handleMessage(address, msg);
-            lastX10Address = null;
+            // store the x10 address to use with the next cmd
+            lastX10Address = msg.isX10Address() ? address : null;
+
         }
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/X10Address.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/X10Address.java
@@ -39,7 +39,7 @@ public class X10Address implements DeviceAddress {
     private final byte unitCode;
 
     public X10Address(byte address) {
-        this.houseCode = (byte) (address >> 4);
+        this.houseCode = (byte) (address >> 4 & 0x0F);
         this.unitCode = (byte) (address & 0x0F);
     }
 
@@ -49,7 +49,7 @@ public class X10Address implements DeviceAddress {
     }
 
     public X10Address(String address) throws IllegalArgumentException {
-        String[] parts = address.replace(".", "").split("");
+        String[] parts = address.replace(".", "").split("", 2);
         if (parts.length != 2) {
             throw new IllegalArgumentException("Invalid X10 address format");
         }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageDispatcher.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageDispatcher.java
@@ -242,11 +242,13 @@ public abstract class MessageDispatcher extends BaseFeatureHandler {
         @Override
         public boolean dispatch(Msg msg) {
             try {
-                byte cmd = msg.getByte("rawX10");
-                MessageHandler handler = feature.getOrDefaultMsgHandler(cmd);
-                logger.debug("{}:{}->{} X10", getX10Device().getAddress(), feature.getName(),
-                        handler.getClass().getSimpleName());
-                handler.handleMessage(cmd, msg);
+                if (msg.isX10Command()) {
+                    byte cmd = (byte) (msg.getByte("rawX10") & 0x0F);
+                    MessageHandler handler = feature.getOrDefaultMsgHandler(cmd);
+                    logger.debug("{}:{}->{} X10", getX10Device().getAddress(), feature.getName(),
+                            handler.getClass().getSimpleName());
+                    handler.handleMessage(cmd, msg);
+                }
             } catch (FieldException e) {
                 logger.warn("error parsing, dropping msg {}", msg);
             }


### PR DESCRIPTION
This change fixes the message handling for x10 device.

This includes 3 bug fixes:

- `X10Address` house code is incorrect when instantiated with a message address byte. This is affecting the legacy implementation as well preventing incoming X10 messages from being processed by the binding.
- `X10Address` failed to instantiate with a string based X10 address including a unit code with more than 1 digit (e.g. `L.15`). This is affecting the legacy implementation which rely on a string based address being parsed, opposed to the new one that has the house and unit configuration already separated.
- X10 messages received by the binding weren't changing their associated feature query status causing a 30 seconds delay for a X10 command to be sent to the device, waiting for the initial X10 address request timeout. This is affecting the new implementation only.

This change should be back ported as the X10 integration is currently broken.