### PR TITLE
[enocean] Fix `NullPointerException`

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanBaseSensorHandler.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/handler/EnOceanBaseSensorHandler.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Hashtable;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -87,7 +88,7 @@ public class EnOceanBaseSensorHandler extends EnOceanBaseThingHandler implements
             config.receivingEEPId.forEach(receivingEEP -> {
                 EEPType receivingEEPType = EEPType.getType(receivingEEP);
                 EEPType existingKey = receivingEEPTypes.putIfAbsent(receivingEEPType.getRORG(), receivingEEPType);
-                if (existingKey != null) {
+                if (!Objects.isNull(existingKey)) {
                     throw new IllegalArgumentException("Receiving more than one EEP of the same RORG is not supported");
                 }
             });
@@ -155,6 +156,9 @@ public class EnOceanBaseSensorHandler extends EnOceanBaseThingHandler implements
         ERP1Message msg = (ERP1Message) packet;
 
         EEPType localReceivingType = receivingEEPTypes.get(msg.getRORG());
+        if (Objects.isNull(localReceivingType)) {
+            return;
+        }
 
         EEP eep = EEPFactory.buildEEP(localReceivingType, (ERP1Message) packet);
         logger.debug("ESP Packet payload {} for {} received", HexUtils.bytesToHex(packet.getPayload()),


### PR DESCRIPTION
Fixes #18032
Regression of #17531

@lovery's original fix [here](https://github.com/openhab/openhab-addons/pull/17531#discussion_r1796912904) was correct. [Hashtable.get](https://docs.oracle.com/en/java/javase/21//docs/api/java.base/java/util/Hashtable.html#get(java.lang.Object)) returns `null` if this map contains no mapping for the key.

Should be backported to `4.3.x`.