### PR TITLE
[insteon] Fix legacy all link broadcast message not processed

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonLegacyBinding.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonLegacyBinding.java
@@ -514,7 +514,7 @@ public class InsteonLegacyBinding implements LegacyDriverListener, LegacyPortLis
 
     private void handleInsteonMessage(Msg msg) throws FieldException {
         InsteonAddress toAddr = msg.getInsteonAddress("toAddress");
-        if (!msg.isBroadcast() && !driver.isMsgForUs(toAddr)) {
+        if (!msg.isBroadcast() && !msg.isAllLinkBroadcast() && !driver.isMsgForUs(toAddr)) {
             // not for one of our modems, do not process
             return;
         }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyDevice.java
@@ -334,7 +334,7 @@ public class LegacyDevice {
             if (qe == null) {
                 return 0L;
             }
-            if (!qe.getMsg().isBroadcast()) {
+            if (!qe.getMsg().isAllLinkBroadcast()) {
                 logger.debug("qe taken off direct: {} {}", qe.getFeature(), qe.getMsg());
                 lastQueryTime = timeNow;
                 // mark feature as pending
@@ -382,7 +382,7 @@ public class LegacyDevice {
         synchronized (mrequestQueue) {
             mrequestQueue.add(new QEntry(feature, msg, now + delay));
         }
-        if (!msg.isBroadcast()) {
+        if (!msg.isAllLinkBroadcast()) {
             msg.setQuietTime(QUIET_TIME_DIRECT_MESSAGE);
         }
         logger.trace("enqueing direct message with delay {}", delay);


### PR DESCRIPTION
This change fixes a bug introduced in the legacy implementation where incoming all link broadcast messages aren't being processed. Previously, the `Msg` class method `isBroadcast` included both broadcast message types (standard and all-link broadcasts). After the rewrite, that method was decoupled only including the standard type, while a new method `isAllLinkBroadcast` was added to check for the other type. For reference, Insteon message requests (outgoing) can only be of direct or all-link broadcast types.

This fix should be back ported as physical button press events aren't processed by the legacy implementation delaying the state update of some of the channels until the next binding poll. I did run a successful test in my environment of this change.