### PR TITLE
[insteon] Fix scene channel state updates

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonBindingConstants.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonBindingConstants.java
@@ -78,7 +78,7 @@ public class InsteonBindingConstants {
     public static final String FEATURE_ON_LEVEL = "onLevel";
     public static final String FEATURE_PING = "ping";
     public static final String FEATURE_RAMP_RATE = "rampRate";
-    public static final String FEATURE_SCENE_ON_OFF = "sceneOnOff";
+    public static final String FEATURE_SCENE = "scene";
     public static final String FEATURE_STAY_AWAKE = "stayAwake";
     public static final String FEATURE_TEMPERATURE_SCALE = "temperatureScale";
     public static final String FEATURE_TWO_GROUPS = "2Groups";

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonSceneHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonSceneHandler.java
@@ -184,7 +184,7 @@ public class InsteonSceneHandler extends InsteonBaseThingHandler {
 
     public void updateState(State state) {
         getThing().getChannels().stream().map(Channel::getUID)
-                .filter(channelUID -> FEATURE_SCENE_ON_OFF.equals(channelUID.getId())).findFirst()
+                .filter(channelUID -> FEATURE_SCENE.equals(channelUID.getId())).findFirst()
                 .ifPresent(channelUID -> updateState(channelUID, state));
     }
 }


### PR DESCRIPTION
This changes fixes a bug where the scene channel state isn't getting updated. This was introduced with the scene channel rename that happened during the [rewrite review process](https://github.com/openhab/openhab-addons/pull/17146#discussion_r1764238746).

This should be back ported since the scene channel state isn't updated currently. I did run a successful test in my environment of this change.