### PR TITLE
[jsscripting] Use OSGi-ified GraalVM dependencies

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/README.md
+++ b/bundles/org.openhab.automation.jsscripting/README.md
@@ -1,6 +1,6 @@
 # JavaScript Scripting
 
-This add-on provides support for JavaScript (ECMAScript 2022+) that can be used as a scripting language within automation rules.
+This add-on provides support for JavaScript (ECMAScript 2024+) that can be used as a scripting language within automation rules.
 It is based on [GraalJS](https://www.graalvm.org/javascript/) from the [GraalVM project](https://www.graalvm.org/).
 
 Also included is [openhab-js](https://github.com/openhab/openhab-js/), a fairly high-level ES6 library to support automation in openHAB. It provides convenient access

--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -11,6 +11,7 @@ Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.1",\
  org.graalvm.sdk.jniutils;bundle-version="24.1.1",\
  org.graalvm.sdk.nativeimage;bundle-version="24.1.1",\
  org.graalvm.sdk.word;bundle-version="24.1.1",\
+ org.graalvm.shadowed.icu4j;bundle-version="24.1.1",\
  org.graalvm.truffle.truffle-compiler;bundle-version="24.1.1"
 
 SPI-Provider: *

--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -12,7 +12,8 @@ Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.1",\
  org.graalvm.sdk.nativeimage;bundle-version="24.1.1",\
  org.graalvm.sdk.word;bundle-version="24.1.1",\
  org.graalvm.shadowed.icu4j;bundle-version="24.1.1",\
- org.graalvm.truffle.truffle-compiler;bundle-version="24.1.1"
+ org.graalvm.truffle.truffle-compiler;bundle-version="24.1.1",\
+ org.graalvm.truffle.truffle-runtime;bundle-version="24.1.1"
 
 SPI-Provider: *
 SPI-Consumer: *

--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -7,13 +7,13 @@ Require-Capability:
     osgi.serviceloader:=
       filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)";
       cardinality:=multiple
-Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.1",\
- org.graalvm.sdk.jniutils;bundle-version="24.1.1",\
- org.graalvm.sdk.nativeimage;bundle-version="24.1.1",\
- org.graalvm.sdk.word;bundle-version="24.1.1",\
- org.graalvm.shadowed.icu4j;bundle-version="24.1.1",\
- org.graalvm.truffle.truffle-compiler;bundle-version="24.1.1",\
- org.graalvm.truffle.truffle-runtime;bundle-version="24.1.1"
+Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.2",\
+ org.graalvm.sdk.jniutils;bundle-version="24.1.2",\
+ org.graalvm.sdk.nativeimage;bundle-version="24.1.2",\
+ org.graalvm.sdk.word;bundle-version="24.1.2",\
+ org.graalvm.shadowed.icu4j;bundle-version="24.1.2",\
+ org.graalvm.truffle.truffle-compiler;bundle-version="24.1.2",\
+ org.graalvm.truffle.truffle-runtime;bundle-version="24.1.2"
 
 SPI-Provider: *
 SPI-Consumer: *

--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -7,6 +7,10 @@ Require-Capability:
     osgi.serviceloader:=
       filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)";
       cardinality:=multiple
+Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.1",\
+ org.graalvm.sdk.jniutils;bundle-version="24.1.1",\
+ org.graalvm.sdk.nativeimage;bundle-version="24.1.1",\
+ org.graalvm.sdk.word;bundle-version="24.1.1"
 
 SPI-Provider: *
 SPI-Consumer: *

--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -10,7 +10,8 @@ Require-Capability:
 Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.1",\
  org.graalvm.sdk.jniutils;bundle-version="24.1.1",\
  org.graalvm.sdk.nativeimage;bundle-version="24.1.1",\
- org.graalvm.sdk.word;bundle-version="24.1.1"
+ org.graalvm.sdk.word;bundle-version="24.1.1",\
+ org.graalvm.truffle.truffle-compiler;bundle-version="24.1.1"
 
 SPI-Provider: *
 SPI-Consumer: *

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -51,6 +51,7 @@
                   <exclude>org.graalvm.sdk:jniutils</exclude>
                   <exclude>org.graalvm.sdk:nativeimage</exclude>
                   <exclude>org.graalvm.sdk:word</exclude>
+                  <exclude>org.graalvm.truffle:truffle-compiler</exclude>
                 </excludes>
               </artifactSet>
               <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -51,6 +51,7 @@
                   <exclude>org.graalvm.sdk:jniutils</exclude>
                   <exclude>org.graalvm.sdk:nativeimage</exclude>
                   <exclude>org.graalvm.sdk:word</exclude>
+                  <exclude>org.graalvm.shadowed:icu4j</exclude>
                   <exclude>org.graalvm.truffle:truffle-compiler</exclude>
                 </excludes>
               </artifactSet>
@@ -173,6 +174,12 @@
       <groupId>org.graalvm.regex</groupId>
       <artifactId>regex</artifactId>
       <version>${graaljs.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.graalvm.shadowed</groupId>
+          <artifactId>icu4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Graal JavaScript engine (depends on Graal TRegex engine, must be added after it) -->
     <dependency>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -46,6 +46,11 @@
                 <excludes>
                   <exclude>org.lastnpe.eea:eea-all</exclude>
                   <exclude>org.apache.karaf.features:framework</exclude>
+                  <!-- we use OSGI-ified version, so we don't need the following -->
+                  <exclude>org.graalvm.sdk:collections</exclude>
+                  <exclude>org.graalvm.sdk:jniutils</exclude>
+                  <exclude>org.graalvm.sdk:nativeimage</exclude>
+                  <exclude>org.graalvm.sdk:word</exclude>
                 </excludes>
               </artifactSet>
               <createDependencyReducedPom>false</createDependencyReducedPom>
@@ -145,6 +150,16 @@
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId>
       <version>${graaljs.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.graalvm.sdk</groupId>
+          <artifactId>collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.graalvm.sdk</groupId>
+          <artifactId>nativeimage</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Graal JavaScript ScriptEngine JSR 223 support -->
     <dependency>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -23,7 +23,7 @@
       !jdk.vm.ci.services
     </bnd.importpackage>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
-    <graaljs.version>24.1.1</graaljs.version>
+    <graaljs.version>24.1.2</graaljs.version>
     <oh.version>${project.version}</oh.version>
     <ohjs.version>openhab@5.8.1</ohjs.version>
   </properties>

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -53,6 +53,7 @@
                   <exclude>org.graalvm.sdk:word</exclude>
                   <exclude>org.graalvm.shadowed:icu4j</exclude>
                   <exclude>org.graalvm.truffle:truffle-compiler</exclude>
+                  <exclude>org.graalvm.truffle:truffle-runtime</exclude>
                 </excludes>
               </artifactSet>
               <createDependencyReducedPom>false</createDependencyReducedPom>
@@ -116,6 +117,7 @@
           </execution>
         </executions>
       </plugin>
+      <!-- embed the JS resources into the bundle -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -148,20 +150,11 @@
   </build>
 
   <dependencies>
+    <!-- Graal Polyglot Framework -->
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId>
       <version>${graaljs.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.graalvm.sdk</groupId>
-          <artifactId>collections</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.graalvm.sdk</groupId>
-          <artifactId>nativeimage</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- Graal JavaScript ScriptEngine JSR 223 support -->
     <dependency>
@@ -174,12 +167,6 @@
       <groupId>org.graalvm.regex</groupId>
       <artifactId>regex</artifactId>
       <version>${graaljs.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.graalvm.shadowed</groupId>
-          <artifactId>icu4j</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- Graal JavaScript engine (depends on Graal TRegex engine, must be added after it) -->
     <dependency>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -9,6 +9,7 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.1.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -5,6 +5,10 @@
 
 	<feature name="openhab-automation-jsscripting" description="JavaScript Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -11,6 +11,7 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.1.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -9,6 +9,7 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.1.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.1.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -5,13 +5,13 @@
 
 	<feature name="openhab-automation-jsscripting" description="JavaScript Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.1.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.1.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.1.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.1.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.1.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.1.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.1.2</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/DelegatingScriptEngineWithInvocableAndCompilableAndAutocloseable.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/DelegatingScriptEngineWithInvocableAndCompilableAndAutocloseable.java
@@ -23,8 +23,6 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptException;
 
-import org.eclipse.jdt.annotation.NonNull;
-
 /**
  * {@link ScriptEngine} implementation that delegates to a supplied ScriptEngine instance. Allows overriding specific
  * methods.
@@ -33,9 +31,9 @@ import org.eclipse.jdt.annotation.NonNull;
  */
 public abstract class DelegatingScriptEngineWithInvocableAndCompilableAndAutocloseable<T extends ScriptEngine & Invocable & Compilable & AutoCloseable>
         implements ScriptEngine, Invocable, Compilable, AutoCloseable {
-    protected @NonNull T delegate;
+    protected T delegate;
 
-    public DelegatingScriptEngineWithInvocableAndCompilableAndAutocloseable(@NonNull T delegate) {
+    public DelegatingScriptEngineWithInvocableAndCompilableAndAutocloseable(T delegate) {
         this.delegate = delegate;
     }
 


### PR DESCRIPTION
Fixes #18054 by using a OSGi-ified Truffle Runtime, which is loaded only once.
It also reduces the add-on size from 34 MB to 16 MB: Truffle ICU4j was pretty big and now is provided as OSGi bundle and hence not bundled with the add-on anymore.

GraalVM Polyglot and Truffle API dependencies cannot be provided as OSGi bundles, because those use the Java ServiceLoader to load the available polyglot and truffle language implementations, which depend on on the individual add-on, and we cannot configure the service loading for those if they are shared OSGi bundles.