### PR TITLE
[dscalarm] Fix update of channel `zone_bypass_mode`

### DIFF
--- a/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmCode.java
+++ b/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmCode.java
@@ -88,6 +88,7 @@ public enum DSCAlarmCode {
     ZoneRestored("610", "Zone Restored", "610: General status of the zone - restored."),
     EnvisalinkZoneTimerDump("615", "Envisalink Zone Timer Dump",
             "615: The raw zone timers used inside the Envisalink."),
+    BypassedZonesBitfield("616", "Bypassed Zones Bitfield", "616: Bypassed zones bitfield."),
     DuressAlarm("620", "Duress Alarm", "620: A duress code has been entered on a system keypad."),
     FireKeyAlarm("621", "Fire Key Alarm", "621: A Fire key alarm has been activated."),
     FireKeyRestored("622", "Fire Key Alarm Restore", "622: A Fire key alarm has been restored."),

--- a/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/handler/DSCAlarmBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/handler/DSCAlarmBaseBridgeHandler.java
@@ -37,6 +37,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -449,94 +450,123 @@ public abstract class DSCAlarmBaseBridgeHandler extends BaseBridgeHandler {
         return thing;
     }
 
+    public List<Thing> findAllZoneThings() {
+        List<Thing> things = getThing().getThings();
+        return things.stream().filter(this::isZoneThing).toList();
+    }
+
+    private boolean isZoneThing(Thing thing) {
+        ThingHandler thingHandler = thing.getHandler();
+        if (thingHandler == null) {
+            return false;
+        }
+
+        DSCAlarmBaseThingHandler handler = (DSCAlarmBaseThingHandler) thingHandler;
+        return DSCAlarmThingType.ZONE.equals(handler.getDSCAlarmThingType());
+    }
+
     /**
      * Handles an incoming message from the DSC Alarm System.
      *
      * @param incomingMessage
      */
     public synchronized void handleIncomingMessage(String incomingMessage) {
-        if (incomingMessage != null && !incomingMessage.isEmpty()) {
-            DSCAlarmMessage dscAlarmMessage = new DSCAlarmMessage(incomingMessage);
-            DSCAlarmMessageType dscAlarmMessageType = dscAlarmMessage.getDSCAlarmMessageType();
+        if (incomingMessage == null || incomingMessage.isEmpty()) {
+            logger.debug("handleIncomingMessage(): No Message Received!");
+            return;
+        }
 
-            logger.debug("handleIncomingMessage(): Message received: {} - {}", incomingMessage,
-                    dscAlarmMessage.toString());
+        DSCAlarmMessage dscAlarmMessage = new DSCAlarmMessage(incomingMessage);
+        DSCAlarmMessageType dscAlarmMessageType = dscAlarmMessage.getDSCAlarmMessageType();
 
-            DSCAlarmEvent event = new DSCAlarmEvent(this);
-            event.dscAlarmEventMessage(dscAlarmMessage);
-            DSCAlarmThingType dscAlarmThingType = null;
-            int partitionId = 0;
-            int zoneId = 0;
+        logger.debug("handleIncomingMessage(): Message received: {} - {}", incomingMessage, dscAlarmMessage);
 
-            DSCAlarmCode dscAlarmCode = DSCAlarmCode
-                    .getDSCAlarmCodeValue(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.CODE));
+        DSCAlarmCode dscAlarmCode = DSCAlarmCode
+                .getDSCAlarmCodeValue(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.CODE));
 
-            if (panelThingHandler != null) {
-                panelThingHandler.setPanelMessage(dscAlarmMessage);
+        if (panelThingHandler != null) {
+            panelThingHandler.setPanelMessage(dscAlarmMessage);
+        }
+
+        if (dscAlarmCode == DSCAlarmCode.LoginResponse) {
+            String dscAlarmMessageData = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
+            if ("3".equals(dscAlarmMessageData)) {
+                sendCommand(DSCAlarmCode.NetworkLogin);
+                // onConnected();
+            } else if ("1".equals(dscAlarmMessageData)) {
+                onConnected();
             }
-
-            if (dscAlarmCode == DSCAlarmCode.LoginResponse) {
-                String dscAlarmMessageData = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
-                if ("3".equals(dscAlarmMessageData)) {
-                    sendCommand(DSCAlarmCode.NetworkLogin);
-                    // onConnected();
-                } else if ("1".equals(dscAlarmMessageData)) {
-                    onConnected();
-                }
-                return;
-            } else if (dscAlarmCode == DSCAlarmCode.CommandAcknowledge) {
-                String dscAlarmMessageData = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
-                if ("000".equals(dscAlarmMessageData)) {
-                    setBridgeStatus(true);
-                }
+            return;
+        } else if (dscAlarmCode == DSCAlarmCode.CommandAcknowledge) {
+            String dscAlarmMessageData = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
+            if ("000".equals(dscAlarmMessageData)) {
+                setBridgeStatus(true);
             }
+        }
 
-            switch (dscAlarmMessageType) {
-                case PANEL_EVENT:
-                    dscAlarmThingType = DSCAlarmThingType.PANEL;
-                    break;
-                case PARTITION_EVENT:
-                    dscAlarmThingType = DSCAlarmThingType.PARTITION;
-                    partitionId = Integer
-                            .parseInt(event.getDSCAlarmMessage().getMessageInfo(DSCAlarmMessageInfoType.PARTITION));
-                    break;
-                case ZONE_EVENT:
-                    dscAlarmThingType = DSCAlarmThingType.ZONE;
-                    zoneId = Integer.parseInt(event.getDSCAlarmMessage().getMessageInfo(DSCAlarmMessageInfoType.ZONE));
-                    break;
-                case KEYPAD_EVENT:
-                    dscAlarmThingType = DSCAlarmThingType.KEYPAD;
-                    break;
-                default:
-                    break;
+        DSCAlarmEvent event = new DSCAlarmEvent(this);
+        event.dscAlarmEventMessage(dscAlarmMessage);
+
+        DSCAlarmThingType dscAlarmThingType = null;
+        int partitionId = 0;
+        int zoneId = 0;
+
+        switch (dscAlarmMessageType) {
+            case PANEL_EVENT:
+                dscAlarmThingType = DSCAlarmThingType.PANEL;
+                break;
+            case PARTITION_EVENT:
+                dscAlarmThingType = DSCAlarmThingType.PARTITION;
+                partitionId = Integer
+                        .parseInt(event.getDSCAlarmMessage().getMessageInfo(DSCAlarmMessageInfoType.PARTITION));
+                break;
+            case ZONE_EVENT:
+                dscAlarmThingType = DSCAlarmThingType.ZONE;
+                zoneId = Integer.parseInt(event.getDSCAlarmMessage().getMessageInfo(DSCAlarmMessageInfoType.ZONE));
+                break;
+            case KEYPAD_EVENT:
+                dscAlarmThingType = DSCAlarmThingType.KEYPAD;
+                break;
+            default:
+                break;
+        }
+
+        if (dscAlarmThingType == null) {
+            return;
+        }
+
+        if (DSCAlarmCode.BypassedZonesBitfield.equals(dscAlarmCode)) {
+            List<Thing> allZoneThings = findAllZoneThings();
+            for (Thing zone : allZoneThings) {
+                handleIncomingMessage(event, zone, dscAlarmThingType);
             }
+        } else {
+            Thing thing = findThing(dscAlarmThingType, partitionId, zoneId);
+            handleIncomingMessage(event, thing, dscAlarmThingType);
+        }
+    }
 
-            if (dscAlarmThingType != null) {
-                Thing thing = findThing(dscAlarmThingType, partitionId, zoneId);
+    private void handleIncomingMessage(DSCAlarmEvent event, Thing thing, DSCAlarmThingType dscAlarmThingType) {
 
-                logger.debug("handleIncomingMessage(): Thing Search - '{}'", thing);
+        logger.debug("handleIncomingMessage(): Thing Search - '{}'", thing);
 
-                if (thing != null) {
-                    DSCAlarmBaseThingHandler thingHandler = (DSCAlarmBaseThingHandler) thing.getHandler();
+        if (thing != null) {
+            DSCAlarmBaseThingHandler thingHandler = (DSCAlarmBaseThingHandler) thing.getHandler();
 
-                    if (thingHandler != null) {
-                        if (thingHandler.isThingHandlerInitialized() && thing.getStatus() == ThingStatus.ONLINE) {
-                            thingHandler.dscAlarmEventReceived(event, thing);
+            if (thingHandler != null) {
+                if (thingHandler.isThingHandlerInitialized() && thing.getStatus() == ThingStatus.ONLINE) {
+                    thingHandler.dscAlarmEventReceived(event, thing);
 
-                        } else {
-                            logger.debug("handleIncomingMessage(): Thing '{}' Not Refreshed!", thing.getUID());
-                        }
-                    }
                 } else {
-                    logger.debug("handleIncomingMessage(): Thing Not Found! Send to Discovery Service!");
-
-                    if (dscAlarmDiscoveryService != null) {
-                        dscAlarmDiscoveryService.addThing(getThing(), dscAlarmThingType, event);
-                    }
+                    logger.debug("handleIncomingMessage(): Thing '{}' Not Refreshed!", thing.getUID());
                 }
             }
         } else {
-            logger.debug("handleIncomingMessage(): No Message Received!");
+            logger.debug("handleIncomingMessage(): Thing Not Found! Send to Discovery Service!");
+
+            if (dscAlarmDiscoveryService != null) {
+                dscAlarmDiscoveryService.addThing(getThing(), dscAlarmThingType, event);
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/handler/ZoneThingHandler.java
+++ b/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/handler/ZoneThingHandler.java
@@ -14,7 +14,9 @@ package org.openhab.binding.dscalarm.internal.handler;
 
 import static org.openhab.binding.dscalarm.internal.DSCAlarmBindingConstants.*;
 
+import java.util.ArrayList;
 import java.util.EventObject;
+import java.util.List;
 
 import org.openhab.binding.dscalarm.internal.DSCAlarmCode;
 import org.openhab.binding.dscalarm.internal.DSCAlarmEvent;
@@ -129,11 +131,11 @@ public class ZoneThingHandler extends DSCAlarmBaseThingHandler {
                 DSCAlarmEvent dscAlarmEvent = (DSCAlarmEvent) event;
                 DSCAlarmMessage dscAlarmMessage = dscAlarmEvent.getDSCAlarmMessage();
 
-                ChannelUID channelUID = null;
                 DSCAlarmCode dscAlarmCode = DSCAlarmCode
                         .getDSCAlarmCodeValue(dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.CODE));
                 logger.debug("dscAlarmEventRecieved(): Thing - {}   Command - {}", thing.getUID(), dscAlarmCode);
 
+                ChannelUID channelUID;
                 int state = 0;
                 String status = "";
 
@@ -173,10 +175,45 @@ public class ZoneThingHandler extends DSCAlarmBaseThingHandler {
                         updateChannel(channelUID, state, "");
                         zoneMessage(status);
                         break;
+                    case BypassedZonesBitfield:
+                        state = isZoneByPassed(dscAlarmMessage) ? 1 : 0;
+                        channelUID = new ChannelUID(getThing().getUID(), ZONE_BYPASS_MODE);
+                        updateChannel(channelUID, state, "");
+                        break;
                     default:
                         break;
                 }
             }
         }
+    }
+
+    private boolean isZoneByPassed(DSCAlarmMessage dscAlarmMessage) {
+        String data = dscAlarmMessage.getMessageInfo(DSCAlarmMessageInfoType.DATA);
+        List<Integer> bypassedZones = parseZoneIdsFromHex(data);
+        return bypassedZones.contains(getZoneNumber());
+    }
+
+    private List<Integer> parseZoneIdsFromHex(String data) {
+        // List to store bypassed zones
+        List<Integer> bypassedZones = new ArrayList<>();
+
+        // Process each byte in the HEX string
+        for (int byteIndex = 0; byteIndex < data.length() / 2; byteIndex++) {
+            // Get two characters representing the byte (2 HEX characters = 1 byte)
+            String byteHex = data.substring(byteIndex * 2, byteIndex * 2 + 2);
+
+            // Convert the HEX string to an integer
+            int byteValue = Integer.parseInt(byteHex, 16);
+
+            // Process each bit in the byte (8 bits per byte)
+            for (int bit = 0; bit < 8; bit++) {
+                if ((byteValue & (1 << bit)) != 0) {
+                    // Calculate the zone number (1-based)
+                    int zoneNumber = byteIndex * 8 + bit + 1;
+                    bypassedZones.add(zoneNumber);
+                }
+            }
+        }
+        return bypassedZones;
     }
 }


### PR DESCRIPTION
Bypassing a zone from the keypad did not reflect the change in openhab, although envisalink board issues a Process Bypassed Zones Bitfield Dump (616) command that can be used to update the appropriate channels.

This change will start processing Bypassed Zones Bitfield Dump (616) command and update every zone's `zone_bypass_mode` channel and it is documented [here](https://forum.eyezon.com/download/file.php?id=379&sid=6b1e1197bad7c56a9e24bf0f697ce420)