### PR TITLE
[speedtest] Fix speedtest thing going offline when image not available

### DIFF
--- a/bundles/org.openhab.binding.speedtest/src/main/java/org/openhab/binding/speedtest/internal/SpeedtestHandler.java
+++ b/bundles/org.openhab.binding.speedtest/src/main/java/org/openhab/binding/speedtest/internal/SpeedtestHandler.java
@@ -365,13 +365,19 @@ public class SpeedtestHandler extends BaseThingHandler {
                 isp = tmpCont.getIsp();
                 interfaceInternalIp = tmpCont.getInterface().getInternalIp();
                 interfaceExternalIp = tmpCont.getInterface().getExternalIp();
-                resultUrl = tmpCont.getResult().getUrl();
-                String url = String.valueOf(resultUrl) + ".png";
-                logger.debug("Downloading result image from: {}", url);
-                RawType image = HttpUtil.downloadImage(url);
-                if (image != null) {
-                    resultImage = image;
+                if (tmpCont.getResult().isPersisted()) {
+                    resultUrl = tmpCont.getResult().getUrl();
+                    String url = String.valueOf(resultUrl) + ".png";
+                    logger.debug("Downloading result image from: {}", url);
+                    RawType image = HttpUtil.downloadImage(url);
+                    if (image != null) {
+                        resultImage = image;
+                    } else {
+                        resultImage = UnDefType.NULL;
+                    }
                 } else {
+                    logger.debug("Result image not persisted");
+                    resultUrl = "";
                     resultImage = UnDefType.NULL;
                 }
 

--- a/bundles/org.openhab.binding.speedtest/src/main/java/org/openhab/binding/speedtest/internal/dto/ResultContainer.java
+++ b/bundles/org.openhab.binding.speedtest/src/main/java/org/openhab/binding/speedtest/internal/dto/ResultContainer.java
@@ -263,6 +263,9 @@ public class ResultContainer {
         @SerializedName("url")
         @Expose
         private String url;
+        @SerializedName("persisted")
+        @Expose
+        private boolean persisted;
 
         public String getId() {
             return id;
@@ -278,6 +281,14 @@ public class ResultContainer {
 
         public void setUrl(String url) {
             this.url = url;
+        }
+
+        public boolean isPersisted() {
+            return persisted;
+        }
+
+        public void setPersisted(boolean persisted) {
+            this.persisted = persisted;
         }
     }
 


### PR DESCRIPTION
The issue is mentioned on the forum, but I ran into the same thing: https://community.openhab.org/t/an-exception-occurred-while-running-speedtest-invalid-uri-host-null-authority-null/156906

The root cause is Ookla does not always create a result image. This is visible through a flag(`persisted`) that is also part of the result. At the moment, the whole things goes offline. With this fix, it will just set the image to UnDefType.NULL but still show the other results.

The root cause of the thing going offline is in https://github.com/openhab/openhab-core/blob/f00c7700cb13b4ab6dbc6a8e493f226d8099689c/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java#L212. If the `url` is not a valid `uri` this line will throw a (somewhat hidden) `IllegalArgumentException`. All other errors in that method are properly catched, but this one does not throw an `IOException`, which could be catched properly.