### PR TITLE
[digiplex] Fix license headers

### DIFF
--- a/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/communication/ErroneousResponse.java
+++ b/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/communication/ErroneousResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.binding.digiplex/src/test/java/org/openhab/binding/digiplex/internal/communication/DigiplexResponseResolverTest.java
+++ b/bundles/org.openhab.binding.digiplex/src/test/java/org/openhab/binding/digiplex/internal/communication/DigiplexResponseResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional


### PR DESCRIPTION
This fixes the build.

Caused by #18035 being merged after #18061 because build was not invalidated.