### PR TITLE
[insteon] Fix imeter solo product first record location

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
@@ -1530,7 +1530,7 @@
 		<description>TED 3000 Three Phase MTU</description>
 		<vendor>Energy Inc.</vendor>
 	</product>
-	<product devCat="0x09" subCat="0x07" productKey="0x00006C">
+	<product devCat="0x09" subCat="0x07" productKey="0x00006C" firstRecord="0x00FF">
 		<description>iMeter Solo</description>
 		<model>2423A1</model>
 		<vendor>Insteon</vendor>


### PR DESCRIPTION
This change corrects the first database record location configuration for iMeter Solo products.

This fix should be backported as the database verification for iMeter Solo products is currently failing leaving the thing in pending configuration status.