### PR TITLE
[lgwebos] Refactor usages of deprecated methods

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/WakeOnLanUtility.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/WakeOnLanUtility.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.binding.lgwebos.internal;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -23,6 +25,7 @@ import java.util.Enumeration;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -170,7 +173,16 @@ public class WakeOnLanUtility {
 
     private static boolean checkIfLinuxCommandExists(String cmd) {
         try {
-            return 0 == Runtime.getRuntime().exec(String.format("which %s", cmd)).waitFor();
+            Process process = new ProcessBuilder("which", cmd).redirectErrorStream(true).start();
+
+            if (LOGGER.isDebugEnabled()) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                    String output = reader.lines().collect(Collectors.joining("\n"));
+                    LOGGER.debug("Command 'which {}' returned {}", cmd, output);
+                }
+            }
+
+            return process.waitFor() == 0;
         } catch (InterruptedException | IOException e) {
             LOGGER.debug("Error trying to check if command {} exists: {}", cmd, e.getMessage());
         }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/action/LGWebOSActions.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/action/LGWebOSActions.java
@@ -16,7 +16,8 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
@@ -100,11 +101,11 @@ public class LGWebOSActions implements ThingActions {
     public void showToast(
             @ActionInput(name = "icon", label = "@text/actionShowToastInputIconLabel", description = "@text/actionShowToastInputIconDesc") String icon,
             @ActionInput(name = "text", label = "@text/actionShowToastInputTextLabel", description = "@text/actionShowToastInputTextDesc") String text)
-            throws IOException {
-        BufferedImage bi = ImageIO.read(new URL(icon));
+            throws IOException, URISyntaxException {
+        BufferedImage bi = ImageIO.read(new URI(icon).toURL());
         try (ByteArrayOutputStream os = new ByteArrayOutputStream(); OutputStream b64 = Base64.getEncoder().wrap(os)) {
             ImageIO.write(bi, "png", b64);
-            String string = os.toString(StandardCharsets.UTF_8.name());
+            String string = os.toString(StandardCharsets.UTF_8);
             getConnectedSocket().ifPresent(control -> control.showToast(text, string, "png", createResponseListener()));
         }
     }
@@ -261,7 +262,8 @@ public class LGWebOSActions implements ThingActions {
         ((LGWebOSActions) actions).showToast(text);
     }
 
-    public static void showToast(ThingActions actions, String icon, String text) throws IOException {
+    public static void showToast(ThingActions actions, String icon, String text)
+            throws IOException, URISyntaxException {
         ((LGWebOSActions) actions).showToast(icon, text);
     }
 


### PR DESCRIPTION
These methods are deprecated:
- The method `exec(java.lang.String)` from the type java.lang.Runtime is deprecated since version 18
- The constructor `java.net.URL(java.lang.String)` is deprecated since version 20