### PR TITLE
[radiothermostat] Refactor usages of deprecated methods

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/discovery/RadioThermostatDiscoveryService.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/discovery/RadioThermostatDiscoveryService.java
@@ -16,12 +16,13 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
+import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
@@ -63,6 +64,8 @@ public class RadioThermostatDiscoveryService extends AbstractDiscoveryService {
     private static final String RADIOTHERMOSTAT_DISCOVERY_MESSAGE = "TYPE: WM-DISCOVER\r\nVERSION: 1.0\r\n\r\nservices:com.marvell.wm.system*\r\n\r\n";
 
     private static final String SSDP_MATCH = "WM-NOTIFY";
+    private static final String MULTICAST_GROUP = "239.255.255.250";
+    private static final int MULTICAST_PORT = 1900;
     private static final int BACKGROUND_SCAN_INTERVAL_SECONDS = 300;
 
     private @Nullable ScheduledFuture<?> scheduledFuture = null;
@@ -119,8 +122,7 @@ public class RadioThermostatDiscoveryService extends AbstractDiscoveryService {
      * @throws SocketException
      */
     private void sendDiscoveryBroacast(NetworkInterface ni) throws UnknownHostException, SocketException {
-        InetAddress m = InetAddress.getByName("239.255.255.250");
-        final int port = 1900;
+        InetAddress m = InetAddress.getByName(MULTICAST_GROUP);
         logger.debug("Sending discovery broadcast");
         try {
             Enumeration<InetAddress> addrs = ni.getInetAddresses();
@@ -143,14 +145,17 @@ public class RadioThermostatDiscoveryService extends AbstractDiscoveryService {
             // this seems to be okay on linux systems, but osx apparently prefers ipv6, so this
             // prevents responses from being received unless the ipv4 stack is given preference.
             MulticastSocket socket = new MulticastSocket(null);
+            InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getByName(MULTICAST_GROUP),
+                    MULTICAST_PORT);
+
             socket.setSoTimeout(5000);
             socket.setReuseAddress(true);
-            // socket.setBroadcast(true);
             socket.setNetworkInterface(ni);
-            socket.joinGroup(m);
+            socket.joinGroup(inetSocketAddress, null);
             logger.debug("Joined UPnP Multicast group on Interface: {}", ni.getName());
             byte[] requestMessage = RADIOTHERMOSTAT_DISCOVERY_MESSAGE.getBytes(StandardCharsets.UTF_8);
-            DatagramPacket datagramPacket = new DatagramPacket(requestMessage, requestMessage.length, m, port);
+            DatagramPacket datagramPacket = new DatagramPacket(requestMessage, requestMessage.length, m,
+                    MULTICAST_PORT);
             socket.send(datagramPacket);
             try {
                 // Try to ensure that joinGroup has taken effect. Without this delay, the query
@@ -178,7 +183,7 @@ public class RadioThermostatDiscoveryService extends AbstractDiscoveryService {
                             "Timed out waiting for multicast response. Presumably all devices have already responded.");
                 }
             } finally {
-                socket.leaveGroup(m);
+                socket.leaveGroup(inetSocketAddress, null);
                 socket.close();
             }
         } catch (IOException | InterruptedException e) {
@@ -215,8 +220,8 @@ public class RadioThermostatDiscoveryService extends AbstractDiscoveryService {
             if ("location".equals(key)) {
                 try {
                     url = value;
-                    ip = new URL(value).getHost();
-                } catch (MalformedURLException e) {
+                    ip = new URI(value).getHost();
+                } catch (URISyntaxException e) {
                     logger.debug("Malfored URL {}", e.getMessage());
                 }
             }
@@ -265,12 +270,12 @@ public class RadioThermostatDiscoveryService extends AbstractDiscoveryService {
 
         logger.debug("Got discovered device.");
 
-        String label = String.format("RadioThermostat (%s)", name);
+        String label = String.format("Radio Thermostat (%s)", name);
         result = DiscoveryResultBuilder.create(thingUid).withLabel(label)
                 .withRepresentationProperty(RadioThermostatBindingConstants.PROPERTY_IP)
                 .withProperty(RadioThermostatBindingConstants.PROPERTY_IP, ip)
                 .withProperty(RadioThermostatBindingConstants.PROPERTY_ISCT80, isCT80).build();
-        logger.debug("New RadioThermostat discovered with ID=<{}>", uuid);
+        logger.debug("New Radio Thermostat discovered with ID=<{}>", uuid);
         this.thingDiscovered(result);
     }
 }


### PR DESCRIPTION
Refactor code in RadioThermostatDiscoveryService to remove deprecated java.net.URL, MulticastSocket.joinGroup() and MulticastSocket.leaveGroup() usage.