### PR TITLE
[insteon] Fix device request failure handling

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonBaseThingHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonBaseThingHandler.java
@@ -330,8 +330,6 @@ public abstract class InsteonBaseThingHandler extends BaseThingHandler implement
         updateStatus();
     }
 
-    public abstract void updateStatus();
-
     public void updateProperties(Device device) {
         Map<String, String> properties = editProperties();
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonThingHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonThingHandler.java
@@ -91,4 +91,9 @@ public interface InsteonThingHandler extends ThingHandler {
      * Refreshes the thing
      */
     public void refresh();
+
+    /**
+     * Updates the thing status
+     */
+    public void updateStatus();
 }


### PR DESCRIPTION
This changes fixes the handling of device request failures when a feature query couldn't be sent or wasn't answered.

While the Insteon Hub generates `0x5C` failure report messages when it's unable to get a response from the intended device, serial PLM do not produce such message. This mean the binding must rely on the query status timeouts to determine if a device is responding or not.

This change should be backported since unavailable devices connected to a serial PLM are currently showing as online status.