### PR TITLE
[basicprofiles] Fix handling of multiple `$DELTA` conditions

### DIFF
--- a/bundles/org.openhab.transform.basicprofiles/src/main/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfile.java
+++ b/bundles/org.openhab.transform.basicprofiles/src/main/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfile.java
@@ -230,6 +230,7 @@ public class StateFilterProfile implements StateProfile {
         }
 
         if (conditions.stream().allMatch(c -> c.check(state))) {
+            acceptedState = state;
             return state;
         } else {
             return configMismatchState;
@@ -344,7 +345,6 @@ public class StateFilterProfile implements StateProfile {
                 } else if (rhsState instanceof FunctionType rhsFunction) {
                     if (acceptedState == UnDefType.UNDEF && (rhsFunction.getType() == FunctionType.Function.DELTA
                             || rhsFunction.getType() == FunctionType.Function.DELTA_PERCENT)) {
-                        acceptedState = input;
                         return true;
                     }
                     rhsItem = getLinkedItem();
@@ -366,7 +366,6 @@ public class StateFilterProfile implements StateProfile {
                 } else if (lhsState instanceof FunctionType lhsFunction) {
                     if (acceptedState == UnDefType.UNDEF && (lhsFunction.getType() == FunctionType.Function.DELTA
                             || lhsFunction.getType() == FunctionType.Function.DELTA_PERCENT)) {
-                        acceptedState = input;
                         return true;
                     }
                     lhsItem = getLinkedItem();
@@ -438,10 +437,6 @@ public class StateFilterProfile implements StateProfile {
                     case LT -> ((Comparable) lhs).compareTo(rhs) < 0;
                     case LTE -> ((Comparable) lhs).compareTo(rhs) <= 0;
                 };
-
-                if (result) {
-                    acceptedState = input;
-                }
 
                 return result;
             } catch (IllegalArgumentException | ClassCastException e) {

--- a/bundles/org.openhab.transform.basicprofiles/src/test/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfileTest.java
+++ b/bundles/org.openhab.transform.basicprofiles/src/test/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfileTest.java
@@ -677,6 +677,10 @@ public class StateFilterProfileTest {
                 Arguments.of(decimalItem, "$DELTA >= 1", decimals, DecimalType.valueOf("10"), true), //
                 Arguments.of(decimalItem, "$DELTA >= 1", decimals, DecimalType.valueOf("5.5"), false), //
 
+                // Multiple delta conditions
+                Arguments.of(decimalItem, "$DELTA >= 1, $DELTA <= 10", decimals, DecimalType.valueOf("15"), true), //
+                Arguments.of(decimalItem, "$DELTA >= 1, $DELTA <= 10", decimals, DecimalType.valueOf("16"), false), //
+
                 Arguments.of(decimalItem, "$DELTA_PERCENT >= 10", decimals, DecimalType.valueOf("4.6"), false), //
                 Arguments.of(decimalItem, "$DELTA_PERCENT >= 10", decimals, DecimalType.valueOf("4.5"), true), //
                 Arguments.of(decimalItem, "$DELTA_PERCENT >= 10", decimals, DecimalType.valueOf("5.4"), false), //


### PR DESCRIPTION
There was a bug when having multiple DELTA conditions, resulting in pematurely saving the previous accepted value.

Example:

`$DELTA > 1, $DELTA < 10`:
- An initial input 50 will be accepted (correct behavior)
- Second input of 60 will pass `$DELTA > 1` (60 - 50 is greater than 1)
- Here, the accepted value was incorrectly saved to be 60 before checking the next condition
- When the next condition is checked, the input of 60 is compared against the acceptedvalue (now 60), so the delta is 60 - 60 which is less than 10.

- The correct behavior should be that input 60 is compared against the accepted value of 50, so 60 - 50 which is not less than 10.

Only after all conditions are checked and met should the accepted value be updated.

Please backport to 4.3