### PR TITLE
[linktap] Improve connection handling

### DIFF
--- a/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/internal/LinkTapHandler.java
+++ b/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/internal/LinkTapHandler.java
@@ -445,6 +445,12 @@ public class LinkTapHandler extends PollingDeviceHandler {
     @Override
     public void handleBridgeDataUpdated() {
         switch (getThing().getStatus()) {
+            case ONLINE:
+                if (!initPending) {
+                    logger.trace("Handling new bridge data for {} not required already online and processed",
+                            getThing().getLabel());
+                    return;
+                }
             case OFFLINE:
             case UNKNOWN:
                 logger.trace("Handling new bridge data for {}", getThing().getLabel());

--- a/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/internal/TransactionProcessor.java
+++ b/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/internal/TransactionProcessor.java
@@ -62,7 +62,7 @@ public final class TransactionProcessor {
     // As the Gateway is an embedded device,
 
     private static final WebServerApi API = WebServerApi.getInstance();
-    private static final int MAX_COMMAND_RETRIES = 3;
+    static final int MAX_COMMAND_RETRIES = 3;
     private static final TransactionProcessor INSTANCE = new TransactionProcessor();
 
     private final Logger logger = LoggerFactory.getLogger(TransactionProcessor.class);
@@ -207,6 +207,14 @@ public final class TransactionProcessor {
             try {
                 return sendSingleRequest(handler, request);
             } catch (TransientCommunicationIssueException tcie) {
+                // Only retry a water timer status read once, with a 3 second delay
+                if (request.command == CMD_UPDATE_WATER_TIMER_STATUS) {
+                    if (retry > 1) {
+                        return "";
+                    } else {
+                        retry = 3;
+                    }
+                }
                 --triesLeft;
                 try {
                     Thread.sleep(1000L * retry);
@@ -286,7 +294,7 @@ public final class TransactionProcessor {
                         case RET_GATEWAY_BUSY:
                         case RET_GW_INTERNAL_ERR:
                             logger.trace("The request can be re-tried");
-                            break;
+                            throw new TransientCommunicationIssueException(GATEWAY_BUSY);
                         case RET_CONFLICT_WATER_PLAN:
                             logger.trace("Gateway rejected command due to water plan conflict");
                             break;

--- a/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/frames/GatewayDeviceResponse.java
+++ b/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/frames/GatewayDeviceResponse.java
@@ -57,7 +57,7 @@ public class GatewayDeviceResponse extends TLGatewayFrame {
 
     public boolean isRetryableError() {
         switch (getRes()) {
-            case RET_CONFLICT_WATER_PLAN: // Conflict with watering plan
+            case RET_GATEWAY_BUSY: // Gateway is busy (likely booting up)
             case RET_GW_INTERNAL_ERR: // Gateway internal error
                 return true;
             default:

--- a/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/frames/GatewayEndDevListReq.java
+++ b/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/frames/GatewayEndDevListReq.java
@@ -29,7 +29,7 @@ import com.google.gson.annotations.SerializedName;
  * @author David Goodyear - Initial contribution
  */
 @NonNullByDefault
-public class GatewayEndDevListReq extends TLGatewayFrame {
+public class GatewayEndDevListReq extends GatewayDeviceResponse {
 
     protected static final Pattern FULL_DEVICE_ID_PATTERN = Pattern.compile("[a-zA-Z0-9]{20}");
 

--- a/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/http/TransientCommunicationIssueException.java
+++ b/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/http/TransientCommunicationIssueException.java
@@ -63,7 +63,12 @@ public class TransientCommunicationIssueException extends I18Exception {
         /**
          * COMMUNICATIONS_LOST
          */
-        COMMUNICATIONS_LOST("Communications Lost", "exception.communications-lost");
+        COMMUNICATIONS_LOST("Communications Lost", "exception.communications-lost"),
+
+        /**
+         * GATEWAY_BUSY
+         */
+        GATEWAY_BUSY("Gateway Busy", "exception.gateway-busy");
 
         private final String description;
         private final String i18Key;

--- a/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/http/WebServerApi.java
+++ b/bundles/org.openhab.binding.linktap/src/main/java/org/openhab/binding/linktap/protocol/http/WebServerApi.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.linktap.protocol.http.TransientCommunicationIs
 
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -166,7 +167,8 @@ public final class WebServerApi {
             throw new TransientCommunicationIssueException(COMMUNICATIONS_LOST);
         } catch (ExecutionException e) {
             final Throwable t = e.getCause();
-            if (t instanceof UnknownHostException || t instanceof SocketTimeoutException) {
+            if (t instanceof UnknownHostException || t instanceof SocketTimeoutException
+                    || t instanceof SocketException) {
                 throw new TransientCommunicationIssueException(HOST_UNREACHABLE);
             } else if (t instanceof SSLHandshakeException) {
                 throw new NotTapLinkGatewayException(UNEXPECTED_HTTPS);
@@ -457,7 +459,7 @@ public final class WebServerApi {
             final Throwable t = e.getCause();
             if (t instanceof UnknownHostException) {
                 throw new TransientCommunicationIssueException(HOST_NOT_RESOLVED);
-            } else if (t instanceof SocketTimeoutException) {
+            } else if (t instanceof SocketTimeoutException || t instanceof SocketException) {
                 throw new TransientCommunicationIssueException(HOST_UNREACHABLE);
             } else if (t instanceof SSLHandshakeException) {
                 throw new NotTapLinkGatewayException(UNEXPECTED_HTTPS);
@@ -490,7 +492,7 @@ public final class WebServerApi {
             final Throwable t = e.getCause();
             if (t instanceof UnknownHostException) {
                 throw new TransientCommunicationIssueException(HOST_NOT_RESOLVED);
-            } else if (t instanceof SocketTimeoutException) {
+            } else if (t instanceof SocketTimeoutException || t instanceof SocketException) {
                 throw new TransientCommunicationIssueException(HOST_UNREACHABLE);
             } else if (t instanceof SSLHandshakeException) {
                 throw new NotTapLinkGatewayException(UNEXPECTED_HTTPS);
@@ -560,7 +562,7 @@ public final class WebServerApi {
             throw new TransientCommunicationIssueException(HOST_NOT_RESOLVED);
         } catch (ExecutionException e) {
             final Throwable t = e.getCause();
-            if (t instanceof UnknownHostException) {
+            if (t instanceof UnknownHostException || t instanceof SocketException) {
                 throw new TransientCommunicationIssueException(HOST_NOT_RESOLVED);
             } else if (t instanceof SSLHandshakeException) {
                 throw new NotTapLinkGatewayException(UNEXPECTED_HTTPS);

--- a/bundles/org.openhab.binding.linktap/src/main/resources/OH-INF/i18n/linktap.properties
+++ b/bundles/org.openhab.binding.linktap/src/main/resources/OH-INF/i18n/linktap.properties
@@ -250,6 +250,10 @@ channel-type.linktap.waterSkipFutureRain.description = Future rainfall calculate
 channel-type.linktap.waterSkipPrevRain.label = Watering Skipped Previous Rain
 channel-type.linktap.waterSkipPrevRain.description = Previous rainfall calculated when watering was skipped
 
+# informative messages
+
+bridge.info.awaiting-init = Awaiting Gateway initialisation
+
 # errors
 
 bridge.error.host-not-found = Hostname / IP cannot be found


### PR DESCRIPTION
[linktap] Bugfix Issue 18076

This is the patch for the main branch for the LinkTap corrections.

Timing changes in the firmware have highlighted some potential race conditions that can occur, with older firmware's it may also happen.

Consequently, these changes ensure that the race conditions cannot happen, meaning the communications stack misses device registration to the gateway's data. New defensive checks on CMD16 ensure that incorrect responses are ignored / handled, which can occur when the gateway is booting up. The new ret code's are being rolled out in a firmware now globally, so these changes ensure that reply has a ret status that shows CMD16 is not ready to be used, the binding falls back, and will try again when the gateway is ready.

In addition it was noted during testing that NoRouteToHost exceptions were not being picked up correctly (when switching WiFi networks during tests), which meant that the auto reconnect capability was not running. This also add's handling by catch the SocketException base class of NoRouteToHostException, to ensure its is handled correctly.

This need's to be cherry picked back to the 4.3.X branch. In case this has to be merged first I'm adding this and linking both the PR's together. (Currently there is a PR against the 4.3.X branch with the same changes in - adding link to the comments).

Fixes #18076
