### PR TITLE
[basicprofiles] Fix inability to filter a percent QuantityType input

### DIFF
--- a/bundles/org.openhab.transform.basicprofiles/README.md
+++ b/bundles/org.openhab.transform.basicprofiles/README.md
@@ -231,11 +231,16 @@ The `LHS_OPERAND` and the `RHS_OPERAND` can be either one of these:
     It is calculated as `($DELTA / current_data) * 100`.
     Note that this can also be done by omitting the `LHS_OPERAND` and using a number followed with a percent sign `%` as the `RHS_OPERAND`.
     See the example below.
+  - `$INPUT` to represent the incoming value.
+    Conditions that compare QuantityType inputs to a constant must include the relevant unit (e.g. `> 100 W`).
+    However, when the unit is `%`, such conditions (e.g. `> 10 %`) will trigger a `$DELTA_PERCENT` check.
+    To avoid this, write the condition as `$INPUT > 10 %`.
   - `$AVERAGE`, or `$AVG` to represent the average of the previous unfiltered incoming values.
   - `$STDDEV` to represent the _population_ standard deviation of the previous unfiltered incoming values.
   - `$MEDIAN` to represent the median value of the previous unfiltered incoming values.
   - `$MIN` to represent the minimum value of the previous unfiltered incoming values.
   - `$MAX` to represent the maximum value of the previous unfiltered incoming values.
+
   These are only applicable to numeric states.
   By default, 5 samples of the previous values are kept.
   This can be customized by specifying the "window size" or sample count applicable to the function, e.g. `$MEDIAN(10)` will return the median of the last 10 values.

--- a/bundles/org.openhab.transform.basicprofiles/src/main/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfile.java
+++ b/bundles/org.openhab.transform.basicprofiles/src/main/java/org/openhab/transform/basicprofiles/internal/profiles/StateFilterProfile.java
@@ -511,6 +511,7 @@ public class StateFilterProfile implements StateProfile {
      */
     class FunctionType implements State {
         enum Function {
+            INPUT,
             DELTA,
             DELTA_PERCENT,
             AVERAGE,
@@ -535,6 +536,7 @@ public class StateFilterProfile implements StateProfile {
             int start = windowSize.map(w -> size - w).orElse(0);
             List<State> states = start <= 0 ? previousStates : previousStates.subList(start, size);
             return switch (type) {
+                case INPUT -> newState;
                 case DELTA -> calculateDelta();
                 case DELTA_PERCENT -> calculateDeltaPercent();
                 case AVG, AVERAGE -> calculateAverage(states);


### PR DESCRIPTION
Normally to filter the values of QuantityType inputs, the conditions are written as `> min_value`, e.g. `> 100 W`. However, when the QuantityType is a percent, writing it as `> 10 %` caused the statefilter parser to think it's a $DELTA_PERCENT check instead of checking the actual input value.

This is a bug and a problem, preventing the state filter from being used to filter a percent quantity type.

This PR fixes this problem by adding a new $INPUT function which can be used in this situation to help the parser, so the condition needs to be rewritten as `$INPUT > 10 %` to achieve "input-value-filter" instead of "delta-percent-filter".

This should be backported to 4.3