### PR TITLE
[Freeathome] Some more fixes

### DIFF
--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDatapoint.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDatapoint.java
@@ -87,7 +87,8 @@ public class FreeAtHomeDatapoint {
                 this.channelId = channelId;
                 this.datapointId = datapointId;
 
-                logger.debug("Datapoint is found - channel {} - datapoint {}", this.channelId, this.datapointId);
+                logger.debug("Datapoint is found - channel {} - datapoint {} - pairngId {}", this.channelId,
+                        this.datapointId, neededPairingIDFunction);
 
                 foundId = true;
             }

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDatapointGroup.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDatapointGroup.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.freeathome.internal.datamodel;
 
-import static org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapoint.*;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapoint.DatapointDirection;
 import org.openhab.binding.freeathome.internal.util.FreeAtHomeGeneralException;
 import org.openhab.binding.freeathome.internal.util.PidTranslationUtils;
 import org.openhab.binding.freeathome.internal.valuestateconverter.BooleanValueStateConverter;
@@ -56,6 +55,10 @@ public class FreeAtHomeDatapointGroup {
         datapointGroupDirection = DatapointGroupDirection.UNDEFINED;
         inputDatapoint = null;
         outputDatapoint = null;
+    }
+
+    public boolean isValid() {
+        return (inputDatapoint != null || outputDatapoint != null);
     }
 
     boolean addDatapointToGroup(DatapointDirection direction, int neededPairingId, String channelId,

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
@@ -520,7 +520,7 @@ public class FreeAtHomeDeviceChannel {
 
                 break;
             }
-            case FID_RAIN_ALARM_SENSOR: { // 0x000C Wind Alarm
+            case FID_RAIN_ALARM_SENSOR: { // 0x000E Wind Alarm
                 this.channelId = channelId;
                 logger.debug("Rain Alarm channel - Channel FID: 0x{}", channelFunctionID);
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
@@ -533,7 +533,7 @@ public class FreeAtHomeDeviceChannel {
             case FID_SCENE_SENSOR: {
                 this.channelId = channelId;
 
-                logger.error("Scene sensor channel - Channel FID: 0x{} is not yet implemented", channelFunctionID);
+                logger.warn("Scene sensor channel - Channel FID: 0x{} is not yet implemented", channelFunctionID);
 
                 break;
             }

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/datamodel/FreeAtHomeDeviceChannel.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.freeathome.internal.datamodel.FreeAtHomeDatapoint.DatapointDirection;
 import org.openhab.binding.freeathome.internal.util.FidTranslationUtils;
 import org.openhab.binding.freeathome.internal.util.FreeAtHomeGeneralException;
 import org.slf4j.Logger;
@@ -70,17 +71,20 @@ public class FreeAtHomeDeviceChannel {
             channelFunctionID = channelFunctionID.substring(0, channelFunctionID.length() - 1) + "0";
         }
 
+        logger.debug("createChannelFromJson - deviceLabel: {} channelLabel {} channelId: {} isScene {} isRule {} ",
+                deviceLabel, channelLabel, channelId, isScene, isRule);
+
         switch (Integer.parseInt(channelFunctionID, 16)) {
             case FID_PANEL_SWITCH_SENSOR:
             case FID_SWITCH_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Switch sensor channel found - Channel FID: {}", channelFunctionID);
+                logger.debug("Switch sensor channel found - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -88,17 +92,17 @@ public class FreeAtHomeDeviceChannel {
             case FID_DIMMING_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Dimming sensor channel found - Channel FID: {}", channelFunctionID);
+                logger.debug("Dimming sensor channel found - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 17, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -106,13 +110,13 @@ public class FreeAtHomeDeviceChannel {
             case FID_SWITCH_ACTUATOR: {
                 this.channelId = channelId;
 
-                logger.debug("Switch actuator channel created - Channel FID: {}", channelFunctionID);
+                logger.debug("Switch actuator channel created - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 256, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 1, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -120,28 +124,28 @@ public class FreeAtHomeDeviceChannel {
             case FID_MOVEMENT_DETECTOR: {
                 this.channelId = channelId;
 
-                logger.debug("Movement detector channel found - Channel FID: {}", channelFunctionID);
+                logger.debug("Movement detector channel found - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 6, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 7, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1027, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT_AS_OUTPUT, 256, channelId,
                         channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -150,47 +154,47 @@ public class FreeAtHomeDeviceChannel {
                 this.channelId = channelId;
 
                 if (Integer.parseInt(channelFunctionID, 16) == FID_RADIATOR_ACTUATOR_MASTER) {
-                    logger.debug("Radiator actuator channel - Channel FID: {}", channelFunctionID);
+                    logger.debug("Radiator actuator channel - Channel FID: 0x{}", channelFunctionID);
                 } else {
-                    logger.debug("Room temperature actuator channel - Channel FID: {}", channelFunctionID);
+                    logger.debug("Room temperature actuator channel - Channel FID: 0x{}", channelFunctionID);
                 }
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 304, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 333, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 331, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 54, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 51, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 320, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 68, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 58, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 56, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 66, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 // Additional channel for RTC device
                 if (Integer.parseInt(channelFunctionID, 16) == FID_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN) {
                     newDatapointGroup = new FreeAtHomeDatapointGroup();
                     newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 48, channelId, channelObject);
-                    datapointGroups.add(newDatapointGroup);
+                    AddDatapointGroup(newDatapointGroup);
                 }
 
                 break;
@@ -199,53 +203,55 @@ public class FreeAtHomeDeviceChannel {
             case FID_WINDOW_DOOR_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Window/Door position sensor channel created - Channel FID: {}", channelFunctionID);
+                logger.debug("Window/Door position sensor channel created - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
+                // 53 AL_WINDOW_DOOR Window/Door Open = 1 / closed = 0
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 53, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
+                // 41 AL_WINDOW_DOOR_POSITION Window/Door position Delivers position for Window/Door(Open/Tilted/Closed)
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 41, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_SCENE_TRIGGER: {
                 this.channelId = channelId;
 
-                logger.debug("Scene trigger channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Scene trigger channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 4, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_RULE_SWITCH: {
                 this.channelId = channelId;
 
-                logger.debug("Rule channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Rule channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 61698, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 61697, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_DES_DOOR_OPENER_ACTUATOR: {
                 this.channelId = channelId;
 
-                logger.debug("Door opener actuator channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Door opener actuator channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 256, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 2, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -253,25 +259,25 @@ public class FreeAtHomeDeviceChannel {
             case FID_DES_DOOR_RINGING_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Door ring sensor channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Door ring sensor channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 2, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_DES_LIGHT_SWITCH_ACTUATOR: {
                 this.channelId = channelId;
 
-                logger.debug("DES light switch channel - Channel FID: {}", channelFunctionID);
+                logger.debug("DES light switch channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 256, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 2, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -279,19 +285,19 @@ public class FreeAtHomeDeviceChannel {
             case FID_DIMMING_ACTUATOR: {
                 this.channelId = channelId;
 
-                logger.debug("Dimming actuator channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Dimming actuator channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 272, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 17, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 256, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 1, channelId, channelObject);
 
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
@@ -301,78 +307,88 @@ public class FreeAtHomeDeviceChannel {
             case FID_SHUTTER_ACTUATOR: {
                 this.channelId = channelId;
 
-                logger.debug("Shutter actuator channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Shutter actuator channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 32, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 288, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 33, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 288, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 289, channelId, channelObject);
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 35, channelId, channelObject);
+                AddDatapointGroup(newDatapointGroup);
 
-                datapointGroups.add(newDatapointGroup);
+                /*
+                 * 290 AL_CURRENT_ABSOLUTE_POSITION_SLATS_PERCENTAGE Current Absolute Position Slats Percentage Indicate
+                 * the current position of the slats in percentage
+                 * 36 AL_SET_ABSOLUTE_POSITION_SLATS_PERCENTAGE Set Absolute Position Slats Moves the slats into a
+                 * specified position
+                 */
+                newDatapointGroup = new FreeAtHomeDatapointGroup();
+                newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 290, channelId, channelObject);
+                newDatapointGroup.addDatapointToGroup(DatapointDirection.INPUT, 36, channelId, channelObject);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_BRIGHTNESS_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Brightness sensor channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Brightness sensor channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1026, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1027, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_RAIN_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Rain sensor channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Rain sensor channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 39, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1029, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1030, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_TEMPERATURE_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Temperature sensor channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Temperature sensor channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 if (newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 38, channelId, channelObject)) {
-                    datapointGroups.add(newDatapointGroup);
+                    AddDatapointGroup(newDatapointGroup);
                 }
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 if (newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1024, channelId, channelObject)) {
-                    datapointGroups.add(newDatapointGroup);
+                    AddDatapointGroup(newDatapointGroup);
                 }
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 if (newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 304, channelId, channelObject)) {
-                    datapointGroups.add(newDatapointGroup);
+                    AddDatapointGroup(newDatapointGroup);
                 }
 
                 break;
@@ -380,123 +396,150 @@ public class FreeAtHomeDeviceChannel {
             case FID_WIND_SENSOR: {
                 this.channelId = channelId;
 
-                logger.debug("Wind sensor channel - Channel FID: {}", channelFunctionID);
+                logger.debug("Wind sensor channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 37, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1025, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1028, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_CO: {
                 this.channelId = channelId;
 
-                logger.debug("AQS CO channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS CO channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1564, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_CO2: {
                 this.channelId = channelId;
 
-                logger.debug("AQS CO2 channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS CO2 channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1563, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_HUMIDITY: {
                 this.channelId = channelId;
 
-                logger.debug("AQS Humidity channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS Humidity channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 337, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_PRESSURE: {
                 this.channelId = channelId;
 
-                logger.debug("AQS Pressure channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS Pressure channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1562, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_NO2: {
                 this.channelId = channelId;
 
-                logger.debug("AQS NO2 channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS NO2 channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1565, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_O3: {
                 this.channelId = channelId;
 
-                logger.debug("AQS O3 channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS O3 channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1566, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_PM10: {
                 this.channelId = channelId;
 
-                logger.debug("AQS PM10 channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS PM10 channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1567, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_VOC: {
                 this.channelId = channelId;
 
-                logger.debug("AQS VOC channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS VOC channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1569, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
             case FID_AIRQUALITYSENSOR_PM25: {
                 this.channelId = channelId;
 
-                logger.debug("AQS PM25 channel - Channel FID: {}", channelFunctionID);
+                logger.debug("AQS PM25 channel - Channel FID: 0x{}", channelFunctionID);
 
                 FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
                 newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 1568, channelId, channelObject);
-                datapointGroups.add(newDatapointGroup);
+                AddDatapointGroup(newDatapointGroup);
 
                 break;
             }
+            case FID_WIND_ALARM_SENSOR: { // 0x000C Wind Alarm
+                this.channelId = channelId;
+                logger.debug("Wind Alarm channel - Channel FID: 0x{}", channelFunctionID);
+                FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
+                newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 37, channelId, channelObject);
+                AddDatapointGroup(newDatapointGroup);
+
+                break;
+            }
+            case FID_RAIN_ALARM_SENSOR: { // 0x000C Wind Alarm
+                this.channelId = channelId;
+                logger.debug("Rain Alarm channel - Channel FID: 0x{}", channelFunctionID);
+                FreeAtHomeDatapointGroup newDatapointGroup = new FreeAtHomeDatapointGroup();
+                newDatapointGroup.addDatapointToGroup(DatapointDirection.OUTPUT, 39, channelId, channelObject);
+                AddDatapointGroup(newDatapointGroup);
+
+                break;
+
+            }
+            case FID_SCENE_SENSOR: {
+                this.channelId = channelId;
+
+                logger.error("Scene sensor channel - Channel FID: 0x{} is not yet implemented", channelFunctionID);
+
+                break;
+            }
+
             default: {
-                logger.debug("Unknown channel found - Channel FID: {}", channelFunctionID);
+                logger.debug("Unknown channel found - Channel FID: 0x{}", channelFunctionID);
 
                 return false;
             }
@@ -538,6 +581,19 @@ public class FreeAtHomeDeviceChannel {
     public void applyChangesForVirtualDevice() {
         for (FreeAtHomeDatapointGroup localDatapointGroup : datapointGroups) {
             localDatapointGroup.applyChangesForVirtualDevice();
+        }
+    }
+
+    private void AddDatapointGroup(FreeAtHomeDatapointGroup DatapointGroup) {
+        if (DatapointGroup.isValid()) {
+            logger.debug("Datapoint group is added");
+            datapointGroups.add(DatapointGroup);
+        } else {
+            /*
+             * There is no constantrelationship between Function IDs and the required pairing IDs. As a result, a
+             * "needed" pairing ID may sometimes not exist. In such cases, we avoid adding an invalid datapoint group.
+             */
+            logger.warn("Datapoint group is not added, because it is not valid");
         }
     }
 }


### PR DESCRIPTION
#Description
Freeathome Binding.
There is no direct 1:1 relationship between Function IDs and the required pairing IDs. As a result, a "needed" pairing ID may sometimes not exist. In such cases, we avoid adding an invalid datapoint group.

Should fix:
https://github.com/openhab/openhab-addons/issues/17353
Added ParingID for Slat Positions

https://github.com/openhab/openhab-addons/issues/17355
Added function IDs for Wind and Rain Alarms

Thanks to @ML19821

Hint: Sorry for the git chaos - we're still exercise and learn ;)
Hint2: Good News, @uha is back again - so we hope that there will be more improvments & fixes.