### PR TITLE
Add Diva Smart Switch to Lutron LEAP autodiscovery

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
@@ -93,6 +93,7 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                             break;
                         case "WallSwitch":
                         case "PlugInSwitch":
+                        case "DivaSmartSwitch":
                             notifyDiscovery(THING_TYPE_SWITCH, deviceId, label);
                             break;
                         case "CasetaFanSpeedController":


### PR DESCRIPTION
# Add Diva Smart Switch to Lutron LEAP autodiscovery

- [jdandrews] Added Diva Smart Switch to the existing set of Lutron devices in Lutron LEAP discovery.

# Description

The Lutron LEAP discovery process finds Diva Smart Switches but didn't categorize them, so they weren't supplied
to the Inbox (they are, however, logged). This small update configures them as switches.