### PR TITLE
[mercedesme] Add missing status parameter for web socket error

### DIFF
--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -225,8 +225,7 @@ public class MBWebsocket {
 
     @OnWebSocketError
     public void onError(Throwable t) {
-        logger.warn("onError {}", t.getMessage());
         accountHandler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                "@text/mercedesme.account.status.websocket-failure");
+                "@text/mercedesme.account.status.websocket-failure [\"" + t.getMessage() + "\"]");
     }
 }


### PR DESCRIPTION
WebSocket error status detail message is declared with a parameter providing the reason. This reason isn't forwarded by the code.
This bugfix corrects it.