### PR TITLE
[insteon] Remove iolinc event button feature

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-types.xml
@@ -811,7 +811,6 @@
 	<device-type name="SensorsActuators_IOLinc">
 		<feature name="switch">GenericSwitch</feature>
 		<feature name="contact" group="2">GenericSensorContact</feature>
-		<feature name="eventButton">GenericButtonEvent</feature>
 		<feature-group name="extDataGroup" type="ExtDataGroup">
 			<feature name="momentaryDuration">IOLincMomentaryDuration</feature>
 		</feature-group>


### PR DESCRIPTION
This change removes the IOLinc device `eventButton` feature. This device doesn't have a physical button that would trigger key press events.

It should be backported as internal relay state update events are triggering false button event.