### PR TITLE
Convert i18n references in addon.xml to actual text

### DIFF
--- a/bundles/org.openhab.binding.amazondashbutton/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.amazondashbutton/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/bindingName</name>
-	<description>@text/bindingDescription</description>
+	<name>Amazon Dash Button Binding</name>
+	<description>This is the binding for the Amazon Dash Button.</description>
 	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.amazondashbutton/src/main/resources/OH-INF/i18n/amazondashbutton.properties
+++ b/bundles/org.openhab.binding.amazondashbutton/src/main/resources/OH-INF/i18n/amazondashbutton.properties
@@ -1,7 +1,7 @@
 # add-on
 
-bindingName = Amazon Dash Button Binding
-bindingDescription = This is the binding for the Amazon Dash Button.
+addon.amazondashbutton.name = Amazon Dash Button Binding
+addon.amazondashbutton.description = This is the binding for the Amazon Dash Button.
 
 # thing types
 

--- a/bundles/org.openhab.binding.digitalstrom/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,9 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/binding_name</name>
-	<description>@text/binding_desc</description>
+	<name>digitalSTROM-Binding</name>
+	<description>The digitalSTROM-Binding integrates the digitalSTROM-System and allows to control the included devices and
+		call scenes.</description>
 	<connection>local</connection>
 
 	<discovery-methods>

--- a/bundles/org.openhab.binding.digitalstrom/src/main/resources/OH-INF/i18n/digitalstrom.properties
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/resources/OH-INF/i18n/digitalstrom.properties
@@ -1,6 +1,6 @@
 # add-on
-binding_name = digitalSTROM-Binding
-binding_desc = The digitalSTROM-Binding integrates the digitalSTROM-System and allows to control the included devices and call scenes.
+addon.digitalstrom.name = digitalSTROM-Binding
+addon.digitalstrom.description = The digitalSTROM-Binding integrates the digitalSTROM-System and allows to control the included devices and call scenes.
 
 #dss-bridge
 dSS_label = digitalSTROM-Server

--- a/bundles/org.openhab.binding.icloud/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.icloud/src/main/resources/OH-INF/addon/addon.xml
@@ -3,7 +3,8 @@
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 	<type>binding</type>
-	<name>@text/icloud.addon.name</name>
-	<description>@text/icloud.addon.description</description>
+	<name>iCloud Binding</name>
+	<description>The Apple iCloud is used to retrieve data such as the battery level or current location of one or multiple
+		Apple devices connected to an iCloud account. Updates are quick and accurate without significant battery time impact.</description>
 	<connection>cloud</connection>
 </addon:addon>

--- a/bundles/org.openhab.binding.icloud/src/main/resources/OH-INF/i18n/iCloud.properties
+++ b/bundles/org.openhab.binding.icloud/src/main/resources/OH-INF/i18n/iCloud.properties
@@ -1,6 +1,6 @@
 # add-on
-icloud.addon.name=iCloud Binding
-icloud.addon.description=The Apple iCloud is used to retrieve data such as the battery level or current location of one or multiple Apple devices connected to an iCloud account. Updates are quick and accurate without significant battery time impact.
+addon.icloud.name=iCloud Binding
+addon.icloud.description=The Apple iCloud is used to retrieve data such as the battery level or current location of one or multiple Apple devices connected to an iCloud account. Updates are quick and accurate without significant battery time impact.
 
 # Account Thing
 icloud.account-thing.label=iCloud Account

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/addon.jeelink.name</name>
-	<description>@text/addon.jeelink.description</description>
+	<name>JeeLink Binding</name>
+	<description>This is the binding for JeeLink USB Receivers, LaCrosseGateways and connected sensors.</description>
 	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/addon.mielecloud.name</name>
-	<description>@text/addon.mielecloud.description</description>
+	<name>Miele@home Cloud Binding</name>
+	<description>This is the cloud-based Miele@home binding.</description>
 	<connection>cloud</connection>
 
 	<discovery-methods>

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/addon.nanoleaf.name</name>
-	<description>@text/addon.nanoleaf.description</description>
+	<name>Nanoleaf Binding</name>
+	<description>Integrates the Nanoleaf light panels</description>
 	<connection>local</connection>
 
 	<discovery-methods>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/bindingName</name>
-	<description>@text/bindingDescription</description>
+	<name>Niko Home Control Binding</name>
+	<description>This is the binding for the Niko Home Control system</description>
 	<connection>local</connection>
 
 	<discovery-methods>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/i18n/nikohomecontrol.properties
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/i18n/nikohomecontrol.properties
@@ -1,6 +1,6 @@
 # add-on
-bindingName = Niko Home Control Binding
-bindingDescription = This is the binding for the Niko Home Control system
+addon.nikohomecontrol.name = Niko Home Control Binding
+addon.nikohomecontrol.description = This is the binding for the Niko Home Control system
 
 # bridge types
 bridgeLabel = Niko Home Control I Bridge

--- a/bundles/org.openhab.binding.sagercaster/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.sagercaster/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/bindingName</name>
-	<description>@text/bindingDescription</description>
+	<name>SagerCaster Binding</name>
+	<description>The Sager Weathercaster is a scientific instrument for accurate prediction of the weather.</description>
 	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.sagercaster/src/main/resources/OH-INF/i18n/sagercaster.properties
+++ b/bundles/org.openhab.binding.sagercaster/src/main/resources/OH-INF/i18n/sagercaster.properties
@@ -1,7 +1,7 @@
 # add-on
 
-bindingName = SagerCaster Binding
-bindingDescription = The Sager Weathercaster is a scientific instrument for accurate prediction of the weather.
+addon.sagercaster.name = SagerCaster Binding
+addon.sagercaster.description = The Sager Weathercaster is a scientific instrument for accurate prediction of the weather.
 
 # thing
 

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/addon.shelly.name</name>
-	<description>@text/addon.shelly.description</description>
+	<name>Shelly Binding</name>
+	<description>This binding integrates Shelly devices that can be controlled via WiFi.</description>
 	<connection>local</connection>
 
 	<config-description>

--- a/bundles/org.openhab.binding.urtsi/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.urtsi/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,8 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/bindingLabel</name>
-	<description>@text/bindingDescription</description>
+	<name>Somfy URTSI II Binding</name>
+	<description>This is the binding for Somfy Universal RTS Interface II (URTSI II).</description>
 	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.urtsi/src/main/resources/OH-INF/i18n/urtsi.properties
+++ b/bundles/org.openhab.binding.urtsi/src/main/resources/OH-INF/i18n/urtsi.properties
@@ -1,7 +1,7 @@
 # add-on
 
-bindingDescription = This is the binding for Somfy Universal RTS Interface II (URTSI II).
-bindingLabel = Somfy URTSI II Binding
+addon.urtsi.name = Somfy URTSI II Binding
+addon.urtsi.description = This is the binding for Somfy Universal RTS Interface II (URTSI II).
 
 # thing types
 

--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/addon/addon.xml
@@ -4,8 +4,10 @@
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 
 	<type>binding</type>
-	<name>@text/addon.velux.name</name>
-	<description>@text/addon.velux.description</description>
+	<name>Velux Binding</name>
+	<description>A binding for the Velux KLF200 Bridge. The Velux Binding interacts via a Velux Bridge with the different
+		Velux devices like controlling window openers, shutters and others. For example a KLF200 can act as interface between
+		the HomeAutomation and the VELUX INTEGRA products with wireless connectivity based on the io-homecontrol standard.</description>
 	<connection>local</connection>
 
 	<discovery-methods>


### PR DESCRIPTION
The corresponding ids in the properties files are converted to the standard naming so they can be automatically inferred.

See the discussion https://github.com/openhab/openhab-addons/pull/14310#issuecomment-2601972772

TL;DR: This change here should not affect the appearance of the add-ons as they're viewed in mainUI. By using actual text, the `runtime/etc/addons.xml` which is built by combining all the addon.xml files, will contain name/description that can be used in MainUI search / display.

