### PR TITLE
Fix table of content tag

### DIFF
--- a/bundles/org.openhab.binding.modbus/README.md
+++ b/bundles/org.openhab.binding.modbus/README.md
@@ -18,10 +18,7 @@ The binding has the following extensions:
 
 The rest of this page contains details for configuring this binding:
 
-{::options toc_levels="2..4"/}
-
-- TOC
-{:toc}
+[[toc]]
 
 ## Main Features
 

--- a/bundles/org.openhab.persistence.dynamodb/README.md
+++ b/bundles/org.openhab.persistence.dynamodb/README.md
@@ -15,11 +15,7 @@ This service is provided "AS IS", and the user takes full responsibility of any 
 
 ## Table of Contents
 
-{::options toc_levels="2..4"/}
-<!-- markdownlint-disable-next-line ul-style -->
-- TOC
-
-{:toc}
+[[toc]]
 
 ## Prerequisites
 


### PR DESCRIPTION
These don't actually render. Not sure what the tags were for.

https://next.openhab.org/addons/binding/modbus/
https://next.openhab.org/addons/persistence/dynamodb/

