### PR TITLE
Provide unit hints for rpm channels

### DIFF
--- a/bundles/org.openhab.binding.comfoair/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.comfoair/src/main/resources/OH-INF/thing/thing-types.xml
@@ -557,7 +557,7 @@
 	</channel-type>
 
 	<channel-type id="fan_in_RPM" advanced="true">
-		<item-type>Number:Frequency</item-type>
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Fan In (rpm)</label>
 		<description>Current rotational speed of incoming fan</description>
 		<category>Number</category>
@@ -565,7 +565,7 @@
 	</channel-type>
 
 	<channel-type id="fan_out_RPM" advanced="true">
-		<item-type>Number:Frequency</item-type>
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Fan Out (rpm)</label>
 		<description>Current rotational speed of outgoing fan</description>
 		<category>Number</category>

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -159,14 +159,14 @@
 		<state step="10" min="0" max="100"/>
 	</channel-type>
 	<channel-type id="supplyFanSpeed">
-		<item-type>Number:Frequency</item-type>
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Supply Fan Speed</label>
 		<description>Current rotation of the fan supplying air to the rooms</description>
 		<category>Fan</category>
 		<state pattern="%.0f rpm" readOnly="true" min="0"/>
 	</channel-type>
 	<channel-type id="extractFanSpeed">
-		<item-type>Number:Frequency</item-type>
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Extract Fan Speed</label>
 		<description>Current rotation of the fan extracting air from the rooms</description>
 		<category>Fan</category>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
@@ -61,7 +61,7 @@
 	</channel-type>
 
 	<channel-type id="filterSpeedRpm">
-		<item-type>Number:Frequency</item-type>
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Filter Speed</label>
 		<description>Filter speed in rpm</description>
 		<state min="0" max="3600" step="200" pattern="%d rpm" readOnly="false"/>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
@@ -46,7 +46,7 @@
 	</channel-type>
 
 	<channel-type id="pumpSpeedRpm">
-		<item-type>Number:Frequency</item-type>
+		<item-type unitHint="rpm">Number:Frequency</item-type>
 		<label>Pump Speed</label>
 		<description>Pump speed in rpm</description>
 		<state min="0" max="3600" step="200" pattern="%d rpm" readOnly="false"/>


### PR DESCRIPTION
This ensures that the UI will suggest "rpm" rather than "Hz" when creating new items.