### PR TITLE
[huesync] - Fix for issue #18096 - docs(items): README updated

### DIFF
--- a/bundles/org.openhab.binding.huesync/README.md
+++ b/bundles/org.openhab.binding.huesync/README.md
@@ -169,7 +169,7 @@ String    huesync_mode                     "Mode"                    <switch>   
 Switch    sync_active                      "Sync active"             <switch>                                  {channel="huesync:box:LivingRoom:device-commands#sync-active"}
 Switch    hdmi_active                      "HDMI active"             <switch>                                  {channel="huesync:box:LivingRoom:device-commands#hdmi-active"}
 String    hdmi_source                      "HDMI Source"             <player>                                  {channel="huesync:box:LivingRoom:device-commands#hdmi-source"}
-Dimmer    huesync_brightness               "Brightness"              <slider>                                  {channel="huesync:box:LivingRoom:device-commands#brightness"}
+Number:Dimensionless  huesync_brightness   "Brightness"              <slider>                                  {channel="huesync:box:LivingRoom:device-commands#brightness"}
 
 ```
 


### PR DESCRIPTION
Channel type for `huesync:box:LivingRoom:device-commands#brightness` changed to `Number:Dimensionless`.

Fixes issue #18096.