### PR TITLE
[bluetooth.bluez] Fix `NullPointerException`

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -218,9 +218,9 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             return null;
         }
         for (BluetoothGattService service : dev.getGattServices()) {
-            for (BluetoothGattCharacteristic c : service.getGattCharacteristics()) {
-                if (uuid.equalsIgnoreCase(c.getUuid())) {
-                    return c;
+            for (BluetoothGattCharacteristic characteristic : service.getGattCharacteristics()) {
+                if (characteristic != null && uuid.equalsIgnoreCase(characteristic.getUuid())) {
+                    return characteristic;
                 }
             }
         }
@@ -235,7 +235,7 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
         for (BluetoothGattService service : dev.getGattServices()) {
             if (dBusPath.startsWith(service.getDbusPath())) {
                 for (BluetoothGattCharacteristic characteristic : service.getGattCharacteristics()) {
-                    if (dBusPath.startsWith(characteristic.getDbusPath())) {
+                    if (characteristic != null && dBusPath.startsWith(characteristic.getDbusPath())) {
                         return characteristic;
                     }
                 }


### PR DESCRIPTION
Fixes #18180

I had another look at the call stack in the linked issue while going through the BlueZ code again, and unfortunately the fix provided in #18181 didn't fix this exception. This PR is technically not a regression (the mentioned PR is harmless and potentially fixes another scenario), but rather a "proper fix". Nevertheless adding the label to not have it mentioned in release notes twice.