### PR TITLE
Add chapter headings for examples

### DIFF
--- a/bundles/org.openhab.binding.benqprojector/README.md
+++ b/bundles/org.openhab.binding.benqprojector/README.md
@@ -11,7 +11,7 @@ This binding supports two thing types based on the connection used: `projector-s
 
 ## Discovery
 
-If the projector has a built-in Ethernet port connected to the same network as the openHAB server and either the 'AMX Device Discovery' or 'Control4' options are present and enabled in the projector's network menu, the thing will be discovered automatically.
+If the projector has a built-in Ethernet port connected to the same network as the openHAB server and either the 'AMX Device Discovery' or 'Control4' options are present and enabled in the projector's network menu, the Thing will be discovered automatically.
 Serial port or serial over IP connections must be configured manually.
 
 ## Binding Configuration
@@ -68,7 +68,7 @@ Some notes:
 
 ## Full Example
 
-things/benq.things:
+### `benq.things` Example
 
 ```java
 // serial port connection
@@ -79,7 +79,7 @@ benqprojector:projector-tcp:hometheater "Projector" [ host="192.168.0.10", port=
 
 ```
 
-items/benq.items
+### `benq.items` Example
 
 ```java
 Switch benqPower                                      { channel="benqprojector:projector-serial:hometheater:power" }
@@ -92,7 +92,7 @@ String benqDirect                                     { channel="benqprojector:p
 Number benqLampTime     "Lamp Time [%d h]"    <light> { channel="benqprojector:projector-serial:hometheater:lamptime" }
 ```
 
-sitemaps/benq.sitemap
+### `benq.sitemap` Example
 
 ```perl
 sitemap benq label="BenQ Projector" {

--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -9,7 +9,7 @@ This binding supports two thing types based on the connection used: `projector-s
 
 ## Discovery
 
-If the projector has a built-in Ethernet port connected to the same network as the openHAB server and either the 'AMX Device Discovery' or 'Control4 SDDP' options are present and enabled in the projector's network menu, the thing will be discovered automatically.
+If the projector has a built-in Ethernet port connected to the same network as the openHAB server and either the 'AMX Device Discovery' or 'Control4 SDDP' options are present and enabled in the projector's network menu, the Thing will be discovered automatically.
 Serial port or serial over IP connections must be configured manually.
 
 ## Binding Configuration
@@ -109,7 +109,7 @@ connection: &conEpson
 
 ## Full Example
 
-things/epson.things:
+### `epson.things` Example
 
 ```java
 // serial port connection
@@ -120,7 +120,7 @@ epsonprojector:projector-tcp:hometheater "Projector" [ host="192.168.0.10", port
 
 ```
 
-items/epson.items
+### `epson.items` Example
 
 ```java
 Switch epsonPower                                      { channel="epsonprojector:projector-serial:hometheater:power" }
@@ -156,7 +156,7 @@ Number epsonErrCode     "Error Code [%d]"    <error>   { channel="epsonprojector
 String epsonErrMessage  "Error Message [%s]" <error>   { channel="epsonprojector:projector-serial:hometheater:errmessage" }
 ```
 
-sitemaps/epson.sitemap
+### `epson.sitemap` Example
 
 ```perl
 sitemap epson label="Epson Projector"

--- a/bundles/org.openhab.binding.kaleidescape/README.md
+++ b/bundles/org.openhab.binding.kaleidescape/README.md
@@ -140,7 +140,7 @@ The following channels are available:
 
 ## Full Example
 
-kaleidescape.things:
+### `kaleidescape.things` Example
 
 ```java
 kaleidescape:strato:myzone1 "Strato Theater Rm" [ host="192.168.1.10", updatePeriod=0, loadHighlightedDetails=true ]
@@ -148,7 +148,7 @@ kaleidescape:player:myzone2 "M500 Living Rm" [ host="192.168.1.11", updatePeriod
 kaleidescape:cinemaone:myzone3 "My Cinema One" [ host="192.168.1.12", updatePeriod=0, loadHighlightedDetails=true, loadAlbumDetails=true ]
 ```
 
-kaleidescape.items:
+### `kaleidescape.items` Example
 
 ```java
 // Virtual switch to send a command, see sitemap and rules below
@@ -236,7 +236,7 @@ String z1_Detail_DiscLocation "Disc Location: [%s]" { channel="kaleidescape:play
 String z1_MovieSearch "Movie Search"
 ```
 
-ksecondsformat.js:
+### `ksecondsformat.js` Example
 
 ```javascript
 (function(timestamp) {
@@ -260,7 +260,7 @@ ksecondsformat.js:
 })(input)
 ```
 
-kaleidescape.sitemap:
+### `kaleidescape.sitemap` Example
 
 ```perl
 sitemap kaleidescape label="Kaleidescape" {
@@ -350,7 +350,7 @@ sitemap kaleidescape label="Kaleidescape" {
 }
 ```
 
-kaleidescape.rules:
+### `kaleidescape.rules` Example
 
 ```java
 var int lightPercent
@@ -379,7 +379,7 @@ when
 then
     var volEvt = newState.toString()
 
-    // When `volumeBasicEnabled` is true for the thing, VOLUME_UP, VOLUME_DOWN and TOGGLE_MUTE are received from the iPad and phone apps
+    // When `volumeBasicEnabled` is true for the Thing, VOLUME_UP, VOLUME_DOWN and TOGGLE_MUTE are received from the iPad and phone apps
     // VOLUME_UP_PRESS/RELEASE, VOLUME_DOWN_PRESS/RELEASE, TOGGLE_MUTE events will always be received from the IR remote
     // *RELEASE events are not used in this example
 
@@ -459,7 +459,7 @@ then
     }
 end
 
-// The following are no longer required since the thing configuration will enable automatic loading of metatdata.
+// The following are no longer required since the Thing configuration will enable automatic loading of metatdata.
 // However the examples are still valid for advanced use cases where retrieving metadata from an arbitrary content handle is desired.
 
 rule "Load selected item Metadata"

--- a/bundles/org.openhab.binding.monopriceaudio/README.md
+++ b/bundles/org.openhab.binding.monopriceaudio/README.md
@@ -115,7 +115,7 @@ Note that `dnd`, `page` and `keypad` are not available on all thing types.
 
 ## Full Example
 
-monoprice.things:
+### `monoprice.things` Example
 
 ```java
 // Monoprice 10761, 39261 / DAX66 (serial port connection)
@@ -139,7 +139,7 @@ monopriceaudio:xantech:myamp "Xantech WHA" [ serialPort="COM5", pollingInterval=
 // Note that host and port can be used with any of the thing types to connect as serial over IP
 ```
 
-monoprice.items:
+### `monoprice.items` Example
 
 ```java
 // substitute 'amplifier' for the appropriate thing id if using 44519, 31028, DAX88 or Xantech amplifier
@@ -163,7 +163,7 @@ Switch z1_keypad "Keypad Connected: [%s]" { channel="monopriceaudio:amplifier:my
 // repeat for total number of zones used (substitute z1 and zone1)
 ```
 
-monoprice.sitemap:
+### `monoprice.sitemap` Example
 
 ```perl
 sitemap monoprice label="Audio Control" {

--- a/bundles/org.openhab.binding.nuvo/README.md
+++ b/bundles/org.openhab.binding.nuvo/README.md
@@ -124,7 +124,7 @@ The following channels are available:
 
 ## Full Example
 
-nuvo.things:
+### `nuvo.things` Example
 
 ```java
 // serial port connection
@@ -138,7 +138,7 @@ nuvo:amplifier:myamp "Nuvo WHA" [ host="192.168.0.10", port=5006, numZones=6, cl
 
 ```
 
-nuvo.items:
+### `nuvo.items` Example
 
 ```java
 // system
@@ -240,7 +240,7 @@ String nuvo_s6_button_press "Button: [%s]" { channel="nuvo:amplifier:myamp:sourc
 
 ```
 
-nuvo.sitemap:
+### `nuvo.sitemap` Example
 
 ```perl
 sitemap nuvo label="Audio Control" {
@@ -345,7 +345,7 @@ sitemap nuvo label="Audio Control" {
 
 ```
 
-nuvo.rules:
+### `nuvo.rules` Example
 
 ```java
 import java.text.Normalizer
@@ -504,7 +504,7 @@ Also if a menu item from a custom menu was selected, ie: `Top menu 1` on Zone 5,
 
 The functionality can be used to create very powerful rules as demontrated below. The following rule triggered from a menu item turns off all zones except for the zone that triggered the rule.
 
-nuvo-turn-off-all-but-caller.rules:
+#### `nuvo-turn-off-all-but-caller.rules` Example
 
 ```java
 rule "Turn off all zones except caller zone"
@@ -545,7 +545,7 @@ By using these rules, it is possible to have artist, album and track names displ
 Global Favorites selection and Menu selections from the custom menus described above are also processed by these rules.
 The list of favorite names should be playable via another thing connected to openHAB and this thing should have a means to accept a text string that tells it to play a particular favorite/playlist.
 
-nuvo-advanced.rules:
+#### `nuvo-advanced.rules.rules` Example
 
 ```java
 import java.text.Normalizer

--- a/bundles/org.openhab.binding.oppo/README.md
+++ b/bundles/org.openhab.binding.oppo/README.md
@@ -118,7 +118,7 @@ The following channels are available:
 
 ## Full Example
 
-oppo.things:
+### `oppo.things` Example
 
 ```java
 // direct IP connection
@@ -132,7 +132,7 @@ oppo:player:myoppo "Oppo Blu-ray" [ host="192.168.0.9", port=4444, model=103, ve
 
 ```
 
-oppo.items:
+### `oppo.items` Example
 
 ```java
 Switch oppo_power "Power" { channel="oppo:player:myoppo:power" }
@@ -163,7 +163,7 @@ String oppo_hdr_mode "HDR Mode [%s]" { channel="oppo:player:myoppo:hdr_mode" }
 String oppo_remote_button "Remote Button [%s]" { channel="oppo:player:myoppo:remote_button" }
 ```
 
-secondsformat.js:
+### `secondsformat.js` Example
 
 ```javascript
 (function(timestamp) {
@@ -190,7 +190,7 @@ secondsformat.js:
 })(input)
 ```
 
-oppo.sitemap:
+### `oppo.sitemap` Example
 
 ```perl
 sitemap oppo label="Oppo Blu-ray" {

--- a/bundles/org.openhab.binding.panasonicbdp/README.md
+++ b/bundles/org.openhab.binding.panasonicbdp/README.md
@@ -43,7 +43,7 @@ Multiple Things can be added if more than one player is to be controlled.
 ## Discovery
 
 Auto-discovery is supported if the player can be located on the local network using UPnP.
-Otherwise the thing must be manually added.
+Otherwise the Thing must be manually added.
 
 ## Binding Configuration
 
@@ -84,14 +84,14 @@ The following channels are available:
 
 ## Full Example
 
-panasonicbdp.things:
+### `panasonicbdp.things` Example
 
 ```java
 panasonicbdp:bd-player:mybdplayer "My Blu-ray player" [ hostName="192.168.10.1", refresh=5 ]
 panasonicbdp:uhd-player:myuhdplayer "My UHD Blu-ray player" [ hostName="192.168.10.1", refresh=5, playerKey="ABCDEF1234567890abcdef0123456789" ]
 ```
 
-panasonicbdp.items:
+### `panasonicbdp.items` Example
 
 ```java
 // BD Player
@@ -112,7 +112,7 @@ String Player_PlayerStatus     "Status: [%s]"              { channel="panasonicb
 Number:Time Player_TimeElapsed "Elapsed Time: [%d %unit%]" { channel="panasonicbdp:uhd-player:myuhdplayer:time-elapsed" }
 ```
 
-panasonicbdp.sitemap:
+### `panasonicbdp.sitemap` Example
 
 ```perl
 sitemap panasonicbdp label="Panasonic Blu-ray" {

--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -17,7 +17,7 @@ Multiple Things can be added if more than one thermostat is to be controlled.
 ## Discovery
 
 Auto-discovery is supported if the thermostat can be located on the local network using SSDP.
-Otherwise the thing must be manually added.
+Otherwise the Thing must be manually added.
 
 ## Thing Configuration
 
@@ -101,7 +101,7 @@ The thermostat information that is retrieved is available as these channels:
 
 ## Full Example
 
-radiotherm.map:
+### `radiotherm.map` Example
 
 ```text
 UNDEF_stus=-
@@ -144,14 +144,14 @@ NULL_over=-
 
 ```
 
-radiotherm.things:
+### `radiotherm.things` Example
 
 ```java
 radiothermostat:rtherm:mytherm1 "My 1st floor thermostat" [ hostName="192.168.10.1", refresh=2, logRefresh=10, isCT80=false, disableLogs=false, setpointMode="temporary" ]
 radiothermostat:rtherm:mytherm2 "My 2nd floor thermostat" [ hostName="mythermhost2", refresh=1, logRefresh=20, isCT80=true, disableLogs=false, setpointMode="absolute" ]
 ```
 
-radiotherm.items:
+### `radiotherm.items` Example
 
 ```java
 Number:Temperature Therm_Temp     "Current Temperature [%.1f °F]" <temperature>   { channel="radiothermostat:rtherm:mytherm1:temperature" }
@@ -188,7 +188,7 @@ Number:Temperature Therm_Rtemp    "Remote Temperature [%d]" <temperature>       
 Switch Therm_mysetting   "Send my preferred setting"
 ```
 
-radiotherm.sitemap:
+### `radiotherm.sitemap` Example
 
 ```perl
 sitemap radiotherm label="My Thermostat" {
@@ -228,7 +228,7 @@ sitemap radiotherm label="My Thermostat" {
 }
 ```
 
-radiotherm.rules:
+### `radiotherm.rules` Example
 
 ```java
 rule "Send my thermostat command"

--- a/bundles/org.openhab.binding.roku/README.md
+++ b/bundles/org.openhab.binding.roku/README.md
@@ -17,7 +17,7 @@ Multiple Things can be added if more than one Roku is to be controlled.
 ## Discovery
 
 Auto-discovery is supported if the Roku can be located on the local network using SSDP.
-Otherwise the thing must be manually added.
+Otherwise the Thing must be manually added.
 
 ## Binding Configuration
 

--- a/bundles/org.openhab.binding.tasmotaplug/README.md
+++ b/bundles/org.openhab.binding.tasmotaplug/README.md
@@ -54,14 +54,14 @@ If the number of channels must be increased, delete the Thing and re-create it w
 
 ## Full Example
 
-tasmotaplug.things:
+### `tasmotaplug.things` Example
 
 ```java
 tasmotaplug:plug:plug1 "Plug 1" [ hostName="192.168.10.1", refresh=30 ]
 tasmotaplug:plug:plug2 "Plug 2" [ hostName="myplug2", refresh=30 ]
 ```
 
-tasmotaplug.items:
+### `tasmotaplug.items` Example
 
 ```java
 Switch Plug1 "Plug 1 Power"                   { channel="tasmotaplug:plug:plug1:power" }
@@ -82,7 +82,7 @@ Switch Plug2c "4ch Power 3" { channel="tasmotaplug:plug:plug2:power3" }
 Switch Plug2d "4ch Power 4" { channel="tasmotaplug:plug:plug2:power4" }
 ```
 
-tasmotaplug.sitemap:
+### `tasmotaplug.sitemap` Example
 
 ```perl
 sitemap tasmotaplug label="My Tasmota Plugs" {

--- a/bundles/org.openhab.binding.tivo/README.md
+++ b/bundles/org.openhab.binding.tivo/README.md
@@ -65,7 +65,7 @@ All devices support the following channels:
 - To send multiple copies of the same keyboard command, append an asterisk with the number of repeats required e.g. NUM2*4 would send the number 2 four times. This is useful for performing searches where the number characters can only be accessed by pressing the keys multiple times in rapid succession i.e. each key press cycles through characters A, B, C, 2.
 - Special characters must also be changed to the appropriate command e.g. the comma symbol(`,`) must not be sent it should be replaced by 'COMMA'.
 
-Available IR Commands to use with `irCommand` channel:
+### Available IR Commands to use with `irCommand` channel:
 
 - UP
 - DOWN
@@ -125,17 +125,16 @@ Available IR Commands to use with `irCommand` channel:
 
 ## Full Example
 
-### tivo.things
+### `tivo.things` Example 
 
 ```java
 tivo:sckt:Living_Room "Living Room TiVo" [ host="192.168.0.19" ]
 
 ```
 
-**tivo.items:**
+### `tivo.items` Example 
 
 ```java
-/* TIVO */
 String      TiVo_Status         "Status"          {channel="tivo:sckt:Living_Room:dvrStatus"}
 String      TiVo_MenuScreen     "Menu Screen"     {channel="tivo:sckt:Living_Room:menuTeleport"}
 Number      TiVo_SetChannel     "Current Channel" {channel="tivo:sckt:Living_Room:channelSet"}
@@ -151,7 +150,7 @@ String      TiVo_KeyboardStr    "Search String"
 - A simulated remote control widget is available using the Buttongrid sitemap element described below.
 - A more advanced simulated remote can also be implemented as described here: (<https://community.openhab.org/t/bogob-big-ol-grid-o-buttons-is-this-even-possible-yes-yes-it-is/115343>).
 
-### tivo.sitemap
+### `tivo.sitemap` Example 
 
 ```perl
 sitemap tivo label="Tivo Central" {
@@ -177,7 +176,7 @@ sitemap tivo label="Tivo Central" {
 
 - This example does not use the 'Current Channel - Forced (FORCECH)' channel. This method will interrupt your recordings in progress when all your tuners are busy, so it is omitted for safety's sake.
 
-### tivo.map
+### `tivo.map` Example 
 
 ```text
 NULL=Unknown
@@ -199,7 +198,7 @@ rec-1=Recording
 etc...
 ```
 
-### tivo.rules
+### `tivo.rules` Example
 
 - The following rule shows how a string change to the item `TiVo_KeyboardStr` is split into individual characters and sent to the Tivo.
 

--- a/bundles/org.openhab.binding.vizio/README.md
+++ b/bundles/org.openhab.binding.vizio/README.md
@@ -11,7 +11,7 @@ Multiple Things can be added if more than one Vizio TV is to be controlled.
 ## Discovery
 
 Auto-discovery is supported if the Vizio TV can be located on the local network using mDNS.
-Otherwise the thing must be manually added.
+Otherwise the Thing must be manually added.
 When the TV is discovered, a pairing process to obtain an authentication token from the TV must be completed using the openHAB console. See below for details.
 
 ## Thing Configuration
@@ -48,12 +48,12 @@ openhab:vizio <thingUID> submit_code <pairingCode>
 Substitute `<thingUID>` with the same thing id used above
 Substitute `<pairingCode>` with the 4-digit pairing code displayed on the TV, ie: `1234`
 
-The console should then indicate that pairing was successful (token will be displayed) and that the token was saved to the thing configuration.
-If using file-based provisioning of the thing, the authorization token must be added to the thing configuration manually.
+The console should then indicate that pairing was successful (token will be displayed) and that the token was saved to the Thing configuration.
+If using file-based provisioning of the Thing, the authorization token must be added to the Thing configuration manually.
 With an authorization token in place, the binding can now control the TV.
 
 The authorization token text can be re-used in the event that it becomes necessary to setup the binding again.
-By simply adding the token that is already recognized by the TV to the thing configuration, the pairing process can be bypassed.
+By simply adding the token that is already recognized by the TV to the Thing configuration, the pairing process can be bypassed.
 
 ## Channels
 
@@ -108,8 +108,8 @@ The following channels are available:
 The Vizio API to launch and identify currently running apps on the TV is very complex.
 To handle this, the binding maintains a JSON database of applications and their associated metadata in order to populate the `activeApp` dropdown with available apps.
 
-When the thing is started for the first time, this JSON database is saved into the `appListJson` configuration parameter.
-This list of apps can be edited via the script editor on the thing configuration.
+When the Thing is started for the first time, this JSON database is saved into the `appListJson` configuration parameter.
+This list of apps can be edited via the script editor on the Thing configuration.
 By editing the JSON, apps that are not desired can be removed from the `activeApp` dropdown and newly discovered apps can be added.
 
 An entry for an application has a `name` element and a `config` element containing `APP_ID`, `NAME_SPACE` and `MESSAGE` (null for most apps):
@@ -134,12 +134,12 @@ If an app that is in the JSON database fails to start when selected, try adjusti
 A current list of `APP_ID`'s can be found at <http://scfs.vizio.com/appservice/vizio_apps_prod.json>
 and `NAME_SPACE` &amp; `MESSAGE` values needed can be found at <http://scfs.vizio.com/appservice/app_availability_prod.json>
 
-If there is an error in the user supplied `appListJson`, the thing will fail to start and display a CONFIGURATION_ERROR message.
-If all text in `appListJson` is removed (set to null) and the thing configuration saved, the binding will restore `appListJson` from the binding's JSON db.
+If there is an error in the user supplied `appListJson`, the Thing will fail to start and display a CONFIGURATION_ERROR message.
+If all text in `appListJson` is removed (set to null) and the Thing configuration saved, the binding will restore `appListJson` from the binding's JSON db.
 
 ## Full Example
 
-vizio.things:
+### `vizio.things` Example
 
 ```java
 // Vizio TV
@@ -147,7 +147,7 @@ vizio:vizio_tv:mytv1 "My Vizio TV" [ hostName="192.168.10.1", port=7345, authTok
 
 ```
 
-vizio.items:
+### `vizio.items` Example
 
 ```java
 // Vizio TV items:
@@ -162,7 +162,7 @@ String TV_Button      "Send Command to TV" { channel="vizio:vizio_tv:mytv1:butto
 
 ```
 
-vizio.sitemap:
+### `vizio.sitemap` Example
 
 ```perl
 sitemap vizio label="Vizio" {


### PR DESCRIPTION
Add chapter headings for examples in all bindings for which I am code owner. This follows the suggestion in #18154 to delineate each file example as a chapter. Also normalize the capitalization of `Thing` throughout.