### PR TITLE
[evcc] Fix missing grid readings after evcc breaking change in 0.133.0

### DIFF
--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -420,7 +420,7 @@ public class EvccHandler extends BaseThingHandler {
             updateStatus(ThingStatus.ONLINE);
             Battery[] batteries = result.getBattery();
             batteryConfigured = ((batteries != null) && (batteries.length > 0));
-            gridConfigured = (result.getGridPower() != null);
+            gridConfigured = result.getGridConfigured();
             PV[] pvs = result.getPV();
             pvConfigured = ((pvs != null) && (pvs.length > 0));
             createChannelsGeneral();
@@ -712,7 +712,7 @@ public class EvccHandler extends BaseThingHandler {
         }
         boolean gridConfigured = this.gridConfigured;
         if (gridConfigured) {
-            float gridPower = ((result.getGridPower() == null) ? 0.0f : result.getGridPower());
+            float gridPower = ((result.getGrid().getPower() == null) ? 0.0f : result.getGrid().getPower());
             channel = new ChannelUID(uid, CHANNEL_GROUP_ID_GENERAL, CHANNEL_GRID_POWER);
             updateState(channel, new QuantityType<>(gridPower, Units.WATT));
         }

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -29,12 +29,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.evcc.internal.api.EvccAPI;
 import org.openhab.binding.evcc.internal.api.EvccApiException;
-import org.openhab.binding.evcc.internal.api.dto.Battery;
-import org.openhab.binding.evcc.internal.api.dto.Loadpoint;
-import org.openhab.binding.evcc.internal.api.dto.PV;
-import org.openhab.binding.evcc.internal.api.dto.Plan;
-import org.openhab.binding.evcc.internal.api.dto.Result;
-import org.openhab.binding.evcc.internal.api.dto.Vehicle;
+import org.openhab.binding.evcc.internal.api.dto.*;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DateTimeType;
@@ -712,7 +707,12 @@ public class EvccHandler extends BaseThingHandler {
         }
         boolean gridConfigured = this.gridConfigured;
         if (gridConfigured) {
-            float gridPower = ((result.getGrid().getPower() == null) ? 0.0f : result.getGrid().getPower());
+            // handling gridPower prior to changes in evcc version 0.133.0
+            float gridPower = ((result.getGridPower() == null) ? 0.0f : result.getGridPower());
+            Grid grid = result.getGrid();
+            if (grid != null) {
+                gridPower = ((grid.getPower() == null) ? 0.0f : grid.getPower());
+            }
             channel = new ChannelUID(uid, CHANNEL_GROUP_ID_GENERAL, CHANNEL_GRID_POWER);
             updateState(channel, new QuantityType<>(gridPower, Units.WATT));
         }

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Grid.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Grid.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.evcc.internal.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * This class represents the grid response (/api/state).
+ * This DTO was written for evcc version 0.133.0
+ *
+ * @author Daniel Kötting - Initial contribution
+ */
+public class Grid {
+    // Data types from https://github.com/evcc-io/evcc/blob/master/api/api.go
+    // and from https://docs.evcc.io/docs/reference/configuration/messaging/#msg
+
+    @SerializedName("currents")
+    private float[] currents;
+
+    @SerializedName("energy")
+    private float energy;
+
+    @SerializedName("power")
+    private Float power;
+
+    /**
+     * @return grid's currents
+     */
+    public float[] getCurrents() {
+        return currents;
+    }
+
+    /**
+     * @return grid's energy
+     */
+    public float getEnergy() {
+        return energy;
+    }
+
+    /**
+     * @return grid's power or {@code null} if not available
+     */
+    public Float getPower() {
+        return power;
+    }
+}

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -49,6 +49,9 @@ public class Result {
     @SerializedName("batteryMode")
     private String batteryMode;
 
+    @SerializedName("gridPower")
+    private Float gridPower;
+
     @SerializedName("grid")
     private Grid grid;
 
@@ -159,6 +162,13 @@ public class Result {
      */
     public String getBatteryMode() {
         return batteryMode;
+    }
+
+    /**
+     * @return gridPower (before evcc version 0.133.0)
+     */
+    public Float getGridPower() {
+        return gridPower;
     }
 
     /**

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -49,14 +49,11 @@ public class Result {
     @SerializedName("batteryMode")
     private String batteryMode;
 
-    @SerializedName("gridCurrents")
-    private float[] gridCurrents;
+    @SerializedName("grid")
+    private Grid grid;
 
-    @SerializedName("gridEnergy")
-    private float gridEnergy;
-
-    @SerializedName("gridPower")
-    private Float gridPower;
+    @SerializedName("gridConfigured")
+    private boolean gridConfigured;
 
     @SerializedName("homePower")
     private float homePower;
@@ -165,24 +162,17 @@ public class Result {
     }
 
     /**
-     * @return grid's currents
+     * @return all grid related values
      */
-    public float[] getGridCurrents() {
-        return gridCurrents;
+    public Grid getGrid() {
+        return grid;
     }
 
     /**
-     * @return grid's energy
+     * @return is grid configured
      */
-    public float getGridEnergy() {
-        return gridEnergy;
-    }
-
-    /**
-     * @return grid's power or {@code null} if not available
-     */
-    public Float getGridPower() {
-        return gridPower;
+    public boolean getGridConfigured() {
+        return gridConfigured;
     }
 
     /**


### PR DESCRIPTION
Fixes #18148

This PR fixes the new alignment of grid data comming from evccs /api/state endpoint.
The old and new structure can be seen in this conversation over at evcc https://github.com/evcc-io/evcc/pull/18063

This change is not backwards compatible with older versions of evcc.