### PR TITLE
[astro] Update real-time Moon Phase Age

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonCalc.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/calc/MoonCalc.java
@@ -118,9 +118,9 @@ public class MoonCalc {
      */
     private void setMoonPhase(Calendar calendar, Moon moon) {
         MoonPhase phase = moon.getPhase();
-        double julianDateEndOfDay = DateTimeUtils.endOfDayDateToJulianDate(calendar);
-        double parentNewMoon = getPreviousPhase(calendar, julianDateEndOfDay, NEW_MOON);
-        double age = Math.abs(parentNewMoon - julianDateEndOfDay);
+        double julianDate = DateTimeUtils.dateToJulianDate(calendar);
+        double parentNewMoon = getPreviousPhase(calendar, julianDate, NEW_MOON);
+        double age = Math.abs(parentNewMoon - julianDate);
         phase.setAge(age);
 
         long parentNewMoonMillis = DateTimeUtils.toCalendar(parentNewMoon).getTimeInMillis();
@@ -129,7 +129,7 @@ public class MoonCalc {
         double agePercent = ageRangeTimeMillis != 0 ? ageCurrentMillis * 100.0 / ageRangeTimeMillis : 0;
         phase.setAgePercent(agePercent);
         phase.setAgeDegree(3.6 * agePercent);
-        double illumination = getIllumination(DateTimeUtils.dateToJulianDate(calendar));
+        double illumination = getIllumination(julianDate);
         phase.setIllumination(illumination);
         boolean isWaxing = age < (29.530588853 / 2);
         if (DateTimeUtils.isSameDay(calendar, phase.getNew())) {

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/util/DateTimeUtils.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/util/DateTimeUtils.java
@@ -130,13 +130,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Returns the end of day julian date from the calendar object.
-     */
-    public static double endOfDayDateToJulianDate(Calendar calendar) {
-        return dateToJulianDate(endOfDayDate(calendar));
-    }
-
-    /**
      * Returns the year of the calendar object as a decimal value.
      */
     public static double getDecimalYear(Calendar calendar) {


### PR DESCRIPTION
Instead of returning a constant value of the moon phase age relative to the start of the day, return the real-time calculation of the moon phase age on each channel update

See https://community.openhab.org/t/astro-binding-is-moon-phase-age-and-other-phase-channels-not-recalculated-with-the-thing-set-interval/162111