### PR TITLE
[mqtt] Set distinct action labels

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/action/MQTTActions.java
@@ -55,7 +55,7 @@ public class MQTTActions implements ThingActions {
         publishMQTT(topic, value, null);
     }
 
-    @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")
+    @RuleAction(label = "@text/actionRetainLabel", description = "@text/actionRetainDesc")
     public void publishMQTT(
             @ActionInput(name = "topic", label = "@text/actionInputTopicLabel", description = "@text/actionInputTopicDesc") @Nullable final String topic,
             @ActionInput(name = "value", label = "@text/actionInputValueLabel", description = "@text/actionInputValueDesc") @Nullable final String value,
@@ -74,7 +74,7 @@ public class MQTTActions implements ThingActions {
         publishMQTT(topic, value, null);
     }
 
-    @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")
+    @RuleAction(label = "@text/actionRetainLabel", description = "@text/actionRetainDesc")
     public void publishMQTT(
             @ActionInput(name = "topic", label = "@text/actionInputTopicLabel", description = "@text/actionInputTopicDesc") @Nullable final String topic,
             @ActionInput(name = "value", label = "@text/actionInputValueLabel", description = "@text/actionInputValueDesc") final byte[] value,

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt.properties
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt.properties
@@ -98,6 +98,8 @@ actionInputRetainLabel = Retain
 actionInputRetainDesc = Retain message
 actionLabel = publish an MQTT message
 actionDesc = Publishes a value to the given MQTT topic.
+actionRetainLabel = publish an MQTT message with retain option
+actionRetainDesc = Publishes a value with retain option to the given MQTT topic.
 
 # thing status
 

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt.properties
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/i18n/mqtt.properties
@@ -98,8 +98,8 @@ actionInputRetainLabel = Retain
 actionInputRetainDesc = Retain message
 actionLabel = publish an MQTT message
 actionDesc = Publishes a value to the given MQTT topic.
-actionRetainLabel = publish an MQTT message with retain option
-actionRetainDesc = Publishes a value with retain option to the given MQTT topic.
+actionRetainLabel = publish an MQTT message with given retain option
+actionRetainDesc = Publishes a value with given retain option to the given MQTT topic.
 
 # thing status
 


### PR DESCRIPTION
This is so they can be differentiated in MainUI

Before
<img width="277" alt="image" src="https://github.com/user-attachments/assets/83c0543d-ef12-4938-ae58-ab5adcba13bf" />


After
<img width="365" alt="image" src="https://github.com/user-attachments/assets/d25731f0-95c9-4b3d-ac14-6161848e6dfa" />
