### PR TITLE
[jsscripting] Fix memory leak caused by GraalJSScriptEngine not closed properly

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/DebuggingGraalScriptEngine.java
@@ -73,12 +73,20 @@ class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoClosea
         // OPS4J Pax Logging holds a reference to the exception, which causes the OpenhabGraalJSScriptEngine to not be
         // removed from heap by garbage collection and causing a memory leak.
         // Therefore, don't pass the exceptions itself to the logger, but only their message!
-        if (cause instanceof IllegalArgumentException) {
-            logger.error("Failed to execute script: {}", stringifyThrowable(cause));
-        } else if (cause instanceof PolyglotException) {
-            logger.error("Failed to execute script: {}", stringifyThrowable(cause));
+        if (cause instanceof IllegalArgumentException || cause instanceof PolyglotException) {
+            String strT = stringifyThrowable(cause);
+            logger.error("Failed to execute script: {}", strT);
         }
         return e;
+    }
+
+    @Override
+    public void close() {
+        try {
+            super.close();
+        } catch (Exception e) {
+            logger.warn("Ignorable exception during close: {}", stringifyThrowable(e));
+        }
     }
 
     private String stringifyThrowable(Throwable throwable) {
@@ -106,10 +114,9 @@ class DebuggingGraalScriptEngine<T extends ScriptEngine & Invocable & AutoClosea
             identifier = fileName.toString().replaceAll("^.*[/\\\\]", "");
         } else if (ruleUID != null) {
             identifier = ruleUID.toString();
-        } else if (ohEngineIdentifier != null) {
-            if (ohEngineIdentifier.toString().startsWith(OPENHAB_TRANSFORMATION_SCRIPT)) {
-                identifier = ohEngineIdentifier.toString().replaceAll(OPENHAB_TRANSFORMATION_SCRIPT, "transformation.");
-            }
+        } else if (ohEngineIdentifier != null
+                && ohEngineIdentifier.toString().startsWith(OPENHAB_TRANSFORMATION_SCRIPT)) {
+            identifier = ohEngineIdentifier.toString().replaceAll(OPENHAB_TRANSFORMATION_SCRIPT, "transformation.");
         }
 
         logger = LoggerFactory.getLogger("org.openhab.automation.script.javascript." + identifier);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -345,8 +345,10 @@ public class OpenhabGraalJSScriptEngine
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
         jsRuntimeFeatures.close();
+        // we must not close the engine before closing the runtime features, otherwise the runtime features cannot be closed properly
+        super.close();
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -54,6 +54,7 @@ import org.openhab.automation.jsscripting.internal.fs.PrefixedSeekableByteChanne
 import org.openhab.automation.jsscripting.internal.fs.ReadOnlySeekableByteArrayChannel;
 import org.openhab.automation.jsscripting.internal.fs.watch.JSDependencyTracker;
 import org.openhab.automation.jsscripting.internal.scriptengine.InvocationInterceptingScriptEngineWithInvocableAndCompilableAndAutoCloseable;
+import org.openhab.automation.jsscripting.internal.scriptengine.helper.LifecycleTracker;
 import org.openhab.core.automation.module.script.ScriptExtensionAccessor;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.types.QuantityType;
@@ -138,6 +139,7 @@ public class OpenhabGraalJSScriptEngine
     /** {@link Lock} synchronization of multi-thread access */
     private final Lock lock = new ReentrantLock();
     private final JSRuntimeFeatures jsRuntimeFeatures;
+    private final LifecycleTracker lifecycleTracker = new LifecycleTracker();
     private final GraalJSScriptEngineConfiguration configuration;
 
     // these fields start as null because they are populated on first use
@@ -145,6 +147,7 @@ public class OpenhabGraalJSScriptEngine
     private String engineIdentifier = "<uninitialized>";
 
     private boolean initialized = false;
+    private boolean closed = false;
 
     /**
      * Creates an implementation of ScriptEngine {@code (& Invocable)}, wrapping the contained engine,
@@ -283,7 +286,7 @@ public class OpenhabGraalJSScriptEngine
         scriptDependencyListener = localScriptDependencyListener;
 
         ScriptExtensionModuleProvider scriptExtensionModuleProvider = new ScriptExtensionModuleProvider(
-                scriptExtensionAccessor, lock);
+                scriptExtensionAccessor, lock, lifecycleTracker);
 
         // Wrap the "require" function to also allow loading modules from the ScriptExtensionModuleProvider
         Function<Function<Object[], Object>, Function<String, Object>> wrapRequireFn = originalRequireFn -> moduleName -> scriptExtensionModuleProvider
@@ -346,10 +349,25 @@ public class OpenhabGraalJSScriptEngine
 
     @Override
     public void close() throws Exception {
+        if (closed) {
+            logger.debug("Engine '{}' is already disposed and closed.", engineIdentifier);
+            return;
+        }
+
+        lock.lock();
         jsRuntimeFeatures.close();
-        // we must not close the engine before closing the runtime features, otherwise the runtime features cannot be
-        // closed properly
-        super.close();
+        try {
+            try {
+                this.lifecycleTracker.dispose();
+            } finally {
+                logger.debug("Engine '{}' disposed.", engineIdentifier);
+                super.close();
+                logger.debug("Engine '{}' closed.", engineIdentifier);
+            }
+        } finally {
+            closed = true;
+            lock.unlock();
+        }
     }
 
     /**

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -356,8 +356,8 @@ public class OpenhabGraalJSScriptEngine
 
         lock.lock();
         try {
-            jsRuntimeFeatures.close();
             try {
+                jsRuntimeFeatures.close();
                 this.lifecycleTracker.dispose();
             } finally {
                 logger.debug("Engine '{}' disposed.", engineIdentifier);

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -355,8 +355,8 @@ public class OpenhabGraalJSScriptEngine
         }
 
         lock.lock();
-        jsRuntimeFeatures.close();
         try {
+            jsRuntimeFeatures.close();
             try {
                 this.lifecycleTracker.dispose();
             } finally {

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/OpenhabGraalJSScriptEngine.java
@@ -347,7 +347,8 @@ public class OpenhabGraalJSScriptEngine
     @Override
     public void close() throws Exception {
         jsRuntimeFeatures.close();
-        // we must not close the engine before closing the runtime features, otherwise the runtime features cannot be closed properly
+        // we must not close the engine before closing the runtime features, otherwise the runtime features cannot be
+        // closed properly
         super.close();
     }
 

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/helper/LifecycleTracker.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/helper/LifecycleTracker.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jsscripting.internal.scriptengine.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * LifecycleTracker implementation
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class LifecycleTracker {
+    private List<Runnable> disposables = new ArrayList<>();
+
+    public void addDisposeHook(Runnable disposable) {
+        disposables.add(disposable);
+    }
+
+    public void dispose() {
+        for (Runnable disposable : disposables) {
+            disposable.run();
+        }
+    }
+}

--- a/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/helper/LifecycleTracker.java
+++ b/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scriptengine/helper/LifecycleTracker.java
@@ -20,6 +20,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 /**
  * LifecycleTracker implementation
  *
+ * <p>
+ * We can't use core's lifecycle tracker for JS Scripting, because its dispose hooks are called after the engine has
+ * been closed (which will not work).
+ *
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault


### PR DESCRIPTION
Fixes #18224.

This overwrites core's LifecycleTracker as we need to handle the lifecycle tracking internally, because if we properly close the engine, core is unable to run the dispose hook of the lifecycle tracker as the context is already closed.
I think the main issue is that core's lifecycle tracker is disposed after core closes the engine, fixing this in core however would require a bigger refactoring.