### PR TITLE
[homekit] fix unit conversions on step values for temperatures

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -610,11 +610,6 @@ public class HomekitCharacteristicFactory {
         return convertAndRound(degrees, SIUnits.CELSIUS, getSystemTemperatureUnit());
     }
 
-    public static double getTemperatureStep(HomekitTaggedItem taggedItem, double defaultValue) {
-        return taggedItem.getConfigurationAsQuantity(HomekitTaggedItem.STEP,
-                new QuantityType(defaultValue, SIUnits.CELSIUS), true).doubleValue();
-    }
-
     private static Supplier<CompletableFuture<Integer>> getAngleSupplier(HomekitTaggedItem taggedItem,
             int defaultValue) {
         return () -> CompletableFuture.completedFuture(getAngleFromItem(taggedItem, defaultValue));
@@ -899,7 +894,7 @@ public class HomekitCharacteristicFactory {
                         Objects.requireNonNull(new QuantityType(CoolingThresholdTemperatureCharacteristic.DEFAULT_STEP,
                                 SIUnits.CELSIUS).toUnit(getSystemTemperatureUnit())),
                         true)
-                .toUnit(SIUnits.CELSIUS).doubleValue();
+                .toUnitRelative(SIUnits.CELSIUS).doubleValue();
         return new CoolingThresholdTemperatureCharacteristic(minValue, maxValue, step,
                 getTemperatureSupplier(taggedItem, minValue), setTemperatureConsumer(taggedItem),
                 getSubscriber(taggedItem, COOLING_THRESHOLD_TEMPERATURE, updater),
@@ -979,7 +974,7 @@ public class HomekitCharacteristicFactory {
                                 new QuantityType(CurrentTemperatureCharacteristic.DEFAULT_STEP, SIUnits.CELSIUS)
                                         .toUnit(getSystemTemperatureUnit())),
                         true)
-                .toUnit(SIUnits.CELSIUS).doubleValue();
+                .toUnitRelative(SIUnits.CELSIUS).doubleValue();
         return new CurrentTemperatureCharacteristic(minValue, maxValue, step,
                 getTemperatureSupplier(taggedItem, minValue), getSubscriber(taggedItem, TARGET_TEMPERATURE, updater),
                 getUnsubscriber(taggedItem, TARGET_TEMPERATURE, updater));
@@ -1073,7 +1068,7 @@ public class HomekitCharacteristicFactory {
                         Objects.requireNonNull(new QuantityType(HeatingThresholdTemperatureCharacteristic.DEFAULT_STEP,
                                 SIUnits.CELSIUS).toUnit(getSystemTemperatureUnit())),
                         true)
-                .toUnit(SIUnits.CELSIUS).doubleValue();
+                .toUnitRelative(SIUnits.CELSIUS).doubleValue();
         return new HeatingThresholdTemperatureCharacteristic(minValue, maxValue, step,
                 getTemperatureSupplier(taggedItem, minValue), setTemperatureConsumer(taggedItem),
                 getSubscriber(taggedItem, HEATING_THRESHOLD_TEMPERATURE, updater),
@@ -1573,7 +1568,7 @@ public class HomekitCharacteristicFactory {
                                 new QuantityType(TargetTemperatureCharacteristic.DEFAULT_STEP, SIUnits.CELSIUS)
                                         .toUnit(getSystemTemperatureUnit())),
                         true)
-                .toUnit(SIUnits.CELSIUS).doubleValue();
+                .toUnitRelative(SIUnits.CELSIUS).doubleValue();
         return new TargetTemperatureCharacteristic(minValue, maxValue, step,
                 getTemperatureSupplier(taggedItem, minValue), setTemperatureConsumer(taggedItem),
                 getSubscriber(taggedItem, TARGET_TEMPERATURE, updater),


### PR DESCRIPTION
`getConfigurationAsQuantity` was using `toUnitRelative` appropriately, but the final conversion to Celsius was not, resulting in a 1 °F step being interpreted as a -17.5 °C step!

