### PR TITLE
[jsonpath] Upgrade json-smart to 2.5.2

### DIFF
--- a/bundles/org.openhab.transform.jsonpath/pom.xml
+++ b/bundles/org.openhab.transform.jsonpath/pom.xml
@@ -35,19 +35,19 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.3</version>
+      <version>9.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>accessors-smart</artifactId>
-      <version>2.5.0</version>
+      <version>2.5.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.5.0</version>
+      <version>2.5.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Fixes [CVE-2024-57699](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-57699)

See:
- https://github.com/openhab/openhab-addons/security/dependabot/100
- https://github.com/netplex/json-smart-v2?tab=readme-ov-file#changelog

Release:
- https://mvnrepository.com/artifact/net.minidev/json-smart
- https://mvnrepository.com/artifact/net.minidev/accessors-smart