### PR TITLE
[velbus] update README

### DIFF
--- a/bundles/org.openhab.binding.velbus/README.md
+++ b/bundles/org.openhab.binding.velbus/README.md
@@ -97,6 +97,7 @@ xidel -e \
 | vmbin         | 1-channel input module                                                                     |
 | vmbkp         | Keypad interface module                                                                    |
 | vmbmeteo      | Weather station with thermometer, anemometer, rain sensor and light sensor                 |
+| vmbpir-20     | Mini motion and twilight sensor for recessed or surface mounting                           |
 | vmbpirc       | Motion and twilight sensor for ceiling mounting                                            |
 | vmbpirm       | Mini motion and twilight sensor for recessed or surface mounting                           |
 | vmbpiro       | Outdoor motion, twilight and temperature sensor, Theben                                    |
@@ -527,7 +528,7 @@ Thing velbus:vmbdali:1:01 [VL1="CH1,CH2,CH3,CH4", VL2="A4,A5,A6"]
 | `clockAlarm`              | `clockAlarm1Enabled`, `clockAlarm2Enabled`                                                                                                                                                                         | OnOff                           |                               |
 | `clockAlarm`              | `clockAlarm1WakeupHour`, `clockAlarm1WakeupMinute`, `clockAlarm1BedtimeHour`, `clockAlarm1BedtimeMinute`, `clockAlarm2WakeupHour`, `clockAlarm2WakeupMinute`, `clockAlarm2BedtimeHour`, `clockAlarm2BedtimeMinute` | Number                          |                               |
 
-### Modules `vmbpirc`, `vmbpirm`
+### Modules `vmbpirc`, `vmbpirm`, `vmbpir-20`
 | Supported channels groups | Supported channels                                                                                                                                                                                                 | Supported command types         | Remarks                       |
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |---------------------------------|-------------------------------|
 | `input`                   | `CH1` ... `CH7`                                                                                                                                                                                                    | Pressed, Released, Long_Pressed | Trigger                       |


### PR DESCRIPTION
Module VMBPIR-20 is missing in the readme.

Signed-off-by: Daniel Rosengarten <github@praetorians.be>