### PR TITLE
[jrubyscripting] Update to JRuby 9.4.12.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional,jdk.crac.management;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.4.11.0</jruby.version>
+    <jruby.version>9.4.12.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This version should fix the bundle installation problem related to snakeyaml. It also has a critical fix for a CME.

https://www.jruby.org/2025/02/11/jruby-9-4-12-0.html