### PR TITLE
[lgtvserial] Update documentation and fix labels/descriptions

### DIFF
--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -35,7 +35,7 @@ The thing has the following configuration parameters:
 | Parameter Label        | Parameter ID         | Description                                                                     | Accepted values  |
 |------------------------|----------------------|---------------------------------------------------------------------------------|------------------|
 | Serial Port            | port                 | Serial port to use for connecting to TV/monitor/projector.                      | Serial port name |
-| Set ID                 | setId                | Set ID configured in the TV. If 0, will send the commands to every chained TV.  | 0-99             |
+| Set ID                 | setId                | Set ID configured in the TV. If 0, will send the commands to every chained TV.  | 0-99; default 1  |
 
 It is necessary to specify the serial port used for communication.
 On Linux systems, this will usually be either `/dev/ttyS0`, `/dev/ttyUSB0` or `/dev/ttyACM0` (or a higher  number than `0` if multiple devices are present).

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -13,11 +13,11 @@ The LG serial command set appears to be similar on many models ([1], [5]), but n
 
 The control port on most TVs is a male DE-9 connector that requires a "Null modem" cable to connect to a serial port or USB to serial adapter.
 
-Some TVs have a 3.5 mm phone jack for the control port instead of the DE-9 connector, and may thus require the use of an adapter cable.
+Some TVs have a 3.5 mm phone jack for the control port instead of a DE-9 connector, and may thus require the use of an adapter cable.
 
 The 3.5 mm phone jack may work with a generic 3.5 mm TRS phone plug to DE-9 cable or possibly LG part # EAD62707901 or EAD62707902 (3.5 mm TRRS to DE-9).
 
-The serial port may be marked "Service Only".
+The control port may be marked "Service Only".
 
 Tested and developed with:
 

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -42,14 +42,14 @@ On Linux systems, this will usually be either `/dev/ttyS0`, `/dev/ttyUSB0` or `/
 On Windows it will be `COM1`, `COM2`, etc.
 
 The Set ID can also be specified when using daisy-chaining.
-This allows you to have a Thing that will handle a particular device (with Set Id other than 0), and another to send commands to all devices (with Set Id equals 0).
-However, the item values for the Thing with Set Id 0 will never display the right values as it receives responses from many devices.
+This allows you to have a Thing that will handle a particular device (with Set ID other than 0), and another to send commands to all devices (with Set  equals 0).
+However, the item values for the Thing with Set ID 0 will never display the right values as it receives responses from many devices.
 
 ## Channels
 
 The following channels are common to most TVs, taken from [4].
 
-| Channel type id | Command | Item type | Description                                      |
+| Channel ID      | Command | Item Type | Description                                      |
 |-----------------|---------|-----------|--------------------------------------------------|
 | aspect-ratio    | k c     | String    | Adjust screen format, at least 4:3, 16:9 formats |
 | power           | k a     | Switch    | Turns the device on or off                       |
@@ -66,7 +66,7 @@ For instance, getting the volume status when the device is off makes no sense.
 
 Here is the list of all the LG TV commands added to the binding, in channel type id alphabetic order:
 
-| Channel type id    | Command | Item type | Description                                         |
+| Channel ID         | Command | Item Type | Description                                         |
 |--------------------|---------|-----------|-----------------------------------------------------|
 | 3d                 | x t     | String    | To change the 3D mode                               |
 | 3d-extended        | x v     | String    | To change the 3D options                            |
@@ -124,7 +124,7 @@ Here is the list of all the LG TV commands added to the binding, in channel type
 
 The following commands/channels are not currently implemented in the binding but the commands could be sent via the `raw` channel.
 
-| Channel type id    | Command | Description
+| Channel ID         | Command | Description
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
 | abnormal-state     | k z     | Used to read the power off status when in Stand-by mode                                                    |
 | auto-configuration | j u     | To adjust picture position and minimize image shaking automatically. it works only in RGB(PC) mode.        |

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -1,28 +1,32 @@
 # LG TV Serial Binding
 
-This binding can send some commands typically used by LG LCD TVs (and some used by projectors).
+This binding controls LG TVs, monitors and projectors that have an RS-232C control port.
 
 See below for a list of supported channels.
 
 ## Supported Things
 
-Supports one TV or projector per thing, also corresponding to a unique serial port.
+Supports one TV, monitor or projector per thing, also corresponding to a unique serial port.
 The protocol supports daisy-chaining of serial devices.
 
 The LG serial command set appears to be similar on many models ([1], [5]), but not all commands will work on all models.
 
-Some TVs may have an alternative port type instead of a standard DB9 connector, and may thus require an adapter.
+The serial port on most TVs is a male DE-9 connector that requires a "Null modem" cable to connect to a serial port or USB to serial adapter.
 
-The serial port may be marked "Service only".
+Some TVs have a 3.5 mm phone jack for the control port instead of a standard DE-9 connector, and may thus require the use of an adapter cable.
 
-Tested and developed with :
+The 3.5 mm phone jack may work with a generic 3.5 mm TRS phone plug to DE-9 cable or possibly LG part # EAD62707901 or EAD62707902 (3.5 mm TRRS to DE-9).
 
-- LG 55UF772V (with [this cable adapter](https://www.ebay.com/itm/DB9-9-Pin-Female-To-TRS-3-5mm-Male-Stereo-Serial-Data-Converter-Cable-1-8M-6Ft-/291541959764?)).
-- LG 47LK520 with a [serial hat](https://www.buyapi.ca/product/serial-hat-rs232/) on a Raspberry Pi
+The serial port may be marked "Service Only".
+
+Tested and developed with:
+
+- LG 55UF772V with a generic 3.5 mm TRS phone plug to DE-9 cable
+- LG 47LK520 with a [serial hat](https://www.pishop.ca/product/serial-hat-rs232/) on a Raspberry Pi
 
 ## Discovery
 
-No discovery supported, manual configuration is required.
+No discovery supported; manual configuration is required.
 
 ## Thing Configuration
 
@@ -31,12 +35,12 @@ On Linux systems, this will usually be either `/dev/ttyS0`, `/dev/ttyUSB0` or `/
 On Windows it will be `COM1`, `COM2`, etc.
 
 The set id can also be specified when using daisy-chaining.
-That allows you to have a thing that will handle a particular device (with set id other than 0), and another to send command on all devices (with set id equals 0).
+This allows you to have a thing that will handle a particular device (with set id other than 0), and another to send commands to all devices (with set id equals 0).
 However, the item values for the thing with set id 0 will never display the right values as it receives responses from many devices.
 
 ## Channels
 
-The following channels are common to most TV through the serial or service port, taken from [4].
+The following channels are common to most TVs, taken from [4].
 
 | Channel type id | Command | Item type | Description                                      |
 |-----------------|---------|-----------|--------------------------------------------------|
@@ -45,24 +49,24 @@ The following channels are common to most TV through the serial or service port,
 | volume          | k f     | Dimmer    | Sets the volume, values are from 0 to 100        |
 | volume-mute     | k e     | Switch    | Set mute on or off                               |
 
-As for others, please refer to the documentation of your device in the section named "Controlling the multiple product", "External control" or any section that refers to RS-232, the names of the channels map the command names.
+As for others, please refer to the documentation of your device in the section named "Controlling the multiple product", "External control" or any section that refers to RS-232.
 If your device documentation doesn't give such information, you can look at the "LG protocol references" below and use the "Generic LG TV" thing which should contain all the different possible channels/commands.
 
-Note: Devices might not respond or return an error to some command when the device is powered off which will make your items look in a wrong state until the TV turns on.
+Note: Devices might not respond or return an error to some command when the device is powered off which can put items in an incorrect state until the device is turned on.
 For instance, getting the volume status when the device is off makes no sense.
 
 ## All channel type ids
 
-Here's a list of all the LG TV commands added to the binding, in channel type id alphabetic order
+Here is the list of all the LG TV commands added to the binding, in channel type id alphabetic order:
 
 | Channel type id    | Command | Item type | Description                                         |
 |--------------------|---------|-----------|-----------------------------------------------------|
-| 3d                 | x t     | String    | To change 3D mode for tv                            |
-| 2d-extended        | x v     | String    | To change 3D options for tv                         |
+| 3d                 | x t     | String    | To change the 3D mode                               |
+| 3d-extended        | x v     | String    | To change the 3D options                            |
 | aspect-ratio       | k c     | String    | To adjust the screen format                         |
-| auto-sleep         | f g     | Switch    | Set Auto Sleep                                      |
-| auto-volume        | d u     | Switch    | Automatically adjust the volume level               |
-| speaker            | d v     | Switch    | Turn the speaker on or off                          |
+| auto-sleep         | f g     | Switch    | To set the Auto Sleep function                      |
+| auto-volume        | d u     | Switch    | To set the Auto Volume adjustment function          |
+| speaker            | d v     | Switch    | To turn the speaker on or off                       |
 | backlight          | m g     | Dimmer    | To adjust screen backlight                          |
 | balance            | k t     | Dimmer    | To adjust balance, from 0 to 100                    |
 | bass               | k s     | Dimmer    | To adjust bass, from 0 to 100                       |
@@ -71,33 +75,32 @@ Here's a list of all the LG TV commands added to the binding, in channel type id
 | color-temperature  | k u     | String    | To adjust the screen color temperature              |
 | color-temperature2 | x u     | Dimmer    | To adjust color temperature, from 0 to 100          |
 | contrast           | k g     | Dimmer    | To adjust screen contrast, from 0 to 100            |
-| dpm                | f j     | Switch    | Set the DPM (Display Power Management) function     |
+| dpm                | f j     | Switch    | To set the DPM (Display Power Management) function  |
 | energy-saving      | j q     | String    | To control the energy saving function               |
-| fan-fault-check    | d w     | Switch    | To check the Fan fault of the TV                    |
+| fan-fault-check    | d w     | Switch    | To read the Fan fault status of the device          |
 | elapsed-time       | d l     | String    | To read the elapsed time                            |
 | h-position         | f q     | Dimmer    | To set the Horizontal position, from 0 to 100       |
-| h-size             | f s     | Dimmer    | To set the Horizontal size, from 0 to 100           |
-| input              | k b     | String    | To select input source for the Set                  |
-| input2             | x b     | String    | To select input source for set                      |
+| input              | k b     | String    | To select the current input source for the device   |
+| input2             | x b     | String    | To select the current input source for the device   |
 | ism-method         | j p     | String    | To avoid having a fixed image remain on screen      |
-| ir-key-code        | m c     | String    | To send IR remote key code                          |
-| lamp-fault-check   | d p     | Switch    | To check lamp fault                                 |
-| power              | k a     | Switch    | To control Power On/Off of the set                  |
-| osd-select         | k l     | Switch    | To select OSD (On Screen Display) on/off            |
-| osd-language       | f i     | String    | Set the OSD language                                |
+| ir-key-code        | m c     | String    | To send an IR remote key code                       |
+| lamp-fault-check   | d p     | Switch    | To read the lamp fault status of the device         |
+| power              | k a     | Switch    | To turn the device on or off                        |
+| osd-select         | k l     | Switch    | To select OSD (On Screen Display) on or off         |
+| osd-language       | f i     | String    | To set the OSD language                             |
 | natural-mode       | d j     | Switch    | To assign the Tile Natural mode for Tiling function |
 | picture-mode       | d x     | String    | To adjust the picture mode                          |
 | power-indicator    | f o     | Switch    | To set the LED for Power Indicator                  |
 | power-saving       | f l     | Switch    | To set the Power saving mode                        |
-| screen-mute        | k d     | String    | To select screen mute on/off                        |
+| screen-mute        | k d     | String    | To select screen mute on or off                     |
 | serial-number      | f y     | String    | To read the serial numbers                          |
-| software-version   | f z     | String    | Check the software version                          |
+| software-version   | f z     | String    | To read the software version                        |
 | sharpness          | k k     | Dimmer    | To adjust screen sharpness, from 0 to 100           |
-| sleep-time         | f f     | String    | Set sleep time                                      |
+| sleep-time         | f f     | String    | To set the sleep timer                              |
 | sound-mode         | d y     | String    | To adjust the Sound mode                            |
-| speaker            | d v     | Switch    | Turn the speaker on or off                          |
+| speaker            | d v     | Switch    | To turn the speaker on or off                       |
 | temperature-value  | d n     | String    | To read the inside temperature value                |
-| tile-mode          | d d     | String    | Change a Tile mode                                  |
+| tile               | d d     | String    | To change the Tile mode                             |
 | tile-h-position    | d e     | Dimmer    | To set the Horizontal position, from 0 to 100       |
 | tile-h-size        | d g     | Dimmer    | To set the Horizontal size, from 0 to 100           |
 | tile-id-set        | d i     | Dimmer    | To assign the Tile ID for Tiling function, 0 to 25  |
@@ -106,15 +109,17 @@ Here's a list of all the LG TV commands added to the binding, in channel type id
 | tint               | k j     | Dimmer    | To adjust screen tint, from 0 to 100                |
 | treble             | k r     | Dimmer    | To adjust treble, from 0 to 100                     |
 | volume             | k f     | Dimmer    | To adjust volume, from 0 to 100                     |
-| volume-mute        | k e     | Switch    | Set mute on or off                                  |
+| volume-mute        | k e     | Switch    | To set mute on or off                               |
 | v-position         | f r     | Dimmer    | To set the Vertical position, from 0 to 100         |
-| v-size             | f t     | Dimmer    | To set the Vertical size, from 0 to 100             |
+| raw **(advanced)** |         | String    | To send a raw command directly to the device(s)     |
 
-## Not added or linked command
+### Not added or linked commands
+
+The following commands/channels are not currently implemented in the binding but the commands could be sent via the `raw` channel.
 
 | Channel type id    | Command | Description
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
-| abnormal-state     | k z     | Used to Read the power off status when Stand-by mode                                                       |
+| abnormal-state     | k z     | Used to read the power off status when in Stand-by mode                                                    |
 | auto-configuration | j u     | To adjust picture position and minimize image shaking automatically. it works only in RGB(PC) mode.        |
 | power-on-delay     | f h     | Set the schedule delay when the power is turned on (Unit: second)                                          |
 | remote-lock        | k m     | To control Remote Lock on/off to the set. Locks the remote control and the local keys.                     |
@@ -125,10 +130,12 @@ Here's a list of all the LG TV commands added to the binding, in channel type id
 | off-timer-on-off   | f c     | Set days for Off Timer                                                                                     |
 | on-timer-time      | f d     | Set On Timer                                                                                               |
 | off-timer-time     | f e     | Set Off Timer                                                                                              |
+| h-size             | f s     | Set the Horizontal size, from 0 to 100                                                                     |
+| v-size             | f t     | Set the Vertical size, from 0 to 100                                                                       |
 
 ## LG protocol references
 
-[1] <https://www.lg.com/us/commercial/documents/m6503ccba-owner-manual.pdf>
+[1] Manual for M6503C monitor <https://gscs-b2c.lge.com/downloadFile?fileId=KROWM000237239.pdf>
 
 [2] <https://sites.google.com/site/brendanrobert/projects/bits-and-pieces/lg-tv-hacks>
 
@@ -136,6 +143,6 @@ Here's a list of all the LG TV commands added to the binding, in channel type id
 
 [4] <https://github.com/suan/libLGTV_serial>
 
-[5] Manual LV series, LK series, PW series and PZ series <https://gscs-b2c.lge.com/downloadFile?fileId=ujpO8yH69djwNZzwuavqpQ>
+[5] Manual for LV series, LK series, PW series and PZ series <https://gscs-b2c.lge.com/downloadFile?fileId=ujpO8yH69djwNZzwuavqpQ>
 
 [6] Manual for LD series, LE series, LX series and PK series <https://gscs-b2c.lge.com/downloadFile?fileId=76If0tKDLOUizuoXikllgQ>

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -42,8 +42,8 @@ On Linux systems, this will usually be either `/dev/ttyS0`, `/dev/ttyUSB0` or `/
 On Windows it will be `COM1`, `COM2`, etc.
 
 The Set ID can also be specified when using daisy-chaining.
-This allows you to have a Thing that will handle a particular device (with set id other than 0), and another to send commands to all devices (with set id equals 0).
-However, the item values for the Thing with set id 0 will never display the right values as it receives responses from many devices.
+This allows you to have a Thing that will handle a particular device (with Set Id other than 0), and another to send commands to all devices (with Set Id equals 0).
+However, the item values for the Thing with Set Id 0 will never display the right values as it receives responses from many devices.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -30,13 +30,20 @@ No discovery supported; manual configuration is required.
 
 ## Thing Configuration
 
-It is necessary to specify the serial port device used for communication.
+The thing has the following configuration parameters:
+
+| Parameter Label        | Parameter ID         | Description                                                                     | Accepted values  |
+|------------------------|----------------------|---------------------------------------------------------------------------------|------------------|
+| Serial Port            | port                 | Serial port to use for connecting to TV/monitor/projector.                      | Serial port name |
+| Set ID                 | setId                | Set ID configured in the TV. If 0, will send the commands to every chained TV.  | 0-99             |
+
+It is necessary to specify the serial port used for communication.
 On Linux systems, this will usually be either `/dev/ttyS0`, `/dev/ttyUSB0` or `/dev/ttyACM0` (or a higher  number than `0` if multiple devices are present).
 On Windows it will be `COM1`, `COM2`, etc.
 
-The set id can also be specified when using daisy-chaining.
-This allows you to have a thing that will handle a particular device (with set id other than 0), and another to send commands to all devices (with set id equals 0).
-However, the item values for the thing with set id 0 will never display the right values as it receives responses from many devices.
+The Set ID can also be specified when using daisy-chaining.
+This allows you to have a Thing that will handle a particular device (with set id other than 0), and another to send commands to all devices (with set id equals 0).
+However, the item values for the Thing with set id 0 will never display the right values as it receives responses from many devices.
 
 ## Channels
 
@@ -113,7 +120,7 @@ Here is the list of all the LG TV commands added to the binding, in channel type
 | v-position         | f r     | Dimmer    | To set the Vertical position, from 0 to 100         |
 | raw **(advanced)** |         | String    | To send a raw command directly to the device(s)     |
 
-### Not added or linked commands
+## Not added or linked commands
 
 The following commands/channels are not currently implemented in the binding but the commands could be sent via the `raw` channel.
 

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -11,7 +11,7 @@ The protocol supports daisy-chaining of serial devices.
 
 The LG serial command set appears to be similar on many models ([1], [5]), but not all commands will work on all models.
 
-The serial port on most TVs is a male DE-9 connector that requires a "Null modem" cable to connect to a serial port or USB to serial adapter.
+The control port on most TVs is a male DE-9 connector that requires a "Null modem" cable to connect to a serial port or USB to serial adapter.
 
 Some TVs have a 3.5 mm phone jack for the control port instead of a standard DE-9 connector, and may thus require the use of an adapter cable.
 

--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -13,7 +13,7 @@ The LG serial command set appears to be similar on many models ([1], [5]), but n
 
 The control port on most TVs is a male DE-9 connector that requires a "Null modem" cable to connect to a serial port or USB to serial adapter.
 
-Some TVs have a 3.5 mm phone jack for the control port instead of a standard DE-9 connector, and may thus require the use of an adapter cable.
+Some TVs have a 3.5 mm phone jack for the control port instead of the DE-9 connector, and may thus require the use of an adapter cable.
 
 The 3.5 mm phone jack may work with a generic 3.5 mm TRS phone plug to DE-9 cable or possibly LG part # EAD62707901 or EAD62707902 (3.5 mm TRRS to DE-9).
 

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/addon/addon.xml
@@ -5,7 +5,7 @@
 
 	<type>binding</type>
 	<name>LG TV Serial Binding</name>
-	<description>Controlling LG TVs using serial (RS232C) protocol</description>
+	<description>Controls LG TVs that have an RS-232C control port</description>
 	<connection>local</connection>
 
 </addon:addon>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/config/config.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="setId" type="integer" required="true">
 			<label>Set ID</label>
-			<description>Set ID configured in the TV. If 0, this will send a command to every chained TV.</description>
+			<description>Set ID configured in the TV. If 0, this will send the commands to every chained TV.</description>
 			<default>1</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/config/config.xml
@@ -12,7 +12,7 @@
 		</parameter>
 		<parameter name="setId" type="integer" required="true">
 			<label>Set ID</label>
-			<description>Set ID configured in the TV. If 0, this will send the commands to every chained TV.</description>
+			<description>Set ID configured in the TV. If 0, will send the commands to every chained TV.</description>
 			<default>1</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/i18n/lgtvserial.properties
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/i18n/lgtvserial.properties
@@ -6,15 +6,15 @@ addon.lgtvserial.description = Controls LG TVs that have an RS-232C control port
 # thing types
 
 thing-type.lgtvserial.lgtv-LK-series.label = LK Series
-thing-type.lgtvserial.lgtv-LK-series.description = This thing supports the LCD TV models <size>LK<type>
+thing-type.lgtvserial.lgtv-LK-series.description = This thing supports the LCD TV models LK
 thing-type.lgtvserial.lgtv-LV-series.label = LV/LW Series
-thing-type.lgtvserial.lgtv-LV-series.description = This thing supports the LED LCD TV models <size>LV<type> and <size>LW<type> except *LV255C, *LV355B, *LV355C models
+thing-type.lgtvserial.lgtv-LV-series.description = This thing supports the LED LCD TV models LV and LW except *LV255C, *LV355B, *LV355C
 thing-type.lgtvserial.lgtv-LVx55-series.label = LV/LW Series
 thing-type.lgtvserial.lgtv-LVx55-series.description = This thing supports the *LV255C, *LV355B, *LV355C models
 thing-type.lgtvserial.lgtv-M6503C.label = M6503C Model
 thing-type.lgtvserial.lgtv-M6503C.description = This thing supports the M6503C monitor
 thing-type.lgtvserial.lgtv-PW-series.label = PW Series
-thing-type.lgtvserial.lgtv-PW-series.description = This thing supports the PLASMA TV models <size>PW<type>
+thing-type.lgtvserial.lgtv-PW-series.description = This thing supports the PLASMA TV models PW
 thing-type.lgtvserial.lgtv.label = Generic LG TV
 thing-type.lgtvserial.lgtv.description = Generic LG television connected through a serial interface. This thing should be used only when there is no proper thing defined for your TV model as it has most existing channels for most known commands.
 
@@ -23,7 +23,7 @@ thing-type.lgtvserial.lgtv.description = Generic LG television connected through
 thing-type.config.lgtvserial.serial.port.label = Serial Port
 thing-type.config.lgtvserial.serial.port.description = Select serial port (COM1, /dev/ttyS0, ...)
 thing-type.config.lgtvserial.serial.setId.label = Set ID
-thing-type.config.lgtvserial.serial.setId.description = Set ID configured in the TV. If 0, this will send the commands to every chained TV.
+thing-type.config.lgtvserial.serial.setId.description = Set ID configured in the TV. If 0, will send the commands to every chained TV.
 
 # channel types
 
@@ -477,7 +477,7 @@ channel-type.lgtvserial.power-saving.state.option.03 = Static level 3
 channel-type.lgtvserial.power.label = Power
 channel-type.lgtvserial.power.description = Power on/off
 channel-type.lgtvserial.raw.label = Raw
-channel-type.lgtvserial.raw.description = Send raw command over the serial port directly to TV(s)
+channel-type.lgtvserial.raw.description = Send raw command over the serial port directly to the device(s)
 channel-type.lgtvserial.screen-mute.label = Screen Mute
 channel-type.lgtvserial.screen-mute.description = Select screen mute on/off
 channel-type.lgtvserial.screen-mute.state.option.00 = Screen mute off (Picture on), Video-out Mute off
@@ -524,7 +524,7 @@ channel-type.lgtvserial.tile-v-position.description = Set the vertical position
 channel-type.lgtvserial.tile-v-size.label = Vertical Size
 channel-type.lgtvserial.tile-v-size.description = Set the vertical size
 channel-type.lgtvserial.tile.label = Tile Mode
-channel-type.lgtvserial.tile.description = Change a tile mode
+channel-type.lgtvserial.tile.description = Change the tile mode
 channel-type.lgtvserial.tile.state.option.00 = Tile mode off
 channel-type.lgtvserial.tile.state.option.11 = 1 x 1 mode (same as off)
 channel-type.lgtvserial.tile.state.option.12 = 1 x 2 mode

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/i18n/lgtvserial.properties
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/i18n/lgtvserial.properties
@@ -1,7 +1,7 @@
 # add-on
 
 addon.lgtvserial.name = LG TV Serial Binding
-addon.lgtvserial.description = Controlling LG TVs using serial (RS232C) protocol
+addon.lgtvserial.description = Controls LG TVs that have an RS-232C control port
 
 # thing types
 
@@ -10,9 +10,9 @@ thing-type.lgtvserial.lgtv-LK-series.description = This thing supports the LCD T
 thing-type.lgtvserial.lgtv-LV-series.label = LV/LW Series
 thing-type.lgtvserial.lgtv-LV-series.description = This thing supports the LED LCD TV models <size>LV<type> and <size>LW<type> except *LV255C, *LV355B, *LV355C models
 thing-type.lgtvserial.lgtv-LVx55-series.label = LV/LW Series
-thing-type.lgtvserial.lgtv-LVx55-series.description = This thing supports the *LV255C, *LV355B, *LV355C models.
+thing-type.lgtvserial.lgtv-LVx55-series.description = This thing supports the *LV255C, *LV355B, *LV355C models
 thing-type.lgtvserial.lgtv-M6503C.label = M6503C Model
-thing-type.lgtvserial.lgtv-M6503C.description = This thing supports the M6503C LG TV
+thing-type.lgtvserial.lgtv-M6503C.description = This thing supports the M6503C monitor
 thing-type.lgtvserial.lgtv-PW-series.label = PW Series
 thing-type.lgtvserial.lgtv-PW-series.description = This thing supports the PLASMA TV models <size>PW<type>
 thing-type.lgtvserial.lgtv.label = Generic LG TV
@@ -23,14 +23,14 @@ thing-type.lgtvserial.lgtv.description = Generic LG television connected through
 thing-type.config.lgtvserial.serial.port.label = Serial Port
 thing-type.config.lgtvserial.serial.port.description = Select serial port (COM1, /dev/ttyS0, ...)
 thing-type.config.lgtvserial.serial.setId.label = Set ID
-thing-type.config.lgtvserial.serial.setId.description = Set ID configured in the TV. If 0, this will send a command to every chained TV.
+thing-type.config.lgtvserial.serial.setId.description = Set ID configured in the TV. If 0, this will send the commands to every chained TV.
 
 # channel types
 
-channel-type.lgtvserial.3d-extended.label = 3d Extended
-channel-type.lgtvserial.3d-extended.description = Change the 3d option, if your TV supports it
-channel-type.lgtvserial.3d.label = 3d
-channel-type.lgtvserial.3d.description = Change the 3d mode, if your TV supports it
+channel-type.lgtvserial.3d-extended.label = 3D Extended
+channel-type.lgtvserial.3d-extended.description = Change the 3D option, if your TV supports it
+channel-type.lgtvserial.3d.label = 3D
+channel-type.lgtvserial.3d.description = Change the 3D mode, if your TV supports it
 channel-type.lgtvserial.aspect-ratio-M6503C.label = Aspect Ratio
 channel-type.lgtvserial.aspect-ratio-M6503C.description = Adjust the screen format
 channel-type.lgtvserial.aspect-ratio-M6503C.state.option.01 = Normal Screen (4:3)
@@ -477,7 +477,7 @@ channel-type.lgtvserial.power-saving.state.option.03 = Static level 3
 channel-type.lgtvserial.power.label = Power
 channel-type.lgtvserial.power.description = Power on/off
 channel-type.lgtvserial.raw.label = Raw
-channel-type.lgtvserial.raw.description = Send raw command over the serial power directly to TV(s)
+channel-type.lgtvserial.raw.description = Send raw command over the serial port directly to TV(s)
 channel-type.lgtvserial.screen-mute.label = Screen Mute
 channel-type.lgtvserial.screen-mute.description = Select screen mute on/off
 channel-type.lgtvserial.screen-mute.state.option.00 = Screen mute off (Picture on), Video-out Mute off

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-channels.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-channels.xml
@@ -6,14 +6,14 @@
 
 	<channel-type id="3d">
 		<item-type>String</item-type>
-		<label>3d</label>
-		<description>Change the 3d mode, if your TV supports it</description>
+		<label>3D</label>
+		<description>Change the 3D mode, if your TV supports it</description>
 	</channel-type>
 
 	<channel-type id="3d-extended">
 		<item-type>String</item-type>
-		<label>3d Extended</label>
-		<description>Change the 3d option, if your TV supports it</description>
+		<label>3D Extended</label>
+		<description>Change the 3D option, if your TV supports it</description>
 	</channel-type>
 
 	<channel-type id="aspect-ratio">
@@ -376,7 +376,7 @@
 	<channel-type id="raw" advanced="true">
 		<item-type>String</item-type>
 		<label>Raw</label>
-		<description>Send raw command over the serial power directly to TV(s)</description>
+		<description>Send raw command over the serial port directly to the device(s)</description>
 	</channel-type>
 
 	<channel-type id="screen-mute">
@@ -468,7 +468,7 @@
 	<channel-type id="tile">
 		<item-type>String</item-type>
 		<label>Tile Mode</label>
-		<description>Change a tile mode</description>
+		<description>Change the tile mode</description>
 		<state>
 			<options>
 				<option value="00">Tile mode off</option>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-M6503C.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-M6503C.xml
@@ -8,7 +8,7 @@
 		input select -->
 	<thing-type id="lgtv-M6503C">
 		<label>M6503C Model</label>
-		<description><![CDATA[This thing supports the M6503C monitor]]></description>
+		<description>This thing supports the M6503C monitor</description>
 
 		<channels>
 			<channel id="aspect-ratio" typeId="aspect-ratio-M6503C"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-M6503C.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-M6503C.xml
@@ -8,7 +8,7 @@
 		input select -->
 	<thing-type id="lgtv-M6503C">
 		<label>M6503C Model</label>
-		<description><![CDATA[This thing supports the M6503C LG TV]]></description>
+		<description><![CDATA[This thing supports the M6503C monitor]]></description>
 
 		<channels>
 			<channel id="aspect-ratio" typeId="aspect-ratio-M6503C"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
@@ -10,7 +10,7 @@
 	<!-- These things supports the LG TV models from the document with P/NO : SAC34134216 -->
 	<thing-type id="lgtv-LV-series">
 		<label>LV/LW Series</label>
-		<description><![CDATA[This thing supports the LED LCD TV models <size>LV<type> and <size>LW<type> except *LV255C, *LV355B, *LV355C models]]></description>
+		<description>This thing supports the LED LCD TV models LV and LW except *LV255C, *LV355B, *LV355C</description>
 
 		<channels>
 			<channel id="3d" typeId="3d"/>
@@ -43,7 +43,7 @@
 
 	<thing-type id="lgtv-LVx55-series">
 		<label>LV/LW Series</label>
-		<description><![CDATA[This thing supports the *LV255C, *LV355B, *LV355C models]]></description>
+		<description>This thing supports the *LV255C, *LV355B, *LV355C models</description>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>
@@ -76,7 +76,7 @@
 
 	<thing-type id="lgtv-LK-series">
 		<label>LK Series</label>
-		<description><![CDATA[This thing supports the LCD TV models <size>LK<type>]]></description>
+		<description>This thing supports the LCD TV models LK</description>
 
 		<channels>
 			<channel id="3d" typeId="3d"/>
@@ -108,7 +108,7 @@
 
 	<thing-type id="lgtv-PW-series">
 		<label>PW Series</label>
-		<description><![CDATA[This thing supports the PLASMA TV models <size>PW<type>]]></description>
+		<description>This thing supports the PLASMA TV models PW</description>
 
 		<channels>
 			<channel id="3d" typeId="3d"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
@@ -43,7 +43,7 @@
 
 	<thing-type id="lgtv-LVx55-series">
 		<label>LV/LW Series</label>
-		<description><![CDATA[This thing supports the *LV255C, *LV355B, *LV355C models.]]></description>
+		<description><![CDATA[This thing supports the *LV255C, *LV355B, *LV355C models]]></description>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>


### PR DESCRIPTION
The PR makes the following improvements to the README and labels & descriptions:

- Improve README content, grammar, punctuation, etc.
- Add missing Thing Configuration parameters table
- Fix incorrect or missing ids and normalize descriptions in the Channels table
- Fix broken links to reference documents
- Fix incorrect or awkward thing and channel labels & descriptions

No code changes were made.