### PR TITLE
[mielecloud] Fix OAuth service handle

### DIFF
--- a/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/MieleCloudBindingConstants.java
+++ b/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/MieleCloudBindingConstants.java
@@ -227,6 +227,7 @@ public final class MieleCloudBindingConstants {
         }
 
         public static final String BRIDGE_STATUS_DESCRIPTION_ACCESS_TOKEN_NOT_CONFIGURED = "@text/mielecloud.bridge.status.access.token.not.configured";
+        public static final String BRIDGE_STATUS_DESCRIPTION_EMAIL_NOT_CONFIGURED = "@text/mielecloud.bridge.status.email.not.configured";
         public static final String BRIDGE_STATUS_DESCRIPTION_ACCOUNT_NOT_AUTHORIZED = "@text/mielecloud.bridge.status.account.not.authorized";
         public static final String BRIDGE_STATUS_DESCRIPTION_ACCESS_TOKEN_REFRESH_FAILED = "@text/mielecloud.bridge.status.access.token.refresh.failed";
         public static final String BRIDGE_STATUS_DESCRIPTION_TRANSIENT_HTTP_ERROR = "@text/mielecloud.bridge.status.transient.http.error";

--- a/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/auth/OpenHabOAuthTokenRefresher.java
+++ b/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/auth/OpenHabOAuthTokenRefresher.java
@@ -72,6 +72,7 @@ public final class OpenHabOAuthTokenRefresher implements OAuthTokenRefresher {
             try {
                 OAuthClientService clientService = getOAuthClientService(serviceHandle);
                 clientService.removeAccessTokenRefreshListener(refreshListener);
+                oauthFactory.ungetOAuthService(serviceHandle);
             } catch (OAuthException e) {
                 logger.warn("Failed to remove refresh listener: OAuth client service is unavailable. Cause: {}",
                         e.getMessage());

--- a/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/config/OAuthAuthorizationHandlerImpl.java
+++ b/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/config/OAuthAuthorizationHandlerImpl.java
@@ -76,8 +76,8 @@ public final class OAuthAuthorizationHandlerImpl implements OAuthAuthorizationHa
             throw new OngoingAuthorizationException("There is already an ongoing authorization!", timerExpiryTimestamp);
         }
 
-        this.oauthClientService = oauthFactory.createOAuthClientService(email, TOKEN_URL, AUTHORIZATION_URL, clientId,
-                clientSecret, null, false);
+        this.oauthClientService = oauthFactory.createOAuthClientService(bridgeUid.getAsString(), TOKEN_URL,
+                AUTHORIZATION_URL, clientId, clientSecret, null, false);
         this.bridgeUid = bridgeUid;
         this.email = email;
         redirectUri = null;
@@ -136,6 +136,12 @@ public final class OAuthAuthorizationHandlerImpl implements OAuthAuthorizationHa
 
             // Although this method is called "get" it actually fetches and stores the token response as a side effect.
             oauthClientService.getAccessTokenResponseByAuthorizationCode(authorizationCode, redirectUri);
+
+            // Remove any legacy OAuth service handle.
+            String email = this.email;
+            if (email != null) {
+                oauthFactory.deleteServiceAndAccessToken(email);
+            }
         } catch (IOException e) {
             throw new OAuthException("Network error while retrieving token response: " + e.getMessage(), e);
         } catch (OAuthResponseException e) {

--- a/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/i18n/mielecloud.properties
+++ b/bundles/org.openhab.binding.mielecloud/src/main/resources/OH-INF/i18n/mielecloud.properties
@@ -249,8 +249,9 @@ channel-type.mielecloud.battery_level.description=The battery level of the robot
 
 # Error message texts
 mielecloud.bridge.status.access.token.not.configured=The OAuth2 access token is not configured.
-mielecloud.bridge.status.account.not.authorized=The account has not been authorized. Please consult the documentation on how to do that.
+mielecloud.bridge.status.account.not.authorized=The account has not been authorized. Please authorize at http(s)://<YOUROPENHAB>:<YOURPORT>/mielecloud
 mielecloud.bridge.status.access.token.refresh.failed=Failed to refresh the OAuth2 access token. Please authorize the account again.
+mielecloud.bridge.status.email.not.configured=E-mail address is not configured.
 mielecloud.bridge.status.transient.http.error=An unexpected HTTP error occurred. Check the logs if this error persists.
 mielecloud.thing.status.webservice.missing=The Miele webservice cannot be accessed over the bridge. Check the bridge configuration.
 mielecloud.thing.status.removed=This Miele device has been removed from the Miele@home account.


### PR DESCRIPTION
This changes the OAuth service handle from the configured e-mail address to the bridge UID in order to avoid conflicts in the global namespace of handles in the OAuth storage.

Automated migration is not supported by the core classes, therefore the logic is as follows:
- If the new service handle is found, it will be used.
- Otherwise, if an old service handle is found, it will be used, and the user will be advised to re-authorize (through logging).
- On successful re-authorization, any old service handle will be removed from the OAuth storage.

Additionally a clickable link will now be provided when authorization is missing.

Fixes #14783
Fixes #18265