### PR TITLE
[insteon] Fix icon products first record config

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
@@ -165,7 +165,7 @@
 		<vendor>Insteon</vendor>
 		<device-type>DimmableLightingControl_InLineLinc</device-type>
 	</product>
-	<product devCat="0x01" subCat="0x03" firstRecord="0x00FF">
+	<product devCat="0x01" subCat="0x03">
 		<description>ICON Dimmer Switch</description>
 		<model>2876DB</model>
 		<vendor>Insteon</vendor>
@@ -189,7 +189,7 @@
 		<vendor>Insteon</vendor>
 		<device-type>DimmableLightingControl_LampLinc</device-type>
 	</product>
-	<product devCat="0x01" subCat="0x07" firstRecord="0x00FF">
+	<product devCat="0x01" subCat="0x07">
 		<description>ICON LampLinc</description>
 		<model>2856D2B</model>
 		<vendor>Insteon</vendor>
@@ -207,7 +207,7 @@
 		<vendor>Insteon</vendor>
 		<device-type>DimmableLightingControl_KeypadButton6</device-type>
 	</product>
-	<product devCat="0x01" subCat="0x0A" firstRecord="0x00FF">
+	<product devCat="0x01" subCat="0x0A">
 		<description>ICON In-Wall Controller</description>
 		<model>2886D</model>
 		<vendor>Insteon</vendor>
@@ -267,7 +267,7 @@
 		<vendor>Insteon</vendor>
 		<device-type>DimmableLightingControl_ToggleLinc</device-type>
 	</product>
-	<product devCat="0x01" subCat="0x18" productKey="0x00003F" firstRecord="0x00FF">
+	<product devCat="0x01" subCat="0x18" productKey="0x00003F">
 		<description>ICON SwitchLinc Dimmer In-Line Companion</description>
 		<model>2474D</model>
 		<vendor>Insteon</vendor>
@@ -303,7 +303,7 @@
 		<vendor>Insteon</vendor>
 		<device-type>DimmableLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x01" subCat="0x1E" firstRecord="0x00FF">
+	<product devCat="0x01" subCat="0x1E">
 		<description>ICON Dimmer Switch</description>
 		<model>2876DB</model>
 		<vendor>Insteon</vendor>
@@ -623,13 +623,13 @@
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x02" subCat="0x0B" firstRecord="0x00FF">
+	<product devCat="0x02" subCat="0x0B">
 		<description>ICON On/Off Switch</description>
 		<model>2876SB</model>
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x02" subCat="0x0C" firstRecord="0x00FF">
+	<product devCat="0x02" subCat="0x0C">
 		<description>ICON Appliance Module</description>
 		<model>2856S3B</model>
 		<vendor>Insteon</vendor>
@@ -672,7 +672,7 @@
 		<device-type>SwitchedLightingControl_InLineLinc</device-type>
 	</product>
 	<product devCat="0x02" subCat="0x13" productKey="0x000033">
-		<description>Icon SwitchLinc Relay (Lixar)</description>
+		<description>ICON SwitchLinc Relay (Lixar)</description>
 		<model>2676R-B</model>
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
@@ -689,13 +689,13 @@
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x02" subCat="0x16" firstRecord="0x00FF">
+	<product devCat="0x02" subCat="0x16">
 		<description>ICON On/Off Switch</description>
 		<model>2876SB</model>
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x02" subCat="0x17" firstRecord="0x00FF">
+	<product devCat="0x02" subCat="0x17">
 		<description>ICON Appliance Module</description>
 		<model>2856S3B</model>
 		<vendor>Insteon</vendor>


### PR DESCRIPTION
This changes fixes the first record config for ICON products. The default value should be used instead.

It should be backported as the status of ICON device things would get stuck in `CONFIGURATION_PENDING` as the database record validation will keep failing due to a different first record address.