### PR TITLE
[insteon] Fix missing links implementation

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonBindingConstants.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonBindingConstants.java
@@ -75,6 +75,7 @@ public class InsteonBindingConstants {
     public static final String FEATURE_LED_ON_OFF = "ledOnOff";
     public static final String FEATURE_LINK_FF_GROUP = "linkFFGroup";
     public static final String FEATURE_LOW_BATTERY_THRESHOLD = "lowBatteryThreshold";
+    public static final String FEATURE_MONITOR_MODE = "monitorMode";
     public static final String FEATURE_ON_LEVEL = "onLevel";
     public static final String FEATURE_PING = "ping";
     public static final String FEATURE_RAMP_RATE = "rampRate";

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/command/DeviceCommand.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/command/DeviceCommand.java
@@ -28,6 +28,7 @@ import org.openhab.binding.insteon.internal.device.InsteonAddress;
 import org.openhab.binding.insteon.internal.device.InsteonDevice;
 import org.openhab.binding.insteon.internal.device.ProductData;
 import org.openhab.binding.insteon.internal.device.database.LinkDBRecord;
+import org.openhab.binding.insteon.internal.device.database.ModemDBRecord;
 import org.openhab.binding.insteon.internal.device.feature.FeatureEnums.KeypadButtonToggleMode;
 import org.openhab.binding.insteon.internal.handler.InsteonDeviceHandler;
 import org.openhab.binding.insteon.internal.handler.InsteonThingHandler;
@@ -465,9 +466,9 @@ public class DeviceCommand extends InsteonCommand {
             console.println("The modem database is not loaded yet.");
         } else {
             List<String> deviceLinks = device.getMissingDeviceLinks().entrySet().stream()
-                    .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue().getRecord())).toList();
+                    .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue())).toList();
             List<String> modemLinks = device.getMissingModemLinks().entrySet().stream()
-                    .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue().getRecord())).toList();
+                    .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue())).toList();
             if (deviceLinks.isEmpty() && modemLinks.isEmpty()) {
                 console.println("There are no missing links for device " + device.getAddress() + ".");
             } else {
@@ -499,33 +500,33 @@ public class DeviceCommand extends InsteonCommand {
             console.println("The device " + thingId + " is not configured or enabled!");
         } else if (!device.getLinkDB().isComplete()) {
             console.println("The link database for device " + thingId + " is not loaded yet.");
-        } else if (!device.getLinkDB().getChanges().isEmpty()) {
-            console.println("The link database for device " + thingId + " has pending changes.");
         } else if (!getModem().getDB().isComplete()) {
             console.println("The modem database is not loaded yet.");
-        } else if (!getModem().getDB().getChanges().isEmpty()) {
-            console.println("The modem database has pending changes.");
         } else {
-            int deviceLinkCount = device.getMissingDeviceLinks().size();
-            int modemLinkCount = device.getMissingModemLinks().size();
-            if (deviceLinkCount == 0 && modemLinkCount == 0) {
+            List<LinkDBRecord> deviceLinks = device.getMissingDeviceLinks().values().stream().toList();
+            List<ModemDBRecord> modemLinks = device.getMissingModemLinks().values().stream().toList();
+            if (deviceLinks.isEmpty() && modemLinks.isEmpty()) {
                 console.println("There are no missing links for device " + device.getAddress() + ".");
             } else {
-                if (deviceLinkCount > 0) {
+                if (!deviceLinks.isEmpty()) {
                     if (!device.isAwake() || !device.isResponding()) {
-                        console.println("Scheduling " + deviceLinkCount + " missing links for device "
+                        console.println("Scheduling " + deviceLinks.size() + " missing links for device "
                                 + device.getAddress() + " to be added to its link database the next time it is "
                                 + (device.isBatteryPowered() ? "awake" : "online") + ".");
                     } else {
-                        console.println("Adding " + deviceLinkCount + " missing links for device " + device.getAddress()
-                                + " to its link database...");
+                        console.println("Adding " + deviceLinks.size() + " missing links for device "
+                                + device.getAddress() + " to its link database...");
                     }
-                    device.addMissingDeviceLinks();
+                    deviceLinks.forEach(record -> device.getLinkDB().markRecordForAddOrModify(record.getAddress(),
+                            record.getGroup(), record.isController(), record.getData()));
+                    device.getLinkDB().update();
                 }
-                if (modemLinkCount > 0) {
-                    console.println("Adding " + modemLinkCount + " missing links for device " + device.getAddress()
+                if (!modemLinks.isEmpty()) {
+                    console.println("Adding " + modemLinks.size() + " missing links for device " + device.getAddress()
                             + " to the modem database...");
-                    device.addMissingModemLinks();
+                    modemLinks.forEach(record -> getModem().getDB().markRecordForAddOrModify(record.getAddress(),
+                            record.getGroup(), record.isController(), record.getData()));
+                    getModem().getDB().update();
                 }
             }
         }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DefaultLink.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DefaultLink.java
@@ -12,12 +12,9 @@
  */
 package org.openhab.binding.insteon.internal.device;
 
-import java.util.List;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.insteon.internal.device.database.LinkDBRecord;
 import org.openhab.binding.insteon.internal.device.database.ModemDBRecord;
-import org.openhab.binding.insteon.internal.transport.message.Msg;
 
 /**
  * The {@link DefaultLink} represents a device default link
@@ -29,13 +26,11 @@ public class DefaultLink {
     private String name;
     private LinkDBRecord linkDBRecord;
     private ModemDBRecord modemDBRecord;
-    private List<Msg> commands;
 
-    public DefaultLink(String name, LinkDBRecord linkDBRecord, ModemDBRecord modemDBRecord, List<Msg> commands) {
+    public DefaultLink(String name, LinkDBRecord linkDBRecord, ModemDBRecord modemDBRecord) {
         this.name = name;
         this.linkDBRecord = linkDBRecord;
         this.modemDBRecord = modemDBRecord;
-        this.commands = commands;
     }
 
     public String getName() {
@@ -50,16 +45,8 @@ public class DefaultLink {
         return modemDBRecord;
     }
 
-    public List<Msg> getCommands() {
-        return commands;
-    }
-
     @Override
     public String toString() {
-        String s = name + "|linkDB:" + linkDBRecord + "|modemDB:" + modemDBRecord;
-        if (!commands.isEmpty()) {
-            s += "|commands:" + commands;
-        }
-        return s;
+        return name + "|linkDB:" + linkDBRecord + "|modemDB:" + modemDBRecord;
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceFeature.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceFeature.java
@@ -236,13 +236,13 @@ public class DeviceFeature {
 
     public int getComponentId() {
         int componentId = 0;
-        if (device instanceof InsteonDevice insteonDevice) {
+        if (device instanceof InsteonDevice insteonDevice && isControllerOrResponderFeature()) {
             // use feature group as component id if device has more than one controller or responder feature,
-            // othewise use the component id of the link db first record
+            // set to 1 if device link db has a matching record, otherwise fall back to 0
             if (insteonDevice.getControllerOrResponderFeatures().size() > 1) {
                 componentId = getGroup();
-            } else {
-                componentId = insteonDevice.getLinkDB().getFirstRecordComponentId();
+            } else if (insteonDevice.getLinkDB().hasComponentIdRecord(1, isControllerFeature())) {
+                componentId = 1;
             }
         }
         return componentId;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceType.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceType.java
@@ -21,10 +21,6 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.insteon.internal.transport.message.FieldException;
-import org.openhab.binding.insteon.internal.transport.message.InvalidMessageTypeException;
-import org.openhab.binding.insteon.internal.transport.message.Msg;
 import org.openhab.binding.insteon.internal.utils.HexUtils;
 
 /**
@@ -175,7 +171,6 @@ public class DeviceType {
         private boolean controller;
         private int group;
         private byte[] data;
-        private List<CommandEntry> commands = new ArrayList<>();
 
         public DefaultLinkEntry(String name, boolean controller, int group, byte[] data) {
             this.name = name;
@@ -196,68 +191,11 @@ public class DeviceType {
             return data;
         }
 
-        public List<CommandEntry> getCommands() {
-            return commands;
-        }
-
-        public void addCommand(CommandEntry command) {
-            commands.add(command);
-        }
-
         @Override
         public String toString() {
             String s = name + "->";
             s += controller ? "CTRL" : "RESP";
             s += "|group:" + group;
-            s += "|data1:" + HexUtils.getHexString(data[0]);
-            s += "|data2:" + HexUtils.getHexString(data[1]);
-            s += "|data3:" + HexUtils.getHexString(data[2]);
-            if (!commands.isEmpty()) {
-                s += "|commands:" + commands;
-            }
-            return s;
-        }
-    }
-
-    /**
-     * Class that reflects a command entry
-     */
-    public static class CommandEntry {
-        private String name;
-        private int ext;
-        private byte cmd1;
-        private byte cmd2;
-        private byte[] data;
-
-        public CommandEntry(String name, int ext, byte cmd1, byte cmd2, byte[] data) {
-            this.name = name;
-            this.ext = ext;
-            this.cmd1 = cmd1;
-            this.cmd2 = cmd2;
-            this.data = data;
-        }
-
-        public @Nullable Msg getMessage(InsteonDevice device) {
-            try {
-                if (ext == 0) {
-                    return Msg.makeStandardMessage(device.getAddress(), cmd1, cmd2);
-                } else if (ext == 1) {
-                    return Msg.makeExtendedMessage(device.getAddress(), cmd1, cmd2, data,
-                            device.getInsteonEngine().supportsChecksum());
-                } else if (ext == 2) {
-                    return Msg.makeExtendedMessageCRC2(device.getAddress(), cmd1, cmd2, data);
-                }
-            } catch (FieldException | InvalidMessageTypeException e) {
-            }
-            return null;
-        }
-
-        @Override
-        public String toString() {
-            String s = name + "->";
-            s += "ext:" + ext;
-            s += "|cmd1:" + HexUtils.getHexString(cmd1);
-            s += "|cmd2:" + HexUtils.getHexString(cmd2);
             s += "|data1:" + HexUtils.getHexString(data[0]);
             s += "|data2:" + HexUtils.getHexString(data[1]);
             s += "|data3:" + HexUtils.getHexString(data[2]);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceTypeRegistry.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceTypeRegistry.java
@@ -19,10 +19,8 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.insteon.internal.InsteonResourceLoader;
-import org.openhab.binding.insteon.internal.device.DeviceType.CommandEntry;
 import org.openhab.binding.insteon.internal.device.DeviceType.DefaultLinkEntry;
 import org.openhab.binding.insteon.internal.device.DeviceType.FeatureEntry;
-import org.openhab.binding.insteon.internal.utils.HexUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -249,50 +247,9 @@ public class DeviceTypeRegistry extends InsteonResourceLoader {
                 getHexAttributeAsByte(element, "data3") };
 
         DefaultLinkEntry link = new DefaultLinkEntry(name, isController, group, data);
-
-        NodeList nodes = element.getChildNodes();
-        for (int i = 0; i < nodes.getLength(); i++) {
-            Node node = nodes.item(i);
-            if (node.getNodeType() == Node.ELEMENT_NODE) {
-                Element child = (Element) node;
-                String nodeName = child.getNodeName();
-                if ("command".equals(nodeName)) {
-                    link.addCommand(getDefaultLinkCommand(child));
-                }
-            }
-        }
-
         if (links.putIfAbsent(name, link) != null) {
             throw new SAXException("duplicate default link: " + name);
         }
-    }
-
-    /**
-     * Returns a default link command
-     *
-     * @param element element to parse
-     * @return default link command
-     * @throws SAXException
-     */
-    private CommandEntry getDefaultLinkCommand(Element element) throws SAXException {
-        String name = element.getAttribute("name");
-        if (name.isEmpty()) {
-            throw new SAXException("undefined default link command name");
-        }
-        int ext = getAttributeAsInteger(element, "ext");
-        if (ext < 0 || ext > 2) {
-            throw new SAXException("out of bound default link command ext argument: " + ext);
-        }
-        byte cmd1 = getHexAttributeAsByte(element, "cmd1");
-        if (cmd1 == 0) {
-            throw new SAXException("invalid default link command cmd1 argument: " + HexUtils.getHexString(cmd1));
-        }
-        byte cmd2 = getHexAttributeAsByte(element, "cmd2", (byte) 0x00);
-        byte[] data = { getHexAttributeAsByte(element, "data1", (byte) 0x00),
-                getHexAttributeAsByte(element, "data2", (byte) 0x00),
-                getHexAttributeAsByte(element, "data3", (byte) 0x00) };
-
-        return new CommandEntry(name, ext, cmd1, cmd2, data);
     }
 
     /**

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
@@ -92,10 +92,6 @@ public class LinkDB {
         }
     }
 
-    public int getFirstRecordComponentId() {
-        return Optional.ofNullable(getFirstRecord()).map(LinkDBRecord::getComponentId).orElse(0);
-    }
-
     public @Nullable LinkDBRecord getRecord(int location) {
         synchronized (records) {
             return records.get(location);
@@ -351,8 +347,8 @@ public class LinkDB {
     public @Nullable LinkDBRecord addRecord(LinkDBRecord record) {
         synchronized (records) {
             LinkDBRecord prevRecord = records.put(record.getLocation(), record);
-            // move last record if overwritten
-            if (prevRecord != null && prevRecord.isLast()) {
+            // move last record if overwritten by a different record
+            if (prevRecord != null && prevRecord.isLast() && !prevRecord.equals(record)) {
                 int location = prevRecord.getLocation() - LinkDBRecord.SIZE;
                 records.put(location, LinkDBRecord.withNewLocation(location, prevRecord));
                 if (logger.isTraceEnabled()) {
@@ -414,7 +410,7 @@ public class LinkDB {
      *
      * @param change the change to add
      */
-    public void addChange(LinkDBChange change) {
+    private void addChange(LinkDBChange change) {
         synchronized (changes) {
             LinkDBChange prevChange = changes.put(change.getLocation(), change);
             if (prevChange == null) {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBChange.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBChange.java
@@ -52,16 +52,6 @@ public class LinkDBChange extends DatabaseChange<LinkDBRecord> {
     }
 
     /**
-     * Factory method for creating a new LinkDBChange for add
-     *
-     * @param record the record to add
-     * @return the link db change
-     */
-    public static LinkDBChange forAdd(LinkDBRecord record) {
-        return new LinkDBChange(record, ChangeType.ADD);
-    }
-
-    /**
      * Factory method for creating a new LinkDBChange for modify
      *
      * @param record the record to modify

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDB.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDB.java
@@ -391,7 +391,7 @@ public class ModemDB {
      *
      * @param change the change to add
      */
-    public void addChange(ModemDBChange change) {
+    private void addChange(ModemDBChange change) {
         ModemDBRecord record = change.getRecord();
         int index = getChangeIndex(record.getAddress(), record.getGroup(), record.isController());
         if (index == -1) {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDBChange.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDBChange.java
@@ -41,16 +41,6 @@ public class ModemDBChange extends DatabaseChange<ModemDBRecord> {
     }
 
     /**
-     * Factory method for creating a new ModemDBChange for add
-     *
-     * @param record the record to add
-     * @return the modem db change
-     */
-    public static ModemDBChange forAdd(ModemDBRecord record) {
-        return new ModemDBChange(record, ChangeType.ADD);
-    }
-
-    /**
      * Factory method for creating a new ModemDBChange for modify
      *
      * @param record the record to modify

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageHandler.java
@@ -1719,6 +1719,20 @@ public abstract class MessageHandler extends BaseFeatureHandler {
     }
 
     /**
+     * Thermostat status reporting reply message handler
+     */
+    public static class ThermostatStatusReportingReplyHandler extends MessageHandler {
+        ThermostatStatusReportingReplyHandler(DeviceFeature feature) {
+            super(feature);
+        }
+
+        @Override
+        public void handleMessage(byte cmd1, Msg msg) {
+            logger.debug("{}: thermostat status reporting enabled on {}", nm(), getInsteonDevice().getAddress());
+        }
+    }
+
+    /**
      * Venstar thermostat system mode message handler
      */
     public static class VenstarSystemModeMsgHandler extends CustomMsgHandler {

--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-features.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-features.xml
@@ -922,6 +922,12 @@
 		<command-handler default="true">NoOpCommandHandler</command-handler>
 		<poll-handler>NoPollHandler</poll-handler>
 	</feature-type>
+	<feature-type name="ThermostatStatusReporting" hidden="true">
+		<message-dispatcher>DefaultDispatcher</message-dispatcher>
+		<message-handler command="0x19">ThermostatStatusReportingReplyHandler</message-handler>
+		<message-handler default="true">NoOpMsgHandler</message-handler>
+		<poll-handler ext="1" cmd1="0x2E" cmd2="0x00" d2="0x08">FlexPollHandler</poll-handler>
+	</feature-type>
 
 	<feature-type name="VenstarCoolSetpoint">
 		<message-dispatcher>DefaultDispatcher</message-dispatcher>

--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-types.xml
@@ -731,13 +731,12 @@
 			<feature name="timeFormat">ThermostatTimeFormat</feature>
 			<feature name="ledOnOff" bit="6">ThermostatOpFlags</feature>
 		</feature-group>
+		<feature name="reporting">ThermostatStatusReporting</feature>
 		<default-link name="cooling" type="controller" group="1" data1="0x03" data2="0x00" data3="0x01"/>
 		<default-link name="heating" type="controller" group="2" data1="0x03" data2="0x00" data3="0x02"/>
 		<default-link name="dehumidifying" type="controller" group="3" data1="0x03" data2="0x00" data3="0x03"/>
 		<default-link name="humidifying" type="controller" group="4" data1="0x03" data2="0x00" data3="0x04"/>
-		<default-link name="broadcast" type="controller" group="239" data1="0x03" data2="0x00" data3="0xEF">
-			<command name="enableStatusReporting" ext="1" cmd1="0x2E" cmd2="0x00" data2="0x08"/>
-		</default-link>
+		<default-link name="broadcast" type="controller" group="239" data1="0x03" data2="0x00" data3="0xEF"/>
 	</device-type>
 
 	<device-type name="ClimateControl_WirelessThermostat" batteryPowered="true">
@@ -773,13 +772,12 @@
 		<feature-group name="opFlagsGroup" type="OpFlagsGroup">
 			<feature name="stayAwake" on="0x06" off="0x07">OpFlags</feature>
 		</feature-group>
+		<feature name="reporting">ThermostatStatusReporting</feature>
 		<default-link name="cooling" type="controller" group="1" data1="0x03" data2="0x00" data3="0x01"/>
 		<default-link name="heating" type="controller" group="2" data1="0x03" data2="0x00" data3="0x02"/>
 		<default-link name="dehumidifying" type="controller" group="3" data1="0x03" data2="0x00" data3="0x03"/>
 		<default-link name="humidifying" type="controller" group="4" data1="0x03" data2="0x00" data3="0x04"/>
-		<default-link name="broadcast" type="controller" group="239" data1="0x03" data2="0x00" data3="0xEF">
-			<command name="enableStatusReporting" ext="1" cmd1="0x2E" cmd2="0x00" data2="0x08"/>
-		</default-link>
+		<default-link name="broadcast" type="controller" group="239" data1="0x03" data2="0x00" data3="0xEF"/>
 	</device-type>
 
 	<device-type name="ClimateControl_VenstarThermostat">
@@ -798,12 +796,11 @@
 			<feature name="programLock" bit="7" on="0x04" off="0x05">OpFlags</feature>
 			<feature name="ledOnOff" bit="5" on="0x06" off="0x07" inverted="true">OpFlags</feature>
 		</feature-group>
+		<feature name="reporting">ThermostatStatusReporting</feature>
 		<default-link name="cooling" type="controller" group="1" data1="0x03" data2="0x00" data3="0x01"/>
 		<default-link name="heating" type="controller" group="2" data1="0x03" data2="0x00" data3="0x02"/>
 		<default-link name="fan" type="controller" group="3" data1="0x03" data2="0x00" data3="0x03"/>
-		<default-link name="broadcast" type="controller" group="239" data1="0x03" data2="0x00" data3="0xEF">
-			<command name="enableStatusReporting" ext="1" cmd1="0x2E" cmd2="0x00" data2="0x08"/>
-		</default-link>
+		<default-link name="broadcast" type="controller" group="239" data1="0x03" data2="0x00" data3="0xEF"/>
 	</device-type>
 
 	<!-- Sensors and Actuators -->


### PR DESCRIPTION
This change fixes the missing links implementation. It includes:

* Ignore missing modem links when its monitor mode is on.
* Allowing device with one component to have a component ID of `0` or `1` instead of being driven by the default link configuration.
* Removing default link command support migrating the configure commands as hidden features.
* Refactoring the device missing links console commands

This should be backported as the current implementation identifies false positives with unnecessary warning log statements, along with the `addMissingLinks` console command failing to add multiple modem missing links in a row requiring the command to be ran multiple times.