### PR TITLE
[energidataservice] Update tariff filter for FLOW Elnet

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/filters/grid_tariffs.yaml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/filters/grid_tariffs.yaml
@@ -48,9 +48,9 @@
 # FLOW Elnet
 - gln: "5790000392551"
   chargeTypeCodes:
-    - "FE2 NT-01"
+    - "FE1 NT-01"
   notes:
-    - "Nettarif C time"
+    - "Nettarif C"
   start: "StartOfDay"
 # Hammel Elforsyning Net
 - gln: "5790001090166"


### PR DESCRIPTION
This reflects data published since 01.01.2025 - see:
https://flow-elnet.dk/fileadmin/user_upload/PDF/Prisblad_Flow-Elnet_2025-01-01.pdf