### PR TITLE
[shelly] Improve smoke sensor wake-up period handling

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -356,9 +356,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             tmpPrf.updatePeriod = "m".equalsIgnoreCase(getString(tmpPrf.settings.sleepMode.unit))
                     ? tmpPrf.settings.sleepMode.period * 60 // minutes
                     : tmpPrf.settings.sleepMode.period * 3600; // hours
-            !tmpPrf.isSmoke
-                    ? tmpPrf.updatePeriod += 60; // give 1min extra
-                    : tmpPrf.updatePeriod += 1800; // for smoke sensor give 30min extra
+                    if (tmpPrf.isSmoke) {
+                        tmpPrf.updatePeriod += 1800; // for smoke sensor give 30min extra
+                    } else {
+                        tmpPrf.updatePeriod += 60; // give 1min extra
+                    }
         } else if (tmpPrf.settings.coiot != null && tmpPrf.settings.coiot.updatePeriod != null) {
             // Derive from CoAP update interval, usually 2*15+10s=40sec -> 70sec
             tmpPrf.updatePeriod = Math.max(UPDATE_SETTINGS_INTERVAL_SECONDS,

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -356,7 +356,9 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             tmpPrf.updatePeriod = "m".equalsIgnoreCase(getString(tmpPrf.settings.sleepMode.unit))
                     ? tmpPrf.settings.sleepMode.period * 60 // minutes
                     : tmpPrf.settings.sleepMode.period * 3600; // hours
-            tmpPrf.updatePeriod += 60; // give 1min extra
+            !tmpPrf.isSmoke
+                    ? tmpPrf.updatePeriod += 60; // give 1min extra
+                    : tmpPrf.updatePeriod += 1800; // for smoke sensor give 30min extra
         } else if (tmpPrf.settings.coiot != null && tmpPrf.settings.coiot.updatePeriod != null) {
             // Derive from CoAP update interval, usually 2*15+10s=40sec -> 70sec
             tmpPrf.updatePeriod = Math.max(UPDATE_SETTINGS_INTERVAL_SECONDS,

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -356,11 +356,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             tmpPrf.updatePeriod = "m".equalsIgnoreCase(getString(tmpPrf.settings.sleepMode.unit))
                     ? tmpPrf.settings.sleepMode.period * 60 // minutes
                     : tmpPrf.settings.sleepMode.period * 3600; // hours
-                    if (tmpPrf.isSmoke) {
-                        tmpPrf.updatePeriod += 1800; // for smoke sensor give 30min extra
-                    } else {
-                        tmpPrf.updatePeriod += 60; // give 1min extra
-                    }
+            if (tmpPrf.isSmoke) {
+                tmpPrf.updatePeriod += 1800; // for smoke sensor give 30min extra
+            } else {
+                tmpPrf.updatePeriod += 60; // give 1min extra
+            }
         } else if (tmpPrf.settings.coiot != null && tmpPrf.settings.coiot.updatePeriod != null) {
             // Derive from CoAP update interval, usually 2*15+10s=40sec -> 70sec
             tmpPrf.updatePeriod = Math.max(UPDATE_SETTINGS_INTERVAL_SECONDS,


### PR DESCRIPTION
To prevent shelly smoke sensors to go offline if they slightly exceed the reported wake up period (24 hours) the time limit is extended by 30 minutes for this kind of devices.

Fixes #17767