### PR TITLE
[Keba] Implement thing action to set display text

### DIFF
--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -70,7 +70,7 @@ end
 
 | Parameter  | Description                                                                                                                                |
 |------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| text  | Text shown on the display. Maximum 23 ASCII characters can be used., ~ == \u03A3, $ == blank, == comma |
+| text  | Text shown on the display. Maximum 23 ASCII characters can be used. `~` == Σ, `$` == blank, `,` == comma |
 | durationMin _(optional)_   | Defines the duration in seconds how long the text will displayed before another display command will be processed (internal MID metering relevant information may overrule this) |
 | durationMax _(optional)_| Defines the duration in seconds how long the text will displayed if no additional display command follows. |
 

--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -48,6 +48,33 @@ All devices support the following channels:
 | maxpilotcurrent         | Number:ElectricCurrent   | yes       | current offered to the vehicle via control pilot signalization          |
 | maxpilotcurrentdutycyle | Number:Dimensionless     | yes       | duty cycle of the control pilot signal                                  |
 
+## Rule Actions
+Certain Keba models support setting the text on the built in display.
+The text cannot be set via a rule action `setDisplay`. It comes in two variants:
+
+```java
+
+rule "Set Display Text"
+when
+  System reached start level 100
+then
+   val keContactActions = getActions("keba", "keba:kecontact:1")
+   // Default duration
+   keContactActions.setDisplay("TEXT$1")
+   // Explicit duration set
+   keContactActions.setDisplay("TEXT$2", 5, 10)
+end
+
+```
+
+
+| Parameter  | Description                                                                                                                                |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| text  | Text shown on the display. Maximum 23 ASCII characters can be used., ~ == \u03A3, $ == blank, == comma |
+| durationMin _(optional)_   | Defines the duration in seconds how long the text will displayed before another display command will be processed (internal MID metering relevant information may overrule this) |
+| durationMax _(optional)_| Defines the duration in seconds how long the text will displayed if no additional display command follows. |
+
+
 ## Example
 
 demo.Things:

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactActions.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactActions.java
@@ -1,0 +1,68 @@
+package org.openhab.binding.keba.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.keba.internal.KebaBindingConstants;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component(scope = ServiceScope.PROTOTYPE, service = KeContactActions.class)
+@ThingActionsScope(name = KebaBindingConstants.BINDING_ID) // Your bindings id is usually the scope
+@NonNullByDefault
+public class KeContactActions implements ThingActions {
+    private final Logger logger = LoggerFactory.getLogger(KeContactActions.class);
+    private @Nullable KeContactHandler handler;
+
+    @Override
+    public void setThingHandler(ThingHandler handler) {
+        this.handler = (KeContactHandler) handler;
+
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")
+    public void setDisplay(
+
+            @ActionInput(name = "text", label = "@text/actionInputTextLabel", description = "@text/actionInputTextDesc") @Nullable String text,
+
+            @ActionInput(name = "durationMin", label = "@text/actionInputDurationMinLabel", description = "@text/actionInputDurationMinDesc") int durationMin,
+
+            @ActionInput(name = "durationMax", label = "@text/actionInputDurationMaxLabel", description = "@text/actionInputDurationMaxDesc") int durationMax) {
+        if (handler == null) {
+            logger.warn("KeContact Action service ThingHandler is null!");
+            return;
+        }
+        handler.setDisplay(text, durationMin, durationMax);
+    }
+
+    public static void setDisplay(ThingActions actions, @Nullable String text, int durationMin, int durationMax) {
+        ((KeContactActions) actions).setDisplay(text, durationMin, durationMax);
+    }
+
+    @RuleAction(label = "@text/actionLabel", description = "@text/actionDesc")
+    public void setDisplay(
+
+            @ActionInput(name = "text", label = "@text/actionInputTextLabel", description = "@text/actionInputTextDesc") @Nullable String text) {
+        if (handler == null) {
+            logger.warn("KeContact Action service ThingHandler is null!");
+            return;
+        }
+        handler.setDisplay(text, -1, -1);
+    }
+
+    public static void setDisplay(ThingActions actions, @Nullable String text) {
+        ((KeContactActions) actions).setDisplay(text);
+    }
+
+}

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactActions.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactActions.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.keba.internal.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -13,8 +25,14 @@ import org.osgi.service.component.annotations.ServiceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The {@link KeContactActions} is responsible for handling actions, which
+ * are sent to the binding.
+ *
+ * @author Simon Spielmann - Initial contribution
+ */
 @Component(scope = ServiceScope.PROTOTYPE, service = KeContactActions.class)
-@ThingActionsScope(name = KebaBindingConstants.BINDING_ID) // Your bindings id is usually the scope
+@ThingActionsScope(name = KebaBindingConstants.BINDING_ID)
 @NonNullByDefault
 public class KeContactActions implements ThingActions {
     private final Logger logger = LoggerFactory.getLogger(KeContactActions.class);
@@ -23,7 +41,6 @@ public class KeContactActions implements ThingActions {
     @Override
     public void setThingHandler(ThingHandler handler) {
         this.handler = (KeContactHandler) handler;
-
     }
 
     @Override
@@ -64,5 +81,4 @@ public class KeContactActions implements ThingActions {
     public static void setDisplay(ThingActions actions, @Nullable String text) {
         ((KeContactActions) actions).setDisplay(text);
     }
-
 }

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/i18n/keba.properties
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/i18n/keba.properties
@@ -90,3 +90,13 @@ channel-type.keba.x1.label = X1
 channel-type.keba.x1.description = State of the X1 input
 channel-type.keba.x2.label = X2
 channel-type.keba.x2.description = State of the X2 output
+
+# thing actions
+actionLabel = set text in display
+actionDesc = Sets a text to show in the display of the wallbox
+actionInputTextLabel = Text
+actionInputTextDesc = Text shown on the display. Maximum 23 ASCII characters can be used., ~ == \u03A3, $ == blank, == comma
+actionInputDurationMinLabel = Duration (min)
+actionInputDurationMinDesc =  Defines the duration in seconds how long the text will displayed before another display command will be processed (internal MID metering relevant information may overrule this).
+actionInputDurationMaxLabel = Duration (max)
+actionInputDurationMaxDesc =  Defines the duration in seconds how long the text will displayed if no additional display command follows.

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/i18n/keba.properties
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/i18n/keba.properties
@@ -95,7 +95,7 @@ channel-type.keba.x2.description = State of the X2 output
 actionLabel = set text in display
 actionDesc = Sets a text to show in the display of the wallbox
 actionInputTextLabel = Text
-actionInputTextDesc = Text shown on the display. Maximum 23 ASCII characters can be used., ~ == \u03A3, $ == blank, == comma
+actionInputTextDesc = Text shown on the display. Maximum 23 ASCII characters can be used. ~ == \u03A3, $ == blank, == comma
 actionInputDurationMinLabel = Duration (min)
 actionInputDurationMinDesc =  Defines the duration in seconds how long the text will displayed before another display command will be processed (internal MID metering relevant information may overrule this).
 actionInputDurationMaxLabel = Duration (max)


### PR DESCRIPTION
This PR is related to the suggestion in #18025.
It implements a new thing action for the keba binding which allows to set the display text:


```java

rule "Set Display Text"
when
  System reached start level 100
then
   val keContactActions = getActions("keba", "keba:kecontact:1")
   // Default duration
   keContactActions.setDisplay("TEXT$1")
   // Explicit duration set
   keContactActions.setDisplay("TEXT$2", 5, 10)
end

```

Regarding QS I created a version for 4.x and tested it. Works quite well. There are now code changes in 5.x, and in the end it uses the existing infrastructure of the binding to set the display text. So assume it will work in 5.x also.
