### PR TITLE
[insteon] Revert specific icon products first record

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
@@ -303,7 +303,7 @@
 		<vendor>Insteon</vendor>
 		<device-type>DimmableLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x01" subCat="0x1E">
+	<product devCat="0x01" subCat="0x1E" firstRecord="0x00FF">
 		<description>ICON Dimmer Switch</description>
 		<model>2876DB</model>
 		<vendor>Insteon</vendor>
@@ -689,13 +689,13 @@
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x02" subCat="0x16">
+	<product devCat="0x02" subCat="0x16" firstRecord="0x00FF">
 		<description>ICON On/Off Switch</description>
 		<model>2876SB</model>
 		<vendor>Insteon</vendor>
 		<device-type>SwitchedLightingControl_SwitchLinc</device-type>
 	</product>
-	<product devCat="0x02" subCat="0x17">
+	<product devCat="0x02" subCat="0x17" firstRecord="0x00FF">
 		<description>ICON Appliance Module</description>
 		<model>2856S3B</model>
 		<vendor>Insteon</vendor>


### PR DESCRIPTION
This reverts the first record config change for specific icon products in #18271. It seems that products from that line with two defined versions use `0x00FF` on the most recent one. This was confirm by the user that reported this issue. It includes the following devices:

* ICON Dimmer Switch (2876DB)
  * `0x01 0x03` @ `0x0FFF`
  * `0x01 0x1E` @ `0x00FF`
* ICON On/Off Switch (2876SB)
  * `0x02 0x0B` @ `0x0FFF`
  * `0x02 0x16` @ `0x00FF`
* ICON Appliance Module (2856S3B)
  * `0x02 0x0C` @ `0x0FFF`
  * `0x02 0x17` @ `0x00FF`

This should be backported.