### PR TITLE
Add lambda heat pump based on modbus binding

### DIFF
--- a/bundles/org.openhab.binding.modbus.lambda/NOTICE
+++ b/bundles/org.openhab.binding.modbus.lambda/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.modbus.lambda/README.md
+++ b/bundles/org.openhab.binding.modbus.lambda/README.md
@@ -1,0 +1,254 @@
+# Lambda Heat Pump
+
+This extension adds support for the Lambda Heat Pump modbus protocol as provided by
+<https://lambda-wp.at/wp-content/uploads/2024/11/Modbus-Protokoll-und-Beschreibung.pdf >
+
+A Lambda Heat Pump has to be reachable within your network.
+If you plan to use the E-Manager part to hand over your PV excess to the heat pump ask Lambda support to 
+configure it to  
+E-Meter Kommunikationsart:          ModBus Client
+E-Meter Messpunkt:                  E-Eintrag
+
+Other configurations of the E-Manager are not supported (yet).
+
+## Supported Things
+
+This bundle adds the following thing types to the Modbus binding.
+Note, that the things will show up under the Modbus binding.
+
+| Thing                  | ThingTypeID         | Description                             |
+| ---------------------- | --------------------| --------------------------------------- |
+| Lambda General         | lambda-general      | General sections Ambient and E-Manager  |
+| Lambda Heatpump        | lambda-heatpump     | Heatpump section                        |
+| Lambda Boiler          | lambda-boiler       | Boiler section                          |
+| Lambda Buffer          | lambda-buffer       | Buffer section                          |
+| Lambda Heating Circuit | lambda-heating      | Heating circuit section                 |
+
+A Modbus Bridge has to be installed before installing the above mentioned things.
+The binding supports installations with more than one Heat Pump, Boiler, Buffer, Heating Circuit.
+For each of these parts you have to provide the Subindex of your thing in the configurations section, 
+usually using the User Interface. So if you have two Heating Circuits use 0 for the first and 1 for 
+the second Heating Circuit.
+Handling of General System Settings (Base Adress 200) and Solar (Base Adress 4000) are not supported (yet).
+Some of the registers noted RW in the manual are read only in the binding.
+
+## Discovery
+
+This extension does not support autodiscovery. The things need to be added manually.
+
+A typical modbus bridge configuration would look like this:
+
+```java
+Bridge modbus:tcp:bridge [ host="10.0.0.2", port=502, id=1 ]
+```
+
+## Thing Configuration
+
+You first need to set up a TCP Modbus bridge according to the Modbus documentation.
+You then add the things of the Lambda Heat Pump system as part of the modbus binding.
+Things in this extension will use the selected bridge to connect to the device.
+
+The following parameters are valid for all things:
+
+| Parameter | Type    | Required | Default if omitted | Description                                                                |
+| --------- | ------- | -------- | ------------------ | -------------------------------------------------------------------------- |
+| refresh   | integer | no       | 30                 | Poll interval in seconds. Increase this if you encounter connection errors |
+| maxTries  | integer | no       | 3                  | Number of retries when before giving up reading from this thing.           |
+
+The other things use another parameter Subindex to add one or more things of this type:
+
+| Parameter | Type    | Required | Default if omitted | Description                                                                |
+| --------- | ------- | -------- | ------------------ | -------------------------------------------------------------------------- |
+| Subindex  | integer | yes      | 0                  | Subindex for things of the same thing type, starting with 0                |
+
+| Thing Type             | Range   | 
+| ---------------------- | ------- | 
+| Lambda Heatpump        | 0..2    | 
+| Lambda Boiler          | 0..4    | 
+| Lambda Buffer          | 0..4    | 
+| Lambda Heating Circuit | 0..11   | 
+
+## Channels
+
+Channels within the things are grouped into channel groups.
+
+### General Ambient Group
+
+| Channel ID                       | Item Type          | Read only | Description                                                              |
+| -------------------------------- | ------------------ | --------- | ------------------------------------------------------------------------ |
+| ambient-error-number             | Number             | true      | Ambient Error Number (0 = No error)                                      |
+| ambient-operating-state          | Number             | true      | Ambient Operating State (0 = OFF, 1 = AUTOMATIC, 2 = MANUAL, 3 = ERROR)  |
+| actual-ambient-temperature       | Number:Temperature | false     | Actual Ambient Temperature (min = -50.0°C); max = 80.0°                  |
+| average-ambient-temperature      | Number:Temperature | true      | Arithmetic average temperature of the last 60 minutes                    |
+| calculated-ambient-temperature   | Number:Temperature | true      | Temperature for calculations in heat distribution modules                |
+
+### Lambda General: General E-Manager Group
+
+This group contains parameters signaling the PV excess to the heat pump.
+
+| Channel ID                       | Item Type          | Read only | Description                                                                              |
+| -------------------------------- | ------------------ | --------- | --------------------------------------------------------------------------------------- |
+| emanager-error-number            | Number             | true      | E-Manager Error Number (0 = No error)                                                   |
+| emanager-operating-state         | Number             | true      | E-Manager Operating State (0 = OFF, 1 = AUTOMATIC, 2 = MANUAL, 3 = ERROR 4 = OFFLINE    |
+| actual-power                     | Number:Power       | false     | Actual excess power -32768 W .. 32767 W                                                 |
+| actual-power-consumption         | Number:Power       | true      | Power consumption of heatpump (only valid when Betriebsart: Automatik, 0 W otherwise)   |
+| power-consumption-setpoint       | Number:Power       | false     | Power consumption setpoint for heat pump 1                                              |
+
+### Heat Pump 1 Group
+
+This group contains general operational information about the heat pump itself.
+
+| Channel ID                     | Item Type                | Read only | Description                                                             |
+| -------------------------------| -------------------------| --------- | ----------------------------------------------------------------------- |
+| heatpump-error-state          | Number                    | true      | Error state  (0 = NONE, 1 = MESSAGE, 2 = WARNING, 3 = ALARM, 4 = FAULT) |
+| heatpump-error-number         | Number                    | true      | Error number: scrolling through all active error numbers (1..99)        |
+| heatpump-state                | Number                    | true      | State: See Modbus description manual, link above                        |
+| heatpump-operating-state      | Number                    | true      | Operating State: See Modbus description manual, link above              |
+| heatpump-t-flow               | Number:Temperature        | true      | Flow line termperature                                                  |
+| heatpump-t-return             | Number:Temperature        | true      | Return line temperature                                                 |
+| heatpump-vol-sink             | Number:VolumetricFlowRate | true      | Volume flow heat sink                                                   |
+| heatpump-t-eqin               | Number:Temperature        | true      | Energy source inlet temperature                                         |
+| heatpump-t-eqout              | Number:Temperature        | true      | Energy source outlet temperature                                        |
+| heatpump-vol-source           | Number:VolumetricFlowRate | true      | Volume flow energy source                                               |
+| heatpump-compressor-rating    | Number                    | true      | Compressor unit rating                                                  |
+| heatpump-qp-heating           | Number:Power              | true      | Actual heating capacity                                                 |
+| heatpump-fi-power-consumption | Number:Power              | true      | Frequency inverter actual power consumption                             |
+| heatpump-cop                  | Number                    | true      | Coefficient of performance                                              | 
+| heatpump-vdae                 | Number:Energy             | true      | Accumulated electrical energy consumption of compressor unit            |
+| heatpump-vdaq                 | Number:Energy             | true      | Accumulated thermal energy output of compressor unit                    |
+| heatpump-set-error-quit       | Number                    | false     | Set Error Quit (1 = Quit all active heat pump errors                    |
+
+### Lambda Boiler: Boiler Group
+
+This group contains information about the boiler for the water for domestic use / tap water / washwater.
+
+| Channel ID                        | Item Type          | Read only | Description                                                        |
+| --------------------------------- | ------------------ | --------- | ------------------------------------------------------------------ |
+| boiler-error-number               | Number             | true      | Boiler Error Number(0 = No error)                                  |
+| boiler-operating-state            | Number             | true      | Boiler Operating State: See Modbus description manual, link above  |
+| boiler-actual-high-temperature    | Number:Temperature | true      | Actual temperature boiler high sensor                              |
+| boiler-actual-low-temperature     | Number:Temperature | true      | Actual temperature boiler low sensor                               |
+| boiler-maximum-boiler-temperature | Number:Temperature | false     | Setting for maximum boiler temperature (min = 25.0°C; max = 65.0°C)|
+
+### Lambda Buffer: Buffer Group
+
+This group contains information about the buffer for the heating circuit.
+
+| Channel ID                             | Item Type          | Read only | Description                                                            |
+| -------------------------------------- | ------------------ | --------- | ---------------------------------------------------------------------- |
+| buffer-error-number                    | Number             | true      | Buffer Error Number (0 = No error)                                     |
+| buffer-operating-state                 | Number             | true      | Buffer Operating State: See Modbus description manual, link above      |
+| buffer-actual-high-temperature         | Number:Temperature | true      | Actual temperature buffer high sensor                                  |
+| buffer-actual-low-temperature          | Number:Temperature | true      | Actual temperature buffer low sensor                                   |
+| buffer-maximum-buffer-temperature      | Number:Temperature | false     | Setting for maximum buffer temperature (min = 25.0°C; max = 65.0°C)    |
+
+
+### Lambda Heating: Heating Circuit Group
+
+This group contains general operational information about the heating circuit.
+
+| Channel ID                                    | Item Type          | Read only | Description                                                                     |
+| --------------------------------------------- | -------------------| --------- | ------------------------------------------------------------------------------- |
+| heatingcircuit-error-number                   | Number             | true      | Error Number (0 = No error)                                                     |
+| heatingcircuit-operating-state                | Number             | true      | Operating State: See Modbus description manual, link above|                     |
+| heatingcircuit-flow-line-temperature          | Number:Temperature | true      | Actual temperature flow line sensor                                             |
+| heatingcircuit-return-line-temperature        | Number:Temperature | true      | Actual temperature return line sensor                                           |
+| heatingcircuit-room-device-temperature        | Number:Temperature | false     | Actual temperature room device sensor (min = -29.9°C; max = 99.9°C)             |
+| heatingcircuit-setpoint-flow-line-temperature | Number:Temperature | false     | Setpoint temperature flow line (min = 15.0°C; max = 65.0°C)                     | 
+| heatingcircuit-operating-mode                 | Number             | false     | Operating Mode: See Modbus description manual, link above                       |
+| heatingcircuit-offset-flow-line-temperature   | Number:Temperature | false     | Setting for flow line temperature setpoint offset(min = -10.0K; max = 10.0K)    |
+| heatingcircuit-room-heating-temperature       | Number:Temperature | false     | Setting for heating mode room setpoint temperature(min = 15.0°C; max = 40.0 °C) |
+| heatingcircuit-room-cooling-temperature       | Number:Temperature | false     | Setting for cooling mode room setpoint temperature(min = 15.0°C; max = 40.0 °C) |
+
+## Full Example
+
+### Things
+```java
+Bridge modbus:tcp:Lambda_Bridge "Lambda Modbus TCP Bridge" [ host="192.168.223.83", port=502, id=1, enableDiscovery=false ] {
+    Thing lambda-general lambdageneral "Lambda General" (modbus:tcp:Lambda_Bridge) [ refresh=60, subindex=0 ] 
+    Thing lambda-heatpump lambdaheatpump "Lambda Heatpump" (modbus:tcp:Lambda_Bridge) [ refresh=60, subindex=0 ]
+    Thing lambda-boiler lambdaboiler "Lambda Boiler" (modbus:tcp:Lambda_Bridge) [ refresh=60, subindex=0 ]
+    Thing lambda-buffer lambdabuffer "Lambda Buffer" (modbus:tcp:Lambda_Bridge) [ refresh=60, subindex=0 ]
+    Thing lambda-heatingcircuit lambdaheatingcircuit "Lambda Heating Circuit" (modbus:tcp:Lambda_Bridge) [ refresh=60, subindex=0 ]
+}
+```
+
+### Items Lambda General
+```java
+Number              lambdaambient_operatingstate               "Ambient Operating State"             (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:ambient-group#ambient-operating-state" }
+Number              lambdaambient_errornumber                  "Ambient Error Number"                (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:ambient-group#ambient-error-number" }
+Number:Temperature  lambdaambient_actualambienttemperature     "Ambient Actual Temperature"          (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:ambient-group#actual-ambient-temperature" }
+Number:Temperature  lambdaambient_averageambienttemperature    "Ambient Average Temperature"         (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:ambient-group#average-ambient-temperature" }
+Number:Temperature  lambdaambient_calculatedambienttemperature "Ambient Calculated Temperature"      (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:ambient-group#calculated-ambient-temperature" }
+Number              lambdaemanager_operatingstate              "EManager Operating State"            (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:emanager-group#emanager-operating-state" }
+Number              lambdaemanager_errornumber                 "EManager Error Number"               (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:emanager-group#emanager-error-number" }
+Number:Power        lambdaemanager_actualpower                 "EManager Actual Power"               (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:emanager-group#actual-power" }
+Number:Power        lambdaemanager_actualpowerconsumption      "EManager Actual Power Consumption"   (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:emanager-group#actual-power-consumption" }
+Number:Power        lambdaemanager_powerconsumptionsetpoint    "EManager Power Consumption Setpoint" (lambdageneral)  { channel="modbus:lambda-general:Lambda_Bridge:lambdageneral:emanager-group#power-consumption-setpoint" }
+```
+
+### Items Lambda Heatpump
+```java
+Number                     lambdaheatpump_errorstate          "Heatpump Error State"                                 (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-error-state" }
+Number                     lambdaheatpump_errornumber         "Heatpump Error Number"                                (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-error-number" }
+Number                     lambdaheatpump_state               "Heatpump State"                                       (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-state" }
+Number                     lambdaheatpump_operatingstate      "Heatpump Operating State"                             (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-operating-state" }
+Number:Temperature         lambdaheatpump_tflow               "Heatpump Flow Line Temperature"                       (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-t-flow" }
+Number:Temperature         lambdaheatpump_treturn             "Heatpump Return Line Temperature"                     (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-t-return" }
+Number:VolumetricFlowRate  lambdaheatpump_volsink             "Heatpump Volume Flow Heat Sink"                       (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-vol-sink" }
+Number:Temperature         lambdaheatpump_teqin               "Heatpump Energy Source Inlet Temperature"             (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-t-eqin" }
+Number:Temperature         lambdaheatpump_teqout              "Heatpump Energy Source Outlet Temperature"            (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-t-eqout" }
+Number:VolumetricFlowRate  lambdaheatpump_volsource           "Heatpump Volume Flow Energy Source"                   (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-vol-source" }
+Number                     lambdaheatpump_compressorrating    "Heatpump Compressor Rating"                           (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-compressor-rating" }
+Number:Power               lambdaheatpump_qpheating           "Heatpump Actual Heating Capacity"                     (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-qp-heating" }
+Number:Power               lambdaheatpump_fipowerconsumption  "Heatpump Frequency inverter Actual Power Consumption" (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-fi-power-consumption" }
+Number                     lambdaheatpump_cop                 "Heatpump COP"                                         (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-cop" }
+Number:Energy              lambdaheatpump_vdae                "Heatpump Accumulated Electrical Energy consumption"   (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-vdae" }
+Number:Energy              lambdaheatpump_vdaq                "Heatpump Accumulated Thermical Energy consumption"    (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-vdaq" }
+Number                     lambdaheatpump_seterrorquit        "Heatpump Set Error Quit"                              (lambdaheatpump)       { channel="modbus:lambda-heatpump:Lambda_Bridge:lambdaheatpump:heatpump-group#heatpump-set-error-quit" }
+```
+
+### Items Lambda Boiler
+```java
+Number              lambdaboiler_operatingstate            "Boiler Operating State"            (lambdaboiler)  { channel="modbus:lambda-boiler:Lambda_Bridge:lambdaboiler:boiler-group#boiler-operating-state" }
+Number              lambdaboiler_errornumber               "Boiler Error Number"               (lambdaboiler)  { channel="modbus:lambda-boiler:Lambda_Bridge:lambdaboiler:boiler-group#boiler-error-number" }
+Number:Temperature  lambdaboiler_actualhightemperature     "Boiler Actual High Temperature"    (lambdaboiler)  { channel="modbus:lambda-boiler:Lambda_Bridge:lambdaboiler:boiler-group#boiler-actual-high-temperature" }
+Number:Temperature  lambdaboiler_actuallowtemperature      "Boiler Actual Low Temperature"     (lambdaboiler)  { channel="modbus:lambda-boiler:Lambda_Bridge:lambdaboiler:boiler-group#boiler-actual-low-temperature" }
+Number:Temperature  lambdaboiler_maximumboilertemperature  "Maximum Boiler Temperature"        (lambdaboiler)  { channel="modbus:lambda-boiler:Lambda_Bridge:lambdaboiler:boiler-group#boiler-maximum-boiler-temperature" }
+```
+
+### Items Lambda Buffer
+```java
+Number              lambdabuffer_operatingstate            "Buffer Operating State"            (lambdabuffer)  { channel="modbus:lambda-buffer:Lambda_Bridge:lambdabuffer:buffer-group#buffer-operating-state" }
+Number              lambdabuffer_errornumber               "Buffer Error Number"               (lambdabuffer)  { channel="modbus:lambda-buffer:Lambda_Bridge:lambdabuffer:buffer-group#buffer-error-number" }
+Number:Temperature  lambdabuffer_actualhightemperature     "Buffer Actual High Temperature"    (lambdabuffer)  { channel="modbus:lambda-buffer:Lambda_Bridge:lambdabuffer:buffer-group#buffer-actual-high-temperature" }
+Number:Temperature  lambdabuffer_actuallowtemperature      "Buffer Actual Low Temperature"     (lambdabuffer)  { channel="modbus:lambda-buffer:Lambda_Bridge:lambdabuffer:buffer-group#buffer-actual-low-temperature" }
+Number:Temperature  lambdabuffer_maximumbuffertemperature  "Maximum Buffer Temperature"        (lambdabuffer)  { channel="modbus:lambda-buffer:Lambda_Bridge:lambdabuffer:buffer-group#buffer-maximum-buffer-temperature" }
+```
+
+
+### Items Heatingcircuit
+```java
+Number                     lambdaheatingcircuit_errornumber                  "Heatingcircuit Error Number"                    (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-error-number" }
+Number                     lambdaheatingcircuit_operatingstate               "Heatingcircuit Operating State"                 (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-operating-state" }
+Number:Temperature         lambdaheatingcircuit_flowlinetemperature          "Heatingcircuit Flow Line Temperature"           (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-flow-line-temperature" }
+Number:Temperature         lambdaheatingcircuit_returnlinetemperature        "Heatingcircuit Return Line Temperature"         (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-return-line-temperature" }
+Number:Temperature         lambdaheatingcircuit_roomdevicetemperature        "Heatingcircuit Room Device Temperature"         (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-room-device-temperature" }
+Number:Temperature         lambdaheatingcircuit_setpointflowlinetemperature  "Heatingcircuit Setpoint Flow Line Temperature"  (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-setpoint-flow-line-temperature" }
+Number                     lambdaheatingcircuit_operatingmode                "Heatingcircuit Operating Mode"                  (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-operating-mode" }
+Number:Temperature         lambdaheatingcircuit_offsetflowlinetemperature    "Heatingcircuit Offset Flow Line Temperature"    (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-offset-flow-line-temperature" }
+Number:Temperature         lambdaheatingcircuit_roomheatingtemperature       "Heatingcircuit Room Heating Temperature"        (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-room-heating-temperature" }
+Number:Temperature         lambdaheatingcircuit_roomcoolingtemperature       "Heatingcircuit Room Cooling Temperature"        (lambdaheatingcircuit)       { channel="modbus:lambda-heatingcircuit:Lambda_Bridge:lambdaheating:heatingcircuit-group#heatingcircuit-room-cooling-temperature" }
+```
+
+### Example: (DSL) Send Power value the E-Manager of the Lambda Heat Pump
+// Sending Value to Heatpump
+// Script has to send a value about every 30 seconds, for example with cron settings
+// Calculate power_to_heatpump using your data provided by the PV system
+// var int power_to_heatpump =  ((lambdaemanager_actualpowerconsumption.state as Number) - (PV_Battery.state as Number) - (PV_Grid.state as Number)).intValue
+
+var int power_to_heatpump = 1000  
+
+  lambdahp_actual_power.sendCommand(power_to_heatpump)
+
+

--- a/bundles/org.openhab.binding.modbus.lambda/pom.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.modbus.lambda</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Lambda Bundle</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.modbus</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/BoilerConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/BoilerConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link BoilerConfiguration} class contains fields mapping
+ * thing configuration parameters.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class BoilerConfiguration {
+
+    /**
+     * Refresh interval in seconds
+     */
+    private int refresh = 30;
+
+    private int maxTries = 3;
+    // backwards compatibility and tests
+
+    /**
+     * Subindex to calculate the base adress of the modbus registers
+     */
+    private int subindex = 0;
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+
+    public int getSubindex() {
+        return subindex;
+    }
+
+    public void setSubindex(int subindex) {
+        this.subindex = subindex;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/BufferConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/BufferConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link BufferConfiguration} class contains fields mapping
+ * thing configuration parameters.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class BufferConfiguration {
+    /**
+     * Refresh interval in seconds
+     */
+    private int refresh = 30;
+
+    private int maxTries = 3;
+    // backwards compatibility and tests
+
+    /**
+     * Subindex to calculate the base adress of the modbus registers
+     */
+    private int subindex = 0;
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+
+    public int getSubindex() {
+        return subindex;
+    }
+
+    public void setSubindex(int subindex) {
+        this.subindex = subindex;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/GeneralConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/GeneralConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link GeneralConfiguration} class contains fields mapping
+ * thing configuration parameters.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class GeneralConfiguration {
+    /**
+     * Refresh interval in seconds
+     */
+    private int refresh = 30;
+
+    private int maxTries = 3;// backwards compatibility and tests
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/HeatingCircuitConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/HeatingCircuitConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link HeatingCircuitConfiguration} class contains fields mapping
+ * thing configuration parameters.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class HeatingCircuitConfiguration {
+    /**
+     * Refresh interval in seconds
+     */
+    private int refresh = 30;
+
+    private int maxTries = 3;
+    // backwards compatibility and tests
+
+    /**
+     * Subindex to calculate the base adress of the modbus registers
+     */
+    private int subindex = 0;
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+
+    public int getSubindex() {
+        return subindex;
+    }
+
+    public void setSubindex(int subindex) {
+        this.subindex = subindex;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/HeatpumpConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/HeatpumpConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link HeatpumpConfiguration} class contains fields mapping
+ * thing configuration parameters.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class HeatpumpConfiguration {
+
+    /**
+     * Refresh interval in seconds
+     */
+    private int refresh = 30;
+
+    private int maxTries = 3;
+
+    // backwards compatibility and tests
+
+    /**
+     * Subindex to calculate the base adress of the modbus registers
+     */
+    private int subindex = 0;
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+
+    public int getSubindex() {
+        return subindex;
+    }
+
+    public void setSubindex(int subindex) {
+        this.subindex = subindex;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaBindingConstants.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaBindingConstants.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.ModbusBindingConstants;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link LambdaBindingConstants} class defines common
+ * constants, which are used across the whole binding.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class LambdaBindingConstants {
+
+    private static final String BINDING_ID = ModbusBindingConstants.BINDING_ID;
+    private static final String LAMBDAGENERAL = "lambda-general";
+    private static final String LAMBDABOILER = "lambda-boiler";
+    private static final String LAMBDABUFFER = "lambda-buffer";
+    private static final String LAMBDAHEATPUMP = "lambda-heatpump";
+    private static final String LAMBDAHEATINGCIRCUIT = "lambda-heatingcircuit";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_LAMBDAGENERAL = new ThingTypeUID(BINDING_ID, LAMBDAGENERAL);
+    public static final ThingTypeUID THING_TYPE_LAMBDABOILER = new ThingTypeUID(BINDING_ID, LAMBDABOILER);
+    public static final ThingTypeUID THING_TYPE_LAMBDABUFFER = new ThingTypeUID(BINDING_ID, LAMBDABUFFER);
+    public static final ThingTypeUID THING_TYPE_LAMBDAHEATPUMP = new ThingTypeUID(BINDING_ID, LAMBDAHEATPUMP);
+    public static final ThingTypeUID THING_TYPE_LAMBDAHEATINGCIRCUIT = new ThingTypeUID(BINDING_ID,
+            LAMBDAHEATINGCIRCUIT);
+
+    // Channel group ids
+    public static final String GROUP_GENERAL_AMBIENT = "ambient-group";
+    public static final String GROUP_GENERAL_EMANAGER = "emanager-group";
+    public static final String GROUP_HEATPUMP = "heatpump-group";
+    public static final String GROUP_HEATPUMP_REG50 = "heatpump-reg50-group";
+    public static final String GROUP_BOILER = "boiler-group";
+    public static final String GROUP_BOILER_REG50 = "boiler-reg50-group";
+    public static final String GROUP_BUFFER = "buffer-group";
+    public static final String GROUP_BUFFER_REG50 = "buffer-reg50-group";
+    public static final String GROUP_HEATINGCIRCUIT = "heatingcircuit-group";
+    public static final String GROUP_HEATINGCIRCUIT_REG50 = "heatingcircuit-reg50-group";
+
+    // List of all Channel ids in device information group
+    // General Ambient
+    public static final String CHANNEL_AMBIENT_ERROR_NUMBER = "ambient-error-number";
+    public static final String CHANNEL_AMBIENT_OPERATING_STATE = "ambient-operating-state";
+    public static final String CHANNEL_ACTUAL_AMBIENT_TEMPERATURE = "actual-ambient-temperature";
+    public static final String CHANNEL_AVERAGE_AMBIENT_TEMPERATURE = "average-ambient-temperature";
+    public static final String CHANNEL_CALCULATED_AMBIENT_TEMPERATURE = "calculated-ambient-temperature";
+
+    // General E-manager
+    public static final String CHANNEL_EMANAGER_ERROR_NUMBER = "emanager-error-number";
+    public static final String CHANNEL_EMANAGER_OPERATING_STATE = "emanager-operating-state";
+    public static final String CHANNEL_ACTUAL_POWER = "actual-power";
+    public static final String CHANNEL_ACTUAL_POWER_CONSUMPTION = "actual-power-consumption";
+    public static final String CHANNEL_POWER_CONSUMPTION_SETPOINT = "power-consumption-setpoint";
+
+    // Heatpump
+    public static final String CHANNEL_HEATPUMP_ERROR_STATE = "heatpump-error-state";
+    public static final String CHANNEL_HEATPUMP_ERROR_NUMBER = "heatpump-error-number";
+    public static final String CHANNEL_HEATPUMP_STATE = "heatpump-state";
+    public static final String CHANNEL_HEATPUMP_OPERATING_STATE = "heatpump-operating-state";
+    public static final String CHANNEL_HEATPUMP_T_FLOW = "heatpump-t-flow";
+    public static final String CHANNEL_HEATPUMP_T_RETURN = "heatpump-t-return";
+    public static final String CHANNEL_HEATPUMP_VOL_SINK = "heatpump-vol-sink";
+    public static final String CHANNEL_HEATPUMP_T_EQIN = "heatpump-t-eqin";
+    public static final String CHANNEL_HEATPUMP_T_EQOUT = "heatpump-t-eqout";
+    public static final String CHANNEL_HEATPUMP_VOL_SOURCE = "heatpump-vol-source";
+    public static final String CHANNEL_HEATPUMP_COMPRESSOR_RATING = "heatpump-compressor-rating";
+    public static final String CHANNEL_HEATPUMP_QP_HEATING = "heatpump-qp-heating";
+    public static final String CHANNEL_HEATPUMP_FI_POWER_CONSUMPTION = "heatpump-fi-power-consumption";
+    public static final String CHANNEL_HEATPUMP_COP = "heatpump-cop";
+    public static final String CHANNEL_HEATPUMP_VDAE = "heatpump-vdae";
+    public static final String CHANNEL_HEATPUMP_VDAQ = "heatpump-vdaq";
+    public static final String CHANNEL_HEATPUMP_SET_ERROR_QUIT = "heatpump-set-error-quit";
+
+    // Boiler
+    public static final String CHANNEL_BOILER_ERROR_NUMBER = "boiler-error-number";
+    public static final String CHANNEL_BOILER_OPERATING_STATE = "boiler-operating-state";
+    public static final String CHANNEL_BOILER_ACTUAL_HIGH_TEMPERATURE = "boiler-actual-high-temperature";
+    public static final String CHANNEL_BOILER_ACTUAL_LOW_TEMPERATURE = "boiler-actual-low-temperature";
+    public static final String CHANNEL_BOILER_MAXIMUM_BOILER_TEMPERATURE = "boiler-maximum-boiler-temperature";
+
+    // Buffer
+    public static final String CHANNEL_BUFFER_ERROR_NUMBER = "buffer-error-number";
+    public static final String CHANNEL_BUFFER_OPERATING_STATE = "buffer-operating-state";
+    public static final String CHANNEL_BUFFER_ACTUAL_HIGH_TEMPERATURE = "buffer-actual-high-temperature";
+    public static final String CHANNEL_BUFFER_ACTUAL_LOW_TEMPERATURE = "buffer-actual-low-temperature";
+    public static final String CHANNEL_BUFFER_MAXIMUM_BUFFER_TEMPERATURE = "buffer-maximum-buffer-temperature";
+
+    // Heating Circuit
+    public static final String CHANNEL_HEATINGCIRCUIT_ERROR_NUMBER = "heatingcircuit-error-number";
+    public static final String CHANNEL_HEATINGCIRCUIT_OPERATING_STATE = "heatingcircuit-operating-state";
+    public static final String CHANNEL_HEATINGCIRCUIT_FLOW_LINE_TEMPERATURE = "heatingcircuit-flow-line-temperature";
+    public static final String CHANNEL_HEATINGCIRCUIT_RETURN_LINE_TEMPERATURE = "heatingcircuit-return-line-temperature";
+    public static final String CHANNEL_HEATINGCIRCUIT_ROOM_DEVICE_TEMPERATURE = "heatingcircuit-room-device-temperature";
+    public static final String CHANNEL_HEATINGCIRCUIT_SETPOINT_FLOW_LINE_TEMPERATURE = "heatingcircuit-setpoint-flow-line-temperature";
+    public static final String CHANNEL_HEATINGCIRCUIT_OPERATING_MODE = "heatingcircuit-operating-mode";
+    // Heating Circuit Set
+    public static final String CHANNEL_HEATINGCIRCUIT_OFFSET_FLOW_LINE_TEMPERATURE = "heatingcircuit-offset-flow-line-temperature";
+    public static final String CHANNEL_HEATINGCIRCUIT_ROOM_HEATING_TEMPERATURE = "heatingcircuit-room-heating-temperature";
+    public static final String CHANNEL_HEATINGCIRCUIT_ROOM_COOLING_TEMPERATURE = "heatingcircuit-room-cooling-temperature";
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link LambdaConfiguration} class contains fields mapping
+ * thing configuration parameters.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+public class LambdaConfiguration {
+    /**
+     * Refresh interval in seconds
+     */
+    private int refresh = 30;
+
+    private int maxTries = 3;// backwards compatibility and tests
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaHandlerFactory.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/LambdaHandlerFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal;
+
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.THING_TYPE_LAMBDABOILER;
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.THING_TYPE_LAMBDABUFFER;
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.THING_TYPE_LAMBDAGENERAL;
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.THING_TYPE_LAMBDAHEATINGCIRCUIT;
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.THING_TYPE_LAMBDAHEATPUMP;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.modbus.lambda.internal.handler.BoilerHandler;
+import org.openhab.binding.modbus.lambda.internal.handler.BufferHandler;
+import org.openhab.binding.modbus.lambda.internal.handler.GeneralHandler;
+import org.openhab.binding.modbus.lambda.internal.handler.HeatingCircuitHandler;
+import org.openhab.binding.modbus.lambda.internal.handler.HeatpumpHandler;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link LambdaHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.lambda", service = ThingHandlerFactory.class)
+public class LambdaHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(LambdaHandlerFactory.class);
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_LAMBDAGENERAL,
+            THING_TYPE_LAMBDAHEATPUMP, THING_TYPE_LAMBDABOILER, THING_TYPE_LAMBDABUFFER,
+            THING_TYPE_LAMBDAHEATINGCIRCUIT);
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        // logger.trace("Query LambdaHandlerFactory supportsThingType {} ?", thingTypeUID.toString());
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        // logger.trace("LambdaHandlerFactory ThingHandler searching of {}", thingTypeUID.toString());
+
+        if (THING_TYPE_LAMBDAGENERAL.equals(thingTypeUID)) {
+            // logger.debug("LambdaHandlerFactory ThingHandler LAMBDAGENERAL found first place {}",
+            // thingTypeUID.toString());
+            return new GeneralHandler(thing);
+        } else if (THING_TYPE_LAMBDAHEATPUMP.equals(thingTypeUID)) {
+
+            return new HeatpumpHandler(thing);
+        } else if (THING_TYPE_LAMBDABUFFER.equals(thingTypeUID)) {
+
+            return new BufferHandler(thing);
+        } else if (THING_TYPE_LAMBDABOILER.equals(thingTypeUID)) {
+
+            return new BoilerHandler(thing);
+        } else if (THING_TYPE_LAMBDAHEATINGCIRCUIT.equals(thingTypeUID)) {
+
+            return new HeatingCircuitHandler(thing);
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/AmbientBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/AmbientBlock.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the Ambient Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class AmbientBlock {
+    public int ambientErrorNumber;
+    public int ambientOperatingState;
+    public int actualAmbientTemperature;
+    public int averageAmbientTemperature;
+    public int calculatedAmbientTemperature;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BoilerBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BoilerBlock.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the Boiler Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class BoilerBlock {
+    public int boilerErrorNumber;
+    public int boilerOperatingState;
+    public int boilerActualHighTemperature;
+    public int boilerActualLowTemperature;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BoilerReg50Block.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BoilerReg50Block.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the BoilerReg50 Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class BoilerReg50Block {
+
+    public int boilerMaximumBoilerTemperature;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BufferBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BufferBlock.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the Buffer Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class BufferBlock {
+    public int bufferErrorNumber;
+    public int bufferOperatingState;
+    public int bufferActualHighTemperature;
+    public int bufferActualLowTemperature;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BufferReg50Block.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/BufferReg50Block.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the BufferReg50 Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class BufferReg50Block {
+
+    public int bufferMaximumBufferTemperature;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/EManagerBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/EManagerBlock.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the EManager Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class EManagerBlock {
+    public int emanagerErrorNumber;
+    public int emanagerOperatingState;
+    public int actualPower;
+    public int actualPowerConsumption;
+    public int powerConsumptionSetpoint;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatingCircuitBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatingCircuitBlock.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the HeatingCircuit Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class HeatingCircuitBlock {
+
+    public int heatingcircuitErrorNumber;
+    public int heatingcircuitOperatingState;
+    public int heatingcircuitFlowLineTemperature;
+    public int heatingcircuitReturnLineTemperature;
+    public int heatingcircuitRoomDeviceTemperature;
+    public int heatingcircuitSetpointFlowLineTemperature;
+    public int heatingcircuitOperatingMode;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatingCircuitReg50Block.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatingCircuitReg50Block.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the HeatingCircuitReg50 Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+
+public class HeatingCircuitReg50Block {
+    public int heatingcircuitOffsetFlowLineTemperature;
+    public int heatingcircuitRoomHeatingTemperature;
+    public int heatingcircuitRoomCoolingTemperature;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatpumpBlock.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatpumpBlock.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the Heatpump Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class HeatpumpBlock {
+    public int heatpumpErrorState;
+    public int heatpumpErrorNumber;
+    public int heatpumpState;
+    public int heatpumpOperatingState;
+    public int heatpumpTFlow;
+    public int heatpumpTReturn;
+    public int heatpumpVolSink;
+    public int heatpumpTEQin;
+    public int heatpumpTEQout;
+    public int heatpumpVolSource;
+    public int heatpumpCompressorRating;
+    public int heatpumpQpHeating;
+    public int heatpumpFIPowerConsumption;
+    public int heatpumpCOP;
+    public long heatpumpVdAE;
+    public long heatpumpVdAQ;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatpumpReg50Block.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/dto/HeatpumpReg50Block.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.dto;
+
+/**
+ * Dto class for the HeatpumpReg50 Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+public class HeatpumpReg50Block {
+
+    public int heatpumpSetErrorQuit;
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/BoilerHandler.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/BoilerHandler.java
@@ -1,0 +1,585 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.handler;
+
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.*;
+import static org.openhab.core.library.unit.SIUnits.CELSIUS;
+import static org.openhab.core.library.unit.Units.*;
+
+import java.util.Optional;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.lambda.internal.BoilerConfiguration;
+import org.openhab.binding.modbus.lambda.internal.dto.BoilerBlock;
+import org.openhab.binding.modbus.lambda.internal.dto.BoilerReg50Block;
+import org.openhab.binding.modbus.lambda.internal.parser.BoilerBlockParser;
+import org.openhab.binding.modbus.lambda.internal.parser.BoilerReg50BlockParser;
+import org.openhab.core.io.transport.modbus.AsyncModbusFailure;
+import org.openhab.core.io.transport.modbus.ModbusCommunicationInterface;
+import org.openhab.core.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.core.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.core.io.transport.modbus.ModbusWriteRegisterRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusWriteRequestBlueprint;
+import org.openhab.core.io.transport.modbus.PollTask;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BoilerHandler} is responsible for handling commands,
+ * which are sent to one of the channels and for polling the modbus.
+ *
+ * @author Paul Frank - Initial contribution
+ */
+@NonNullByDefault
+public class BoilerHandler extends BaseThingHandler {
+
+    public abstract class AbstractBasePoller {
+
+        private final Logger logger = LoggerFactory.getLogger(BoilerHandler.class);
+
+        private volatile @Nullable PollTask pollTask;
+
+        public synchronized void unregisterPollTask() {
+            PollTask task = pollTask;
+            if (task == null) {
+                return;
+            }
+
+            ModbusCommunicationInterface mycomms = BoilerHandler.this.comms;
+            if (mycomms != null) {
+                mycomms.unregisterRegularPoll(task);
+            }
+            pollTask = null;
+        }
+
+        /**
+         * Register poll task This is where we set up our regular poller
+         */
+        public synchronized void registerPollTask(int address, int length, ModbusReadFunctionCode readFunctionCode) {
+            logger.debug("Setting up regular polling Address: {}", address);
+
+            ModbusCommunicationInterface mycomms = BoilerHandler.this.comms;
+            BoilerConfiguration myconfig = BoilerHandler.this.config;
+            if (myconfig == null || mycomms == null) {
+                throw new IllegalStateException("Boiler: registerPollTask called without proper configuration");
+            }
+
+            ModbusReadRequestBlueprint request = new ModbusReadRequestBlueprint(getSlaveId(), readFunctionCode, address,
+                    length, myconfig.getMaxTries());
+
+            long refreshMillis = myconfig.getRefreshMillis();
+
+            pollTask = mycomms.registerRegularPoll(request, refreshMillis, 1000, result -> {
+                result.getRegisters().ifPresent(this::handlePolledData);
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            }, BoilerHandler.this::handleReadError);
+        }
+
+        public synchronized void poll() {
+            PollTask task = pollTask;
+            ModbusCommunicationInterface mycomms = BoilerHandler.this.comms;
+            if (task != null && mycomms != null) {
+                mycomms.submitOneTimePoll(task.getRequest(), task.getResultCallback(), task.getFailureCallback());
+            }
+        }
+
+        protected abstract void handlePolledData(ModbusRegisterArray registers);
+    }
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(BoilerHandler.class);
+
+    /**
+     * Configuration instance
+     */
+    protected @Nullable BoilerConfiguration config = null;
+    /**
+     * Parser used to convert incoming raw messages into system blocks
+     * private final SystemInfromationBlockParser systemInformationBlockParser = new SystemInfromationBlockParser();
+     */
+    /**
+     * Parsers used to convert incoming raw messages into state blocks
+     */
+
+    private final BoilerBlockParser boilerBlockParser = new BoilerBlockParser();
+    private final BoilerReg50BlockParser boilerReg50BlockParser = new BoilerReg50BlockParser();
+
+    /**
+     * These are the tasks used to poll the device
+     */
+
+    private volatile @Nullable AbstractBasePoller boilerPoller = null;
+    private volatile @Nullable AbstractBasePoller boilerReg50Poller = null;
+
+    /**
+     * Communication interface to the slave endpoint we're connecting to
+     */
+    protected volatile @Nullable ModbusCommunicationInterface comms = null;
+    /**
+     * This is the slave id, we store this once initialization is complete
+     */
+    private volatile int slaveId;
+
+    /**
+     * Instances of this handler should get a reference to the modbus manager
+     *
+     * @param thing the thing to handle
+     */
+    public BoilerHandler(Thing thing) {
+        super(thing);
+    }
+
+    /**
+     * @param address address of the value to be written on the modbus
+     * 
+     * @param shortValue value to be written on the modbus
+     */
+    protected void writeInt16(int address, short shortValue) {
+        logger.trace("Boiler: writeInt16: Es wird geschrieben, Adresse: {} Wert: {}", address, shortValue);
+        BoilerConfiguration myconfig = BoilerHandler.this.config;
+        ModbusCommunicationInterface mycomms = BoilerHandler.this.comms;
+
+        if (myconfig == null || mycomms == null) {
+            throw new IllegalStateException("registerPollTask called without proper configuration");
+        }
+        // big endian byte ordering
+        byte hi = (byte) (shortValue >> 8);
+        byte lo = (byte) shortValue;
+        ModbusRegisterArray data = new ModbusRegisterArray(hi, lo);
+
+        logger.trace("Boiler: hi: {}, lo: {}", hi, lo);
+        ModbusWriteRegisterRequestBlueprint request = new ModbusWriteRegisterRequestBlueprint(slaveId, address, data,
+                true, myconfig.getMaxTries());
+
+        mycomms.submitOneTimeWrite(request, result -> {
+            if (hasConfigurationError()) {
+                return;
+            }
+            logger.trace("Boiler: Successful write, matching request {}", request);
+            BoilerHandler.this.updateStatus(ThingStatus.ONLINE);
+        }, failure -> {
+            BoilerHandler.this.handleWriteError(failure);
+            logger.trace("Boiler: Unsuccessful write, matching request {}", request);
+        });
+    }
+
+    /**
+     * @param command get the value of this command.
+     * 
+     * @return short the value of the command as short
+     */
+    private short getInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(WATT);
+            if (c != null) {
+                return c.shortValue();
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return c.shortValue();
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    private short getScaledInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(CELSIUS);
+            if (c != null) {
+                return (short) (c.doubleValue() * 10);
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return (short) (c.doubleValue() * 10);
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    /**
+     * Handle incoming commands.
+     */
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.trace("Boiler: handleCommand, channelUID: {} command {} ", channelUID, command);
+        if (RefreshType.REFRESH == command) {
+            String groupId = channelUID.getGroupId();
+            if (groupId != null) {
+                AbstractBasePoller poller;
+                switch (groupId) {
+                    case GROUP_BOILER:
+                        poller = boilerPoller;
+                        break;
+                    case GROUP_BOILER_REG50:
+                        poller = boilerReg50Poller;
+                        break;
+
+                    default:
+                        poller = null;
+                        break;
+                }
+                if (poller != null) {
+                    logger.trace("Boiler: Es wird gepollt }");
+                    poller.poll();
+                }
+            }
+        } else {
+            // logger.trace("Boiler: handleCommand: Es wird geschrieben, GroupID: {}, command {}",
+            // channelUID.getGroupId(), command);
+            try {
+
+                if (GROUP_BOILER_REG50.equals(channelUID.getGroupId())) {
+                    // logger.trace("Boiler: im BOILER_REG50 channelUID {} ", channelUID.getIdWithoutGroup());
+
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_BOILER_MAXIMUM_BOILER_TEMPERATURE:
+
+                            // logger.trace("Boiler: command: {}", command);
+                            writeInt16(reg50baseadress, getScaledInt16Value(command));
+                            break;
+
+                    }
+                }
+
+            }
+
+            catch (LambdaException error) {
+                if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+                    return;
+                }
+                String cls = error.getClass().getName();
+                String msg = error.getMessage();
+
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        String.format("Error with: %s: %s", cls, msg));
+            }
+        }
+    }
+
+    /**
+     * Initialization: Load the config object of the block Connect to the slave
+     * bridge Start the periodic polling
+     */
+    @Override
+    public void initialize() {
+        config = getConfigAs(BoilerConfiguration.class);
+        // logger.debug("Initializing thing with properties: {}", thing.getProperties());
+
+        startUp();
+    }
+
+    /**
+     * Adresses for the polling registers, used for reading and writing
+     */
+    private int baseadress;
+    private int reg50baseadress;
+
+    /**
+     * This method starts the operation of this handler Connect to the slave bridge
+     * Start the periodic polling1
+     */
+    private void startUp() {
+        if (comms != null) {
+            return;
+        }
+
+        ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
+        if (slaveEndpointThingHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "Bridge is offline");
+            return;
+        }
+
+        try {
+            slaveId = slaveEndpointThingHandler.getSlaveId();
+
+            comms = slaveEndpointThingHandler.getCommunicationInterface();
+        } catch (EndpointNotInitializedException e) {
+            // this will be handled below as endpoint remains null
+        }
+
+        if (comms == null) {
+            @SuppressWarnings("null")
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' not completely initialized", label));
+            return;
+        }
+
+        if (config == null) {
+            // logger.debug("Invalid comms/config/manager ref for lambda-boiler handler");
+            return;
+        }
+
+        BoilerConfiguration myconfig = BoilerHandler.this.config;
+
+        baseadress = 2000 + 100 * myconfig.getSubindex();
+        reg50baseadress = baseadress + 50;
+
+        // logger.debug("Boiler config.baseadress = {} ", baseadress);
+        // logger.debug("BoilerReg50 baseadress = {} ", reg50baseadress);
+
+        if (boilerPoller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledBoilerData(registers);
+                }
+            };
+
+            poller.registerPollTask(baseadress, 4, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            boilerPoller = poller;
+        }
+
+        if (boilerReg50Poller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledBoilerReg50Data(registers);
+                }
+            };
+
+            poller.registerPollTask(reg50baseadress, 1, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            boilerReg50Poller = poller;
+        }
+
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    /**
+     * Dispose the binding correctly
+     */
+    @Override
+    public void dispose() {
+        tearDown();
+    }
+
+    /**
+     * Unregister the poll tasks and release the endpoint reference
+     */
+    private void tearDown() {
+
+        AbstractBasePoller poller = boilerPoller;
+
+        poller = boilerPoller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            boilerPoller = null;
+        }
+        poller = boilerReg50Poller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            boilerReg50Poller = null;
+        }
+
+        comms = null;
+    }
+
+    /**
+     * Returns the current slave id from the bridge
+     */
+    public int getSlaveId() {
+        return slaveId;
+    }
+
+    /**
+     * Get the endpoint handler from the bridge this handler is connected to Checks
+     * that we're connected to the right type of bridge
+     *
+     * @return the endpoint handler or null if the bridge does not exist
+     */
+    private @Nullable ModbusEndpointThingHandler getEndpointThingHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            logger.debug("Bridge is null");
+            return null;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Bridge is not online");
+            return null;
+        }
+
+        ThingHandler handler = bridge.getHandler();
+        if (handler == null) {
+            logger.debug("Bridge handler is null");
+            return null;
+        }
+
+        if (handler instanceof ModbusEndpointThingHandler thingHandler) {
+            return thingHandler;
+        } else {
+            throw new IllegalStateException("Unexpected bridge handler: " + handler.toString());
+        }
+    }
+
+    protected State getScaled(Number value, Unit<?> unit, Double pow) {
+        // logger.trace("Boiler: value: {}", value.intValue());
+        double factor = Math.pow(10, pow);
+        return QuantityType.valueOf(value.doubleValue() * factor, unit);
+    }
+
+    protected State getUnscaled(Number value, Unit<?> unit) {
+        return QuantityType.valueOf(value.doubleValue(), unit);
+    }
+
+    /**
+     * Returns high value * 1000 + low value
+     *
+     * @param high the high value
+     * 
+     * @param low the low valze
+     * 
+     * @return the scaled value as a DecimalType
+     */
+    protected State getEnergyQuantity(int high, int low) {
+        double value = high * 1000 + low;
+        return QuantityType.valueOf(value, KILOWATT_HOUR);
+    }
+
+    /**
+     * These methods are called each time new data has been polled from the modbus
+     * slave The register array is first parsed, then each of the channels are
+     * updated to the new values
+     *
+     * @param registers byte array read from the modbus slave
+     */
+
+    protected void handlePolledBoilerData(ModbusRegisterArray registers) {
+        // logger.trace("Boiler block received, size: {}", registers.size());
+
+        BoilerBlock block = boilerBlockParser.parse(registers);
+
+        // Boiler group
+        updateState(channelUID(GROUP_BOILER, CHANNEL_BOILER_ERROR_NUMBER), new DecimalType(block.boilerErrorNumber));
+        updateState(channelUID(GROUP_BOILER, CHANNEL_BOILER_OPERATING_STATE),
+                new DecimalType(block.boilerOperatingState));
+        updateState(channelUID(GROUP_BOILER, CHANNEL_BOILER_ACTUAL_HIGH_TEMPERATURE),
+                getScaled(block.boilerActualHighTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_BOILER, CHANNEL_BOILER_ACTUAL_LOW_TEMPERATURE),
+                getScaled(block.boilerActualLowTemperature, CELSIUS, -1.0));
+        resetCommunicationError();
+    }
+
+    protected void handlePolledBoilerReg50Data(ModbusRegisterArray registers) {
+        // logger.trace("BoilerReg50 block received, size: {}", registers.size());
+
+        BoilerReg50Block block = boilerReg50BlockParser.parse(registers);
+
+        // BoilerReg50 group
+        updateState(channelUID(GROUP_BOILER_REG50, CHANNEL_BOILER_MAXIMUM_BOILER_TEMPERATURE),
+                getScaled(block.boilerMaximumBoilerTemperature, CELSIUS, -1.0));
+        resetCommunicationError();
+    }
+
+    /**
+     * @param bridgeStatusInfo
+     */
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            startUp();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            tearDown();
+        }
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with read: %s: %s", cls, msg));
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleWriteError(AsyncModbusFailure<ModbusWriteRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with write: %s: %s", cls, msg));
+    }
+
+    /**
+     * Returns true, if we're in a CONFIGURATION_ERROR state
+     *
+     * @return
+     */
+    protected boolean hasConfigurationError() {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        return statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR;
+    }
+
+    /**
+     * Reset communication status to ONLINE if we're in an OFFLINE state
+     */
+    protected void resetCommunicationError() {
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
+        if (ThingStatus.OFFLINE.equals(statusInfo.getStatus())
+                && ThingStatusDetail.COMMUNICATION_ERROR.equals(statusInfo.getStatusDetail())) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    /**
+     * Returns the channel UID for the specified group and channel id
+     *
+     * @param string the channel group
+     * 
+     * @param string the channel id in that group
+     * 
+     * @return the globally unique channel uid
+     */
+    ChannelUID channelUID(String group, String id) {
+        return new ChannelUID(getThing().getUID(), group, id);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/BufferHandler.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/BufferHandler.java
@@ -1,0 +1,583 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.handler;
+
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.*;
+import static org.openhab.core.library.unit.SIUnits.CELSIUS;
+import static org.openhab.core.library.unit.Units.*;
+
+import java.util.Optional;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.lambda.internal.BufferConfiguration;
+import org.openhab.binding.modbus.lambda.internal.dto.BufferBlock;
+import org.openhab.binding.modbus.lambda.internal.dto.BufferReg50Block;
+import org.openhab.binding.modbus.lambda.internal.parser.BufferBlockParser;
+import org.openhab.binding.modbus.lambda.internal.parser.BufferReg50BlockParser;
+import org.openhab.core.io.transport.modbus.AsyncModbusFailure;
+import org.openhab.core.io.transport.modbus.ModbusCommunicationInterface;
+import org.openhab.core.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.core.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.core.io.transport.modbus.ModbusWriteRegisterRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusWriteRequestBlueprint;
+import org.openhab.core.io.transport.modbus.PollTask;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BufferHandler} is responsible for handling commands,
+ * which are sent to one of the channels and for polling the modbus.
+ *
+ * @author Paul Frank - Initial contribution
+ */
+@NonNullByDefault
+public class BufferHandler extends BaseThingHandler {
+
+    public abstract class AbstractBasePoller {
+
+        private final Logger logger = LoggerFactory.getLogger(BufferHandler.class);
+
+        private volatile @Nullable PollTask pollTask;
+
+        public synchronized void unregisterPollTask() {
+            PollTask task = pollTask;
+            if (task == null) {
+                return;
+            }
+
+            ModbusCommunicationInterface mycomms = BufferHandler.this.comms;
+            if (mycomms != null) {
+                mycomms.unregisterRegularPoll(task);
+            }
+            pollTask = null;
+        }
+
+        /**
+         * Register poll task This is where we set up our regular poller
+         */
+        public synchronized void registerPollTask(int address, int length, ModbusReadFunctionCode readFunctionCode) {
+            // logger.debug("Setting up regular polling Address: {}", address);
+
+            ModbusCommunicationInterface mycomms = BufferHandler.this.comms;
+            BufferConfiguration myconfig = BufferHandler.this.config;
+            if (myconfig == null || mycomms == null) {
+                throw new IllegalStateException("registerPollTask called without proper configuration");
+            }
+
+            ModbusReadRequestBlueprint request = new ModbusReadRequestBlueprint(getSlaveId(), readFunctionCode, address,
+                    length, myconfig.getMaxTries());
+
+            long refreshMillis = myconfig.getRefreshMillis();
+
+            pollTask = mycomms.registerRegularPoll(request, refreshMillis, 1000, result -> {
+                result.getRegisters().ifPresent(this::handlePolledData);
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            }, BufferHandler.this::handleReadError);
+        }
+
+        public synchronized void poll() {
+            PollTask task = pollTask;
+            ModbusCommunicationInterface mycomms = BufferHandler.this.comms;
+            if (task != null && mycomms != null) {
+                mycomms.submitOneTimePoll(task.getRequest(), task.getResultCallback(), task.getFailureCallback());
+            }
+        }
+
+        protected abstract void handlePolledData(ModbusRegisterArray registers);
+    }
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(BufferHandler.class);
+
+    /**
+     * Configuration instance
+     */
+    protected @Nullable BufferConfiguration config = null;
+    /**
+     * Parser used to convert incoming raw messages into system blocks
+     * private final SystemInfromationBlockParser systemInformationBlockParser = new SystemInfromationBlockParser();
+     */
+    /**
+     * Parsers used to convert incoming raw messages into state blocks
+     */
+
+    private final BufferBlockParser bufferBlockParser = new BufferBlockParser();
+    private final BufferReg50BlockParser bufferReg50BlockParser = new BufferReg50BlockParser();
+
+    /**
+     * These are the tasks used to poll the device
+     */
+    private volatile @Nullable AbstractBasePoller bufferPoller = null;
+    private volatile @Nullable AbstractBasePoller bufferReg50Poller = null;
+    /**
+     * Communication interface to the slave endpoint we're connecting to
+     */
+    protected volatile @Nullable ModbusCommunicationInterface comms = null;
+    /**
+     * This is the slave id, we store this once initialization is complete
+     */
+    private volatile int slaveId;
+
+    /**
+     * Instances of this handler should get a reference to the modbus manager
+     *
+     * @param thing the thing to handle
+     */
+    public BufferHandler(Thing thing) {
+        super(thing);
+    }
+
+    /**
+     * @param address address of the value to be written on the modbus
+     * 
+     * @param shortValue value to be written on the modbus
+     */
+    protected void writeInt16(int address, short shortValue) {
+        // logger.trace("Buffer: writeInt16: Es wird geschrieben, Adresse: {} Wert: {}", address, shortValue);
+        BufferConfiguration myconfig = BufferHandler.this.config;
+        ModbusCommunicationInterface mycomms = BufferHandler.this.comms;
+
+        if (myconfig == null || mycomms == null) {
+            throw new IllegalStateException("registerPollTask called without proper configuration");
+        }
+        // big endian byte ordering
+        byte hi = (byte) (shortValue >> 8);
+        byte lo = (byte) shortValue;
+        ModbusRegisterArray data = new ModbusRegisterArray(hi, lo);
+
+        // logger.trace("Buffer: hi: {}, lo: {}", hi, lo);
+        ModbusWriteRegisterRequestBlueprint request = new ModbusWriteRegisterRequestBlueprint(slaveId, address, data,
+                true, myconfig.getMaxTries());
+
+        mycomms.submitOneTimeWrite(request, result -> {
+            if (hasConfigurationError()) {
+                return;
+            }
+            // logger.trace("Buffer: Successful write, matching request {}", request);
+            BufferHandler.this.updateStatus(ThingStatus.ONLINE);
+        }, failure -> {
+            BufferHandler.this.handleWriteError(failure);
+            // logger.trace("Buffer: Unsuccessful write, matching request {}", request);
+        });
+    }
+
+    /**
+     * @param command get the value of this command.
+     * 
+     * @return short the value of the command as short
+     */
+    private short getInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(WATT);
+            if (c != null) {
+                return c.shortValue();
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return c.shortValue();
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    private short getScaledInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(CELSIUS);
+            if (c != null) {
+                return (short) (c.doubleValue() * 10);
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return (short) (c.doubleValue() * 10);
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    /**
+     * Handle incoming commands.
+     */
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // logger.trace("Buffer: handleCommand, channelUID: {} command {} ", channelUID, command);
+        if (RefreshType.REFRESH == command) {
+            String groupId = channelUID.getGroupId();
+            if (groupId != null) {
+                AbstractBasePoller poller;
+                switch (groupId) {
+
+                    case GROUP_BUFFER:
+                        poller = bufferPoller;
+                        break;
+                    case GROUP_BUFFER_REG50:
+                        poller = bufferReg50Poller;
+                        break;
+                    default:
+                        poller = null;
+                        break;
+                }
+                if (poller != null) {
+                    // logger.trace("Buffer: Es wird gepollt }");
+                    poller.poll();
+                }
+            }
+        } else {
+            // logger.trace("Buffer: handleCommand: Es wird geschrieben, GroupID: {}, command {}",
+            // channelUID.getGroupId(), command);
+            try {
+
+                if (GROUP_BUFFER_REG50.equals(channelUID.getGroupId())) {
+                    // logger.trace("Buffer: im BUFFER_REG50 channelUID {} ", channelUID.getIdWithoutGroup());
+
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_BUFFER_MAXIMUM_BUFFER_TEMPERATURE:
+
+                            logger.trace("Buffer: command: {}", command);
+                            writeInt16(reg50baseadress, getScaledInt16Value(command));
+                            break;
+
+                    }
+                }
+            }
+
+            catch (LambdaException error) {
+                if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+                    return;
+                }
+                String cls = error.getClass().getName();
+                String msg = error.getMessage();
+
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        String.format("Error with: %s: %s", cls, msg));
+            }
+        }
+    }
+
+    /**
+     * Initialization: Load the config object of the block Connect to the slave
+     * bridge Start the periodic polling
+     */
+    @Override
+    public void initialize() {
+        config = getConfigAs(BufferConfiguration.class);
+
+        logger.debug("Initializing thing with properties: {}", thing.getProperties());
+
+        startUp();
+    }
+
+    /**
+     * Adresses for the polling registers, used for reading and writing
+     */
+    private int baseadress;
+    private int reg50baseadress;
+
+    /**
+     * This method starts the operation of this handler Connect to the slave bridge
+     * Start the periodic polling1
+     */
+    private void startUp() {
+        if (comms != null) {
+            return;
+        }
+
+        ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
+        if (slaveEndpointThingHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "Bridge is offline");
+            return;
+        }
+
+        try {
+            slaveId = slaveEndpointThingHandler.getSlaveId();
+
+            comms = slaveEndpointThingHandler.getCommunicationInterface();
+        } catch (EndpointNotInitializedException e) {
+            // this will be handled below as endpoint remains null
+        }
+
+        if (comms == null) {
+            @SuppressWarnings("null")
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' not completely initialized", label));
+            return;
+        }
+
+        if (config == null) {
+            logger.debug("Invalid comms/config/manager ref for Buffer handler");
+            return;
+        }
+
+        BufferConfiguration myconfig = BufferHandler.this.config;
+
+        baseadress = 3000 + 100 * myconfig.getSubindex();
+        reg50baseadress = baseadress + 50;
+
+        // logger.debug("Buffer config.baseadress = {} ", baseadress);
+        // logger.debug("BufferReg50 baseadress = {} ", reg50baseadress);
+
+        if (bufferPoller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledBufferData(registers);
+                }
+            };
+
+            poller.registerPollTask(baseadress, 4, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+
+            bufferPoller = poller;
+        }
+        if (bufferReg50Poller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledBufferReg50Data(registers);
+                }
+            };
+
+            poller.registerPollTask(reg50baseadress, 1, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            bufferReg50Poller = poller;
+        }
+
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    /**
+     * Dispose the binding correctly
+     */
+    @Override
+    public void dispose() {
+        tearDown();
+    }
+
+    /**
+     * Unregister the poll tasks and release the endpoint reference
+     */
+    private void tearDown() {
+
+        AbstractBasePoller poller = bufferPoller;
+
+        poller = bufferPoller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            bufferPoller = null;
+        }
+        poller = bufferReg50Poller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            bufferReg50Poller = null;
+        }
+
+        comms = null;
+    }
+
+    /**
+     * Returns the current slave id from the bridge
+     */
+    public int getSlaveId() {
+        return slaveId;
+    }
+
+    /**
+     * Get the endpoint handler from the bridge this handler is connected to Checks
+     * that we're connected to the right type of bridge
+     *
+     * @return the endpoint handler or null if the bridge does not exist
+     */
+    private @Nullable ModbusEndpointThingHandler getEndpointThingHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            logger.debug("Bridge is null");
+            return null;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Bridge is not online");
+            return null;
+        }
+
+        ThingHandler handler = bridge.getHandler();
+        if (handler == null) {
+            logger.debug("Bridge handler is null");
+            return null;
+        }
+
+        if (handler instanceof ModbusEndpointThingHandler thingHandler) {
+            return thingHandler;
+        } else {
+            throw new IllegalStateException("Unexpected bridge handler: " + handler.toString());
+        }
+    }
+
+    protected State getScaled(Number value, Unit<?> unit, Double pow) {
+        // logger.trace("Buffer: value: {}", value.intValue());
+        double factor = Math.pow(10, pow);
+        return QuantityType.valueOf(value.doubleValue() * factor, unit);
+    }
+
+    protected State getUnscaled(Number value, Unit<?> unit) {
+        return QuantityType.valueOf(value.doubleValue(), unit);
+    }
+
+    /**
+     * Returns high value * 1000 + low value
+     *
+     * @param high the high value
+     * 
+     * @param low the low valze
+     * 
+     * @return the scaled value as a DecimalType
+     */
+    protected State getEnergyQuantity(int high, int low) {
+        double value = high * 1000 + low;
+        return QuantityType.valueOf(value, KILOWATT_HOUR);
+    }
+
+    /**
+     * These methods are called each time new data has been polled from the modbus
+     * slave The register array is first parsed, then each of the channels are
+     * updated to the new values
+     *
+     * @param registers byte array read from the modbus slave
+     */
+
+    protected void handlePolledBufferData(ModbusRegisterArray registers) {
+        // logger.trace("Buffer block received, size: {}", registers.size());
+
+        BufferBlock block = bufferBlockParser.parse(registers);
+
+        // Buffer group
+        updateState(channelUID(GROUP_BUFFER, CHANNEL_BUFFER_ERROR_NUMBER), new DecimalType(block.bufferErrorNumber));
+        updateState(channelUID(GROUP_BUFFER, CHANNEL_BUFFER_OPERATING_STATE),
+                new DecimalType(block.bufferOperatingState));
+        updateState(channelUID(GROUP_BUFFER, CHANNEL_BUFFER_ACTUAL_HIGH_TEMPERATURE),
+                getScaled(block.bufferActualHighTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_BUFFER, CHANNEL_BUFFER_ACTUAL_LOW_TEMPERATURE),
+                getScaled(block.bufferActualLowTemperature, CELSIUS, -1.0));
+        resetCommunicationError();
+    }
+
+    protected void handlePolledBufferReg50Data(ModbusRegisterArray registers) {
+        // logger.trace("BufferReg50 block received, size: {}", registers.size());
+
+        BufferReg50Block block = bufferReg50BlockParser.parse(registers);
+
+        // BufferReg50 group
+        updateState(channelUID(GROUP_BUFFER_REG50, CHANNEL_BUFFER_MAXIMUM_BUFFER_TEMPERATURE),
+                getScaled(block.bufferMaximumBufferTemperature, CELSIUS, -1.0));
+        resetCommunicationError();
+    }
+
+    /**
+     * @param bridgeStatusInfo
+     */
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            startUp();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            tearDown();
+        }
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with read: %s: %s", cls, msg));
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleWriteError(AsyncModbusFailure<ModbusWriteRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with write: %s: %s", cls, msg));
+    }
+
+    /**
+     * Returns true, if we're in a CONFIGURATION_ERROR state
+     *
+     * @return
+     */
+    protected boolean hasConfigurationError() {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        return statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR;
+    }
+
+    /**
+     * Reset communication status to ONLINE if we're in an OFFLINE state
+     */
+    protected void resetCommunicationError() {
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
+        if (ThingStatus.OFFLINE.equals(statusInfo.getStatus())
+                && ThingStatusDetail.COMMUNICATION_ERROR.equals(statusInfo.getStatusDetail())) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    /**
+     * Returns the channel UID for the specified group and channel id
+     *
+     * @param string the channel group
+     * 
+     * @param string the channel id in that group
+     * 
+     * @return the globally unique channel uid
+     */
+    ChannelUID channelUID(String group, String id) {
+        return new ChannelUID(getThing().getUID(), group, id);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/GeneralHandler.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/GeneralHandler.java
@@ -1,0 +1,588 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.handler;
+
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.*;
+import static org.openhab.core.library.unit.SIUnits.CELSIUS;
+import static org.openhab.core.library.unit.Units.*;
+
+import java.util.Optional;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.lambda.internal.GeneralConfiguration;
+import org.openhab.binding.modbus.lambda.internal.dto.AmbientBlock;
+import org.openhab.binding.modbus.lambda.internal.dto.EManagerBlock;
+import org.openhab.binding.modbus.lambda.internal.parser.AmbientBlockParser;
+import org.openhab.binding.modbus.lambda.internal.parser.EManagerBlockParser;
+import org.openhab.core.io.transport.modbus.AsyncModbusFailure;
+import org.openhab.core.io.transport.modbus.ModbusCommunicationInterface;
+import org.openhab.core.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.core.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.core.io.transport.modbus.ModbusWriteRegisterRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusWriteRequestBlueprint;
+import org.openhab.core.io.transport.modbus.PollTask;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link GeneralHandler} is responsible for handling commands,
+ * which are sent to one of the channels and for polling the modbus.
+ *
+ * @author Paul Frank - Initial contribution
+ */
+@NonNullByDefault
+public class GeneralHandler extends BaseThingHandler {
+
+    public abstract class AbstractBasePoller {
+
+        private final Logger logger = LoggerFactory.getLogger(GeneralHandler.class);
+
+        private volatile @Nullable PollTask pollTask;
+
+        public synchronized void unregisterPollTask() {
+            PollTask task = pollTask;
+            if (task == null) {
+                return;
+            }
+
+            ModbusCommunicationInterface mycomms = GeneralHandler.this.comms;
+            if (mycomms != null) {
+                mycomms.unregisterRegularPoll(task);
+            }
+            pollTask = null;
+        }
+
+        /**
+         * Register poll task This is where we set up our regular poller
+         */
+        public synchronized void registerPollTask(int address, int length, ModbusReadFunctionCode readFunctionCode) {
+            // logger.debug("Setting up regular polling Address: {}", address);
+
+            ModbusCommunicationInterface mycomms = GeneralHandler.this.comms;
+            GeneralConfiguration myconfig = GeneralHandler.this.config;
+            if (myconfig == null || mycomms == null) {
+                throw new IllegalStateException("registerPollTask called without proper configuration");
+            }
+
+            ModbusReadRequestBlueprint request = new ModbusReadRequestBlueprint(getSlaveId(), readFunctionCode, address,
+                    length, myconfig.getMaxTries());
+
+            long refreshMillis = myconfig.getRefreshMillis();
+
+            pollTask = mycomms.registerRegularPoll(request, refreshMillis, 1000, result -> {
+                result.getRegisters().ifPresent(this::handlePolledData);
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            }, GeneralHandler.this::handleReadError);
+        }
+
+        public synchronized void poll() {
+            PollTask task = pollTask;
+            ModbusCommunicationInterface mycomms = GeneralHandler.this.comms;
+            if (task != null && mycomms != null) {
+                mycomms.submitOneTimePoll(task.getRequest(), task.getResultCallback(), task.getFailureCallback());
+            }
+        }
+
+        protected abstract void handlePolledData(ModbusRegisterArray registers);
+    }
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(GeneralHandler.class);
+
+    /**
+     * Configuration instance
+     */
+    protected @Nullable GeneralConfiguration config = null;
+    /**
+     * Parser used to convert incoming raw messages into system blocks
+     * private final SystemInfromationBlockParser systemInformationBlockParser = new SystemInfromationBlockParser();
+     */
+    /**
+     * Parsers used to convert incoming raw messages into state blocks
+     */
+    private final AmbientBlockParser ambientBlockParser = new AmbientBlockParser();
+    private final EManagerBlockParser emanagerBlockParser = new EManagerBlockParser();
+
+    /**
+     * These are the tasks used to poll the device
+     */
+    private volatile @Nullable AbstractBasePoller ambientPoller = null;
+    private volatile @Nullable AbstractBasePoller emanagerPoller = null;
+
+    /**
+     * Communication interface to the slave endpoint we're connecting to
+     */
+    protected volatile @Nullable ModbusCommunicationInterface comms = null;
+    /**
+     * This is the slave id, we store this once initialization is complete
+     */
+    private volatile int slaveId;
+
+    /**
+     * Instances of this handler should get a reference to the modbus manager
+     *
+     * @param thing the thing to handle
+     */
+    public GeneralHandler(Thing thing) {
+        super(thing);
+    }
+
+    /**
+     * @param address address of the value to be written on the modbus
+     * 
+     * @param shortValue value to be written on the modbus
+     */
+    protected void writeInt16(int address, short shortValue) {
+        // logger.trace("General: writeInt16: Es wird geschrieben, Adresse: {} Wert: {}", address, shortValue);
+        GeneralConfiguration myconfig = GeneralHandler.this.config;
+        ModbusCommunicationInterface mycomms = GeneralHandler.this.comms;
+
+        if (myconfig == null || mycomms == null) {
+            throw new IllegalStateException("registerPollTask called without proper configuration");
+        }
+        // big endian byte ordering
+        byte hi = (byte) (shortValue >> 8);
+        byte lo = (byte) shortValue;
+        ModbusRegisterArray data = new ModbusRegisterArray(hi, lo);
+
+        // logger.trace("General: hi: {}, lo: {}", hi, lo);
+        ModbusWriteRegisterRequestBlueprint request = new ModbusWriteRegisterRequestBlueprint(slaveId, address, data,
+                true, myconfig.getMaxTries());
+
+        mycomms.submitOneTimeWrite(request, result -> {
+            if (hasConfigurationError()) {
+                return;
+            }
+            // logger.trace("General: Successful write, matching request {}", request);
+            GeneralHandler.this.updateStatus(ThingStatus.ONLINE);
+        }, failure -> {
+            GeneralHandler.this.handleWriteError(failure);
+            // logger.trace("General: Unsuccessful write, matching request {}", request);
+        });
+    }
+
+    /**
+     * @param command get the value of this command.
+     * 
+     * @return short the value of the command as short
+     */
+    private short getInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(WATT);
+            if (c != null) {
+                return c.shortValue();
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return c.shortValue();
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    private short getScaledInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(CELSIUS);
+            if (c != null) {
+                return (short) (c.doubleValue() * 10);
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return (short) (c.doubleValue() * 10);
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    /**
+     * Handle incoming commands.
+     */
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // logger.trace("General: handleCommand, channelUID: {} command {} ", channelUID, command);
+        if (RefreshType.REFRESH == command) {
+            String groupId = channelUID.getGroupId();
+            if (groupId != null) {
+                AbstractBasePoller poller;
+                switch (groupId) {
+                    case GROUP_GENERAL_AMBIENT:
+                        poller = ambientPoller;
+                        break;
+                    case GROUP_GENERAL_EMANAGER:
+                        poller = emanagerPoller;
+                        break;
+                    default:
+                        poller = null;
+                        break;
+                }
+                if (poller != null) {
+                    // logger.trace("General Es wird gepollt }");
+                    poller.poll();
+                }
+            }
+        } else {
+
+            try {
+
+                if (GROUP_GENERAL_AMBIENT.equals(channelUID.getGroupId())) {
+
+                    // logger.trace(": im AMBIENT channelUID {} ", channelUID.getIdWithoutGroup());
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_ACTUAL_AMBIENT_TEMPERATURE:
+
+                            // logger.trace("write Actual Ambient Temperature command: {}", command);
+                            writeInt16(2, getInt16Value(command));
+                            break;
+
+                    }
+                }
+
+                // logger.trace("write EMANAGER");
+                if (GROUP_GENERAL_EMANAGER.equals(channelUID.getGroupId())) {
+
+                    // logger.trace("General: im EMANAGER channelUID {} ", channelUID.getIdWithoutGroup());
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_ACTUAL_POWER:
+
+                            // logger.trace("336 command: {}", command);
+                            writeInt16(102, getInt16Value(command));
+                            break;
+
+                    }
+                }
+            }
+
+            catch (LambdaException error) {
+                if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+                    return;
+                }
+                String cls = error.getClass().getName();
+                String msg = error.getMessage();
+
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        String.format("Error with: %s: %s", cls, msg));
+            }
+        }
+    }
+
+    /**
+     * Initialization: Load the config object of the block Connect to the slave
+     * bridge Start the periodic polling
+     */
+    @Override
+    public void initialize() {
+        config = getConfigAs(GeneralConfiguration.class);
+
+        logger.debug("Initializing thing with properties: {}", thing.getProperties());
+
+        startUp();
+    }
+
+    /**
+     * This method starts the operation of this handler Connect to the slave bridge
+     * Start the periodic polling1
+     */
+    private void startUp() {
+        if (comms != null) {
+            return;
+        }
+
+        ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
+        if (slaveEndpointThingHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "Bridge is offline");
+            return;
+        }
+
+        try {
+            slaveId = slaveEndpointThingHandler.getSlaveId();
+
+            comms = slaveEndpointThingHandler.getCommunicationInterface();
+        } catch (EndpointNotInitializedException e) {
+            // this will be handled below as endpoint remains null
+        }
+
+        if (comms == null) {
+            @SuppressWarnings("null")
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' not completely initialized", label));
+            return;
+        }
+
+        if (config == null) {
+            logger.debug("Invalid comms/config/manager ref for lambda general handler");
+            return;
+        }
+
+        if (ambientPoller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledAmbientData(registers);
+                }
+            };
+            poller.registerPollTask(0, 5, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            ambientPoller = poller;
+        }
+
+        if (emanagerPoller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledEManagerData(registers);
+                }
+            };
+            poller.registerPollTask(100, 5, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            emanagerPoller = poller;
+        }
+
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    /**
+     * Dispose the binding correctly
+     */
+    @Override
+    public void dispose() {
+        tearDown();
+    }
+
+    /**
+     * Unregister the poll tasks and release the endpoint reference
+     */
+    private void tearDown() {
+
+        AbstractBasePoller poller = ambientPoller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            ambientPoller = null;
+        }
+
+        poller = emanagerPoller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            emanagerPoller = null;
+        }
+
+        comms = null;
+    }
+
+    /**
+     * Returns the current slave id from the bridge
+     */
+    public int getSlaveId() {
+        return slaveId;
+    }
+
+    /**
+     * Get the endpoint handler from the bridge this handler is connected to Checks
+     * that we're connected to the right type of bridge
+     *
+     * @return the endpoint handler or null if the bridge does not exist
+     */
+    private @Nullable ModbusEndpointThingHandler getEndpointThingHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            logger.debug("Bridge is null");
+            return null;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Bridge is not online");
+            return null;
+        }
+
+        ThingHandler handler = bridge.getHandler();
+        if (handler == null) {
+            logger.debug("Bridge handler is null");
+            return null;
+        }
+
+        if (handler instanceof ModbusEndpointThingHandler thingHandler) {
+            return thingHandler;
+        } else {
+            throw new IllegalStateException("Unexpected bridge handler: " + handler.toString());
+        }
+    }
+
+    protected State getScaled(Number value, Unit<?> unit, Double pow) {
+        // logger.trace("General: value: {}", value.intValue());
+        double factor = Math.pow(10, pow);
+        return QuantityType.valueOf(value.doubleValue() * factor, unit);
+    }
+
+    protected State getUnscaled(Number value, Unit<?> unit) {
+        return QuantityType.valueOf(value.doubleValue(), unit);
+    }
+
+    /**
+     * Returns high value * 1000 + low value
+     *
+     * @param high the high value
+     * 
+     * @param low the low valze
+     * 
+     * @return the scaled value as a DecimalType
+     */
+    protected State getEnergyQuantity(int high, int low) {
+        double value = high * 1000 + low;
+        return QuantityType.valueOf(value, KILOWATT_HOUR);
+    }
+
+    /**
+     * These methods are called each time new data has been polled from the modbus
+     * slave The register array is first parsed, then each of the channels are
+     * updated to the new values
+     *
+     * @param registers byte array read from the modbus slave
+     */
+    protected void handlePolledAmbientData(ModbusRegisterArray registers) {
+        // logger.trace("Ambient block received, size: {}", registers.size());
+
+        // Ambient group
+        AmbientBlock block = ambientBlockParser.parse(registers);
+
+        updateState(channelUID(GROUP_GENERAL_AMBIENT, CHANNEL_AMBIENT_ERROR_NUMBER),
+                new DecimalType(block.ambientErrorNumber));
+        updateState(channelUID(GROUP_GENERAL_AMBIENT, CHANNEL_AMBIENT_OPERATING_STATE),
+                new DecimalType(block.ambientOperatingState));
+        updateState(channelUID(GROUP_GENERAL_AMBIENT, CHANNEL_ACTUAL_AMBIENT_TEMPERATURE),
+                getScaled(block.actualAmbientTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_GENERAL_AMBIENT, CHANNEL_AVERAGE_AMBIENT_TEMPERATURE),
+                getScaled(block.averageAmbientTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_GENERAL_AMBIENT, CHANNEL_CALCULATED_AMBIENT_TEMPERATURE),
+                getScaled(block.calculatedAmbientTemperature, CELSIUS, -1.0));
+        resetCommunicationError();
+    }
+
+    protected void handlePolledEManagerData(ModbusRegisterArray registers) {
+        // logger.trace("EManager block received, size: {}", registers.size());
+
+        // EManager group
+        EManagerBlock block = emanagerBlockParser.parse(registers);
+        updateState(channelUID(GROUP_GENERAL_EMANAGER, CHANNEL_EMANAGER_ERROR_NUMBER),
+                new DecimalType(block.emanagerErrorNumber));
+        updateState(channelUID(GROUP_GENERAL_EMANAGER, CHANNEL_EMANAGER_OPERATING_STATE),
+                new DecimalType(block.emanagerOperatingState));
+        updateState(channelUID(GROUP_GENERAL_EMANAGER, CHANNEL_ACTUAL_POWER_CONSUMPTION),
+                getUnscaled(block.actualPowerConsumption, WATT));
+        updateState(channelUID(GROUP_GENERAL_EMANAGER, CHANNEL_ACTUAL_POWER), getUnscaled(block.actualPower, WATT));
+        updateState(channelUID(GROUP_GENERAL_EMANAGER, CHANNEL_POWER_CONSUMPTION_SETPOINT),
+                getUnscaled(block.powerConsumptionSetpoint, WATT));
+
+        resetCommunicationError();
+    }
+
+    /**
+     * @param bridgeStatusInfo
+     */
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            startUp();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            tearDown();
+        }
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with read: %s: %s", cls, msg));
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleWriteError(AsyncModbusFailure<ModbusWriteRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with write: %s: %s", cls, msg));
+    }
+
+    /**
+     * Returns true, if we're in a CONFIGURATION_ERROR state
+     *
+     * @return
+     */
+    protected boolean hasConfigurationError() {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        return statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR;
+    }
+
+    /**
+     * Reset communication status to ONLINE if we're in an OFFLINE state
+     */
+    protected void resetCommunicationError() {
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
+        if (ThingStatus.OFFLINE.equals(statusInfo.getStatus())
+                && ThingStatusDetail.COMMUNICATION_ERROR.equals(statusInfo.getStatusDetail())) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    /**
+     * Returns the channel UID for the specified group and channel id
+     *
+     * @param string the channel group
+     * 
+     * @param string the channel id in that group
+     * 
+     * @return the globally unique channel uid
+     */
+    ChannelUID channelUID(String group, String id) {
+        return new ChannelUID(getThing().getUID(), group, id);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/HeatingCircuitHandler.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/HeatingCircuitHandler.java
@@ -1,0 +1,631 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.handler;
+
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.*;
+import static org.openhab.core.library.unit.SIUnits.CELSIUS;
+import static org.openhab.core.library.unit.Units.*;
+
+import java.util.Optional;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.lambda.internal.HeatingCircuitConfiguration;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatingCircuitBlock;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatingCircuitReg50Block;
+import org.openhab.binding.modbus.lambda.internal.parser.HeatingCircuitBlockParser;
+import org.openhab.binding.modbus.lambda.internal.parser.HeatingCircuitReg50BlockParser;
+import org.openhab.core.io.transport.modbus.AsyncModbusFailure;
+import org.openhab.core.io.transport.modbus.ModbusCommunicationInterface;
+import org.openhab.core.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.core.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.core.io.transport.modbus.ModbusWriteRegisterRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusWriteRequestBlueprint;
+import org.openhab.core.io.transport.modbus.PollTask;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link HeatingCircuitHandler} is responsible for handling commands,
+ * which are sent to one of the channels and for polling the modbus.
+ *
+ * @author Paul Frank - Initial contribution
+ */
+@NonNullByDefault
+public class HeatingCircuitHandler extends BaseThingHandler {
+
+    public abstract class AbstractBasePoller {
+
+        private final Logger logger = LoggerFactory.getLogger(HeatingCircuitHandler.class);
+
+        private volatile @Nullable PollTask pollTask;
+
+        public synchronized void unregisterPollTask() {
+            PollTask task = pollTask;
+            if (task == null) {
+                return;
+            }
+
+            ModbusCommunicationInterface mycomms = HeatingCircuitHandler.this.comms;
+            if (mycomms != null) {
+                mycomms.unregisterRegularPoll(task);
+            }
+            pollTask = null;
+        }
+
+        /**
+         * Register poll task This is where we set up our regular poller
+         */
+        public synchronized void registerPollTask(int address, int length, ModbusReadFunctionCode readFunctionCode) {
+            logger.debug("Setting up regular polling Address: {}", address);
+
+            ModbusCommunicationInterface mycomms = HeatingCircuitHandler.this.comms;
+            HeatingCircuitConfiguration myconfig = HeatingCircuitHandler.this.config;
+            if (myconfig == null || mycomms == null) {
+                throw new IllegalStateException("HeatingCircuit: registerPollTask called without proper configuration");
+            }
+
+            ModbusReadRequestBlueprint request = new ModbusReadRequestBlueprint(getSlaveId(), readFunctionCode, address,
+                    length, myconfig.getMaxTries());
+
+            long refreshMillis = myconfig.getRefreshMillis();
+
+            pollTask = mycomms.registerRegularPoll(request, refreshMillis, 1000, result -> {
+                result.getRegisters().ifPresent(this::handlePolledData);
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            }, HeatingCircuitHandler.this::handleReadError);
+        }
+
+        public synchronized void poll() {
+            PollTask task = pollTask;
+            ModbusCommunicationInterface mycomms = HeatingCircuitHandler.this.comms;
+            if (task != null && mycomms != null) {
+                mycomms.submitOneTimePoll(task.getRequest(), task.getResultCallback(), task.getFailureCallback());
+            }
+        }
+
+        protected abstract void handlePolledData(ModbusRegisterArray registers);
+    }
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(HeatingCircuitHandler.class);
+
+    /**
+     * Configuration instance
+     */
+    protected @Nullable HeatingCircuitConfiguration config = null;
+    /**
+     * Parser used to convert incoming raw messages into system blocks
+     * private final SystemInfromationBlockParser systemInformationBlockParser = new SystemInfromationBlockParser();
+     */
+    /**
+     * Parsers used to convert incoming raw messages into state blocks
+     */
+
+    private final HeatingCircuitBlockParser heatingcircuitBlockParser = new HeatingCircuitBlockParser();
+    private final HeatingCircuitReg50BlockParser heatingcircuitReg50BlockParser = new HeatingCircuitReg50BlockParser();
+
+    /**
+     * These are the tasks used to poll the device
+     */
+
+    private volatile @Nullable AbstractBasePoller heatingcircuitPoller = null;
+    private volatile @Nullable AbstractBasePoller heatingcircuitReg50Poller = null;
+    /**
+     * Communication interface to the slave endpoint we're connecting to
+     */
+    protected volatile @Nullable ModbusCommunicationInterface comms = null;
+    /**
+     * This is the slave id, we store this once initialization is complete
+     */
+    private volatile int slaveId;
+
+    /**
+     * Instances of this handler should get a reference to the modbus manager
+     *
+     * @param thing the thing to handle
+     */
+    public HeatingCircuitHandler(Thing thing) {
+        super(thing);
+    }
+
+    /**
+     * @param address address of the value to be written on the modbus
+     * 
+     * @param shortValue value to be written on the modbus
+     */
+    protected void writeInt16(int address, short shortValue) {
+        // logger.trace("HeatingCircuit: writeInt16: Es wird geschrieben, Adresse: {} Wert: {}", address, shortValue);
+        HeatingCircuitConfiguration myconfig = HeatingCircuitHandler.this.config;
+        ModbusCommunicationInterface mycomms = HeatingCircuitHandler.this.comms;
+
+        if (myconfig == null || mycomms == null) {
+            throw new IllegalStateException("registerPollTask called without proper configuration");
+        }
+        // big endian byte ordering
+        byte hi = (byte) (shortValue >> 8);
+        byte lo = (byte) shortValue;
+        ModbusRegisterArray data = new ModbusRegisterArray(hi, lo);
+
+        // logger.trace("HeatingCircuit: hi: {}, lo: {}", hi, lo);
+        ModbusWriteRegisterRequestBlueprint request = new ModbusWriteRegisterRequestBlueprint(slaveId, address, data,
+                true, myconfig.getMaxTries());
+
+        mycomms.submitOneTimeWrite(request, result -> {
+            if (hasConfigurationError()) {
+                return;
+            }
+            // logger.trace("HeatingCircuit: Successful write, matching request {}", request);
+            HeatingCircuitHandler.this.updateStatus(ThingStatus.ONLINE);
+        }, failure -> {
+            HeatingCircuitHandler.this.handleWriteError(failure);
+            // logger.trace("HeatingCircuit: Unsuccessful write, matching request {}", request);
+        });
+    }
+
+    /**
+     * @param command get the value of this command.
+     * 
+     * @return short the value of the command as short
+     */
+    private short getInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(WATT);
+            if (c != null) {
+                return c.shortValue();
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return c.shortValue();
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    private short getScaledInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(CELSIUS);
+            if (c != null) {
+                return (short) (c.doubleValue() * 10);
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return (short) (c.doubleValue() * 10);
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    /**
+     * Handle incoming commands.
+     */
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // logger.trace("HeatingCircuit: handleCommand, channelUID: {} command {} ", channelUID, command);
+        if (RefreshType.REFRESH == command) {
+            String groupId = channelUID.getGroupId();
+            if (groupId != null) {
+                AbstractBasePoller poller;
+                switch (groupId) {
+                    case GROUP_HEATINGCIRCUIT:
+                        poller = heatingcircuitPoller;
+                        break;
+                    case GROUP_HEATINGCIRCUIT_REG50:
+                        poller = heatingcircuitReg50Poller;
+                        break;
+                    default:
+                        poller = null;
+                        break;
+                }
+                if (poller != null) {
+                    // logger.trace("HeatingCircuit: Es wird gepollt }");
+                    poller.poll();
+                }
+            }
+        } else {
+            // logger.trace("HeatingCircuit: handleCommand: Es wird geschrieben, GroupID: {}, command {}",
+            // channelUID.getGroupId(), command);
+            try {
+
+                if (GROUP_HEATINGCIRCUIT.equals(channelUID.getGroupId())) {
+                    // logger.trace("HeatingCircuit: im HEATINGCIRCUI1 channelUID {} ", channelUID.getIdWithoutGroup());
+
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_HEATINGCIRCUIT_ROOM_DEVICE_TEMPERATURE:
+                            // logger.trace("HeatingCircuit: command: {}", command);
+                            writeInt16(baseadress + 4, getScaledInt16Value(command));
+                            break;
+                        case CHANNEL_HEATINGCIRCUIT_SETPOINT_FLOW_LINE_TEMPERATURE:
+                            // logger.trace("HeatingCircuit: command: {}", command);
+                            writeInt16(baseadress + 5, getScaledInt16Value(command));
+                            break;
+                        case CHANNEL_HEATINGCIRCUIT_OPERATING_MODE:
+                            // logger.trace("HeatingCircuit: command: {}", command);
+                            writeInt16(baseadress + 6, getInt16Value(command));
+                            break;
+
+                    }
+                }
+
+                if (GROUP_HEATINGCIRCUIT_REG50.equals(channelUID.getGroupId())) {
+                    // logger.trace("HeatingCircuit: im HEATINGCIRCUIT1 channelUID {} ",
+                    // channelUID.getIdWithoutGroup());
+
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_HEATINGCIRCUIT_OFFSET_FLOW_LINE_TEMPERATURE:
+
+                            // logger.trace("HeatingCircuit: command: {}", command);
+                            writeInt16(reg50baseadress, getScaledInt16Value(command));
+                            break;
+                        case CHANNEL_HEATINGCIRCUIT_ROOM_HEATING_TEMPERATURE:
+
+                            // logger.trace("HeatingCircuit: command: {}", command);
+                            writeInt16(reg50baseadress + 1, getScaledInt16Value(command));
+                            break;
+                        case CHANNEL_HEATINGCIRCUIT_ROOM_COOLING_TEMPERATURE:
+
+                            // logger.trace("HeatingCircuit: command: {}", command);
+                            writeInt16(reg50baseadress + 2, getScaledInt16Value(command));
+                            break;
+
+                    }
+
+                }
+
+            } catch (LambdaException error) {
+                if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+                    return;
+                }
+                String cls = error.getClass().getName();
+                String msg = error.getMessage();
+
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        String.format("Error with: %s: %s", cls, msg));
+            }
+        }
+    }
+
+    /**
+     * Initialization: Load the config object of the block Connect to the slave
+     * bridge Start the periodic polling
+     */
+    @Override
+    public void initialize() {
+        config = getConfigAs(HeatingCircuitConfiguration.class);
+
+        logger.debug("Initializing thing with properties: {}", thing.getProperties());
+
+        startUp();
+    }
+
+    /**
+     * Adresses for the polling registers, used for reading and writing
+     */
+    private int baseadress;
+    private int reg50baseadress;
+
+    /**
+     * This method starts the operation of this handler Connect to the slave bridge
+     * Start the periodic polling1
+     */
+    private void startUp() {
+        if (comms != null) {
+            return;
+        }
+
+        ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
+        if (slaveEndpointThingHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "Bridge is offline");
+            return;
+        }
+
+        try {
+            slaveId = slaveEndpointThingHandler.getSlaveId();
+
+            comms = slaveEndpointThingHandler.getCommunicationInterface();
+        } catch (EndpointNotInitializedException e) {
+            // this will be handled below as endpoint remains null
+        }
+
+        if (comms == null) {
+            @SuppressWarnings("null")
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' not completely initialized", label));
+            return;
+        }
+
+        if (config == null) {
+            logger.debug("Invalid comms/config/manager ref for lambda heatingcircuitcirciut handler");
+            return;
+        }
+
+        HeatingCircuitConfiguration myconfig = HeatingCircuitHandler.this.config;
+
+        baseadress = 5000 + 100 * myconfig.getSubindex();
+        reg50baseadress = baseadress + 50;
+
+        // logger.debug("Heating Circuit SubIndex = {} ", myconfig.getSubindex());
+        // logger.debug("Heating Circuit Baseadress = {} ", baseadress);
+        // logger.debug("Heating Circuit Reg 50 Baseadress = {} ", reg50baseadress);
+
+        if (heatingcircuitPoller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledHeatingData(registers);
+                }
+            };
+
+            poller.registerPollTask(baseadress, 7, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            // logger.trace("Poller Heating erzeugt");
+            heatingcircuitPoller = poller;
+        }
+        if (heatingcircuitReg50Poller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledHeatingReg50Data(registers);
+                }
+            };
+
+            poller.registerPollTask(reg50baseadress, 3, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            // logger.trace("Poller HeatingReg50 erzeugt");
+            heatingcircuitReg50Poller = poller;
+        }
+
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    /**
+     * Dispose the binding correctly
+     */
+    @Override
+    public void dispose() {
+        tearDown();
+    }
+
+    /**
+     * Unregister the poll tasks and release the endpoint reference
+     */
+    private void tearDown() {
+
+        AbstractBasePoller poller = heatingcircuitPoller;
+        if (poller != null) {
+            // logger.debug("Unregistering heatingcircuitPoller from ModbusManager");
+            poller.unregisterPollTask();
+            heatingcircuitPoller = null;
+        }
+
+        poller = heatingcircuitReg50Poller;
+        if (poller != null) {
+            // logger.debug("Unregistering heatingcircuitReg50Poller from ModbusManager");
+            poller.unregisterPollTask();
+            heatingcircuitReg50Poller = null;
+        }
+        comms = null;
+    }
+
+    /**
+     * Returns the current slave id from the bridge
+     */
+    public int getSlaveId() {
+        return slaveId;
+    }
+
+    /**
+     * Get the endpoint handler from the bridge this handler is connected to Checks
+     * that we're connected to the right type of bridge
+     *
+     * @return the endpoint handler or null if the bridge does not exist
+     */
+    private @Nullable ModbusEndpointThingHandler getEndpointThingHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            logger.debug("Bridge is null");
+            return null;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Bridge is not online");
+            return null;
+        }
+
+        ThingHandler handler = bridge.getHandler();
+        if (handler == null) {
+            logger.debug("Bridge handler is null");
+            return null;
+        }
+
+        if (handler instanceof ModbusEndpointThingHandler thingHandler) {
+            return thingHandler;
+        } else {
+            throw new IllegalStateException("Unexpected bridge handler: " + handler.toString());
+        }
+    }
+
+    protected State getScaled(Number value, Unit<?> unit, Double pow) {
+        // logger.trace("HeatingCircuit: value: {}", value.intValue());
+        double factor = Math.pow(10, pow);
+        return QuantityType.valueOf(value.doubleValue() * factor, unit);
+    }
+
+    protected State getUnscaled(Number value, Unit<?> unit) {
+        return QuantityType.valueOf(value.doubleValue(), unit);
+    }
+
+    /**
+     * Returns high value * 1000 + low value
+     *
+     * @param high the high value
+     * 
+     * @param low the low valze
+     * 
+     * @return the scaled value as a DecimalType
+     */
+    protected State getEnergyQuantity(int high, int low) {
+        double value = high * 1000 + low;
+        return QuantityType.valueOf(value, KILOWATT_HOUR);
+    }
+
+    /**
+     * These methods are called each time new data has been polled from the modbus
+     * slave The register array is first parsed, then each of the channels are
+     * updated to the new values
+     *
+     * @param registers byte array read from the modbus slave
+     */
+
+    protected void handlePolledHeatingData(ModbusRegisterArray registers) {
+        // logger.trace("Heating block received, size: {}", registers.size());
+
+        HeatingCircuitBlock block = heatingcircuitBlockParser.parse(registers);
+
+        // HeatingCircuit1 group
+
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_ERROR_NUMBER),
+                new DecimalType(block.heatingcircuitErrorNumber));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_OPERATING_STATE),
+                new DecimalType(block.heatingcircuitOperatingState));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_FLOW_LINE_TEMPERATURE),
+                getScaled(block.heatingcircuitFlowLineTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_RETURN_LINE_TEMPERATURE),
+                getScaled(block.heatingcircuitReturnLineTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_ROOM_DEVICE_TEMPERATURE),
+                getScaled(block.heatingcircuitRoomDeviceTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_SETPOINT_FLOW_LINE_TEMPERATURE),
+                getScaled(block.heatingcircuitSetpointFlowLineTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT, CHANNEL_HEATINGCIRCUIT_OPERATING_MODE),
+                new DecimalType(block.heatingcircuitOperatingMode));
+
+        resetCommunicationError();
+    }
+
+    protected void handlePolledHeatingReg50Data(ModbusRegisterArray registers) {
+        // logger.trace("HeatingCircuitReg50 block received, size: {}", registers.size());
+
+        HeatingCircuitReg50Block block = heatingcircuitReg50BlockParser.parse(registers);
+
+        // HeatingCircuit1Settting group
+
+        updateState(channelUID(GROUP_HEATINGCIRCUIT_REG50, CHANNEL_HEATINGCIRCUIT_OFFSET_FLOW_LINE_TEMPERATURE),
+                getScaled(block.heatingcircuitOffsetFlowLineTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT_REG50, CHANNEL_HEATINGCIRCUIT_ROOM_HEATING_TEMPERATURE),
+                getScaled(block.heatingcircuitRoomHeatingTemperature, CELSIUS, -1.0));
+        updateState(channelUID(GROUP_HEATINGCIRCUIT_REG50, CHANNEL_HEATINGCIRCUIT_ROOM_COOLING_TEMPERATURE),
+                getScaled(block.heatingcircuitRoomCoolingTemperature, CELSIUS, -1.0));
+        resetCommunicationError();
+    }
+
+    /**
+     * @param bridgeStatusInfo
+     */
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            startUp();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            tearDown();
+        }
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with read: %s: %s", cls, msg));
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleWriteError(AsyncModbusFailure<ModbusWriteRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with write: %s: %s", cls, msg));
+    }
+
+    /**
+     * Returns true, if we're in a CONFIGURATION_ERROR state
+     *
+     * @return
+     */
+    protected boolean hasConfigurationError() {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        return statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR;
+    }
+
+    /**
+     * Reset communication status to ONLINE if we're in an OFFLINE state
+     */
+    protected void resetCommunicationError() {
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
+        if (ThingStatus.OFFLINE.equals(statusInfo.getStatus())
+                && ThingStatusDetail.COMMUNICATION_ERROR.equals(statusInfo.getStatusDetail())) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    /**
+     * Returns the channel UID for the specified group and channel id
+     *
+     * @param string the channel group
+     * 
+     * @param string the channel id in that group
+     * 
+     * @return the globally unique channel uid
+     */
+    ChannelUID channelUID(String group, String id) {
+        return new ChannelUID(getThing().getUID(), group, id);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/HeatpumpHandler.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/HeatpumpHandler.java
@@ -1,0 +1,606 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.handler;
+
+import static org.openhab.binding.modbus.lambda.internal.LambdaBindingConstants.*;
+import static org.openhab.core.library.unit.SIUnits.CELSIUS;
+import static org.openhab.core.library.unit.Units.*;
+
+import java.util.Optional;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.lambda.internal.HeatpumpConfiguration;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatpumpBlock;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatpumpReg50Block;
+import org.openhab.binding.modbus.lambda.internal.parser.HeatpumpBlockParser;
+import org.openhab.binding.modbus.lambda.internal.parser.HeatpumpReg50BlockParser;
+import org.openhab.core.io.transport.modbus.AsyncModbusFailure;
+import org.openhab.core.io.transport.modbus.ModbusCommunicationInterface;
+import org.openhab.core.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.core.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.core.io.transport.modbus.ModbusWriteRegisterRequestBlueprint;
+import org.openhab.core.io.transport.modbus.ModbusWriteRequestBlueprint;
+import org.openhab.core.io.transport.modbus.PollTask;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link HeatpumpHandler} is responsible for handling commands,
+ * which are sent to one of the channels and for polling the modbus.
+ *
+ * @author Paul Frank - Initial contribution
+ */
+@NonNullByDefault
+public class HeatpumpHandler extends BaseThingHandler {
+
+    public abstract class AbstractBasePoller {
+
+        private final Logger logger = LoggerFactory.getLogger(HeatpumpHandler.class);
+
+        private volatile @Nullable PollTask pollTask;
+
+        public synchronized void unregisterPollTask() {
+            PollTask task = pollTask;
+            if (task == null) {
+                return;
+            }
+
+            ModbusCommunicationInterface mycomms = HeatpumpHandler.this.comms;
+            if (mycomms != null) {
+                mycomms.unregisterRegularPoll(task);
+            }
+            pollTask = null;
+        }
+
+        /**
+         * Register poll task This is where we set up our regular poller
+         */
+        public synchronized void registerPollTask(int address, int length, ModbusReadFunctionCode readFunctionCode) {
+            // logger.debug("Setting up regular polling Address: {}", address);
+
+            ModbusCommunicationInterface mycomms = HeatpumpHandler.this.comms;
+            HeatpumpConfiguration myconfig = HeatpumpHandler.this.config;
+
+            if (myconfig == null || mycomms == null) {
+                throw new IllegalStateException("Heatpump: registerPollTask called without proper configuration");
+            }
+
+            ModbusReadRequestBlueprint request = new ModbusReadRequestBlueprint(getSlaveId(), readFunctionCode, address,
+                    length, myconfig.getMaxTries());
+
+            long refreshMillis = myconfig.getRefreshMillis();
+
+            pollTask = mycomms.registerRegularPoll(request, refreshMillis, 1000, result -> {
+                result.getRegisters().ifPresent(this::handlePolledData);
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            }, HeatpumpHandler.this::handleReadError);
+        }
+
+        public synchronized void poll() {
+            PollTask task = pollTask;
+            ModbusCommunicationInterface mycomms = HeatpumpHandler.this.comms;
+            if (task != null && mycomms != null) {
+                mycomms.submitOneTimePoll(task.getRequest(), task.getResultCallback(), task.getFailureCallback());
+            }
+        }
+
+        protected abstract void handlePolledData(ModbusRegisterArray registers);
+    }
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(HeatpumpHandler.class);
+
+    /**
+     * Configuration instance
+     */
+    protected @Nullable HeatpumpConfiguration config = null;
+    /**
+     * Parser used to convert incoming raw messages into system blocks
+     * private final SystemInfromationBlockParser systemInformationBlockParser = new SystemInfromationBlockParser();
+     */
+    /**
+     * Parsers used to convert incoming raw messages into state blocks
+     */
+
+    private final HeatpumpBlockParser heatpumpBlockParser = new HeatpumpBlockParser();
+    private final HeatpumpReg50BlockParser heatpumpReg50BlockParser = new HeatpumpReg50BlockParser();
+
+    /**
+     * These are the tasks used to poll the device
+     */
+    private volatile @Nullable AbstractBasePoller heatpumpPoller = null;
+    private volatile @Nullable AbstractBasePoller heatpumpReg50Poller = null;
+
+    /**
+     * Communication interface to the slave endpoint we're connecting to
+     */
+    protected volatile @Nullable ModbusCommunicationInterface comms = null;
+    /**
+     * This is the slave id, we store this once initialization is complete
+     */
+    private volatile int slaveId;
+
+    /**
+     * Instances of this handler should get a reference to the modbus manager
+     *
+     * @param thing the thing to handle
+     */
+    public HeatpumpHandler(Thing thing) {
+        super(thing);
+    }
+
+    /**
+     * @param address address of the value to be written on the modbus
+     * 
+     * @param shortValue value to be written on the modbus
+     */
+    protected void writeInt16(int address, short shortValue) {
+        // logger.trace("Heatpump: writeInt16: Es wird geschrieben, Adresse: {} Wert: {}", address, shortValue);
+        HeatpumpConfiguration myconfig = HeatpumpHandler.this.config;
+        ModbusCommunicationInterface mycomms = HeatpumpHandler.this.comms;
+
+        if (myconfig == null || mycomms == null) {
+            throw new IllegalStateException("registerPollTask called without proper configuration");
+        }
+        // big endian byte ordering
+        byte hi = (byte) (shortValue >> 8);
+        byte lo = (byte) shortValue;
+        ModbusRegisterArray data = new ModbusRegisterArray(hi, lo);
+
+        // logger.trace("Heatpump: hi: {}, lo: {}", hi, lo);
+        ModbusWriteRegisterRequestBlueprint request = new ModbusWriteRegisterRequestBlueprint(slaveId, address, data,
+                true, myconfig.getMaxTries());
+
+        mycomms.submitOneTimeWrite(request, result -> {
+            if (hasConfigurationError()) {
+                return;
+            }
+            // logger.trace("Heatpump: Successful write, matching request {}", request);
+            HeatpumpHandler.this.updateStatus(ThingStatus.ONLINE);
+        }, failure -> {
+            HeatpumpHandler.this.handleWriteError(failure);
+            // logger.trace("Heatpump: Unsuccessful write, matching request {}", request);
+        });
+    }
+
+    /**
+     * @param command get the value of this command.
+     * 
+     * @return short the value of the command as short
+     */
+    private short getInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(WATT);
+            if (c != null) {
+                return c.shortValue();
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return c.shortValue();
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    private short getScaledInt16Value(Command command) throws LambdaException {
+        if (command instanceof QuantityType quantityCommand) {
+            QuantityType<?> c = quantityCommand.toUnit(CELSIUS);
+            if (c != null) {
+                return (short) (c.doubleValue() * 10);
+            } else {
+                throw new LambdaException("Unsupported unit");
+            }
+        }
+        if (command instanceof DecimalType c) {
+            return (short) (c.doubleValue() * 10);
+        }
+        throw new LambdaException("Unsupported command type");
+    }
+
+    /**
+     * Handle incoming commands.
+     */
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // logger.trace("Heatpump: handleCommand, channelUID: {} command {} ", channelUID, command);
+        if (RefreshType.REFRESH == command) {
+            String groupId = channelUID.getGroupId();
+            if (groupId != null) {
+                AbstractBasePoller poller;
+                switch (groupId) {
+                    case GROUP_HEATPUMP:
+                        poller = heatpumpPoller;
+                        break;
+                    case GROUP_HEATPUMP_REG50:
+                        poller = heatpumpReg50Poller;
+                        break;
+                    default:
+                        poller = null;
+                        break;
+                }
+                if (poller != null) {
+                    // logger.trace("Heatpump: Es wird gepollt }");
+                    poller.poll();
+                }
+            }
+        } else {
+            // logger.trace("Heatpump: handleCommand: Es wird geschrieben, GroupID: {}, command {}",
+            // channelUID.getGroupId(), command);
+            try {
+
+                if (GROUP_HEATPUMP_REG50.equals(channelUID.getGroupId())) {
+                    // logger.trace("Heatpump: im GROUP_HEATPUMP_REG50 channelUID {} ", channelUID.getIdWithoutGroup());
+
+                    switch (channelUID.getIdWithoutGroup()) {
+
+                        case CHANNEL_HEATPUMP_SET_ERROR_QUIT:
+
+                            // logger.trace("Heatpump: Heatpumpseterrorquit command: {}", command);
+                            writeInt16(reg50baseadress, getScaledInt16Value(command));
+                            break;
+
+                    }
+                }
+            } catch (LambdaException error) {
+                if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+                    return;
+                }
+                String cls = error.getClass().getName();
+                String msg = error.getMessage();
+
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        String.format("Error with: %s: %s", cls, msg));
+            }
+        }
+    }
+
+    /**
+     * Initialization: Load the config object of the block Connect to the slave
+     * bridge Start the periodic polling
+     */
+    @Override
+    public void initialize() {
+        config = getConfigAs(HeatpumpConfiguration.class);
+
+        logger.debug("Initializing thing with properties: {}", thing.getProperties());
+
+        startUp();
+    }
+
+    /**
+     * Adresses for the polling registers, used for reading and writing
+     */
+    private int baseadress;
+    private int reg50baseadress;
+
+    /**
+     * This method starts the operation of this handler Connect to the slave bridge
+     * Start the periodic polling1
+     */
+    private void startUp() {
+        if (comms != null) {
+            return;
+        }
+
+        ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
+        if (slaveEndpointThingHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "Bridge is offline");
+            return;
+        }
+
+        try {
+            slaveId = slaveEndpointThingHandler.getSlaveId();
+
+            comms = slaveEndpointThingHandler.getCommunicationInterface();
+        } catch (EndpointNotInitializedException e) {
+            // this will be handled below as endpoint remains null
+        }
+
+        if (comms == null) {
+            @SuppressWarnings("null")
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' not completely initialized", label));
+            return;
+        }
+
+        if (config == null) {
+            logger.debug("Invalid comms/config/manager ref for lambda heatpump handler");
+            return;
+        }
+
+        HeatpumpConfiguration myconfig = HeatpumpHandler.this.config;
+
+        baseadress = 1000 + 100 * myconfig.getSubindex();
+        reg50baseadress = baseadress + 50;
+
+        // logger.debug("Heatpump config.baseadress = {} ", baseadress);
+        // logger.debug("HeatpumpReg50 baseadress = {} ", reg50baseadress);
+
+        if (heatpumpPoller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledHeatpumpData(registers);
+                }
+            };
+
+            poller.registerPollTask(baseadress, 24, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            // logger.trace("Poller Heatpump erzeugt");
+            heatpumpPoller = poller;
+        }
+
+        if (heatpumpReg50Poller == null) {
+            AbstractBasePoller poller = new AbstractBasePoller() {
+                @Override
+                protected void handlePolledData(ModbusRegisterArray registers) {
+                    handlePolledHeatpumpReg50Data(registers);
+                }
+            };
+
+            poller.registerPollTask(reg50baseadress, 1, ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS);
+            // logger.trace("Poller GROUP_HEATPUMP_REG50 erzeugt");
+            heatpumpReg50Poller = poller;
+        }
+
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    /**
+     * Dispose the binding correctly
+     */
+    @Override
+    public void dispose() {
+        tearDown();
+    }
+
+    /**
+     * Unregister the poll tasks and release the endpoint reference
+     */
+    private void tearDown() {
+
+        AbstractBasePoller poller = heatpumpPoller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            heatpumpPoller = null;
+        }
+
+        poller = heatpumpReg50Poller;
+        if (poller != null) {
+            poller.unregisterPollTask();
+            heatpumpReg50Poller = null;
+        }
+
+        comms = null;
+    }
+
+    /**
+     * Returns the current slave id from the bridge
+     */
+    public int getSlaveId() {
+        return slaveId;
+    }
+
+    /**
+     * Get the endpoint handler from the bridge this handler is connected to Checks
+     * that we're connected to the right type of bridge
+     *
+     * @return the endpoint handler or null if the bridge does not exist
+     */
+    private @Nullable ModbusEndpointThingHandler getEndpointThingHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            logger.debug("Bridge is null");
+            return null;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Bridge is not online");
+            return null;
+        }
+
+        ThingHandler handler = bridge.getHandler();
+        if (handler == null) {
+            logger.debug("Bridge handler is null");
+            return null;
+        }
+
+        if (handler instanceof ModbusEndpointThingHandler thingHandler) {
+            return thingHandler;
+        } else {
+            throw new IllegalStateException("Unexpected bridge handler: " + handler.toString());
+        }
+    }
+
+    protected State getScaled(Number value, Unit<?> unit, Double pow) {
+        // logger.trace("Heatpump: value: {}", value.intValue());
+        double factor = Math.pow(10, pow);
+        return QuantityType.valueOf(value.doubleValue() * factor, unit);
+    }
+
+    protected State getUnscaled(Number value, Unit<?> unit) {
+        return QuantityType.valueOf(value.doubleValue(), unit);
+    }
+
+    /**
+     * Returns high value * 1000 + low value
+     *
+     * @param high the high value
+     * 
+     * @param low the low valze
+     * 
+     * @return the scaled value as a DecimalType
+     */
+    protected State getEnergyQuantity(int high, int low) {
+        double value = high * 1000 + low;
+        return QuantityType.valueOf(value, KILOWATT_HOUR);
+    }
+
+    /**
+     * These methods are called each time new data has been polled from the modbus
+     * slave The register array is first parsed, then each of the channels are
+     * updated to the new values
+     *
+     * @param registers byte array read from the modbus slave
+     */
+
+    protected void handlePolledHeatpumpData(ModbusRegisterArray registers) {
+        // logger.trace("Heatpump block received, size: {}", registers.size());
+
+        HeatpumpBlock block = heatpumpBlockParser.parse(registers);
+
+        // Heatpump group
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_ERROR_STATE),
+                new DecimalType(block.heatpumpErrorState));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_ERROR_NUMBER),
+                new DecimalType(block.heatpumpErrorNumber));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_OPERATING_STATE),
+                new DecimalType(block.heatpumpOperatingState));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_STATE), new DecimalType(block.heatpumpState));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_T_FLOW), getScaled(block.heatpumpTFlow, CELSIUS, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_T_RETURN),
+                getScaled(block.heatpumpTReturn, CELSIUS, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_VOL_SINK),
+                getScaled(block.heatpumpVolSink, LITRE_PER_MINUTE, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_T_EQIN), getScaled(block.heatpumpTEQin, CELSIUS, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_T_EQOUT),
+                getScaled(block.heatpumpTEQout, CELSIUS, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_VOL_SOURCE),
+                getScaled(block.heatpumpVolSource, LITRE_PER_MINUTE, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_COMPRESSOR_RATING),
+                getScaled(block.heatpumpCompressorRating, PERCENT, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_QP_HEATING),
+                getScaled(block.heatpumpQpHeating, WATT, 2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_FI_POWER_CONSUMPTION),
+                getUnscaled(block.heatpumpFIPowerConsumption, WATT));
+
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_COP), getScaled(block.heatpumpCOP, PERCENT, -2.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_VDAE),
+                getScaled(block.heatpumpVdAE, KILOWATT_HOUR, -3.0));
+        updateState(channelUID(GROUP_HEATPUMP, CHANNEL_HEATPUMP_VDAQ),
+                getScaled(block.heatpumpVdAQ, KILOWATT_HOUR, -3.0));
+
+        resetCommunicationError();
+    }
+
+    protected void handlePolledHeatpumpReg50Data(ModbusRegisterArray registers) {
+        // logger.trace("HeatpumpReg50 block received, size: {}", registers.size());
+
+        HeatpumpReg50Block block = heatpumpReg50BlockParser.parse(registers);
+
+        // Heatpump group
+        updateState(channelUID(GROUP_HEATPUMP_REG50, CHANNEL_HEATPUMP_SET_ERROR_QUIT),
+                new DecimalType(block.heatpumpSetErrorQuit));
+        resetCommunicationError();
+    }
+
+    /**
+     * @param bridgeStatusInfo
+     */
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            startUp();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            tearDown();
+        }
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with read: %s: %s", cls, msg));
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleWriteError(AsyncModbusFailure<ModbusWriteRequestBlueprint> failure) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || getThing().getStatus() == ThingStatus.OFFLINE) {
+            return;
+        }
+        String msg = failure.getCause().getMessage();
+        String cls = failure.getCause().getClass().getName();
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with write: %s: %s", cls, msg));
+    }
+
+    /**
+     * Returns true, if we're in a CONFIGURATION_ERROR state
+     *
+     * @return
+     */
+    protected boolean hasConfigurationError() {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        return statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR;
+    }
+
+    /**
+     * Reset communication status to ONLINE if we're in an OFFLINE state
+     */
+    protected void resetCommunicationError() {
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
+        if (ThingStatus.OFFLINE.equals(statusInfo.getStatus())
+                && ThingStatusDetail.COMMUNICATION_ERROR.equals(statusInfo.getStatusDetail())) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    /**
+     * Returns the channel UID for the specified group and channel id
+     *
+     * @param string the channel group
+     * 
+     * @param string the channel id in that group
+     * 
+     * @return the globally unique channel uid
+     */
+    ChannelUID channelUID(String group, String id) {
+        return new ChannelUID(getThing().getUID(), group, id);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/LambdaException.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/handler/LambdaException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown when the lambda-heatpump handler sees an error.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ */
+@SuppressWarnings("serial")
+@NonNullByDefault
+public class LambdaException extends Exception {
+
+    public LambdaException() {
+    }
+
+    public LambdaException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/AbstractBaseParser.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.io.transport.modbus.ModbusBitUtilities;
+import org.openhab.core.io.transport.modbus.ModbusConstants.ValueType;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.core.library.types.DecimalType;
+
+/**
+ * Base class for parsers with some helper methods
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ * @author Paul Frank - Added more methods
+ */
+@NonNullByDefault
+public class AbstractBaseParser {
+
+    /**
+     * Extract an optional double value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Double> extractOptionalDouble(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT16)
+                .map(value -> ((double) value.intValue()) / 10.0).filter(value -> value != (short) 0x8000);
+    }
+
+    /**
+     * Extract a mandatory double value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @param def the default value
+     * 
+     * @return the parsed value or the default if the field is not implemented
+     */
+    protected Double extractDouble(ModbusRegisterArray raw, int index, double def) {
+        return Objects.requireNonNull(extractOptionalDouble(raw, index).orElse(def));
+    }
+
+    /**
+     * Extract an optional int16 value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Short> extractOptionalInt16(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT16).map(DecimalType::shortValue)
+                .filter(value -> value != (short) 0x8000);
+    }
+
+    /**
+     * Extract a mandatory int16 value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @param def the default value
+     * 
+     * @return the parsed value or the default if the field is not implemented
+     */
+    protected Short extractInt16(ModbusRegisterArray raw, int index, short def) {
+        return Objects.requireNonNull(extractOptionalInt16(raw, index).orElse(def));
+    }
+
+    /**
+     * Extract an optional uint16 value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Integer> extractOptionalUInt16(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT16).map(DecimalType::intValue)
+                .filter(value -> value != 0xffff);
+    }
+
+    /**
+     * Extract a mandatory uint16 value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @param def the default value
+     * 
+     * @return the parsed value or the default if the field is not implemented
+     */
+    protected Integer extractUInt16(ModbusRegisterArray raw, int index, int def) {
+        return Objects.requireNonNull(extractOptionalUInt16(raw, index).orElse(def));
+    }
+
+    /**
+     * Extract an optional acc32 value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Long> extractOptionalUInt32(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT32).map(DecimalType::longValue)
+                .filter(value -> value != 0);
+    }
+
+    protected Optional<Long> extractOptionalInt32(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT32).map(DecimalType::longValue)
+                .filter(value -> value != 0);
+    }
+
+    /**
+     * Extract a mandatory acc32 value
+     *
+     * @param raw the register array to extract from
+     * 
+     * @param index the address of the field
+     * 
+     * @param def the default value
+     * 
+     * @return the parsed value or default if the field is not implemented
+     */
+    protected Long extractUInt32(ModbusRegisterArray raw, int index, long def) {
+        return Objects.requireNonNull(extractOptionalUInt32(raw, index).orElse(def));
+    }
+
+    protected Long extractInt32(ModbusRegisterArray raw, int index, long def) {
+        return Objects.requireNonNull(extractOptionalInt32(raw, index).orElse(def));
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/AmbientBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/AmbientBlockParser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.AmbientBlock;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses labmda modbus data into an Ambient Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class AmbientBlockParser extends AbstractBaseParser {
+
+    public AmbientBlock parse(ModbusRegisterArray raw) {
+        AmbientBlock block = new AmbientBlock();
+        block.ambientErrorNumber = extractInt16(raw, 0, (short) 0);
+        block.ambientOperatingState = extractUInt16(raw, 1, (short) 0);
+        block.actualAmbientTemperature = extractInt16(raw, 2, (short) 0);
+        block.averageAmbientTemperature = extractInt16(raw, 3, (short) 0);
+        block.calculatedAmbientTemperature = extractInt16(raw, 4, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BoilerBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BoilerBlockParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.BoilerBlock;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses lambda modbus data into a Boiler Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class BoilerBlockParser extends AbstractBaseParser {
+
+    public BoilerBlock parse(ModbusRegisterArray raw) {
+        BoilerBlock block = new BoilerBlock();
+        block.boilerErrorNumber = extractUInt16(raw, 0, (short) 0);
+        block.boilerOperatingState = extractInt16(raw, 1, (short) 0);
+        block.boilerActualHighTemperature = extractInt16(raw, 2, (short) 0);
+        block.boilerActualLowTemperature = extractInt16(raw, 3, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BoilerReg50BlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BoilerReg50BlockParser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.BoilerReg50Block;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses modbus data into an BoilerReg50 Block -
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class BoilerReg50BlockParser extends AbstractBaseParser {
+
+    public BoilerReg50Block parse(ModbusRegisterArray raw) {
+        BoilerReg50Block block = new BoilerReg50Block();
+        block.boilerMaximumBoilerTemperature = extractUInt16(raw, 0, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BufferBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BufferBlockParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.BufferBlock;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses lambda modbus data into a Buffer Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class BufferBlockParser extends AbstractBaseParser {
+
+    public BufferBlock parse(ModbusRegisterArray raw) {
+        BufferBlock block = new BufferBlock();
+        block.bufferErrorNumber = extractInt16(raw, 0, (short) 0);
+        block.bufferOperatingState = extractUInt16(raw, 1, (short) 0);
+        block.bufferActualHighTemperature = extractInt16(raw, 2, (short) 0);
+        block.bufferActualLowTemperature = extractInt16(raw, 3, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BufferReg50BlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/BufferReg50BlockParser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.BufferReg50Block;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/*
+ * Parses lambda modbus data into an BufferReg50 Block -
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class BufferReg50BlockParser extends AbstractBaseParser {
+
+    public BufferReg50Block parse(ModbusRegisterArray raw) {
+        BufferReg50Block block = new BufferReg50Block();
+        block.bufferMaximumBufferTemperature = extractUInt16(raw, 0, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/EManagerBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/EManagerBlockParser.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.EManagerBlock;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/*
+ * Parses inverter modbus data into an EManger Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class EManagerBlockParser extends AbstractBaseParser {
+
+    public EManagerBlock parse(ModbusRegisterArray raw) {
+        EManagerBlock block = new EManagerBlock();
+        block.emanagerErrorNumber = extractInt16(raw, 0, (short) 0);
+        block.emanagerOperatingState = extractUInt16(raw, 1, (short) 0);
+        block.actualPower = extractUInt16(raw, 2, (short) 0);
+        block.actualPowerConsumption = extractInt16(raw, 3, (short) 0);
+        block.powerConsumptionSetpoint = extractInt16(raw, 4, (short) 0);
+
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatingCircuitBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatingCircuitBlockParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatingCircuitBlock;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses lambda
+ * modbus data into a Heating Circuit Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class HeatingCircuitBlockParser extends AbstractBaseParser {
+
+    public HeatingCircuitBlock parse(ModbusRegisterArray raw) {
+        HeatingCircuitBlock block = new HeatingCircuitBlock();
+        block.heatingcircuitErrorNumber = extractInt16(raw, 0, (short) 0);
+        block.heatingcircuitOperatingState = extractUInt16(raw, 1, (short) 0);
+        block.heatingcircuitFlowLineTemperature = extractInt16(raw, 2, (short) 0);
+        block.heatingcircuitReturnLineTemperature = extractInt16(raw, 3, (short) 0);
+        block.heatingcircuitRoomDeviceTemperature = extractInt16(raw, 4, (short) 0);
+        block.heatingcircuitSetpointFlowLineTemperature = extractInt16(raw, 5, (short) 0);
+        block.heatingcircuitOperatingMode = extractInt16(raw, 6, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatingCircuitReg50BlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatingCircuitReg50BlockParser.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatingCircuitReg50Block;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses lambda modbus data into a HeatingCircuitReg50 Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class HeatingCircuitReg50BlockParser extends AbstractBaseParser {
+
+    public HeatingCircuitReg50Block parse(ModbusRegisterArray raw) {
+        HeatingCircuitReg50Block block = new HeatingCircuitReg50Block();
+        block.heatingcircuitOffsetFlowLineTemperature = extractInt16(raw, 0, (short) 0);
+        block.heatingcircuitRoomHeatingTemperature = extractInt16(raw, 1, (short) 0);
+        block.heatingcircuitRoomCoolingTemperature = extractInt16(raw, 2, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatpumpBlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatpumpBlockParser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatpumpBlock;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses lambda modbus data into a Heatpump Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class HeatpumpBlockParser extends AbstractBaseParser {
+
+    public HeatpumpBlock parse(ModbusRegisterArray raw) {
+        HeatpumpBlock block = new HeatpumpBlock();
+        block.heatpumpErrorState = extractUInt16(raw, 0, (short) 0);
+        block.heatpumpErrorNumber = extractInt16(raw, 1, (short) 0);
+        block.heatpumpState = extractUInt16(raw, 2, (short) 0);
+        block.heatpumpOperatingState = extractUInt16(raw, 3, (short) 0);
+        block.heatpumpTFlow = extractInt16(raw, 4, (short) 0);
+        block.heatpumpTReturn = extractInt16(raw, 5, (short) 0);
+        block.heatpumpVolSink = extractInt16(raw, 6, (short) 0);
+        block.heatpumpTEQin = extractInt16(raw, 7, (short) 0);
+        block.heatpumpTEQout = extractInt16(raw, 8, (short) 0);
+        block.heatpumpVolSource = extractInt16(raw, 9, (short) 0);
+        block.heatpumpCompressorRating = extractUInt16(raw, 10, (short) 0);
+        block.heatpumpQpHeating = extractInt16(raw, 11, (short) 0);
+        block.heatpumpFIPowerConsumption = extractInt16(raw, 12, (short) 0);
+        block.heatpumpCOP = extractInt16(raw, 13, (short) 0);
+        block.heatpumpVdAE = extractInt32(raw, 20, (long) 0);
+        block.heatpumpVdAQ = extractInt32(raw, 22, (long) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatpumpReg50BlockParser.java
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/java/org/openhab/binding/modbus/lambda/internal/parser/HeatpumpReg50BlockParser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.lambda.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.lambda.internal.dto.HeatpumpReg50Block;
+import org.openhab.core.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses inlambda modbus data into a HeatpumpReg50 Block
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Christian Koch - modified for lambda heat pump based on stiebeleltron binding for modbus
+ *
+ */
+@NonNullByDefault
+public class HeatpumpReg50BlockParser extends AbstractBaseParser {
+
+    public HeatpumpReg50Block parse(ModbusRegisterArray raw) {
+        HeatpumpReg50Block block = new HeatpumpReg50Block();
+        block.heatpumpSetErrorQuit = extractInt16(raw, 0, (short) 0);
+        return block;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/config/config-descriptions.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/config/config-descriptions.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:lambda-general:modbusconfig">
+
+		<parameter name="refresh" type="integer" min="0" unit="s">
+			<label>Refresh Interval</label>
+			<description>Refresh interval in seconds. Use zero to disable automatic polling.</description>
+			<default>30</default>
+			<unitLabel>s</unitLabel>
+		</parameter>
+
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum Tries</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+			<advanced>true</advanced>
+		</parameter>
+
+	</config-description>
+
+	<config-description uri="thing-type:lambda-heatpump:modbusconfig">
+
+		<parameter name="refresh" type="integer" min="0" unit="s">
+			<label>Refresh Interval</label>
+			<description>Refresh interval in seconds. Use zero to disable automatic polling.</description>
+			<default>30</default>
+			<unitLabel>s</unitLabel>
+		</parameter>
+
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum Tries</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="subindex" type="integer" required="true" min="0" max="2">
+			<label>Subindex of Heatpump Thing (0..2)</label>
+			<description>See Lambda Modbus description</description>
+			<default>0</default>
+		</parameter>
+
+	</config-description>
+
+
+	<config-description uri="thing-type:lambda-boiler:modbusconfig">
+
+		<parameter name="refresh" type="integer" min="0" unit="s">
+			<label>Refresh Interval</label>
+			<description>Refresh interval in seconds. Use zero to disable automatic polling.</description>
+			<default>30</default>
+			<unitLabel>s</unitLabel>
+		</parameter>
+
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum Tries</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="subindex" type="integer" required="true" min="0" max="4">
+			<label>Subindex of Boiler (0..4)</label>
+			<description>See Lambda Modbus description</description>
+			<default>0</default>
+		</parameter>
+
+	</config-description>
+
+	<config-description uri="thing-type:lambda-buffer:modbusconfig">
+
+		<parameter name="refresh" type="integer" min="0" unit="s">
+			<label>Refresh Interval</label>
+			<description>Refresh interval in seconds. Use zero to disable automatic polling.</description>
+			<default>30</default>
+			<unitLabel>s</unitLabel>
+		</parameter>
+
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum Tries</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="subindex" type="integer" required="true" min="0" max="4">
+			<label>Subindex of Buffer (0..4)</label>
+			<description>See Lambda Modbus description</description>
+			<default>0</default>
+		</parameter>
+
+	</config-description>
+
+	<config-description uri="thing-type:lambda-heatingcircuit:modbusconfig">
+
+		<parameter name="refresh" type="integer" min="0" unit="s">
+			<label>Refresh Interval</label>
+			<description>Refresh interval in seconds. Use zero to disable automatic polling.</description>
+			<default>30</default>
+			<unitLabel>s</unitLabel>
+		</parameter>
+
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum Tries</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="subindex" type="integer" required="true" min="0" max="11">
+			<label>Subindex of Heating Circuit (0..11)</label>
+			<description>See Lambda Modbus description</description>
+			<default>0</default>
+		</parameter>
+
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/i18n/lambda.properties
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/i18n/lambda.properties
@@ -1,0 +1,116 @@
+# add-on
+
+addon.modbus.lambda.name = Lambda Heat Pump Binding
+addon.modbus.lambda.description = The Lambda Heat Pump binding supports the different parts of a Lambda Heat Pump heating.
+
+# thing types
+
+thing-type.modbus.lambda-general.label = Lambda General Sections
+thing-type.modbus.lambda-general.description = Provides Channels of the General Sections
+thing-type.modbus.lambda-heatpump.label = Lambda Heatpump
+thing-type.modbus.lambda-heatpump.description = Provides Channels of a Heatpump
+thing-type.modbus.lambda-boiler.label = Lambda Boiler
+thing-type.modbus.lambda-boiler.description = Provides Channels of a Boiler
+thing-type.modbus.lambda-buffer.label = Lambda Buffer
+thing-type.modbus.lambda-buffer.description = Provides Channels of a Buffer
+thing-type.modbus.lambda-heatingcircuit.label = Lambda Heating Circuit
+thing-type.modbus.lambda-heatingcircuit.description = Provides Channels of a Heating Circuit
+
+# thing types config
+
+thing-type.config.lambda-general.modbusconfig.maxTries.label = Maximum Tries When Reading
+thing-type.config.lambda-general.modbusconfig.maxTries.description = Number of tries when reading data, if some of the reading fail. For single try, enter 1.
+thing-type.config.lambda-general.modbusconfig.refresh.label = Refresh Interval
+thing-type.config.lambda-general.modbusconfig.refresh.description = Refresh interval in seconds. Use zero to disable automatic polling.
+
+thing-type.config.lambda-boiler.modbusconfig.maxTries.label = Maximum Tries When Reading
+thing-type.config.lambda-boiler.modbusconfig.maxTries.description = Number of tries when reading data, if some of the reading fail. For single try, enter 1.
+thing-type.config.lambda-boiler.modbusconfig.refresh.label = Refresh Interval
+thing-type.config.lambda-boiler.modbusconfig.refresh.description = Refresh interval in seconds. Use zero to disable automatic polling.thing-type.config.lambda-general.modbusconfig.maxTries.label = Maximum Tries When Reading
+
+thing-type.config.lambda-buffer.modbusconfig.maxTries.label = Maximum Tries When Reading
+thing-type.config.lambda-buffer.modbusconfig.maxTries.description = Number of tries when reading data, if some of the reading fail. For single try, enter 1.
+thing-type.config.lambda-buffer.modbusconfig.refresh.label = Refresh Interval
+thing-type.config.lambda-buffer.modbusconfig.refresh.description = Refresh interval in seconds. Use zero to disable automatic polling.thing-type.config.lambda-boiler.baseadress.label = BaseAdress of boiler
+
+thing-type.config.lambda-heatpump.modbusconfig.maxTries.label = Maximum Tries When Reading
+thing-type.config.lambda-heatpump.modbusconfig.maxTries.description = Number of tries when reading data, if some of the reading fail. For single try, enter 1.
+thing-type.config.lambda-heatpump.modbusconfig.refresh.label = Refresh Interval
+thing-type.config.lambda-heatpump.modbusconfig.refresh.description = Refresh interval in seconds. Use zero to disable automatic polling.thing-type.config.lambda-heatingcircuit.baseadress.label = BaseAdress of Heating Circuit
+
+thing-type.config.lambda-heatingcircuit.modbusconfig.maxTries.label = Maximum Tries When Reading
+thing-type.config.lambda-heatingcircuit.modbusconfig.maxTries.description = Number of tries when reading data, if some of the reading fail. For single try, enter 1.
+thing-type.config.lambda-heatingcircuit.modbusconfig.refresh.label = Refresh Interval
+thing-type.config.lambda-heatingcircuit.modbusconfig.refresh.description = Refresh interval in seconds. Use zero to disable automatic polling.thing-type.config.lambda-heatingcircuit.baseadress.label = BaseAdress of Heating Circuit
+
+# channel group types
+
+channel-group-type.modbus.ambient-type.label = General Ambient Group
+channel-group-type.modbus.emanager-type.label = General E-Manager  Group
+channel-group-type.modbus.heatpump-type.label = Heatpump Group
+channel-group-type.modbus.boiler-type.label = Boiler Group
+channel-group-type.modbus.buffer-type.label = Buffer Group
+channel-group-type.modbus.heatingcircuit-type.label = Heating Circuit Group
+
+# channel types
+
+# General Ambient
+channel-type.modbus.ambient-error-number-type.label = Ambient Error Number
+channel-type.modbus.ambient-operating-state-type.label = Ambient Operating State
+channel-type.modbus.actual-ambient-temperature-type.label = Actual Ambient Temperature
+channel-type.modbus.average-ambient-temperature-type.label = Average Ambient Temperature 1h
+channel-type.modbus.calculated-ambient-temperature-type.label = Calculated Ambient Temperature
+
+# General E-Manager
+channel-type.modbus.emanager-error-number-type.label = E-Manager Error Number
+channel-type.modbus.emanager-operating-state-type.label = E-Manager Operating State
+channel-type.modbus.actual-power-type.label = Actual Power (input or excess)
+channel-type.modbus.actual-power-consumption-type.label = Actual Power Consumption
+channel-type.modbus.power-consumption-setpoint-type.label = Power Consumption setpoint as sum of all heat pumps
+
+# Heat Pump
+
+channel-type.modbus.heatpump-error-state-type.label = Heatpump Error State
+channel-type.modbus.heatpump-error-number-type.label = Heatpump Error Number
+channel-type.modbus.heatpump-state-type.label = Heatpump State
+channel-type.modbus.heatpump-operating-state-type.label = Heatpump Operating State
+channel-type.modbus.heatpump-t-flow-type.label = Heatpump T-Flow
+channel-type.modbus.heatpump-t-return-type.label = Heatpump T-Return
+channel-type.modbus.heatpump-vol-sink-type.label = Heatpump Volume flow heat sink
+channel-type.modbus.heatpump-t-eqin-type.label = Heatpump Energy source inlet temperature
+channel-type.modbus.heatpump-t-eqout-type.label = Heatpump Energy source outlet temperature
+channel-type.modbus.heatpump-vol-source-type.label = Heatpump Volume flow energy source
+channel-type.modbus.heatpump-compressor-rating-type.label = Heatpump Compressor unit rating
+channel-type.modbus.heatpump-qp-heating-type.label = Heatpump Actual heating capacity
+channel-type.modbus.heatpump-fi-power-consumption-type.label = Heatpump Frequency inverter actual power consumption
+channel-type.modbus.heatpump-cop-type.label = Heatpump COP
+channel-type.modbus.heatpump-vdae-type.label = Heatpump VdA E
+channel-type.modbus.heatpump-vdaq-type.label = Heatpump VdA Q 
+channel-type.modbus.heatpump-set-error-quit.label = Heatpump Set Error Quit
+
+# Boiler
+channel-type.modbus.boiler-error-number-type.label = Boiler Error Number
+channel-type.modbus.boiler-operating-state-type.label = Boiler Operating State
+channel-type.modbus.boiler-actual-high-temperature-type.label = Boiler Actual High Temperature
+channel-type.modbus.boiler-actual-low-temperature-type.label = Boiler Actual Low Temperature
+channel-type.modbus.boiler-maximum-boiler-temperature-type.label = Boiler Maximum Temperature
+
+# Buffer
+channel-type.modbus.buffer-error-number-type.label = Buffer Error Number
+channel-type.modbus.buffer-operating-state-type.label = Buffer Operating State
+channel-type.modbus.buffer-actual-high-temperature-type.label = Buffer Actual High Temperature
+channel-type.modbus.buffer-actual-low-temperature-type.label = Buffer Actual Low Temperature
+channel-type.modbus.buffer-maximum-buffer-temperature-type.label = Buffer Maximum Temperature
+
+# Heating Circuit
+channel-type.modbus.heatingcircuit-error-number-type.label = Heating circuit Error Number;
+channel-type.modbus.heatingcircuit-operating-state-type.label = Heating circuit Operating State;
+channel-type.modbus.heatingcircuit-flow-line-temperature-type.label = Heating circuit Flow Line Temperature;
+channel-type.modbus.heatingcircuit-return-line-temperature-type.label = Heating circuit Return Line Temperature;
+channel-type.modbus.heatingcircuit-room-device-temperature-type.label = Heating circuit Room Device Temperature;
+channel-type.modbus.heatingcircuit-setpoint-flow-line-temperature-type.label = Heating circuit Setpoint Flow Line Temperature;
+channel-type.modbus.heatingcircuit-operating-mode-type.label = Heating circuit Operating Mode;
+channel-type.modbus.heatingcircuit-offset-flow-line-temperature-type.label = Heating circuit Offset Flow Line Temperature;
+channel-type.modbus.heatingcircuit-room-heating-temperature-type.label = Heating circuit Room Heating Temperature;
+channel-type.modbus.heatingcircuit-room-cooling-temperature-type.label = Heating circuit Room Cooling Temperature;
+

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/boiler-channel-group-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/boiler-channel-group-types.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="boiler-type">
+		<label>Boiler</label>
+		<channels>
+			<channel id="boiler-error-number" typeId="boiler-error-number-type"/>
+			<channel id="boiler-operating-state" typeId="boiler-operating-state-type"/>
+			<channel id="boiler-actual-high-temperature" typeId="boiler-actual-high-temperature-type"/>
+			<channel id="boiler-actual-low-temperature" typeId="boiler-actual-low-temperature-type"/>
+			<channel id="boiler-maximum-boiler-temperature" typeId="boiler-maximum-boiler-temperature-type"/>
+		</channels>
+	</channel-group-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/boiler-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/boiler-channel-types.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="boiler-error-number-type">
+		<item-type>Number</item-type>
+		<label>Boiler Error Number</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">No Error</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="boiler-operating-state-type">
+		<item-type>Number</item-type>
+		<label>Boiler Operating State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">STBY</option>
+				<option value="1">DHW</option>
+				<option value="2">LEGIO</option>
+				<option value="3">SUMMER</option>
+				<option value="4">FROST</option>
+				<option value="5">HOLIDAY</option>
+				<option value="6">PRIO-STOP</option>
+				<option value="7">ERROR</option>
+				<option value="8">OFF</option>
+				<option value="9">PROMPT-DHW</option>
+				<option value="10">TRAILING-STOP</option>
+				<option value="11">TEMP-LOCK</option>
+				<option value="12">STBY-FROST</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="boiler-actual-high-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Boiler Actual High Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="boiler-actual-low-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Boiler Actual Low Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="boiler-maximum-boiler-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Boiler Maximum Boiler Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/boiler-thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/boiler-thing-types.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="lambda-boiler">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp"/>
+		</supported-bridge-type-refs>
+		<label>Lambda Boiler Section</label>
+		<description>Lambda Boiler connected through modbus</description>
+
+		<channel-groups>
+
+			<channel-group id="boiler-group" typeId="boiler-type"/>
+
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:lambda-boiler:modbusconfig"/>
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/buffer-channel-group-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/buffer-channel-group-types.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="buffer-type">
+		<label>Buffer</label>
+		<channels>
+			<channel id="buffer-error-number" typeId="buffer-error-number-type"/>
+			<channel id="buffer-operating-state" typeId="buffer-operating-state-type"/>
+			<channel id="buffer-actual-high-temperature" typeId="buffer-actual-high-temperature-type"/>
+			<channel id="buffer-actual-low-temperature" typeId="buffer-actual-low-temperature-type"/>
+			<channel id="buffer-maximum-buffer-temperature" typeId="buffer-maximum-buffer-temperature-type"/>
+		</channels>
+	</channel-group-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/buffer-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/buffer-channel-types.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="buffer-error-number-type">
+		<item-type>Number</item-type>
+		<label>buffer Error Number</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">No Error</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="buffer-operating-state-type">
+		<item-type>Number</item-type>
+		<label>buffer Operating State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">STBY</option>
+				<option value="1">HEATING</option>
+				<option value="2">COOLING</option>
+				<option value="3">SUMMER</option>
+				<option value="4">FROST</option>
+				<option value="5">HOLIDAY</option>
+				<option value="6">PRIO-STOP</option>
+				<option value="7">ERROR</option>
+				<option value="8">OFF</option>
+				<option value="9">STBY-FROST</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="buffer-actual-high-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Buffer Actual High Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="buffer-actual-low-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Buffer Actual Low Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="buffer-maximum-buffer-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Buffer Maximum Buffer Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/buffer-thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/buffer-thing-types.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="lambda-buffer">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp"/>
+		</supported-bridge-type-refs>
+		<label>Lambda Buffer Section</label>
+		<description>Lambda Buffer connected through modbus</description>
+
+		<channel-groups>
+
+			<channel-group id="buffer-group" typeId="buffer-type"/>
+
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:lambda-buffer:modbusconfig"/>
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/general-channel-group-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/general-channel-group-types.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="ambient-type">
+		<label>General Ambient</label>
+		<channels>
+			<channel id="ambient-error-number" typeId="ambient-error-number-type"/>
+			<channel id="ambient-operating-state" typeId="ambient-operating-state-type"/>
+			<channel id="actual-ambient-temperature" typeId="actual-ambient-temperature-type"/>
+			<channel id="average-ambient-temperature" typeId="average-ambient-temperature-type"/>
+			<channel id="calculated-ambient-temperature" typeId="calculated-ambient-temperature-type"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="emanager-type">
+		<label>General E-Manager</label>
+		<channels>
+			<channel id="emanager-error-number" typeId="emanager-error-number-type"/>
+			<channel id="emanager-operating-state" typeId="emanager-operating-state-type"/>
+			<channel id="actual-power" typeId="actual-power-type"/>
+			<channel id="actual-power-consumption" typeId="actual-power-consumption-type"/>
+			<channel id="power-consumption-setpoint" typeId="power-consumption-setpoint-type"/>
+		</channels>
+	</channel-group-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/general-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/general-channel-types.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="ambient-error-number-type">
+		<item-type>Number</item-type>
+		<label>Ambient Error Number</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">No Error</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="ambient-operating-state-type">
+		<item-type>Number</item-type>
+		<label>Ambient Operating State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">OFF</option>
+				<option value="1">AUTOMATIC</option>
+				<option value="2">MANUAL</option>
+				<option value="3">ERROR</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="actual-ambient-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Actual Ambient Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+
+	</channel-type>
+
+	<channel-type id="average-ambient-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Average Ambient Temperature 1h</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="calculated-ambient-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Calculated Ambient Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="emanager-error-number-type">
+		<item-type>Number</item-type>
+		<label>E-Manager Error Number</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">No Error</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="emanager-operating-state-type">
+		<item-type>Number</item-type>
+		<label>E-Manager Operating State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">OFF</option>
+				<option value="1">AUTOMATIC</option>
+				<option value="2">MANUAL</option>
+				<option value="3">ERROR</option>
+				<option value="4">OFFLINE</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="actual-power-type">
+		<item-type>Number:Power</item-type>
+		<label>Actual Power (input or excess)</label>
+		<state readOnly="false" pattern="%.0f %unit%"/>
+	</channel-type>
+
+	<channel-type id="actual-power-consumption-type">
+		<item-type>Number:Power</item-type>
+		<label>Actual Power Consumption</label>
+		<state readOnly="true" pattern="%.0f %unit%"/>
+	</channel-type>
+
+	<channel-type id="power-consumption-setpoint-type">
+		<item-type>Number:Power</item-type>
+		<label>Power consumption setpoint of all Heat Pumps</label>
+		<state readOnly="true" pattern="%.0f %unit%"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/general-thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/general-thing-types.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="lambda-general">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp"/>
+		</supported-bridge-type-refs>
+		<label>Lambda General Group</label>
+		<description> Ambient and E-Manager groups connected through modbus</description>
+
+		<channel-groups>
+
+			<channel-group id="ambient-group" typeId="ambient-type"/>
+			<channel-group id="emanager-group" typeId="emanager-type"/>
+
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:lambda-general:modbusconfig"/>
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatingcircuit-channel-group-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatingcircuit-channel-group-types.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="heatingcircuit-type">
+		<label>Heating Circuit</label>
+		<channels>
+			<channel id="heatingcircuit-error-number" typeId="heatingcircuit-error-number-type"/>
+			<channel id="heatingcircuit-operating-state" typeId="heatingcircuit-operating-state-type"/>
+			<channel id="heatingcircuit-flow-line-temperature" typeId="heatingcircuit-flow-line-temperature-type"/>
+			<channel id="heatingcircuit-return-line-temperature" typeId="heatingcircuit-return-line-temperature-type"/>
+			<channel id="heatingcircuit-room-device-temperature" typeId="heatingcircuit-room-device-temperature-type"/>
+			<channel id="heatingcircuit-setpoint-flow-line-temperature"
+				typeId="heatingcircuit-setpoint-flow-line-temperature-type"/>
+			<channel id="heatingcircuit-operating-mode" typeId="heatingcircuit-operating-mode-type"/>
+			<channel id="heatingcircuit-offset-flow-line-temperature"
+				typeId="heatingcircuit-offset-flow-line-temperature-type"/>
+			<channel id="heatingcircuit-room-heating-temperature" typeId="heatingcircuit-room-heating-temperature-type"/>
+			<channel id="heatingcircuit-room-cooling-temperature" typeId="heatingcircuit-room-cooling-temperature-type"/>
+		</channels>
+	</channel-group-type>
+
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatingcircuit-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatingcircuit-channel-types.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+
+	<channel-type id="heatingcircuit-error-number-type">
+		<item-type>Number</item-type>
+		<label>Heating Circuit Error Number</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">No Error</option>
+			</options>
+		</state>
+	</channel-type>
+
+
+	<channel-type id="heatingcircuit-operating-state-type">
+		<item-type>Number</item-type>
+		<label>Heating Circuit Operating State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">HEATING</option>
+				<option value="1">ECO</option>
+				<option value="2">COOLING</option>
+				<option value="3">FLOORDRY</option>
+				<option value="4">FROST</option>
+				<option value="5">MAX-TEMP</option>
+				<option value="6">ERROR</option>
+				<option value="7">SERVICE</option>
+				<option value="8">HOLIDAY</option>
+				<option value="9">CH-SUMMER</option>
+				<option value="10">CC-WINTER</option>
+				<option value="11">PRIO-STOP</option>
+				<option value="12">OFF</option>
+				<option value="13">RELEASE-OFF</option>
+				<option value="14">TIME-OFF</option>
+				<option value="15">STBY</option>
+				<option value="16">STBY-HEATING</option>
+				<option value="17">STBY-ECHO</option>
+				<option value="18">STBY-COOLING</option>
+				<option value="19">STBY-FROST</option>
+				<option value="20">STB-FLOORDRY</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-flow-line-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating Circuit Flow Line Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-return-line-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating Circuit Return Line Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-room-device-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating circuit 1 Room Device Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-setpoint-flow-line-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating Circuit Setpoint Flow Line Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-operating-mode-type">
+		<item-type>Number</item-type>
+		<label>Heating Circuit Operating Mode</label>
+		<state readOnly="false">
+			<options>
+				<option value="0">OFF(RW)</option>
+				<option value="1">MANUAL(R)</option>
+				<option value="2">AUTOMATIK(RW)</option>
+				<option value="3">AUTO-HEATING(RW)</option>
+				<option value="4">AUTO-COOLING(RW)</option>
+				<option value="5">FROST(RW)</option>
+				<option value="6">SUMMER(RW)</option>
+				<option value="7">FLOOR-DRY(R)</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-offset-flow-line-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating Circuit Set Offset Flow Line Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-room-heating-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating Circuit Set Room Heating Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatingcircuit-room-cooling-temperature-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heating Circuit Set Room Cooling Temperature</label>
+		<state readOnly="false" pattern="%.1f %unit%"/>
+	</channel-type>
+
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatingcircuit-thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatingcircuit-thing-types.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="lambda-heatingcircuit">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp"/>
+		</supported-bridge-type-refs>
+		<label>Lambda Heating Circuit</label>
+		<description>Lambda Heating Circuit connected through modbus</description>
+
+		<channel-groups>
+
+			<channel-group id="heatingcircuit-group" typeId="heatingcircuit-type"/>
+
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:lambda-heatingcircuit:modbusconfig"/>
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatpump-channel-group-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatpump-channel-group-types.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="heatpump-type">
+		<label>Heat Pump</label>
+		<channels>
+			<channel id="heatpump-error-state" typeId="heatpump-error-state-type"/>
+			<channel id="heatpump-error-number" typeId="heatpump-error-number-type"/>
+			<channel id="heatpump-state" typeId="heatpump-state-type"/>
+			<channel id="heatpump-operating-state" typeId="heatpump-operating-state-type"/>
+			<channel id="heatpump-t-flow" typeId="heatpump-t-flow-type"/>
+			<channel id="heatpump-t-return" typeId="heatpump-t-return-type"/>
+			<channel id="heatpump-vol-sink" typeId="heatpump-vol-sink-type"/>
+			<channel id="heatpump-t-eqin" typeId="heatpump-t-eqin-type"/>
+			<channel id="heatpump-t-eqout" typeId="heatpump-t-eqout-type"/>
+			<channel id="heatpump-vol-source" typeId="heatpump-vol-source-type"/>
+			<channel id="heatpump-compressor-rating" typeId="heatpump-compressor-rating-type"/>
+			<channel id="heatpump-qp-heating" typeId="heatpump-qp-heating-type"/>
+			<channel id="heatpump-fi-power-consumption" typeId="heatpump-fi-power-consumption-type"/>
+			<channel id="heatpump-cop" typeId="heatpump-cop-type"/>
+			<channel id="heatpump-vdae" typeId="heatpump-vdae-type"/>
+			<channel id="heatpump-vdaq" typeId="heatpump-vdaq-type"/>
+			<channel id="heatpump-set-error-quit" typeId="heatpump-set-error-quit-type"/>
+		</channels>
+	</channel-group-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatpump-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatpump-channel-types.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="heatpump-error-state-type">
+		<item-type>Number</item-type>
+		<label>Heatpump Error State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">NONE</option>
+				<option value="1">MESSAGE</option>
+				<option value="2">WARNING</option>
+				<option value="3">ALARM</option>
+				<option value="4">FAULT</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heatpump-error-number-type">
+		<item-type>Number</item-type>
+		<label>Heatpump Error Number</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">No Error</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heatpump-state-type">
+		<item-type>Number</item-type>
+		<label>Heatpump State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">INIT</option>
+				<option value="1">REFERENCE</option>
+				<option value="2">RESTART-BLOCK</option>
+				<option value="3">READY</option>
+				<option value="4">START PUMPS</option>
+				<option value="5">START COMPRESSOR</option>
+				<option value="6">PRE-REGULATION</option>
+				<option value="7">REGULATION</option>
+				<option value="8">Not used</option>
+				<option value="9">COOLING</option>
+				<option value="10">DEFROSTING</option>
+				<option value="20">STOPPING</option>
+				<option value="30">FAULT-LOCK</option>
+				<option value="31">ALARM-BLOCK</option>
+				<option value="40">ERROR-RESET</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heatpump-operating-state-type">
+		<item-type>Number</item-type>
+		<label>Heatpump Operating State</label>
+		<state readOnly="true">
+			<options>
+				<option value="0">STBY</option>
+				<option value="1">CH</option>
+				<option value="2">DHW</option>
+				<option value="3">CC</option>
+				<option value="4">CIRCULATE</option>
+				<option value="5">DEFROST</option>
+				<option value="6">OFF</option>
+				<option value="7">FROST</option>
+				<option value="8">STBY-FROST</option>
+				<option value="9">Not used</option>
+				<option value="10">SUMMER</option>
+				<option value="11">HOLIDAY</option>
+				<option value="12">ERROR</option>
+				<option value="13">WARNING</option>
+				<option value="14">INFO-MESSAGE</option>
+				<option value="15">TIME-BLOCK</option>
+				<option value="16">RELEASE-BLOCK</option>
+				<option value="17">MINTEMP-BLOCK</option>
+				<option value="18">FIRMWARE-DOWNLOAD</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heatpump-t-flow-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heatpump T-Flow</label>
+		<state readOnly="true" pattern="%.2f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatpump-t-return-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heatpump T-Return</label>
+		<state readOnly="true" pattern="%.2f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatpump-vol-sink-type">
+		<item-type>Number:VolumetricFlowRate</item-type>
+		<label>Heatpump Volume flow heat sink</label>
+		<state readOnly="true" pattern="%.2f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatpump-t-eqin-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heatpump Energy source inlet temperature</label>
+		<state readOnly="true" pattern="%.2f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatpump-t-eqout-type">
+		<item-type>Number:Temperature</item-type>
+		<label>Heatpump Energy source outlet temperature</label>
+		<state readOnly="true" pattern="%.2f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatpump-vol-source-type">
+		<item-type>Number:VolumetricFlowRate</item-type>
+		<label>Heatpump Volume flow energy source</label>
+		<state readOnly="true" pattern="%.2f %unit%"/>
+	</channel-type>
+
+	<channel-type id="heatpump-compressor-rating-type">
+		<item-type>Number</item-type>
+		<label>Heatpump Compressor unit rating</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heatpump-qp-heating-type">
+		<item-type>Number:Power</item-type>
+		<label>Heatpump Actual heating capacity</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heatpump-fi-power-consumption-type">
+		<item-type>Number:Power</item-type>
+		<label>Heatpump Frequency inverter actual power consumption</label>
+		<state readOnly="true" pattern="%.1f kW"/>
+	</channel-type>
+
+	<channel-type id="heatpump-cop-type">
+		<item-type>Number</item-type>
+		<label>Heatpump COP</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heatpump-vdae-type">
+		<item-type>Number:Energy</item-type>
+		<label>Heatpump VdA E since last reset</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heatpump-vdaq-type">
+		<item-type>Number:Energy</item-type>
+		<label>Heatpump VdA Q since last reset</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="heatpump-set-error-quit-type">
+		<item-type>Number</item-type>
+		<label>Heatpump Set Error Quit</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatpump-thing-types.xml
+++ b/bundles/org.openhab.binding.modbus.lambda/src/main/resources/OH-INF/thing/heatpump-thing-types.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="lambda-heatpump">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp"/>
+		</supported-bridge-type-refs>
+		<label>Lambda Heat Pump Group</label>
+		<description>Lambda Heat Pump connected through modbus</description>
+
+		<channel-groups>
+
+			<channel-group id="heatpump-group" typeId="heatpump-type"/>
+
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:lambda-heatpump:modbusconfig"/>
+
+	</thing-type>
+
+</thing:thing-descriptions>


### PR DESCRIPTION
Based on the Stiebel Eltron bundle by Paul Frank I contribute a bundle to manage Lambda Heat Pumps as a OSG addon to the Modbus Binding.

I did some testing by adding my jar to the local addon directory.
@agio tested it with two instances of heating circuits - thank you!

See the README.md for restrictions on usage.

The binding is based on the Modbus description of the manufacturer:
(https://lambda-wp.at/wp-content/uploads/2024/11/Modbus-Protokoll-und-Beschreibung.pdf)
A few parts of the description are not implemented. If you feel you need them, just open a request.

Compressed directory:
[org.openhab.binding.modbus.lambda.zip](https://github.com/user-attachments/files/18731611/org.openhab.binding.modbus.lambda.zip)