### PR TITLE
[LuxtronikHeatpump] Enable Utility Lock 2 channel (EVU2)

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
@@ -950,7 +950,7 @@ public enum HeatpumpChannel {
      * EVU 2
      * (original: EVU 2)
      */
-    // CHANNEL_HZIO_EVU2(185, "HZIO_EVU2", NumberItem.class, null, false, null),
+    CHANNEL_HZIO_EVU2(185, "inputUtilityLock2", SwitchItem.class, null, false, HeatpumpVisibility.IN_EVU),
 
     /**
      * Safety tempearture limiter floor heating

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump.properties
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump.properties
@@ -112,6 +112,7 @@ channel-type.luxtronikheatpump.inputSPL.label = Input SPL
 channel-type.luxtronikheatpump.inputSwimmingPoolThermostat.label = Input "Swimming Pool Thermostat"
 channel-type.luxtronikheatpump.inputSwitchHighPressure2.label = Input Pressure Switch High Pressure 2
 channel-type.luxtronikheatpump.inputUtilityLock.label = Input "Utility Lock"
+channel-type.luxtronikheatpump.inputUtilityLock2.label = Input "Utility Lock 2"
 channel-type.luxtronikheatpump.linBusInstalled.label = LIN BUS Installed
 channel-type.luxtronikheatpump.lowPressure.label = Low Pressure
 channel-type.luxtronikheatpump.lowPressure2.label = Low Pressure 2

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
@@ -1584,6 +1584,12 @@
 		<state pattern="%.1f rpm" readOnly="true"/>
 	</channel-type>
 
+	<channel-type id="inputUtilityLock2" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Input "Utility Lock 2"</label>
+		<state readOnly="true"/>
+	</channel-type>
+
 	<channel-type id="temperatureSafetyLimitFloorHeating" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Safety Temp. Limiter Floor Heating</label>

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
@@ -168,6 +168,7 @@
 			<channel id="outputCompressorHeating" typeId="outputCompressorHeating"/>
 			<channel id="controlSignalCirculatingPump" typeId="controlSignalCirculatingPump"/>
 			<channel id="fanSpeed" typeId="fanSpeed"/>
+			<channel id="inputUtilityLock2" typeId="inputUtilityLock2"/>
 			<channel id="temperatureSafetyLimitFloorHeating" typeId="temperatureSafetyLimitFloorHeating"/>
 			<channel id="powerTargetValue" typeId="powerTargetValue"/>
 			<channel id="powerActualValue" typeId="powerActualValue"/>
@@ -309,7 +310,7 @@
 		</channels>
 
 		<properties>
-			<property name="thingTypeVersion">2</property>
+			<property name="thingTypeVersion">3</property>
 		</properties>
 
 		<config-description>

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/update/instructions.xml
@@ -27,19 +27,53 @@
 			<remove-channel id="channel260"/>
 
 			<!-- add renamed channels -->
-			<add-channel id="temperatureVapourisation"/>
-			<add-channel id="temperatureLiquefaction"/>
-			<add-channel id="frequencyCompressorMin"/>
-			<add-channel id="frequencyCompressorMax"/>
-			<add-channel id="temperatureVBOTarget"/>
-			<add-channel id="temperatureVBO"/>
-			<add-channel id="controlSignalHeatingCirculationPump"/>
-			<add-channel id="temperatureHeatingCirculationPumpTarget"/>
-			<add-channel id="temperatureHeatingCirculationPump"/>
-			<add-channel id="temperatureHotGasMax"/>
-			<add-channel id="controlSignalHeatingCirculationPump"/>
-			<add-channel id="outputControlSignalCooling"/>
-			<add-channel id="timeCoolingRelease"/>
+			<add-channel id="temperatureVapourisation">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="temperatureLiquefaction">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="frequencyCompressorMin">
+				<type>Number:Frequency</type>
+			</add-channel>
+			<add-channel id="frequencyCompressorMax">
+				<type>Number:Frequency</type>
+			</add-channel>
+			<add-channel id="temperatureVBOTarget">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="temperatureVBO">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="controlSignalHeatingCirculationPump">
+				<type>Number:Dimensionless</type>
+			</add-channel>
+			<add-channel id="temperatureHeatingCirculationPumpTarget">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="temperatureHeatingCirculationPump">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="temperatureHotGasMax">
+				<type>Number:Temperature</type>
+			</add-channel>
+			<add-channel id="controlSignalHeatingCirculationPump">
+				<type>Number:Dimensionless</type>
+			</add-channel>
+			<add-channel id="outputControlSignalCooling">
+				<type>Switch</type>
+			</add-channel>
+			<add-channel id="timeCoolingRelease">
+				<type>Number:Time</type>
+			</add-channel>
+		</instruction-set>
+		<instruction-set targetVersion="3">
+			<add-channel id="powerConsumption">
+				<type>Number:Power</type>
+			</add-channel>
+			<add-channel id="inputUtilityLock2">
+				<type>Switch</type>
+			</add-channel>
 		</instruction-set>
 	</thing-type>
 


### PR DESCRIPTION
Enables the channel `Input "Utility Lock 2"`

fixes #18255 

Note: I have also added type definitions to the update instructions. Without them the handler triggered this error for all  things:

``` 
[org.openhab.core.thing.internal.ThingManagerImpl(269)] : The addThingHandlerFactory method has thrown an exception
java.lang.NullPointerException: Cannot invoke "String.split(String)" because "id" is null
	at org.openhab.core.common.AbstractUID.splitToSegments(AbstractUID.java:124) ~[?:?]
	at org.openhab.core.common.AbstractUID.<init>(AbstractUID.java:49) ~[?:?]
	at org.openhab.core.thing.UID.<init>(UID.java:48) ~[?:?]
	at org.openhab.core.thing.type.ChannelTypeUID.<init>(ChannelTypeUID.java:42) ~[?:?]
	at org.openhab.core.thing.internal.update.UpdateChannelInstructionImpl.<init>(UpdateChannelInstructionImpl.java:79) ~[?:?]
	at org.openhab.core.thing.internal.update.ThingUpdateInstructionReaderImpl.readForFactory(ThingUpdateInstructionReaderImpl.java:99) ~[?:?]
```