### PR TITLE
[ipcamera] Fixed missing break and incorrect default logic in Reolink handler

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -324,7 +324,8 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                     break;
                 default:
                     // ignore responses from all Setxx commands
-                    if (!cutDownURL.startsWith("/cgi-bin/api.cgi?cmd=Set") && !cutDownURL.startsWith("/api.cgi?cmd=Set")) {
+                    if (!cutDownURL.startsWith("/cgi-bin/api.cgi?cmd=Set")
+                            && !cutDownURL.startsWith("/api.cgi?cmd=Set")) {
                         ipCameraHandler.logger.warn(
                                 "URL {} is not handled currently by the binding, please report this message",
                                 cutDownURL);


### PR DESCRIPTION
This fixes a couple of bugs in the Reolink handler.

Signed-off-by: Simmon Yau <simmonyau@gmail.com>