### PR TITLE
[homewizard] Fix for incorrect thing type id for kWh meter

### DIFF
--- a/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/HomeWizardEnergyMeterMeasurementPayload.java
+++ b/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/HomeWizardEnergyMeterMeasurementPayload.java
@@ -250,7 +250,8 @@ public class HomeWizardEnergyMeterMeasurementPayload {
                         voltage: %f voltageL1: %f voltageL2: %f voltageL3: %f
                         current: %f currentL1: %f currentL2: %f currentL3: %f frequency: %f
                         ]
-                """, energyImport, energyImportT1, energyExportT2, energyExport, energyExportT1, energyExportT2,
-                voltage, voltageL1, voltageL2, voltageL3, current, currentL1, currentL2, currentL3, frequency);
+                """, energyImport, energyImportT1, energyImportT2, energyExport, energyExportT1, energyExportT2, power,
+                powerL1, powerL2, powerL3, voltage, voltageL1, voltageL2, voltageL3, current, currentL1, currentL2,
+                currentL3, frequency);
     }
 }

--- a/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/p1_meter/HomeWizardP1MeterMeasurementPayload.java
+++ b/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/p1_meter/HomeWizardP1MeterMeasurementPayload.java
@@ -160,8 +160,8 @@ public class HomeWizardP1MeterMeasurementPayload extends HomeWizardEnergyMeterMe
     @Override
     public String toString() {
         return super.toString() + "  " + String.format("""
-                Data [protocolVersion: %d meterModel: %s anyPowerFailCount: %f longPowerFailCount: %f"
-                totalGasM3: %f gasTimestamp: %.0f"
+                Data [protocolVersion: %d meterModel: %s anyPowerFailCount: %d longPowerFailCount: %d"
+                totalGasM3: %f gasTimestamp: %d"
 
                 """, protocolVersion, meterModel, anyPowerFailCount, longPowerFailCount, totalGasM3, gasTimestamp);
     }

--- a/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/plug_in_battery/HomeWizardPlugInBatteryMeasurementPayload.java
+++ b/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/plug_in_battery/HomeWizardPlugInBatteryMeasurementPayload.java
@@ -53,7 +53,7 @@ public class HomeWizardPlugInBatteryMeasurementPayload extends HomeWizardEnergyM
     @Override
     public String toString() {
         return String.format("""
-                Battery Data [stateOfCharge: %d cycles: %d"]
+                Battery Data [stateOfCharge: %f cycles: %f"]
                  """, stateOfCharge, cycles);
     }
 }

--- a/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/water_meter/HomeWizardWaterMeterHandler.java
+++ b/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/water_meter/HomeWizardWaterMeterHandler.java
@@ -57,7 +57,7 @@ public class HomeWizardWaterMeterHandler extends HomeWizardDeviceHandler {
      */
     @Override
     protected void handleDataPayload(String data) {
-        var payload = gson.fromJson(data, HomeWizardWaterMeterDataPayload.class);
+        var payload = gson.fromJson(data, HomeWizardWaterMeterMeasurementPayload.class);
         if (payload != null) {
             if (!thing.getThingTypeUID().equals(HomeWizardBindingConstants.THING_TYPE_WATERMETER)) {
                 updateState(HomeWizardBindingConstants.CHANNEL_GROUP_WATER,

--- a/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/water_meter/HomeWizardWaterMeterMeasurementPayload.java
+++ b/bundles/org.openhab.binding.homewizard/src/main/java/org/openhab/binding/homewizard/internal/devices/water_meter/HomeWizardWaterMeterMeasurementPayload.java
@@ -24,7 +24,7 @@ import com.google.gson.annotations.SerializedName;
  *
  */
 @NonNullByDefault
-public class HomeWizardWaterMeterDataPayload {
+public class HomeWizardWaterMeterMeasurementPayload {
 
     @SerializedName("active_liter_lpm")
     private double activeLiter;

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/i18n/homewizard.properties
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/i18n/homewizard.properties
@@ -5,8 +5,8 @@ addon.homewizard.description = This binding provides access to the data provided
 
 # thing types
 
-thing-type.homewizard.HWE-kwh.label = HomeWizard kWh Meter
-thing-type.homewizard.HWE-kwh.description = This thing provides the measurement data that is available through the API of a HomeWizard kWh Meter.
+thing-type.homewizard.hwe-kwh.label = HomeWizard kWh Meter
+thing-type.homewizard.hwe-kwh.description = This thing provides the measurement data that is available through the API of a HomeWizard kWh Meter.
 thing-type.homewizard.energy_socket.label = HomeWizard Energysocket
 thing-type.homewizard.energy_socket.description = This thing provides the measurement data that is available through the http interface of a HomeWizard Energysocket.
 thing-type.homewizard.hwe-bat.label = HomeWizard Plug-In Battery

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-kwh.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-kwh.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="HWE-kwh">
+	<thing-type id="hwe-kwh">
 		<label>HomeWizard kWh Meter</label>
 		<description>This thing provides the measurement data that is available through the API of a HomeWizard
 			kWh Meter.</description>

--- a/bundles/org.openhab.binding.homewizard/src/test/java/org/openhab/binding/homewizard/internal/devices/water_meter/HomeWizardWaterMeterMeasurementPayloadTest.java
+++ b/bundles/org.openhab.binding.homewizard/src/test/java/org/openhab/binding/homewizard/internal/devices/water_meter/HomeWizardWaterMeterMeasurementPayloadTest.java
@@ -34,8 +34,8 @@ public class HomeWizardWaterMeterMeasurementPayloadTest {
 
     @Test
     public void deserializeResponse() throws IOException {
-        HomeWizardWaterMeterDataPayload key = DATA_UTIL.fromJson("response-measurement-water-meter.json",
-                HomeWizardWaterMeterDataPayload.class);
+        HomeWizardWaterMeterMeasurementPayload key = DATA_UTIL.fromJson("response-measurement-water-meter.json",
+                HomeWizardWaterMeterMeasurementPayload.class);
         assertThat(key, is(notNullValue()));
 
         assertThat(key.getActiveLiter(), is(7.2));
@@ -44,8 +44,8 @@ public class HomeWizardWaterMeterMeasurementPayloadTest {
 
     @Test
     public void deserializeResponseEmpty() throws IOException {
-        HomeWizardWaterMeterDataPayload key = DATA_UTIL.fromJson("response-empty.json",
-                HomeWizardWaterMeterDataPayload.class);
+        HomeWizardWaterMeterMeasurementPayload key = DATA_UTIL.fromJson("response-empty.json",
+                HomeWizardWaterMeterMeasurementPayload.class);
         assertThat(key, is(notNullValue()));
 
         assertThat(key.getActiveLiter(), is(0.0));


### PR DESCRIPTION
Contains a fix for an incorrect thing type id for the kWh meter. 
In addition, it also contains fixes for errors in toString() in a couple of payload classes.
