### PR TITLE
[casokitchen] Bugfix unit test status online

### DIFF
--- a/bundles/org.openhab.binding.casokitchen/src/test/java/org/openhab/binding/caso/internal/TestHandler.java
+++ b/bundles/org.openhab.binding.casokitchen/src/test/java/org/openhab/binding/caso/internal/TestHandler.java
@@ -113,6 +113,13 @@ class TestHandler {
         assertEquals(ThingStatus.OFFLINE, tsi.getStatus());
         assertEquals(ThingStatusDetail.CONFIGURATION_ERROR, tsi.getStatusDetail());
         assertEquals("@text/casokitchen.winecooler-2z.status.device-id-missing", tsi.getDescription());
+
+        config.put("deviceId", "xyz");
+        thing.setConfiguration(config);
+        winecoolerHandler.initialize();
+        callback.waitForOnline();
+        tsi = thing.getStatusInfo();
+        assertEquals(ThingStatus.ONLINE, tsi.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Sorry for introducing [flaky test of casokitchen](https://github.com/openhab/openhab-addons/pull/18243#issuecomment-2692883178)!
Never occurred during my eclipse / mvn testing but root cause is clear!

Test is adapted to check `ONLINE` status after config is valid.
