### PR TITLE
[modbus.sunspec] Fix acc32 and uint32

### DIFF
--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
@@ -79,19 +79,19 @@ public class AbstractBaseParser {
     }
 
     /**
-     * Extract an optional acc32 value
+     * Extract an optional acc32/uint32 value
      *
      * @param raw the register array to extract from
      * @param index the address of the field
      * @return the parsed value or empty if the field is not implemented
      */
     protected Optional<Long> extractOptionalAcc32(ModbusRegisterArray raw, int index) {
-        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT32).map(DecimalType::longValue)
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT32).map(DecimalType::longValue)
                 .filter(value -> value != 0);
     }
 
     /**
-     * Extract a mandatory acc32 value
+     * Extract a mandatory acc32/uint32 value
      *
      * @param raw the register array to extract from
      * @param index the address of the field


### PR DESCRIPTION
In 2020 the ACC32 fields were changed from unsigned int to signed, ref. #7826 . This is incorrect. The acc32 is an unsigned integer. On top of that, the sunspec meter handlers had values assigned with acc32 that are uint32 according to the sunspec specification.

https://sunspec.org/wp-content/uploads/2025/01/SunSpec-Device-Information-Model-Specificiation-V1-2-1-1.pdf

This is the latest specification from 2024. Here it is stated that: acc32 = Unsigned 32-bit accumulator (deprecated in favor of uint32)

Basically both acc32 and uint32 can have values from 0 to 4294967294 acc32 even until 4294967295, which is due to uint32 0xFFFFFFFF is specified as "not implemented".

See also https://community.openhab.org/t/modbus-sunspec-showing-negative-total-exported-energy/161611/13 for the bug.

Please cherrypick to 4.3.x branch as well.