### PR TITLE
[solarforecast] Fix `latest-update` channel typo

### DIFF
--- a/bundles/org.openhab.binding.solarforecast/README.md
+++ b/bundles/org.openhab.binding.solarforecast/README.md
@@ -348,9 +348,9 @@ Number:Energy    Solcast_Site_Pessimistic_Today               "Today's total ene
 
 // site API call counter 
 Number           Solcast_Site_API_Sucess_Counter              "Site API Counter"                                                       {channel="solarforecast:sc-site:homeSite:update#api-count" [ profile="transform:JSONPATH", function="$.200"]}
-Number           Solcast_Site_API_Throttle_Counter            "Site API Throttle Counter"                                              {channel="solarforecast:sc-site:homeSite:update#api-count" [ profile="transform:JSONPATH", function="$.200"]}
-Number           Solcast_Site_API_Error_Counter               "Site API ErrorCounter"                                                  {channel="solarforecast:sc-site:homeSite:update#api-count" [ profile="transform:JSONPATH", function="$.200"]}
-DateTime         Solcast_Site_API_LastUpdate                  "Site API Last Update"                                                   {channel="solarforecast:sc-site:homeSite:update#lastest-update"}
+Number           Solcast_Site_API_Throttle_Counter            "Site API Throttle Counter"                                              {channel="solarforecast:sc-site:homeSite:update#api-count" [ profile="transform:JSONPATH", function="$.429"]}
+Number           Solcast_Site_API_Error_Counter               "Site API ErrorCounter"                                                  {channel="solarforecast:sc-site:homeSite:update#api-count" [ profile="transform:JSONPATH", function="$.other"]}
+DateTime         Solcast_Site_API_LastUpdate                  "Site API Last Update"                                                   {channel="solarforecast:sc-site:homeSite:update#latest-update"}
 
 // estimation items
 Group            influxdb
@@ -381,9 +381,9 @@ Number:Energy    Solcast_Plane_Pessimistic_Today_SW           "SW Today's pessim
 
 // plane API call counter
 Number           Solcast_Plane_API_Sucess_Counter             "Plane API Counter"                                                      {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#api-count" [ profile="transform:JSONPATH", function="$.200"]}
-Number           Solcast_Plane_API_Throttle_Counter           "Plane API Throttle Counter"                                             {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#api-count" [ profile="transform:JSONPATH", function="$.200"]}
-Number           Solcast_Plane_API_Error_Counter              "Plane API ErrorCounter"                                                 {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#api-count" [ profile="transform:JSONPATH", function="$.200"]}
-DateTime         Solcast_Plane_API_LastUpdate                 "Plane API Last Update"                                                  {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#lastest-update"}
+Number           Solcast_Plane_API_Throttle_Counter           "Plane API Throttle Counter"                                             {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#api-count" [ profile="transform:JSONPATH", function="$.429"]}
+Number           Solcast_Plane_API_Error_Counter              "Plane API ErrorCounter"                                                 {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#api-count" [ profile="transform:JSONPATH", function="$.other"]}
+DateTime         Solcast_Plane_API_LastUpdate                 "Plane API Last Update"                                                  {channel="solarforecast:sc-plane:homeSite:planeSouthWest:update#latest-update"}
 
 // plane estimation items
 Number:Power     Solcast_Plane_Average_Power_Estimate         "Plane Average Power estimations"                          (influxdb)    {channel="solarforecast:sc-plane:homeSite:planeSouthWest:average#power-estimate", stateDescription=" "[ pattern="%.0f %unit%" ], unit="W"}

--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/thing/sc-plane-type.xml
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/thing/sc-plane-type.xml
@@ -21,7 +21,7 @@
 		</channel-groups>
 
 		<properties>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:solarforecast:sc-plane"/>

--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/thing/sc-site-type.xml
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/thing/sc-site-type.xml
@@ -16,7 +16,7 @@
 		</channel-groups>
 
 		<properties>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 
 		<config-description-ref uri="thing-type:solarforecast:sc-site"/>

--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/thing/update-group.xml
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/thing/update-group.xml
@@ -8,7 +8,7 @@
 		<description>Channels regarding forecast updates</description>
 		<channels>
 			<channel id="api-count" typeId="api-count"/>
-			<channel id="lastest-update" typeId="latest-update"/>
+			<channel id="latest-update" typeId="latest-update"/>
 		</channels>
 	</channel-group-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/update/instructions.xml
@@ -12,6 +12,13 @@
 				<type>solarforecast:latest-update</type>
 			</add-channel>
 		</instruction-set>
+		<instruction-set targetVersion="2">
+			<remove-channel id="lastest-update" groupIds="update">
+			</remove-channel>
+			<add-channel id="latest-update" groupIds="update">
+				<type>solarforecast:latest-update</type>
+			</add-channel>
+		</instruction-set>
 	</thing-type>
 
 	<thing-type uid="solarforecast:sc-site">
@@ -19,6 +26,13 @@
 			<add-channel id="api-count" groupIds="update">
 				<type>solarforecast:api-count</type>
 			</add-channel>
+			<add-channel id="latest-update" groupIds="update">
+				<type>solarforecast:latest-update</type>
+			</add-channel>
+		</instruction-set>
+		<instruction-set targetVersion="2">
+			<remove-channel id="lastest-update" groupIds="update">
+			</remove-channel>
 			<add-channel id="latest-update" groupIds="update">
 				<type>solarforecast:latest-update</type>
 			</add-channel>


### PR DESCRIPTION
Fix channel typo and example mentioned in [community](https://community.openhab.org/t/solar-forecast-pv/137681/311) 