### PR TITLE
[plex] Document the `user` channel

### DIFF
--- a/bundles/org.openhab.binding.plex/README.md
+++ b/bundles/org.openhab.binding.plex/README.md
@@ -118,6 +118,7 @@ The PLEX Player supports the following channels:
 | ratingKey            | String   | RO         | The unique key in the Plex library identifying the media that is playing                                         |
 | parentRatingKey      | String   | RO         | The unique key in the Plex library identifying the parent (TV show season or album) of the media that is playing |
 | grandparentRatingKey | String   | RO         | The unique key in the Plex library identifying the grandparent (TV show) of the media that is playing            |
+| user                 | String   | RO         | The user title                                                          |
 
 ## Full Example
 


### PR DESCRIPTION
I've just noticed this channel missing from the doc. I can't really find a more comprehensive explanation, but at least it's now being listed in the doc.

