### PR TITLE
[jrubyscripting] Disallow Process.exec

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -300,6 +300,7 @@ public class JRubyScriptEngineConfiguration {
         });
 
         configureRubyLib(scriptEngine);
+        disallowExec(scriptEngine);
     }
 
     /**
@@ -319,6 +320,24 @@ public class JRubyScriptEngineConfiguration {
             } catch (ScriptException exception) {
                 logger.warn("Error setting $LOAD_PATH from RUBYLIB='{}'", rubyLib, unwrap(exception));
             }
+        }
+    }
+
+    private void disallowExec(ScriptEngine engine) {
+        try {
+            engine.eval("""
+                      def Process.exec(*)
+                        raise NotImplementedError, "You cannot call `exec` from within openHAB"
+                      end
+
+                      module Kernel
+                        module_function def exec(*)
+                          raise NotImplementedError, "You cannot call `exec` from within openHAB"
+                        end
+                      end
+                    """);
+        } catch (ScriptException exception) {
+            logger.warn("Error preventing exec", unwrap(exception));
         }
     }
 


### PR DESCRIPTION
If a script (or a library it calls) accidentally calls Process.exec, it will immediately terminate all of openHAB. That is bad. An example is Bundler trying to shell out to `man` to display its help page.
