### PR TITLE
[solarforecast] Bugfix channel typo

### DIFF
--- a/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.solarforecast/src/main/resources/OH-INF/update/instructions.xml
@@ -15,6 +15,8 @@
 		<instruction-set targetVersion="2">
 			<remove-channel id="lastest-update" groupIds="update">
 			</remove-channel>
+			<remove-channel id="latest-update" groupIds="update">
+			</remove-channel>
 			<add-channel id="latest-update" groupIds="update">
 				<type>solarforecast:latest-update</type>
 			</add-channel>
@@ -32,6 +34,8 @@
 		</instruction-set>
 		<instruction-set targetVersion="2">
 			<remove-channel id="lastest-update" groupIds="update">
+			</remove-channel>
+			<remove-channel id="latest-update" groupIds="update">
 			</remove-channel>
 			<add-channel id="latest-update" groupIds="update">
 				<type>solarforecast:latest-update</type>


### PR DESCRIPTION
Additional bugfix to the channel typo of solarforecast PR #18373. See possibilities regarding `thing type version`: 

0 | 1 | 2
--- | --- | ---
create | upgrade => _channel name correct_ | upgrade => **duplicate channel detected**
X | create => _channel name incorrect_ | upgrade => channel name corrected
X | X | create  => channel name correct

**Solution:**
Due to the fact that channel names of `thingtype version 1` maybe **correct or incorrect** remove both channels and add correct one.


