### PR TITLE
[jrubyscripting] Add "dummy" openHAB gem to environment

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -301,6 +301,7 @@ public class JRubyScriptEngineConfiguration {
 
         configureRubyLib(scriptEngine);
         disallowExec(scriptEngine);
+        configureOpenHABGem(scriptEngine);
     }
 
     /**
@@ -338,6 +339,30 @@ public class JRubyScriptEngineConfiguration {
                     """);
         } catch (ScriptException exception) {
             logger.warn("Error preventing exec", unwrap(exception));
+        }
+    }
+
+    private void configureOpenHABGem(ScriptEngine engine) {
+        try {
+            engine.eval("""
+                    openhab_spec = Gem::Specification.new do |s|
+                      s.name    = "openhab"
+                      s.version = org.openhab.core.OpenHAB.version.freeze
+
+                      def s.deleted_gem?
+                        false
+                      end
+
+                      def s.installation_missing?
+                        false
+                      end
+                    end
+
+                    Gem::Specification.add_spec(openhab_spec)
+                    Gem.post_reset { Gem::Specification.add_spec(openhab_spec) }
+                    """);
+        } catch (ScriptException exception) {
+            logger.warn("Error creating openHAB gem", unwrap(exception));
         }
     }
 


### PR DESCRIPTION
This allows the helper library to have a dependency on the openHAB version, allowing us to drop support for older openHAB versions without doing a major version bump (and thus possibly requiring the user to make changes to their config to get a new major version).

Ideally this will be backported to 4.3, so that we're able to do the helper library change sooner. This will have no effect on 4.3 with the current helper library, since it has no dependency on the "openhab" gem. https://github.com/ccutrer/openhab-jruby/commit/9bfbdc99babd191e2efc6c1eccdfaa55e11fda45 is the helper library change that will lock out any version of openHAB that doesn't have _this_ PR.