### PR TITLE
[jrubyscripting] Support using Gemfile with Bundler

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
@@ -63,10 +63,9 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
     private static final String CONSOLE = "console";
     private static final String BUNDLE = "bundle";
     private static final String GEM = "gem";
-    private static final String UPDATE = "update";
     private static final String PRUNE = "prune";
 
-    private static final List<String> SUB_COMMANDS = List.of(INFO, CONSOLE, BUNDLE, GEM, UPDATE, PRUNE);
+    private static final List<String> SUB_COMMANDS = List.of(INFO, CONSOLE, BUNDLE, GEM, PRUNE);
 
     private final ScriptEngineManager scriptEngineManager;
     private final JRubyScriptEngineFactory jRubyScriptEngineFactory;
@@ -102,7 +101,6 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
                         "starts an interactive JRuby console"), //
                 buildCommandUsage(BUNDLE + " [arguments]", "runs Ruby bundler in the main Script path"), //
                 buildCommandUsage(GEM + " [arguments]", "manages JRuby Scripting add-on's RubyGems"), //
-                buildCommandUsage(UPDATE, "updates the configured gems"), //
                 buildCommandUsage(PRUNE + " [-f|--force]", "cleans up older versions in the .gem directory") //
         );
     }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
@@ -100,7 +100,7 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 buildCommandUsage(INFO, "displays information about JRuby Scripting add-on"), //
                 buildCommandUsage(CONSOLE + " [--list|-l|--help|-h] | [script] [options]",
                         "starts an interactive JRuby console"), //
-                buildCommandUsage(BUNDLE + " [arguments]", "runs Ruby bundler in the main Script path"), //
+                buildCommandUsage(BUNDLE + " [arguments]", "runs Ruby bundler against your Gemfile"), //
                 buildCommandUsage(GEM + " [arguments]", "manages JRuby Scripting add-on's RubyGems"), //
                 buildCommandUsage(PRUNE + " [-f|--force]", "cleans up older versions in the .gem directory") //
         );
@@ -316,7 +316,7 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
         final String gemfilePath = jRubyScriptEngineFactory.getConfiguration().getGemfilePath();
         if (gemfilePath == null) {
             console.println(
-                    "No Gemfile configured. Please set the 'bundle_gemfile_path' or 'bundle_gemfile_content' property in the add-on configuration.");
+                    "No Gemfile configured. Please set the 'bundle_gemfile' setting in the add-on configuration, and ensure that the Gemfile exists.");
             return;
         }
 

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
@@ -354,7 +354,8 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 end
                 """;
 
-        // We need to set user.dir because bundle init creates the Gemfile there (the current directory)
+        // We need to set user.dir because bundle init creates the Gemfile there
+        // and ignores BUNDLE_GEMFILE environment variable
         String gemfileDir = gemfile.getParent();
         if (gemfileDir == null) {
             console.println("Error: Unable to determine Gemfile directory.");

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
@@ -318,12 +318,12 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
 
     synchronized private void bundler(Console console, String[] args) {
         final File gemfile = jRubyScriptEngineFactory.getConfiguration().getGemfile();
-        boolean bundle_init = args.length >= 1 && "init".equals(args[0]);
+        boolean bundleInit = args.length >= 1 && "init".equals(args[0]);
 
-        if (bundle_init && gemfile.exists()) {
+        if (bundleInit && gemfile.exists()) {
             console.printf("Gemfile '%s' already exists.\n", gemfile.toString());
             return;
-        } else if (!bundle_init && !gemfile.exists()) {
+        } else if (!bundleInit && !gemfile.exists()) {
             console.printf("""
                     No Gemfile found. Please ensure the 'bundle_gemfile' setting is correct and the Gemfile exists.
 
@@ -372,7 +372,7 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
             logger.debug("Bundler result: {}", result);
             // A null result indicates a successful creation of Gemfile.
             // Otherwise, if a Gemfile already exists, it will return `1`
-            if (bundle_init && result == null) {
+            if (bundleInit && result == null) {
                 try {
                     // bundler init always creates a file called "Gemfile".
                     // if our setting points to any file other than "Gemfile",

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -97,7 +97,7 @@ public class JRubyScriptEngineConfiguration {
         // leaving the default values in place when it's null or not set in the map.
         configuration = new Configuration(config).as(JRubyScriptingConfiguration.class);
 
-        bundleGemfile = getGemfilePath();
+        bundleGemfile = resolveGemfilePath();
         specificGemHome = resolveSpecificGemHome();
         ensureGemHomeExists(specificGemHome);
 
@@ -211,12 +211,7 @@ public class JRubyScriptEngineConfiguration {
         return true;
     }
 
-    /**
-     * Returns the path to the Gemfile.
-     *
-     * @return the path to the Gemfile or null if no Gemfile is found
-     */
-    public @Nullable String getGemfilePath() {
+    private @Nullable String resolveGemfilePath() {
         Path gemfilePath = Path.of(configuration.bundle_gemfile);
 
         if (gemfilePath.equals(Path.of(""))) {
@@ -230,6 +225,15 @@ public class JRubyScriptEngineConfiguration {
         }
 
         return null;
+    }
+
+    /**
+     * Returns the absolute path to the Gemfile.
+     *
+     * @return the path to the Gemfile or null if no actual Gemfile is found.
+     */
+    public @Nullable String getGemfilePath() {
+        return bundleGemfile;
     }
 
     /**

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -14,11 +14,10 @@ package org.openhab.automation.jrubyscripting.internal;
 
 import java.io.File;
 import java.io.StringWriter;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -455,7 +454,7 @@ public class JRubyScriptEngineConfiguration {
                       end
                     """);
         } catch (ScriptException exception) {
-            LOGGER.warn("Error preventing exec", unwrap(exception)); =
+            LOGGER.warn("Error preventing exec", unwrap(exception));
         }
     }
 
@@ -479,7 +478,7 @@ public class JRubyScriptEngineConfiguration {
                     Gem.post_reset { Gem::Specification.add_spec(openhab_spec) }
                     """);
         } catch (ScriptException exception) {
-            logger.warn("Error creating openHAB gem", unwrap(exception));
+            LOGGER.warn("Error creating openHAB gem", unwrap(exception));
         }
     }
 

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -220,7 +220,14 @@ public class JRubyScriptEngineConfiguration {
             gemfilePath = HOME_PATH_ABS.resolve(gemfilePath);
         }
 
-        return gemfilePath.toFile();
+        File gemfile = gemfilePath.toFile();
+        if (gemfile.isDirectory()) {
+            gemfile = gemfilePath.resolve("Gemfile").toFile();
+            LOGGER.warn(
+                    "The Gemfile setting is set to '{}' which is a directory. It should be set to a file. Setting it to '{}'",
+                    gemfilePath, gemfile);
+        }
+        return gemfile;
     }
 
     /**

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineConfiguration.java
@@ -136,7 +136,7 @@ public class JRubyScriptEngineConfiguration {
                 });
         return objectMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
             if (entry.getValue() instanceof List<?> listValue) {
-                return listValue.stream().map(Object::toString).collect(Collectors.joining("\n")).toString();
+                return listValue.stream().map(Object::toString).collect(Collectors.joining("\n"));
             }
             return entry.getValue().toString();
         }));

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
@@ -140,6 +140,7 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
         // presets, including 'ir'. We wait for the second call before running the
         // require statements.
         if (scopeValues.containsKey("ir")) {
+            configuration.bundlerSetup(scriptEngine);
             configuration.injectRequire(scriptEngine);
         }
     }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
@@ -162,7 +162,6 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
             return null;
         }
         ScriptEngine engine = factory.getScriptEngine();
-        logger.debug("Creating JRuby engine {}", engine);
         configuration.configureRubyEnvironment(engine);
         return new JRubyEngineWrapper((org.jruby.embed.jsr223.JRubyEngine) engine);
     }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyScriptEngineFactory.java
@@ -135,10 +135,9 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
             scriptEngine.put("$dependencyListener", jrubyDependencyTracker.getTracker(wrapper.getScriptIdentifier()));
         }
 
-        // scopeValues is called twice. The first call only passed 'se'. The second call
-        // passed the rest of the
-        // presets, including 'ir'. We wait for the second call before running the
-        // require statements.
+        // scopeValues is called twice. The first call only passed 'se'.
+        // The second call passed the rest of the presets, including 'ir'.
+        // We wait for the second call before running the require statements.
         if (scopeValues.containsKey("ir")) {
             configuration.bundlerSetup(scriptEngine);
             configuration.injectRequire(scriptEngine);
@@ -163,6 +162,7 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
             return null;
         }
         ScriptEngine engine = factory.getScriptEngine();
+        logger.debug("Creating JRuby engine {}", engine);
         configuration.configureRubyEnvironment(engine);
         return new JRubyEngineWrapper((org.jruby.embed.jsr223.JRubyEngine) engine);
     }
@@ -204,9 +204,5 @@ public class JRubyScriptEngineFactory extends AbstractScriptEngineFactory {
             return false;
         }
         return file.startsWith(gemHome + File.separator);
-    }
-
-    public void updateGems(ScriptEngine engine) {
-        configuration.configureGems(engine, true);
     }
 }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/BidiSetBag.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/BidiSetBag.java
@@ -39,6 +39,7 @@ public class BidiSetBag<K, V> {
     private final Map<K, Set<V>> keyToValues = new HashMap<>();
     private final Map<V, Set<K>> valueToKeys = new HashMap<>();
 
+    @SuppressWarnings("null")
     public void put(K key, V value) {
         lock.writeLock().lock();
         try {

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/JRubyScriptFileWatcher.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/JRubyScriptFileWatcher.java
@@ -28,8 +28,6 @@ import org.openhab.core.service.WatchService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Monitors {@code <openHAB-conf>/automation/ruby} for Ruby files, but not libraries in lib or gems
@@ -41,8 +39,6 @@ import org.slf4j.LoggerFactory;
         ScriptDependencyTracker.Listener.class })
 @NonNullByDefault
 public class JRubyScriptFileWatcher extends AbstractScriptFileWatcher {
-    private final Logger logger = LoggerFactory.getLogger(JRubyScriptFileWatcher.class);
-
     private final JRubyScriptEngineFactory scriptEngineFactory;
 
     @Activate
@@ -50,7 +46,8 @@ public class JRubyScriptFileWatcher extends AbstractScriptFileWatcher {
             final @Reference ReadyService readyService, final @Reference StartLevelService startLevelService,
             final @Reference JRubyScriptEngineFactory scriptEngineFactory,
             final @Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService) {
-        super(watchService, manager, readyService, startLevelService, JRubyScriptEngineConfiguration.HOME_PATH, true);
+        super(watchService, manager, readyService, startLevelService,
+                JRubyScriptEngineConfiguration.HOME_PATH.toString(), true);
 
         this.scriptEngineFactory = scriptEngineFactory;
     }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/JRubyScriptFileWatcher.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/watch/JRubyScriptFileWatcher.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.automation.jrubyscripting.internal.watch;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.automation.jrubyscripting.internal.JRubyScriptEngineConfiguration;
 import org.openhab.automation.jrubyscripting.internal.JRubyScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
@@ -43,8 +43,6 @@ import org.slf4j.LoggerFactory;
 public class JRubyScriptFileWatcher extends AbstractScriptFileWatcher {
     private final Logger logger = LoggerFactory.getLogger(JRubyScriptFileWatcher.class);
 
-    private static final String FILE_DIRECTORY = "automation" + File.separator + "ruby";
-
     private final JRubyScriptEngineFactory scriptEngineFactory;
 
     @Activate
@@ -52,7 +50,7 @@ public class JRubyScriptFileWatcher extends AbstractScriptFileWatcher {
             final @Reference ReadyService readyService, final @Reference StartLevelService startLevelService,
             final @Reference JRubyScriptEngineFactory scriptEngineFactory,
             final @Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService) {
-        super(watchService, manager, readyService, startLevelService, FILE_DIRECTORY, true);
+        super(watchService, manager, readyService, startLevelService, JRubyScriptEngineConfiguration.HOME_PATH, true);
 
         this.scriptEngineFactory = scriptEngineFactory;
     }

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
@@ -2,8 +2,7 @@
 <config-description:config-descriptions
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
-		https://openhab.org/schemas/config-description-1.0.0.xsd">
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 	<config-description uri="automation:jrubyscripting">
 
 		<parameter-group name="gems">
@@ -20,6 +19,12 @@
 		<parameter-group name="system">
 			<label>System Properties</label>
 			<description>This group defines JRuby system properties.</description>
+			<advanced>true</advanced>
+		</parameter-group>
+
+		<parameter-group name="bundler">
+			<label>Bundler</label>
+			<description>This group defines the Bundler settings.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
@@ -105,6 +110,34 @@
 				<option value="persistent">Persistent</option>
 				<option value="global">Global</option>
 			</options>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="bundle_gemfile_path" type="text" required="false" groupName="bundler">
+			<label>Gemfile Path</label>
+			<description><![CDATA[Path to Gemfile relative to <tt>OPENHAB_CONF/automation/ruby/</tt>.
+				An absolute path can be used.
+			  If this file exists, <tt>require 'bundler/setup'</tt> will be inserted for all scripts.
+				Defaults to "<tt>Gemfile</tt>" when not specified.
+				]]></description>
+			<default>Gemfile</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="bundle_gemfile_content" type="text" multiple="true" required="false" groupName="bundler">
+			<label>Gemfile Content</label>
+			<description><![CDATA[Literal content of bundler's Gemfile.
+				This will be used when the Gemfile doesn't exist in the Gemfile path above.
+				]]></description>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="bundle_install" type="boolean" required="true" groupName="bundler">
+			<label>Run Bundler Install at Startup</label>
+			<description><![CDATA[Run <tt>bundle install</tt> when the add-on loads or the configuration is changed.
+			  This will install any gems specified in the Gemfile.
+				]]></description>
+			<default>true</default>
 			<advanced>true</advanced>
 		</parameter>
 

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
@@ -40,7 +40,7 @@
 			<label>Gemfile Path</label>
 			<description><![CDATA[Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>.
 				An absolute path can be used.
-			  If this file exists, it will be used instead of the <code>gems</code> setting above,
+			    If this file exists, the <code>gems</code> setting above will be ignored,
 				so your Gemfile must include <code>openhab-scripting</code> to use the helper library.
 				]]></description>
 			<default>Gemfile</default>

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
@@ -7,7 +7,7 @@
 
 		<parameter-group name="gems">
 			<label>Ruby Gems</label>
-			<description>This group defines the list of Ruby Gems to install.</description>
+			<description>This group defines the management of Ruby Gems.</description>
 		</parameter-group>
 
 		<parameter-group name="environment">
@@ -22,12 +22,6 @@
 			<advanced>true</advanced>
 		</parameter-group>
 
-		<parameter-group name="bundler">
-			<label>Bundler</label>
-			<description>This group defines the Bundler settings.</description>
-			<advanced>true</advanced>
-		</parameter-group>
-
 		<parameter-group name="console">
 			<label>JRuby Console</label>
 			<description>This group defines the JRuby console settings.</description>
@@ -37,33 +31,49 @@
 		<parameter name="gems" type="text" required="false" groupName="gems">
 			<label>Ruby Gems</label>
 			<description><![CDATA[A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an
-				<tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0</tt>".
+				<code>=</code> and then the standard RubyGems version constraint, such as "<code>openhab-scripting=~>5.0</code>".
 				]]></description>
-			<default>openhab-scripting=~>5.0.0</default>
+			<default>openhab-scripting=~&gt;5.0</default>
 		</parameter>
 
-		<parameter name="require" type="text" required="false" groupName="gems">
-			<label>Require Scripts</label>
-			<description>A comma separated list of script names to be required by the JRuby Scripting Engine before running user
-				scripts.</description>
-			<default>openhab/dsl</default>
+		<parameter name="bundle_gemfile" type="text" required="false" groupName="gems">
+			<label>Gemfile Path</label>
+			<description><![CDATA[Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>.
+				An absolute path can be used.
+			  If this file exists, it will be used instead of the <code>gems</code> setting above,
+				so your Gemfile must include <code>openhab-scripting</code> to use the helper library.
+				]]></description>
+			<default>Gemfile</default>
+			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="check_update" type="boolean" required="true" groupName="gems">
 			<label>Check for Gem Updates</label>
-			<description>Check RubyGems for updates to the above gems when OpenHAB starts or JRuby settings are changed.
-				Otherwise it will try to fulfill the requirements with locally installed gems, and you can manage them yourself with
-				an external Ruby by setting the same GEM_HOME.</description>
+			<description><![CDATA[Check RubyGems for updated gems when OpenHAB starts or JRuby settings are changed.
+				Otherwise it will try to fulfill the requirements with locally installed gems,
+				and you can manage them yourself with either the <code>jrubyscripting gem</code>
+				or <code>jrubyscripting bundle</code> console commands, or
+				an external Ruby by setting the same GEM_HOME.]]></description>
 			<default>true</default>
 			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="require" type="text" required="false" groupName="gems">
+			<label>Require Scripts</label>
+			<description><![CDATA[A comma separated list of script names to be required by the
+			  JRuby Scripting Engine before running user scripts.
+				This can be used to automatically include a common (personal) library
+				without having to add a <code>require</code> line in every script.]]>
+			</description>
+			<default>openhab/dsl</default>
 		</parameter>
 
 		<parameter name="gem_home" type="text" required="false" groupName="environment">
 			<label>GEM_HOME</label>
 			<description><![CDATA[Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary.
-				You can use <tt>{RUBY_ENGINE_VERSION}</tt>, <tt>{RUBY_ENGINE}</tt> and/or <tt>{RUBY_VERSION}</tt> replacements in this value to automatically point to
+				You can use <code>{RUBY_ENGINE_VERSION}</code>, <code>{RUBY_ENGINE}</code> and/or <code>{RUBY_VERSION}</code> replacements in this value to automatically point to
 				a new directory when the addon is updated with a new version of JRuby.
-				Defaults to "<tt>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</tt>" when not specified.
+				Defaults to "<code>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</code>" when not specified.
 				]]></description>
 			<advanced>true</advanced>
 		</parameter>
@@ -71,7 +81,7 @@
 		<parameter name="rubylib" type="text" required="false" groupName="environment">
 			<label>RUBYLIB</label>
 			<description><![CDATA[Search path for user libraries. Separate each path with a colon (semicolon in Windows). Defaults to
-				"<tt>OPENHAB_CONF/automation/ruby/lib</tt>" when not specified.]]></description>
+				"<code>OPENHAB_CONF/automation/ruby/lib</code>" when not specified.]]></description>
 			<advanced>true</advanced>
 		</parameter>
 
@@ -113,38 +123,10 @@
 			<advanced>true</advanced>
 		</parameter>
 
-		<parameter name="bundle_gemfile_path" type="text" required="false" groupName="bundler">
-			<label>Gemfile Path</label>
-			<description><![CDATA[Path to Gemfile relative to <tt>OPENHAB_CONF/automation/ruby/</tt>.
-				An absolute path can be used.
-			  If this file exists, <tt>require 'bundler/setup'</tt> will be inserted for all scripts.
-				Defaults to "<tt>Gemfile</tt>" when not specified.
-				]]></description>
-			<default>Gemfile</default>
-			<advanced>true</advanced>
-		</parameter>
-
-		<parameter name="bundle_gemfile_content" type="text" multiple="true" required="false" groupName="bundler">
-			<label>Gemfile Content</label>
-			<description><![CDATA[Literal content of bundler's Gemfile.
-				This will be used when the Gemfile doesn't exist in the Gemfile path above.
-				]]></description>
-			<advanced>true</advanced>
-		</parameter>
-
-		<parameter name="bundle_install" type="boolean" required="true" groupName="bundler">
-			<label>Run Bundler Install at Startup</label>
-			<description><![CDATA[Run <tt>bundle install</tt> when the add-on loads or the configuration is changed.
-			  This will install any gems specified in the Gemfile.
-				]]></description>
-			<default>true</default>
-			<advanced>true</advanced>
-		</parameter>
-
 		<parameter name="console" type="text" required="false" groupName="console">
 			<label>Console Script</label>
-			<description><![CDATA[The script file to be required by the <tt>jrubyscripting console</tt>
-			console command. When specified without any path, <tt>openhab/console/</tt> will be prepended.]]></description>
+			<description><![CDATA[The script file to be required by the <code>jrubyscripting console</code>
+			console command. When specified without any path, <code>openhab/console/</code> will be prepended.]]></description>
 			<default>irb</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/config/config.xml
@@ -30,38 +30,44 @@
 
 		<parameter name="gems" type="text" required="false" groupName="gems">
 			<label>Ruby Gems</label>
-			<description><![CDATA[A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an
-				<code>=</code> and then the standard RubyGems version constraint, such as "<code>openhab-scripting=~>5.0</code>".
-				]]></description>
+			<description>
+				<![CDATA[A comma separated list of Ruby Gems to install.
+				Versions may be constrained by separating with an <code>=</code> followed by standard
+				RubyGems version constraint, such as "<code>openhab-scripting=~>5.0</code>".]]>
+			</description>
 			<default>openhab-scripting=~&gt;5.0</default>
 		</parameter>
 
 		<parameter name="bundle_gemfile" type="text" required="false" groupName="gems">
 			<label>Gemfile Path</label>
-			<description><![CDATA[Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>.
+			<description>
+				<![CDATA[Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>.
 				An absolute path can be used.
-			    If this file exists, the <code>gems</code> setting above will be ignored,
-				so your Gemfile must include <code>openhab-scripting</code> to use the helper library.
-				]]></description>
+				If this file exists, the <code>gems</code> setting above will be ignored,
+				so your Gemfile must include <code>openhab-scripting</code> to use the helper library.]]>
+			</description>
 			<default>Gemfile</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="check_update" type="boolean" required="true" groupName="gems">
 			<label>Check for Gem Updates</label>
-			<description><![CDATA[Check RubyGems for updated gems when OpenHAB starts or JRuby settings are changed.
+			<description>
+				<![CDATA[Check RubyGems for updated gems when OpenHAB starts or JRuby settings are changed.
 				Otherwise it will try to fulfill the requirements with locally installed gems,
 				and you can manage them yourself with either the <code>jrubyscripting gem</code>
-				or <code>jrubyscripting bundle</code> console commands, or
-				an external Ruby by setting the same GEM_HOME.]]></description>
+				or <code>jrubyscripting bundle</code> console commands,
+				or an external Ruby by setting the same GEM_HOME.]]>
+			</description>
 			<default>true</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="require" type="text" required="false" groupName="gems">
 			<label>Require Scripts</label>
-			<description><![CDATA[A comma separated list of script names to be required by the
-			  JRuby Scripting Engine before running user scripts.
+			<description>
+				<![CDATA[A comma separated list of file names to be required by the
+				JRuby Scripting Engine before running user scripts.
 				This can be used to automatically include a common (personal) library
 				without having to add a <code>require</code> line in every script.]]>
 			</description>
@@ -70,18 +76,22 @@
 
 		<parameter name="gem_home" type="text" required="false" groupName="environment">
 			<label>GEM_HOME</label>
-			<description><![CDATA[Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary.
-				You can use <code>{RUBY_ENGINE_VERSION}</code>, <code>{RUBY_ENGINE}</code> and/or <code>{RUBY_VERSION}</code> replacements in this value to automatically point to
+			<description>
+				<![CDATA[Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary.
+				You can use <code>{RUBY_ENGINE_VERSION}</code>, <code>{RUBY_ENGINE}</code> and/or
+				<code>{RUBY_VERSION}</code> replacements in this value to automatically point to
 				a new directory when the addon is updated with a new version of JRuby.
-				Defaults to "<code>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</code>" when not specified.
-				]]></description>
+				Defaults to "<code>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</code>" when not specified.]]>
+			</description>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="rubylib" type="text" required="false" groupName="environment">
 			<label>RUBYLIB</label>
-			<description><![CDATA[Search path for user libraries. Separate each path with a colon (semicolon in Windows). Defaults to
-				"<code>OPENHAB_CONF/automation/ruby/lib</code>" when not specified.]]></description>
+			<description>
+				<![CDATA[Search path for user libraries. Separate each path with a colon (semicolon in Windows).
+				Defaults to "<code>OPENHAB_CONF/automation/ruby/lib</code>" when not specified.]]>
+			</description>
 			<advanced>true</advanced>
 		</parameter>
 
@@ -96,9 +106,11 @@
 
 		<parameter name="local_context" type="text" required="false" groupName="system">
 			<label>Context Instance Type</label>
-			<description><![CDATA[The local context holds Ruby runtime, name-value pairs for sharing variables between Java and Ruby. See
-				<a href="https://github.com/jruby/jruby/wiki/RedBridge#Context_Instance_Type">the documentation</a> for options and details.
-				]]></description>
+			<description>
+				<![CDATA[The local context holds Ruby runtime, name-value pairs for sharing variables between Java and Ruby.
+				See <a href="https://github.com/jruby/jruby/wiki/RedBridge#Context_Instance_Type">the documentation</a>
+				for options and details.]]>
+			</description>
 			<default>singlethread</default>
 			<options>
 				<option value="singleton">Singleton</option>
@@ -111,9 +123,11 @@
 
 		<parameter name="local_variable" type="text" required="false" groupName="system">
 			<label>Local Variable Behavior</label>
-			<description><![CDATA[Defines how variables are shared between Ruby and Java. See
-				<a href="https://github.com/jruby/jruby/wiki/RedBridge#local-variable-behavior-options">the documentation</a> for options and details.
-				]]></description>
+			<description>
+				<![CDATA[Defines how variables are shared between Ruby and Java.
+				See <a href="https://github.com/jruby/jruby/wiki/RedBridge#local-variable-behavior-options">the documentation</a>
+				for options and details.]]>
+			</description>
 			<default>transient</default>
 			<options>
 				<option value="transient">Transient</option>
@@ -125,8 +139,10 @@
 
 		<parameter name="console" type="text" required="false" groupName="console">
 			<label>Console Script</label>
-			<description><![CDATA[The script file to be required by the <code>jrubyscripting console</code>
-			console command. When specified without any path, <code>openhab/console/</code> will be prepended.]]></description>
+			<description>
+				<![CDATA[The script file to be required by the <code>jrubyscripting console</code> console command.
+				When specified without any path, <code>openhab/console/</code> will be prepended.]]>
+			</description>
 			<default>irb</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
@@ -6,7 +6,7 @@ addon.jrubyscripting.description = This adds a JRuby script engine.
 # add-on config
 
 automation.config.jrubyscripting.bundle_gemfile.label = Gemfile Path
-automation.config.jrubyscripting.bundle_gemfile.description = Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>. An absolute path can be used. If this file exists, it will be used instead of the <code>gems</code> setting above, so your Gemfile must include <code>openhab-scripting</code> to use the helper library.
+automation.config.jrubyscripting.bundle_gemfile.description = Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>. An absolute path can be used. If this file exists, the <code>gems</code> setting above will be ignored, so your Gemfile must include <code>openhab-scripting</code> to use the helper library.
 automation.config.jrubyscripting.check_update.label = Check for Gem Updates
 automation.config.jrubyscripting.check_update.description = Check RubyGems for updated gems when OpenHAB starts or JRuby settings are changed. Otherwise it will try to fulfill the requirements with locally installed gems, and you can manage them yourself with either the <code>jrubyscripting gem</code> or <code>jrubyscripting bundle</code> console commands, or an external Ruby by setting the same GEM_HOME.
 automation.config.jrubyscripting.console.label = Console Script

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
@@ -3,8 +3,14 @@
 addon.jrubyscripting.name = JRuby Scripting
 addon.jrubyscripting.description = This adds a JRuby script engine.
 
-# add-on
+# add-on config
 
+automation.config.jrubyscripting.bundle_gemfile_content.label = Gemfile Content
+automation.config.jrubyscripting.bundle_gemfile_content.description = Literal content of bundler's Gemfile. This will be used when the Gemfile doesn't exist in the Gemfile path above.
+automation.config.jrubyscripting.bundle_gemfile_path.label = Gemfile Path
+automation.config.jrubyscripting.bundle_gemfile_path.description = Path to Gemfile relative to <tt>OPENHAB_CONF/automation/ruby/</tt>. An absolute path can be used. If this file exists, <tt>require 'bundler/setup'</tt> will be inserted for all scripts. Defaults to "<tt>Gemfile</tt>" when not specified.
+automation.config.jrubyscripting.bundle_install.label = Run Bundler Install at Startup
+automation.config.jrubyscripting.bundle_install.description = Run <tt>bundle install</tt> when the add-on loads or the configuration is changed. This will install any gems specified in the Gemfile.
 automation.config.jrubyscripting.check_update.label = Check for Gem Updates
 automation.config.jrubyscripting.check_update.description = Check RubyGems for updates to the above gems when OpenHAB starts or JRuby settings are changed. Otherwise it will try to fulfill the requirements with locally installed gems, and you can manage them yourself with an external Ruby by setting the same GEM_HOME.
 automation.config.jrubyscripting.console.label = Console Script
@@ -15,6 +21,8 @@ automation.config.jrubyscripting.gem_home.label = GEM_HOME
 automation.config.jrubyscripting.gem_home.description = Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary. You can use <tt>{RUBY_ENGINE_VERSION}</tt>, <tt>{RUBY_ENGINE}</tt> and/or <tt>{RUBY_VERSION}</tt> replacements in this value to automatically point to a new directory when the addon is updated with a new version of JRuby. Defaults to "<tt>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</tt>" when not specified.
 automation.config.jrubyscripting.gems.label = Ruby Gems
 automation.config.jrubyscripting.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0</tt>".
+automation.config.jrubyscripting.group.bundler.label = Bundler
+automation.config.jrubyscripting.group.bundler.description = This group defines the Bundler settings.
 automation.config.jrubyscripting.group.console.label = JRuby Console
 automation.config.jrubyscripting.group.console.description = This group defines the JRuby console settings.
 automation.config.jrubyscripting.group.environment.label = Ruby Environment

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
@@ -5,30 +5,24 @@ addon.jrubyscripting.description = This adds a JRuby script engine.
 
 # add-on config
 
-automation.config.jrubyscripting.bundle_gemfile_content.label = Gemfile Content
-automation.config.jrubyscripting.bundle_gemfile_content.description = Literal content of bundler's Gemfile. This will be used when the Gemfile doesn't exist in the Gemfile path above.
-automation.config.jrubyscripting.bundle_gemfile_path.label = Gemfile Path
-automation.config.jrubyscripting.bundle_gemfile_path.description = Path to Gemfile relative to <tt>OPENHAB_CONF/automation/ruby/</tt>. An absolute path can be used. If this file exists, <tt>require 'bundler/setup'</tt> will be inserted for all scripts. Defaults to "<tt>Gemfile</tt>" when not specified.
-automation.config.jrubyscripting.bundle_install.label = Run Bundler Install at Startup
-automation.config.jrubyscripting.bundle_install.description = Run <tt>bundle install</tt> when the add-on loads or the configuration is changed. This will install any gems specified in the Gemfile.
+automation.config.jrubyscripting.bundle_gemfile.label = Gemfile Path
+automation.config.jrubyscripting.bundle_gemfile.description = Path to your own Gemfile relative to <code>OPENHAB_CONF/automation/ruby/</code>. An absolute path can be used. If this file exists, it will be used instead of the <code>gems</code> setting above, so your Gemfile must include <code>openhab-scripting</code> to use the helper library.
 automation.config.jrubyscripting.check_update.label = Check for Gem Updates
-automation.config.jrubyscripting.check_update.description = Check RubyGems for updates to the above gems when OpenHAB starts or JRuby settings are changed. Otherwise it will try to fulfill the requirements with locally installed gems, and you can manage them yourself with an external Ruby by setting the same GEM_HOME.
+automation.config.jrubyscripting.check_update.description = Check RubyGems for updated gems when OpenHAB starts or JRuby settings are changed. Otherwise it will try to fulfill the requirements with locally installed gems, and you can manage them yourself with either the <code>jrubyscripting gem</code> or <code>jrubyscripting bundle</code> console commands, or an external Ruby by setting the same GEM_HOME.
 automation.config.jrubyscripting.console.label = Console Script
-automation.config.jrubyscripting.console.description = The script file to be required by the <tt>jrubyscripting console</tt> console command. When specified without any path, <tt>openhab/console/</tt> will be prepended.
+automation.config.jrubyscripting.console.description = The script file to be required by the <code>jrubyscripting console</code> console command. When specified without any path, <code>openhab/console/</code> will be prepended.
 automation.config.jrubyscripting.dependency_tracking.label = Enable Dependency Tracking
 automation.config.jrubyscripting.dependency_tracking.description = Dependency tracking allows your scripts to automatically reload when one of its dependencies is updated. You may want to disable dependency tracking if you plan on editing or updating a shared library, but don't want all your scripts to reload until you can test it.
 automation.config.jrubyscripting.gem_home.label = GEM_HOME
-automation.config.jrubyscripting.gem_home.description = Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary. You can use <tt>{RUBY_ENGINE_VERSION}</tt>, <tt>{RUBY_ENGINE}</tt> and/or <tt>{RUBY_VERSION}</tt> replacements in this value to automatically point to a new directory when the addon is updated with a new version of JRuby. Defaults to "<tt>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</tt>" when not specified.
+automation.config.jrubyscripting.gem_home.description = Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary. You can use <code>{RUBY_ENGINE_VERSION}</code>, <code>{RUBY_ENGINE}</code> and/or <code>{RUBY_VERSION}</code> replacements in this value to automatically point to a new directory when the addon is updated with a new version of JRuby. Defaults to "<code>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</code>" when not specified.
 automation.config.jrubyscripting.gems.label = Ruby Gems
-automation.config.jrubyscripting.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <tt>=</tt> and then the standard RubyGems version constraint, such as "<tt>openhab-scripting=~>5.0</tt>".
-automation.config.jrubyscripting.group.bundler.label = Bundler
-automation.config.jrubyscripting.group.bundler.description = This group defines the Bundler settings.
+automation.config.jrubyscripting.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <code>=</code> and then the standard RubyGems version constraint, such as "<code>openhab-scripting=~>5.0</code>".
 automation.config.jrubyscripting.group.console.label = JRuby Console
 automation.config.jrubyscripting.group.console.description = This group defines the JRuby console settings.
 automation.config.jrubyscripting.group.environment.label = Ruby Environment
 automation.config.jrubyscripting.group.environment.description = This group defines Ruby's environment.
 automation.config.jrubyscripting.group.gems.label = Ruby Gems
-automation.config.jrubyscripting.group.gems.description = This group defines the list of Ruby Gems to install.
+automation.config.jrubyscripting.group.gems.description = This group defines the management of Ruby Gems.
 automation.config.jrubyscripting.group.system.label = System Properties
 automation.config.jrubyscripting.group.system.description = This group defines JRuby system properties.
 automation.config.jrubyscripting.local_context.label = Context Instance Type
@@ -43,6 +37,6 @@ automation.config.jrubyscripting.local_variable.option.transient = Transient
 automation.config.jrubyscripting.local_variable.option.persistent = Persistent
 automation.config.jrubyscripting.local_variable.option.global = Global
 automation.config.jrubyscripting.require.label = Require Scripts
-automation.config.jrubyscripting.require.description = A comma separated list of script names to be required by the JRuby Scripting Engine before running user scripts.
+automation.config.jrubyscripting.require.description = A comma separated list of script names to be required by the JRuby Scripting Engine before running user scripts. This can be used to automatically include a common (personal) library without having to add a <code>require</code> line in every script.
 automation.config.jrubyscripting.rubylib.label = RUBYLIB
-automation.config.jrubyscripting.rubylib.description = Search path for user libraries. Separate each path with a colon (semicolon in Windows). Defaults to "<tt>OPENHAB_CONF/automation/ruby/lib</tt>" when not specified.
+automation.config.jrubyscripting.rubylib.description = Search path for user libraries. Separate each path with a colon (semicolon in Windows). Defaults to "<code>OPENHAB_CONF/automation/ruby/lib</code>" when not specified.

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/resources/OH-INF/i18n/jrubyscripting.properties
@@ -16,7 +16,7 @@ automation.config.jrubyscripting.dependency_tracking.description = Dependency tr
 automation.config.jrubyscripting.gem_home.label = GEM_HOME
 automation.config.jrubyscripting.gem_home.description = Location Ruby Gems will be installed to and loaded from. Directory will be created if necessary. You can use <code>{RUBY_ENGINE_VERSION}</code>, <code>{RUBY_ENGINE}</code> and/or <code>{RUBY_VERSION}</code> replacements in this value to automatically point to a new directory when the addon is updated with a new version of JRuby. Defaults to "<code>OPENHAB_CONF/automation/ruby/.gem/{RUBY_ENGINE_VERSION}</code>" when not specified.
 automation.config.jrubyscripting.gems.label = Ruby Gems
-automation.config.jrubyscripting.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <code>=</code> and then the standard RubyGems version constraint, such as "<code>openhab-scripting=~>5.0</code>".
+automation.config.jrubyscripting.gems.description = A comma separated list of Ruby Gems to install. Versions may be constrained by separating with an <code>=</code> followed by standard RubyGems version constraint, such as "<code>openhab-scripting=~>5.0</code>".
 automation.config.jrubyscripting.group.console.label = JRuby Console
 automation.config.jrubyscripting.group.console.description = This group defines the JRuby console settings.
 automation.config.jrubyscripting.group.environment.label = Ruby Environment
@@ -37,6 +37,6 @@ automation.config.jrubyscripting.local_variable.option.transient = Transient
 automation.config.jrubyscripting.local_variable.option.persistent = Persistent
 automation.config.jrubyscripting.local_variable.option.global = Global
 automation.config.jrubyscripting.require.label = Require Scripts
-automation.config.jrubyscripting.require.description = A comma separated list of script names to be required by the JRuby Scripting Engine before running user scripts. This can be used to automatically include a common (personal) library without having to add a <code>require</code> line in every script.
+automation.config.jrubyscripting.require.description = A comma separated list of file names to be required by the JRuby Scripting Engine before running user scripts. This can be used to automatically include a common (personal) library without having to add a <code>require</code> line in every script.
 automation.config.jrubyscripting.rubylib.label = RUBYLIB
 automation.config.jrubyscripting.rubylib.description = Search path for user libraries. Separate each path with a colon (semicolon in Windows). Defaults to "<code>OPENHAB_CONF/automation/ruby/lib</code>" when not specified.


### PR DESCRIPTION

- By default, if `bundle_gemfile` (default: `CONF/automation/ruby/Gemfile`) exists:
  - the `gems` setting will be ignored
  - Execute bundle install / bundle update (depending on `check_update` setting) on startup/config updates
  - Bundler.setup + require will be executed on user script startups
- If Gemfile doesn't exist, continue with the original gems handling
- `require` continues to be executed regardless
- the console command `jrubyscripting bundle init` can be used to create a new Gemfile and it inserts
   ```
   gem "openhab-scripting", "~> 5.0"
   ```
- https://github.com/openhab/openhab-jruby/pull/428 will provide the default require file

The configuration system has been refactored to support the use of multiline / List configuration, to support entering UI Gemfile but that idea is dropped for now. The refactoring should stay nevertheless.

