### PR TITLE
Add support for grid power due to changes in evcc api since 0.133.0

### DIFF
--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/EvccHandler.java
@@ -29,12 +29,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.evcc.internal.api.EvccAPI;
 import org.openhab.binding.evcc.internal.api.EvccApiException;
-import org.openhab.binding.evcc.internal.api.dto.Battery;
-import org.openhab.binding.evcc.internal.api.dto.Loadpoint;
-import org.openhab.binding.evcc.internal.api.dto.PV;
-import org.openhab.binding.evcc.internal.api.dto.Plan;
-import org.openhab.binding.evcc.internal.api.dto.Result;
-import org.openhab.binding.evcc.internal.api.dto.Vehicle;
+import org.openhab.binding.evcc.internal.api.dto.*;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DateTimeType;
@@ -420,7 +415,7 @@ public class EvccHandler extends BaseThingHandler {
             updateStatus(ThingStatus.ONLINE);
             Battery[] batteries = result.getBattery();
             batteryConfigured = ((batteries != null) && (batteries.length > 0));
-            gridConfigured = (result.getGridPower() != null);
+            gridConfigured = result.getGridConfigured();
             PV[] pvs = result.getPV();
             pvConfigured = ((pvs != null) && (pvs.length > 0));
             createChannelsGeneral();
@@ -712,7 +707,13 @@ public class EvccHandler extends BaseThingHandler {
         }
         boolean gridConfigured = this.gridConfigured;
         if (gridConfigured) {
+            // handling gridPower prior to changes in evcc version 0.133.0
             float gridPower = ((result.getGridPower() == null) ? 0.0f : result.getGridPower());
+            Grid grid = result.getGrid();
+            if (grid != null) {
+                // handling gridPower since evcc version 0.133.0
+                gridPower = ((grid.getPower() == null) ? 0.0f : grid.getPower());
+            }
             channel = new ChannelUID(uid, CHANNEL_GROUP_ID_GENERAL, CHANNEL_GRID_POWER);
             updateState(channel, new QuantityType<>(gridPower, Units.WATT));
         }

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Grid.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Grid.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.evcc.internal.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * This class represents the grid response (/api/state).
+ * This DTO was written for evcc version 0.133.0
+ *
+ * @author Daniel Kötting - Initial contribution
+ */
+public class Grid {
+    // Data types from https://github.com/evcc-io/evcc/blob/master/api/api.go
+    // and from https://docs.evcc.io/docs/reference/configuration/messaging/#msg
+
+    @SerializedName("currents")
+    private Float[] currents;
+
+    @SerializedName("energy")
+    private Float energy;
+
+    @SerializedName("power")
+    private Float power;
+
+    /**
+     * @return grid's currents
+     */
+    public Float[] getCurrents() {
+        return currents;
+    }
+
+    /**
+     * @return grid's energy
+     */
+    public Float getEnergy() {
+        return energy;
+    }
+
+    /**
+     * @return grid's power or {@code null} if not available
+     */
+    public Float getPower() {
+        return power;
+    }
+}

--- a/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
+++ b/bundles/org.openhab.binding.evcc/src/main/java/org/openhab/binding/evcc/internal/api/dto/Result.java
@@ -49,14 +49,14 @@ public class Result {
     @SerializedName("batteryMode")
     private String batteryMode;
 
-    @SerializedName("gridCurrents")
-    private float[] gridCurrents;
-
-    @SerializedName("gridEnergy")
-    private float gridEnergy;
-
     @SerializedName("gridPower")
     private Float gridPower;
+
+    @SerializedName("grid")
+    private Grid grid;
+
+    @SerializedName("gridConfigured")
+    private boolean gridConfigured;
 
     @SerializedName("homePower")
     private float homePower;
@@ -165,24 +165,24 @@ public class Result {
     }
 
     /**
-     * @return grid's currents
-     */
-    public float[] getGridCurrents() {
-        return gridCurrents;
-    }
-
-    /**
-     * @return grid's energy
-     */
-    public float getGridEnergy() {
-        return gridEnergy;
-    }
-
-    /**
-     * @return grid's power or {@code null} if not available
+     * @return gridPower (before evcc version 0.133.0)
      */
     public Float getGridPower() {
         return gridPower;
+    }
+
+    /**
+     * @return all grid related values (since evcc version 0.133.0)
+     */
+    public Grid getGrid() {
+        return grid;
+    }
+
+    /**
+     * @return is grid configured (since evcc version 0.133.0)
+     */
+    public boolean getGridConfigured() {
+        return gridConfigured;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/18148

This PR fixes the new alignment of grid data comming from evccs /api/state endpoint.
The old and new structure can be seen in this conversation over at evcc https://github.com/evcc-io/evcc/pull/18063

This is backward compatible!

Please note: this is duplicated to #18199 since there is no update anymore.