### PR TITLE
[tado] fix regression

### DIFF
--- a/bundles/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/internal/handler/TadoHandlerFactory.java
+++ b/bundles/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/internal/handler/TadoHandlerFactory.java
@@ -44,6 +44,7 @@ import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
@@ -87,6 +88,13 @@ public class TadoHandlerFactory extends BaseThingHandlerFactory {
         this.httpService = httpService;
         this.oAuthFactory = oAuthFactory;
         this.httpServlet = new TadoAuthenticationServlet(this);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        if (oAuthClientService != null) {
+            oAuthFactory.ungetOAuthService(THING_TYPE_HOME.toString());
+        }
     }
 
     @Override
@@ -179,7 +187,6 @@ public class TadoHandlerFactory extends BaseThingHandlerFactory {
     public void unsubscribeOAuthClientService(TadoHomeHandler tadoHomeHandler) {
         if (oAuthClientServiceSubscribers.remove(tadoHomeHandler) && oAuthClientServiceSubscribers.isEmpty()) {
             httpService.unregister(TadoAuthenticationServlet.PATH);
-            oAuthFactory.ungetOAuthService(THING_TYPE_HOME.toString());
         }
     }
 


### PR DESCRIPTION
Since https://github.com/openhab/openhab-addons/pull/18354 now when you disable and re-enable the Home Thing, it requires a restart of OH before the Thing comes online again. This PR fixes that regression.

Fixes #18418

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>