### PR TITLE
[jsscripting] Upgrade GraalJS to 24.2.0

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -7,13 +7,13 @@ Require-Capability:
     osgi.serviceloader:=
       filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)";
       cardinality:=multiple
-Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.1.2",\
- org.graalvm.sdk.jniutils;bundle-version="24.1.2",\
- org.graalvm.sdk.nativeimage;bundle-version="24.1.2",\
- org.graalvm.sdk.word;bundle-version="24.1.2",\
- org.graalvm.shadowed.icu4j;bundle-version="24.1.2",\
- org.graalvm.truffle.truffle-compiler;bundle-version="24.1.2",\
- org.graalvm.truffle.truffle-runtime;bundle-version="24.1.2"
+Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.2.0",\
+ org.graalvm.sdk.jniutils;bundle-version="24.2.0",\
+ org.graalvm.sdk.nativeimage;bundle-version="24.2.0",\
+ org.graalvm.sdk.word;bundle-version="24.2.0",\
+ org.graalvm.shadowed.icu4j;bundle-version="24.2.0",\
+ org.graalvm.truffle.truffle-compiler;bundle-version="24.2.0",\
+ org.graalvm.truffle.truffle-runtime;bundle-version="24.2.0"
 
 SPI-Provider: *
 SPI-Consumer: *

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -21,7 +21,7 @@
       !jdk.internal.reflect.*,
       !jdk.vm.ci.services</bnd.importpackage>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
-    <graaljs.version>24.1.2</graaljs.version>
+    <graaljs.version>24.2.0</graaljs.version>
     <oh.version>${project.version}</oh.version>
     <ohjs.version>openhab@5.9.0</ohjs.version>
   </properties>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -10,6 +10,7 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.2.0</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.2.0</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/24.2.0</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.2.0</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.2.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -5,13 +5,13 @@
 
 	<feature name="openhab-automation-jsscripting" description="JavaScript Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.1.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.1.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.1.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.1.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.1.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.1.2</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.1.2</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.2.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.2.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-osgiify/pull/59.

Changelog: https://github.com/oracle/graaljs/blob/master/CHANGELOG.md#version-2420