### PR TITLE
[rrd4j] Fix chart servlet build

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/charts/RRD4jChartServlet.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/charts/RRD4jChartServlet.java
@@ -150,7 +150,7 @@ public class RRD4jChartServlet implements Servlet, ChartProvider {
 
         try {
             BufferedImage chart = createChart(null, null, timeBegin, timeEnd, height, width, req.getParameter("items"),
-                    req.getParameter("groups"), null, null);
+                    req.getParameter("groups"), null, null, null);
             // Set the content type to that provided by the chart provider
             res.setContentType("image/" + getChartType());
             ImageIO.write(chart, getChartType().toString(), res.getOutputStream());
@@ -246,7 +246,8 @@ public class RRD4jChartServlet implements Servlet, ChartProvider {
     @Override
     public BufferedImage createChart(@Nullable String service, @Nullable String theme, ZonedDateTime startTime,
             ZonedDateTime endTime, int height, int width, @Nullable String items, @Nullable String groups,
-            @Nullable Integer dpi, @Nullable Boolean legend) throws ItemNotFoundException {
+            @Nullable Integer dpi, @Nullable String interpolation, @Nullable Boolean legend)
+            throws ItemNotFoundException {
         RrdGraphDef graphDef = new RrdGraphDef(startTime.toEpochSecond(), endTime.toEpochSecond());
         graphDef.setWidth(width);
         graphDef.setHeight(height);


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/4610 introduced an interpolation parameter for charts.

rrd4j persistence has its own chart servlet that implements the core chart provider interface. I am not  even sure it is still used anywhere as core has an implementation of a chart servlet and that is used for sitemaps. Anyway, to make the build work, the rrd4j chart servlet needs to have an extra parameter.