### PR TITLE
[insteon] Fix scene channels not responding after modem db reload

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonBaseThingHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonBaseThingHandler.java
@@ -317,6 +317,11 @@ public abstract class InsteonBaseThingHandler extends BaseThingHandler implement
                 .forEach(this::channelLinked);
     }
 
+    protected void unlinkChannels() {
+        getThing().getChannels().stream().map(Channel::getUID).filter(channelHandlers::containsKey)
+                .forEach(this::channelUnlinked);
+    }
+
     @Override
     public void refresh() {
         InsteonModem modem = getModem();

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonSceneHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonSceneHandler.java
@@ -131,6 +131,7 @@ public class InsteonSceneHandler extends InsteonBaseThingHandler {
         if (scene != null) {
             scene.setModem(null);
         }
+        unlinkChannels();
     }
 
     @Override


### PR DESCRIPTION
This fixes an issue where scene channels would not respond to commands after a modem db reload was initiated from the console. The root cause was that these channels would remain linked to the previous `InsteonModem` object prior to the reload, and never got relinked to the new one.

This should be backported.