### PR TITLE
[insteon] Improve modem db default controller group support

### DIFF
--- a/bundles/org.openhab.binding.insteon/README.md
+++ b/bundles/org.openhab.binding.insteon/README.md
@@ -115,7 +115,7 @@ Likewise, for a device that wasn't accessible during the binding initialization 
 
 | Parameter | Required | Description                                                                                                                |
 | --------- | :------: | -------------------------------------------------------------------------------------------------------------------------- |
-| group     |   Yes    | Insteon scene group number between 2 and 254. It can be found in the scene detailed information in the Insteon mobile app. |
+| group     |   Yes    | Insteon scene group number between 0 and 255. It can be found in the scene detailed information in the Insteon mobile app. |
 
 ### `x10`
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonScene.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonScene.java
@@ -33,11 +33,11 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class InsteonScene implements Scene {
-    public static final int GROUP_MIN = 2;
-    public static final int GROUP_MAX = 254;
+    public static final int GROUP_MIN = 0;
+    public static final int GROUP_MAX = 255;
     // limit new scene group minimum to 25 matching the current Insteon app behavior
     public static final int GROUP_NEW_MIN = 25;
-    public static final int GROUP_NEW_MAX = 254;
+    public static final int GROUP_NEW_MAX = 255;
 
     private final Logger logger = LoggerFactory.getLogger(InsteonScene.class);
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LinkManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LinkManager.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class LinkManager implements PortListener {
     private static final int LINKING_TIMEOUT = 30000; // in milliseconds
-    private static final int DEFAULT_CONTROLLER_GROUP = 0;
     private static final int DEFAULT_RESPONDER_GROUP = 1;
 
     private final Logger logger = LoggerFactory.getLogger(LinkManager.class);
@@ -93,7 +92,7 @@ public class LinkManager implements PortListener {
 
     public void link(@Nullable InsteonAddress address) {
         addLinkingRequest(LinkMode.RESPONDER, DEFAULT_RESPONDER_GROUP);
-        addLinkingRequest(LinkMode.CONTROLLER, DEFAULT_CONTROLLER_GROUP);
+        addLinkingRequest(LinkMode.CONTROLLER, modem.getDB().getDefaultControllerGroup());
         start(address);
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.insteon.internal.device.InsteonAddress;
 import org.openhab.binding.insteon.internal.device.InsteonDevice;
 import org.openhab.binding.insteon.internal.device.InsteonModem;
-import org.openhab.binding.insteon.internal.device.InsteonScene;
 import org.openhab.binding.insteon.internal.utils.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,9 +50,9 @@ public class LinkDB {
 
     private final Logger logger = LoggerFactory.getLogger(LinkDB.class);
 
-    private InsteonDevice device;
-    private TreeMap<Integer, LinkDBRecord> records = new TreeMap<>(Collections.reverseOrder());
-    private TreeMap<Integer, LinkDBChange> changes = new TreeMap<>(Collections.reverseOrder());
+    private final InsteonDevice device;
+    private final TreeMap<Integer, LinkDBRecord> records = new TreeMap<>(Collections.reverseOrder());
+    private final TreeMap<Integer, LinkDBChange> changes = new TreeMap<>(Collections.reverseOrder());
     private DatabaseStatus status = DatabaseStatus.EMPTY;
     private int delta = -1;
     private int firstLocation = 0x0FFF;
@@ -556,8 +555,8 @@ public class LinkDB {
                     .filter(record -> record.isActive() && record.isResponder()
                             && record.getAddress().equals(modem.getAddress()) && record.getComponentId() == componentId
                             && record.getOnLevel() > 0)
-                    .map(LinkDBRecord::getGroup).filter(InsteonScene::isValidGroup).map(Integer::valueOf).distinct()
-                    .toList();
+                    .map(LinkDBRecord::getGroup).filter(modem.getDB()::isValidBroadcastGroup).map(Integer::valueOf)
+                    .distinct().toList();
         }
         return groups;
     }

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/scene.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/scene.xml
@@ -23,7 +23,7 @@
 		<representation-property>group</representation-property>
 
 		<config-description>
-			<parameter name="group" type="integer" min="2" max="254" required="true">
+			<parameter name="group" type="integer" min="0" max="255" required="true">
 				<label>Group</label>
 				<description>Insteon scene group number.</description>
 			</parameter>


### PR DESCRIPTION
The change improves the way the modem db tracks the default controller group by using the database information to determine that value instead of having a static interval.