### PR TITLE
[emotiva] Fix keep alive when adding devices manually

### DIFF
--- a/bundles/org.openhab.binding.emotiva/README.md
+++ b/bundles/org.openhab.binding.emotiva/README.md
@@ -11,7 +11,15 @@ Tested models: Emotiva XMC-2
 
 ## Discovery
 
-The binding automatically discovers devices on your network.
+The binding can discover devices on your network as long as port 7001 is opened on the openHAB machine.
+
+### Network Openings
+
+The following ports are required to be opened in the firewall of you OpenHAB machine to have a fully working binding:
+
+* 7001/udp - Used for device discovery, cannot be changed.
+* 7003/udp - Used for regular notifications from the Emotiva device, can be changed via the **notifyPort** configuration.
+* 7005/udp - Used for menu notifications from the Emotiva device, can be changed via the **menuNotifyPort** configuration.
 
 ## Thing Configuration
 
@@ -29,17 +37,28 @@ There are more parameters which all have defaults set.
 | activateFrontBar       | Activates Front Bar channels                                  | false   |
 | activateOSDMenu        | Activates OSD menu channels                                   | false   |
 | activateZone2          | Activates Zone 2 channels                                     | false   |
-| protocolVersion        | Emotiva Network Protocol version, e.g. 3.0                    | 2.0     |
+| protocolVersion        | Emotiva Network Protocol version, 2.0 or 3.0 supported        | 3.0     |
 | keepAlive              | Time between notification update from device, in milliseconds | 7500    |
 | retryConnectInMinutes  | Time between connection retry, in minutes                     | 2       |
 
 ### Dynamic channels and extended functionality
 
-Emotiva processors have limited processing power, so if the binding subscribes to all channels simultaneously the 
-device might grind to a halt after a while, requiring a manual reboot of the device. The binding is designed to 
-dynamically enable and disabled channels based on the selected source. Furthermore, the configuration values 
-**activateFrontBar**, **activateOSDMenu** and **activateZone2** controls extra functionality this is default off to 
-reduce the overall load on the device.
+Emotiva processors have limited processing power, so if the binding subscribes to all channels simultaneously the device might grind to a halt after a while, requiring a manual reboot of the device.
+The binding is designed to dynamically enable and disabled channels based on the selected source. 
+Furthermore, the configuration values **activateFrontBar**, **activateOSDMenu** and **activateZone2** controls extra functionality this is default off to reduce the overall load on the device.
+
+### Protocol Version
+
+Protocol version is usually reported by the device to the binding during discovery, but if a device is added manually, version 3.0 is set by default. 
+Most modern Emotiva devices supports Emotiva Network Protocol version 3.0, but some devices with older firmware versions might require version 2.0.
+
+### Keep Alive
+
+A job to monitor the availability of the device is started whenever a successful connection is made. 
+This monitors the regular a notification message received via the Control Protocol, and whenever a keep alive message is not received, the device is set OFFLINE. 
+This might be an indication the device either has been disconnected or has been turned off manually. 
+The binding will retry connecting to the device every 2 minutes, so if a device is turned back on it will automatically be discovered by the binding. 
+If the devices goes away within minutes after an initial connection, this might be an indication that the **notifyPort** has not been opened in the firewall.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.emotiva/README.md
+++ b/bundles/org.openhab.binding.emotiva/README.md
@@ -15,7 +15,7 @@ The binding can discover devices on your network as long as port 7001 is opened 
 
 ### Network Openings
 
-The following ports are required to be opened in the firewall of you OpenHAB machine to have a fully working binding:
+The following ports are required to be opened in the firewall of you openHAB machine to have a fully working binding:
 
 * 7001/udp - Used for device discovery, cannot be changed.
 * 7003/udp - Used for regular notifications from the Emotiva device, can be changed via the **notifyPort** configuration.

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaBindingConstants.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaBindingConstants.java
@@ -82,7 +82,7 @@ public class EmotivaBindingConstants {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(List.of(THING_PROCESSOR));
 
     /** Default values for Emotiva channels **/
-    public static final String DEFAULT_EMOTIVA_PROTOCOL_VERSION = "2.0";
+    public static final String DEFAULT_EMOTIVA_PROTOCOL_VERSION = "3.0";
     public static final int DEFAULT_VOLUME_MIN_DECIBEL = -96;
     public static final int DEFAULT_VOLUME_MAX_DECIBEL = 15;
     public static final int DEFAULT_TRIM_MIN_DECIBEL = -12;

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaUdpBroadcastService.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaUdpBroadcastService.java
@@ -62,7 +62,7 @@ public class EmotivaUdpBroadcastService {
     private final String broadcastAddress;
 
     public EmotivaUdpBroadcastService(String broadcastAddress) throws IllegalArgumentException, JAXBException {
-        if (broadcastAddress.trim().isEmpty()) {
+        if (broadcastAddress.isBlank()) {
             throw new IllegalArgumentException("Missing broadcast address");
         }
         this.broadcastAddress = broadcastAddress;

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaUdpReceivingService.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaUdpReceivingService.java
@@ -87,7 +87,7 @@ public class EmotivaUdpReceivingService {
         if (receivingPort <= 0) {
             throw new IllegalArgumentException("Invalid receivingPort: " + receivingPort);
         }
-        if (config.ipAddress.trim().isEmpty()) {
+        if (config.ipAddress.isBlank()) {
             throw new IllegalArgumentException("Missing ipAddress");
         }
         this.ipAddress = config.ipAddress;

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaUdpSendingService.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/EmotivaUdpSendingService.java
@@ -93,7 +93,7 @@ public class EmotivaUdpSendingService {
         if (config.controlPort <= 0) {
             throw new IllegalArgumentException("Invalid udpSendingControlPort: " + config.controlPort);
         }
-        if (config.ipAddress.trim().isEmpty()) {
+        if (config.ipAddress.isBlank()) {
             throw new IllegalArgumentException("Missing ipAddress");
         }
         this.ipAddress = config.ipAddress;

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/dto/EmotivaBarNotifyDTO.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/dto/EmotivaBarNotifyDTO.java
@@ -51,7 +51,11 @@ public class EmotivaBarNotifyDTO {
     }
 
     public EmotivaBarNotifyDTO(String name) {
-        this.name = name;
+        if (name == null) {
+            throw new IllegalArgumentException("Name cannot be null");
+        } else {
+            this.name = name.trim();
+        }
     }
 
     public String getName() {

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/protocol/EmotivaDataType.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/protocol/EmotivaDataType.java
@@ -24,6 +24,7 @@ public enum EmotivaDataType {
     DIMENSIONLESS_DECIBEL("decibel"),
     DIMENSIONLESS_PERCENT("percent"),
     FREQUENCY_HERTZ("hertz"),
+    KEEP_ALIVE("keep_alive"),
     NUMBER("number"),
     NUMBER_TIME("number_time"),
     GOODBYE("goodbye"),

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/protocol/EmotivaSubscriptionTags.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/protocol/EmotivaSubscriptionTags.java
@@ -86,7 +86,7 @@ public enum EmotivaSubscriptionTags {
     menu_update("menu-update", STRING, CHANNEL_MENU_DISPLAY_PREFIX, UI_MENU),
 
     /* Protocol V3 notify tags */
-    keepAlive("keepAlive", NUMBER_TIME, "", GENERAL),
+    keepAlive("keepAlive", KEEP_ALIVE, "", GENERAL),
     goodBye("goodBye", GOODBYE, "", GENERAL),
     bar_update("bar-update", STRING, CHANNEL_BAR, UI_DEVICE),
     width("width", DIMENSIONLESS_DECIBEL, CHANNEL_WIDTH, AUDIO_ADJUSTMENT),

--- a/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/protocol/EmotivaXmlUtils.java
+++ b/bundles/org.openhab.binding.emotiva/src/main/java/org/openhab/binding/emotiva/internal/protocol/EmotivaXmlUtils.java
@@ -214,8 +214,7 @@ public class EmotivaXmlUtils {
 
             String[] lines = elementAsString.split("\n");
             for (String line : lines) {
-
-                if (line.trim().startsWith("<") && line.trim().endsWith("/>")) {
+                if (line != null && line.trim().startsWith("<") && line.trim().endsWith("/>")) {
                     Document doc = db.parse(new ByteArrayInputStream(line.getBytes(StandardCharsets.UTF_8)));
                     doc.getDocumentElement();
                     EmotivaCommandDTO commandDTO = getEmotivaCommandDTO(doc.getDocumentElement());
@@ -231,7 +230,13 @@ public class EmotivaXmlUtils {
     private static EmotivaCommandDTO getEmotivaCommandDTO(Element xmlElement) {
         EmotivaControlCommands commandType;
         try {
-            commandType = EmotivaControlCommands.valueOf(xmlElement.getTagName().trim());
+            String tagName = xmlElement.getTagName();
+            if (tagName == null || tagName.isBlank()) {
+                LOGGER.debug("Could not create EmotivaCommand, tag name was '{}'", tagName);
+                commandType = EmotivaControlCommands.none;
+            } else {
+                commandType = EmotivaControlCommands.valueOf(tagName.trim());
+            }
         } catch (IllegalArgumentException e) {
             LOGGER.debug("Could not create EmotivaCommand, unknown command {}", xmlElement.getTagName());
             commandType = EmotivaControlCommands.none;
@@ -250,7 +255,7 @@ public class EmotivaXmlUtils {
     }
 
     private static EmotivaBarNotifyDTO getEmotivaBarNotify(Element xmlElement) {
-        var barNotify = new EmotivaBarNotifyDTO(xmlElement.getTagName().trim());
+        var barNotify = new EmotivaBarNotifyDTO(xmlElement.getTagName());
         if (xmlElement.hasAttribute("type")) {
             barNotify.setType(xmlElement.getAttribute("type"));
         }
@@ -275,7 +280,13 @@ public class EmotivaXmlUtils {
     private static EmotivaNotifyDTO getEmotivaNotifyTags(Element xmlElement) {
         String notifyTagName;
         try {
-            notifyTagName = EmotivaSubscriptionTags.valueOf(xmlElement.getTagName().trim()).name();
+            String tagName = xmlElement.getTagName();
+            if (tagName == null || tagName.isBlank()) {
+                LOGGER.debug("Could not create EmotivaNotify, subscription tag name was '{}'", tagName);
+                notifyTagName = UNKNOWN_TAG;
+            } else {
+                notifyTagName = EmotivaSubscriptionTags.valueOf(tagName.trim()).name();
+            }
         } catch (IllegalArgumentException e) {
             LOGGER.debug("Could not create EmotivaNotify, unknown subscription tag {}", xmlElement.getTagName());
             notifyTagName = UNKNOWN_TAG;

--- a/bundles/org.openhab.binding.emotiva/src/main/resources/OH-INF/i18n/emotiva.properties
+++ b/bundles/org.openhab.binding.emotiva/src/main/resources/OH-INF/i18n/emotiva.properties
@@ -199,7 +199,7 @@ channel-type.emotiva.zonePower.description = Power ON/OFF this zone of the unit
 # User Messages
 message.processor.connecting = Connecting
 message.processor.connection.failed = Failed to connect, check network connectivity and configuration
-message.processor.connection.error.keep-alive = Failed to receive keepAlive message from device, check network connectivity!
+message.processor.connection.error.keep-alive = Failed to receive keep alive notification, check network connectivity and if the notify port is open!
 message.processor.connection.error.port = portNumber is invalid!
 message.processor.connection.error.address-empty = IP Address must be configured!
 message.processor.connection.error.address-invalid = IP Address is not valid!


### PR DESCRIPTION
Fixes #18468.

* Improves handling of keep alive poll job.
* Bumps default Emotiva protocol version to 3.0.
* Add documentation about opening of ports, protocol versions and keep alive.

Has been tested on 4.3.x and 5.0.0-SNAPSHOT. Backporting should be possible, and probably disariable to avoid this issue for users.
