### PR TITLE
[froniuswattpilot] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,7 @@
 /bundles/org.openhab.binding.freecurrency/ @J-N-K
 /bundles/org.openhab.binding.frenchgovtenergydata/ @clinique
 /bundles/org.openhab.binding.fronius/ @trokohl @florian-h05
+/bundles/org.openhab.binding.froniuswattpilot/ @florian-h05
 /bundles/org.openhab.binding.fsinternetradio/ @paphko
 /bundles/org.openhab.binding.ftpupload/ @paulianttila
 /bundles/org.openhab.binding.gardena/ @gerrieg @andrewfg

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -653,6 +653,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.froniuswattpilot</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.fsinternetradio</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.froniuswattpilot/NOTICE
+++ b/bundles/org.openhab.binding.froniuswattpilot/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.froniuswattpilot/README.md
+++ b/bundles/org.openhab.binding.froniuswattpilot/README.md
@@ -30,27 +30,27 @@ After adding it from the inbox, you need to configure the password for accessing
 
 ## Channels
 
-| Channel                         | Type                   | Read/Write | Description                                                                                            |
-|---------------------------------|------------------------|------------|--------------------------------------------------------------------------------------------------------|
-| control#enforced-charging-state | String                 | RW         | Force (`ON`) or Forbid (`OFF`) charging, or let the wallbox decide (`NEUTRAL`)                         |
-| control#charging-mode           | String                 | RW         | The mode of charging: `DEFAULT`, `ECO`, `NEXT_TRIP`                                                    |
-| control#charging-current        | Number:ElectricCurrent | RW         | The current to charge with                                                                             |
-| control#pv-surplus-threshold    | Number:Power           | RW         | The PV surplus power at which surplus charging starts                                                  |
-| status#charging-state           | String                 | R          | Charging state: `NO_CAR`, `CHARGING`, `READY` or `COMPLETE`                                            |
-| status#charging-allows          | Switch                 | R          | Whether charging is currently allowed, e.g. when using eco mode too low PV surplus can forbid charging |
-| status#single-phase             | Switch                 | R          | Whether the wallbox is currently charging single phase only                                            |
-| metrics#power                   | Number:Power           | R          | Total power                                                                                            |
-| metrics#energy-session          | Number:Energy          | R          | Amount of energy charged in the current/last charging session                                          |
-| metrics#energy-total            | Number:Energy          | R          | Amount of energy charged in total                                                                      |
-| metrics#l1-power                | Number:Power           | R          | Power of phase 1                                                                                       |
-| metrics#l2-power                | Number:Power           | R          | Power of phase 2                                                                                       |
-| metrics#l3-power                | Number:Power           | R          | Power of phase 3                                                                                       |
-| metrics#l1-voltage              | Number:Voltage         | R          | Voltage of phase 1                                                                                     |
-| metrics#l2-voltage              | Number:Voltage         | R          | Voltage of phase 2                                                                                     |
-| metrics#l3-voltage              | Number:Voltage         | R          | Voltage of phase 3                                                                                     |
-| metrics#l1-current              | Number:ElectricCurrent | R          | Current/amperage of phase 1                                                                            |
-| metrics#l2-current              | Number:ElectricCurrent | R          | Current/amperage of phase 2                                                                            |
-| metrics#l3-current              | Number:ElectricCurrent | R          | Current/amperage of phase 3                                                                            |
+| Channel                      | Type                   | Read/Write | Description                                                                                             |
+|------------------------------|------------------------|------------|---------------------------------------------------------------------------------------------------------|
+| control#charging-allowed     | Switch                 | RW         | Allow (`ON`) or forbid (`OFF`) charging                                                                 |
+| control#charging-mode        | String                 | RW         | The mode of charging: `DEFAULT`, `ECO`, `NEXT_TRIP`                                                     |
+| control#charging-current     | Number:ElectricCurrent | RW         | The current to charge with                                                                              |
+| control#pv-surplus-threshold | Number:Power           | RW         | The PV surplus power at which surplus charging starts                                                   |
+| status#charging-state        | String                 | R          | Charging state: `NO_CAR`, `CHARGING`, `READY` or `COMPLETE`                                             |
+| status#charging-possible     | Switch                 | R          | Whether charging is currently possible, e.g. when using ECO mode, too low PV surplus can block charging |
+| status#single-phase          | Switch                 | R          | Whether the wallbox is currently charging single phase only                                             |
+| metrics#power                | Number:Power           | R          | Total power                                                                                             |
+| metrics#energy-session       | Number:Energy          | R          | Amount of energy charged in the current/last charging session                                           |
+| metrics#energy-total         | Number:Energy          | R          | Amount of energy charged in total                                                                       |
+| metrics#l1-power             | Number:Power           | R          | Power of phase 1                                                                                        |
+| metrics#l2-power             | Number:Power           | R          | Power of phase 2                                                                                        |
+| metrics#l3-power             | Number:Power           | R          | Power of phase 3                                                                                        |
+| metrics#l1-voltage           | Number:Voltage         | R          | Voltage of phase 1                                                                                      |
+| metrics#l2-voltage           | Number:Voltage         | R          | Voltage of phase 2                                                                                      |
+| metrics#l3-voltage           | Number:Voltage         | R          | Voltage of phase 3                                                                                      |
+| metrics#l1-current           | Number:ElectricCurrent | R          | Current/amperage of phase 1                                                                             |
+| metrics#l2-current           | Number:ElectricCurrent | R          | Current/amperage of phase 2                                                                             |
+| metrics#l3-current           | Number:ElectricCurrent | R          | Current/amperage of phase 3                                                                             |
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.froniuswattpilot/README.md
+++ b/bundles/org.openhab.binding.froniuswattpilot/README.md
@@ -1,94 +1,94 @@
 # Fronius Wattpilot Binding
 
-_Give some details about what this binding is meant for - a protocol, system, specific device._
+This binding integrates the [Fronius Wattpilot EV charging stations](https://www.fronius.com/en-gb/uk/solar-energy/installers-partners/products-solutions/residential-energy-solutions/e-mobility-and-photovoltaic-residential/wattpilot-ev-charging-solution-for-homes)
+through their unofficial WebSocket API, which is also used by the [Fronius Solar.Wattpilot app](https://www.fronius.com/en-gb/uk/solar-energy/installers-partners/products-solutions/residential-energy-solutions/e-mobility-and-photovoltaic-residential/wattpilot-ev-charging-solution-for-homes#anc_app).
 
-_If possible, provide some resources like pictures (only PNG is supported currently), a video, etc. to give an impression of what can be done with this binding._
-_You can place such resources into a `doc` folder next to this README.md._
+It should support all Fronius Wattpilot wallboxes and has been tested with the following models:
 
-_Put each sentence in a separate line to improve readability of diffs._
+- Fronius Wattpilot Home 22J
 
 ## Supported Things
 
-_Please describe the different supported things / devices including their ThingTypeUID within this section._
-_Which different types are supported, which models were tested etc.?_
-_Note that it is planned to generate some part of this based on the XML files within ```src/main/resources/OH-INF/thing``` of your binding._
-
-- `bridge`: Short description of the Bridge, if any
-- `sample`: Short description of the Thing with the ThingTypeUID `sample`
+- `wattpilot`: A Fronius Wattpilot wallbox
 
 ## Discovery
 
-_Describe the available auto-discovery features here._
-_Mention for what it works and what needs to be kept in mind when using it._
+The binding implements auto-discovery of Wattpilot wallboxes through mDNS.
 
-## Binding Configuration
-
-_If your binding requires or supports general configuration settings, please create a folder ```cfg``` and place the configuration file ```<bindingId>.cfg``` inside it._
-_In this section, you should link to this file and provide some information about the options._
-_The file could e.g. look like:_
-
-```
-# Configuration for the FroniusWattpilot Binding
-#
-# Default secret key for the pairing of the FroniusWattpilot Thing.
-# It has to be between 10-40 (alphanumeric) characters.
-# This may be changed by the user for security reasons.
-secret=openHABSecret
-```
-
-_Note that it is planned to generate some part of this based on the information that is available within ```src/main/resources/OH-INF/binding``` of your binding._
-
-_If your binding does not offer any generic configurations, you can remove this section completely._
+If the binding discovered a Wattpilot, it is added to the inbox.
+After adding it from the inbox, you need to configure the password for accessing the Wattpilot.
 
 ## Thing Configuration
 
-_Describe what is needed to manually configure a thing, either through the UI or via a thing-file._
-_This should be mainly about its mandatory and optional configuration parameters._
-
-_Note that it is planned to generate some part of this based on the XML files within ```src/main/resources/OH-INF/thing``` of your binding._
-
-### `sample` Thing Configuration
+### `wattpilot` Thing Configuration
 
 | Name            | Type    | Description                           | Default | Required | Advanced |
 |-----------------|---------|---------------------------------------|---------|----------|----------|
 | hostname        | text    | Hostname or IP address of the device  | N/A     | yes      | no       |
 | password        | text    | Password to access the device         | N/A     | yes      | no       |
-| refreshInterval | integer | Interval the device is polled in sec. | 600     | no       | yes      |
 
 ## Channels
 
-_Here you should provide information about available channel types, what their meaning is and how they can be used._
-
-_Note that it is planned to generate some part of this based on the XML files within ```src/main/resources/OH-INF/thing``` of your binding._
-
-| Channel | Type   | Read/Write | Description                 |
-|---------|--------|------------|-----------------------------|
-| control | Switch | RW         | This is the control channel |
+| Channel                         | Type                   | Read/Write | Description                                                                                            |
+|---------------------------------|------------------------|------------|--------------------------------------------------------------------------------------------------------|
+| control#enforced-charging-state | String                 | RW         | Force (`ON`) or Forbid (`OFF`) charging, or let the wallbox decide (`NEUTRAL`)                         |
+| control#charging-mode           | String                 | RW         | The mode of charging: `DEFAULT`, `ECO`, `NEXT_TRIP`                                                    |
+| control#charging-current        | Number:ElectricCurrent | RW         | The current to charge with                                                                             |
+| control#pv-surplus-threshold    | Number:Power           | RW         | The PV surplus power at which surplus charging starts                                                  |
+| status#charging-state           | String                 | R          | Charging state: `NO_CAR`, `CHARGING`, `READY` or `COMPLETE`                                            |
+| status#charging-allows          | Switch                 | R          | Whether charging is currently allowed, e.g. when using eco mode too low PV surplus can forbid charging |
+| status#single-phase             | Switch                 | R          | Whether the wallbox is currently charging single phase only                                            |
+| metrics#power                   | Number:Power           | R          | Total power                                                                                            |
+| metrics#energy-session          | Number:Energy          | R          | Amount of energy charged in the current/last charging session                                          |
+| metrics#energy-total            | Number:Energy          | R          | Amount of energy charged in total                                                                      |
+| metrics#l1-power                | Number:Power           | R          | Power of phase 1                                                                                       |
+| metrics#l2-power                | Number:Power           | R          | Power of phase 2                                                                                       |
+| metrics#l3-power                | Number:Power           | R          | Power of phase 3                                                                                       |
+| metrics#l1-voltage              | Number:Voltage         | R          | Voltage of phase 1                                                                                     |
+| metrics#l2-voltage              | Number:Voltage         | R          | Voltage of phase 2                                                                                     |
+| metrics#l3-voltage              | Number:Voltage         | R          | Voltage of phase 3                                                                                     |
+| metrics#l1-current              | Number:ElectricCurrent | R          | Current/amperage of phase 1                                                                            |
+| metrics#l2-current              | Number:ElectricCurrent | R          | Current/amperage of phase 2                                                                            |
+| metrics#l3-current              | Number:ElectricCurrent | R          | Current/amperage of phase 3                                                                            |
 
 ## Full Example
-
-_Provide a full usage example based on textual configuration files._
-_*.things, *.items examples are mandatory as textual configuration is well used by many users._
-_*.sitemap examples are optional._
 
 ### Thing Configuration
 
 ```java
-Example thing configuration goes here.
+Thing froniuswattpilot:wattpilot:garage "Wattpilot Garage" [hostname="xxx.xxx.xxx.xxx", password="secret"]
 ```
+
 ### Item Configuration
 
 ```java
-Example item configuration goes here.
+Group                     Wattpilot_Garage                             "Wattpilot Garage"                                                          ["Equipment"]
+
+// Control
+String                    Wattpilot_Garage_Enforced_Charging_State     "Enforced Charging State"               <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#enforced-charging-state"}
+String                    Wattpilot_Garage_Charging_Mode               "Charging Mode"                         <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#charging-mode"}
+Number:ElectricCurrent    Wattpilot_Garage_Charging_Current            "Charging Current [%d A]"               <Energy>        (Wattpilot_Garage)  ["Current", "Setpoint"]     {channel="froniuswattpilot:wattpilot:garage:control#charging-current", unit="A"}
+Number:Power              Wattpilot_Garage_PV_Surplus_Power_Threshold  "PV Surplus Power Threshold [%.1f kW]"  <SolarPlant>    (Wattpilot_Garage)  ["Power", "Setpoint"]       {channel="froniuswattpilot:wattpilot:garage:control#pv-surplus-threshold", unit="W"}
+
+// Status
+Switch                    Wattpilot_Garage_Charging_Allowed            "Charging Allowed"                      <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#charging-allowed"}
+String                    Wattpilot_Garage_Charging_State              "Charging State"                        <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#charging-state"}
+Switch                    Wattpilot_Garage_Single_Phase_Charging       "Single Phase Charging"                 <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#single-phase"}
+
+// Metrics total
+Number:Power              Wattpilot_Garage_Total_Power                 "Total Power [%.2f kW]"                 <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#power", unit="W"}
+Number:Energy             Wattpilot_Garage_Charged_Energy              "Charged Energy [%.2f kWh]"             <Energy>        (Wattpilot_Garage)  ["Energy", "Measurement"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-session", unit="kWh"}
+Number:Energy             Wattpilot_Garage_Total_Charged_Energy        "Total Charged Energy [%.0f kWh]"       <Energy>        (Wattpilot_Garage)  ["Energy", "Measurement"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-total", unit="kWh"}
+// Metrics phase 1
+Number:Power              Wattpilot_Garage_Phase_1_Power               "Phase 1 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l1-power", unit="W"}
+Number:ElectricPotential  Wattpilot_Garage_Phase_1_Voltage             "Phase 1 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-voltage", unit="V"}
+Number:ElectricCurrent    Wattpilot_Garage_Phase_1_Current             "Phase 1 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-current", unit="A"}
+// Metrics phase 2
+Number:Power              Wattpilot_Garage_Phase_2_Power               "Phase 2 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l2-power", unit="W"}
+Number:ElectricPotential  Wattpilot_Garage_Phase_2_Voltage             "Phase 2 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-voltage", unit="V"}
+Number:ElectricCurrent    Wattpilot_Garage_Phase_2_Current             "Phase 2 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-current", unit="A"}
+// Metrics phase 3
+Number:Power              Wattpilot_Garage_Phase_3_Power               "Phase 3 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l3-power", unit="W"}
+Number:ElectricPotential  Wattpilot_Garage_Phase_3_Voltage             "Phase 3 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-voltage", unit="V"}
+Number:ElectricCurrent    Wattpilot_Garage_Phase_3_Current             "Phase 3 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-current", unit="A"}
 ```
-
-### Sitemap Configuration
-
-```perl
-Optional Sitemap configuration goes here.
-Remove this section, if not needed.
-```
-
-## Any custom content here!
-
-_Feel free to add additional sections for whatever you think should also be mentioned about your binding!_

--- a/bundles/org.openhab.binding.froniuswattpilot/README.md
+++ b/bundles/org.openhab.binding.froniuswattpilot/README.md
@@ -1,0 +1,94 @@
+# Fronius Wattpilot Binding
+
+_Give some details about what this binding is meant for - a protocol, system, specific device._
+
+_If possible, provide some resources like pictures (only PNG is supported currently), a video, etc. to give an impression of what can be done with this binding._
+_You can place such resources into a `doc` folder next to this README.md._
+
+_Put each sentence in a separate line to improve readability of diffs._
+
+## Supported Things
+
+_Please describe the different supported things / devices including their ThingTypeUID within this section._
+_Which different types are supported, which models were tested etc.?_
+_Note that it is planned to generate some part of this based on the XML files within ```src/main/resources/OH-INF/thing``` of your binding._
+
+- `bridge`: Short description of the Bridge, if any
+- `sample`: Short description of the Thing with the ThingTypeUID `sample`
+
+## Discovery
+
+_Describe the available auto-discovery features here._
+_Mention for what it works and what needs to be kept in mind when using it._
+
+## Binding Configuration
+
+_If your binding requires or supports general configuration settings, please create a folder ```cfg``` and place the configuration file ```<bindingId>.cfg``` inside it._
+_In this section, you should link to this file and provide some information about the options._
+_The file could e.g. look like:_
+
+```
+# Configuration for the FroniusWattpilot Binding
+#
+# Default secret key for the pairing of the FroniusWattpilot Thing.
+# It has to be between 10-40 (alphanumeric) characters.
+# This may be changed by the user for security reasons.
+secret=openHABSecret
+```
+
+_Note that it is planned to generate some part of this based on the information that is available within ```src/main/resources/OH-INF/binding``` of your binding._
+
+_If your binding does not offer any generic configurations, you can remove this section completely._
+
+## Thing Configuration
+
+_Describe what is needed to manually configure a thing, either through the UI or via a thing-file._
+_This should be mainly about its mandatory and optional configuration parameters._
+
+_Note that it is planned to generate some part of this based on the XML files within ```src/main/resources/OH-INF/thing``` of your binding._
+
+### `sample` Thing Configuration
+
+| Name            | Type    | Description                           | Default | Required | Advanced |
+|-----------------|---------|---------------------------------------|---------|----------|----------|
+| hostname        | text    | Hostname or IP address of the device  | N/A     | yes      | no       |
+| password        | text    | Password to access the device         | N/A     | yes      | no       |
+| refreshInterval | integer | Interval the device is polled in sec. | 600     | no       | yes      |
+
+## Channels
+
+_Here you should provide information about available channel types, what their meaning is and how they can be used._
+
+_Note that it is planned to generate some part of this based on the XML files within ```src/main/resources/OH-INF/thing``` of your binding._
+
+| Channel | Type   | Read/Write | Description                 |
+|---------|--------|------------|-----------------------------|
+| control | Switch | RW         | This is the control channel |
+
+## Full Example
+
+_Provide a full usage example based on textual configuration files._
+_*.things, *.items examples are mandatory as textual configuration is well used by many users._
+_*.sitemap examples are optional._
+
+### Thing Configuration
+
+```java
+Example thing configuration goes here.
+```
+### Item Configuration
+
+```java
+Example item configuration goes here.
+```
+
+### Sitemap Configuration
+
+```perl
+Optional Sitemap configuration goes here.
+Remove this section, if not needed.
+```
+
+## Any custom content here!
+
+_Feel free to add additional sections for whatever you think should also be mentioned about your binding!_

--- a/bundles/org.openhab.binding.froniuswattpilot/README.md
+++ b/bundles/org.openhab.binding.froniuswattpilot/README.md
@@ -68,8 +68,8 @@ Group                     Wattpilot_Garage                             "Wattpilo
 // Control
 Switch                    Wattpilot_Garage_Charging_Allowed            "Charging Allowed"                      <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#charging-allowed"}
 String                    Wattpilot_Garage_Charging_Mode               "Charging Mode"                         <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#charging-mode"}
-Number:ElectricCurrent    Wattpilot_Garage_Charging_Current            "Charging Current [%d A]"               <Energy>        (Wattpilot_Garage)  ["Current", "Setpoint"]     {channel="froniuswattpilot:wattpilot:garage:control#charging-current", unit="A"}
-Number:Power              Wattpilot_Garage_PV_Surplus_Power_Threshold  "PV Surplus Power Threshold [%.1f kW]"  <SolarPlant>    (Wattpilot_Garage)  ["Power", "Setpoint"]       {channel="froniuswattpilot:wattpilot:garage:control#pv-surplus-threshold", unit="kW"}
+Number:ElectricCurrent    Wattpilot_Garage_Charging_Current            "Charging Current [%d A]"               <Energy>        (Wattpilot_Garage)  ["Setpoint", "Current"]     {channel="froniuswattpilot:wattpilot:garage:control#charging-current", unit="A"}
+Number:Power              Wattpilot_Garage_PV_Surplus_Power_Threshold  "PV Surplus Power Threshold [%.1f kW]"  <SolarPlant>    (Wattpilot_Garage)  ["Setpoint", "Power"]       {channel="froniuswattpilot:wattpilot:garage:control#pv-surplus-threshold", unit="kW"}
 
 // Status
 Switch                    Wattpilot_Garage_Charging_Possible           "Charging Possible"                     <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#charging-possible"}
@@ -78,18 +78,18 @@ Switch                    Wattpilot_Garage_Single_Phase_Charging       "Single P
 
 // Metrics total
 Number:Power              Wattpilot_Garage_Total_Power                 "Total Power [%.2f kW]"                 <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#power", unit="kW"}
-Number:Energy             Wattpilot_Garage_Charged_Energy              "Charged Energy [%.2f kWh]"             <Energy>        (Wattpilot_Garage)  ["Energy", "Measurement"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-session", unit="kWh"}
-Number:Energy             Wattpilot_Garage_Total_Charged_Energy        "Total Charged Energy [%.0f kWh]"       <Energy>        (Wattpilot_Garage)  ["Energy", "Measurement"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-total", unit="kWh"}
+Number:Energy             Wattpilot_Garage_Charged_Energy              "Charged Energy [%.2f kWh]"             <Energy>        (Wattpilot_Garage)  ["Measurement", "Energy"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-session", unit="kWh"}
+Number:Energy             Wattpilot_Garage_Total_Charged_Energy        "Total Charged Energy [%.0f kWh]"       <Energy>        (Wattpilot_Garage)  ["Measurement", "Energy"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-total", unit="kWh"}
 // Metrics phase 1
 Number:Power              Wattpilot_Garage_Phase_1_Power               "Phase 1 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l1-power", unit="kW"}
 Number:ElectricPotential  Wattpilot_Garage_Phase_1_Voltage             "Phase 1 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-voltage", unit="V"}
-Number:ElectricCurrent    Wattpilot_Garage_Phase_1_Current             "Phase 1 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-current", unit="A"}
+Number:ElectricCurrent    Wattpilot_Garage_Phase_1_Current             "Phase 1 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Measurement", "Current"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-current", unit="A"}
 // Metrics phase 2
 Number:Power              Wattpilot_Garage_Phase_2_Power               "Phase 2 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l2-power", unit="kW"}
 Number:ElectricPotential  Wattpilot_Garage_Phase_2_Voltage             "Phase 2 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-voltage", unit="V"}
-Number:ElectricCurrent    Wattpilot_Garage_Phase_2_Current             "Phase 2 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-current", unit="A"}
+Number:ElectricCurrent    Wattpilot_Garage_Phase_2_Current             "Phase 2 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Measurement", "Current"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-current", unit="A"}
 // Metrics phase 3
 Number:Power              Wattpilot_Garage_Phase_3_Power               "Phase 3 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l3-power", unit="kW"}
 Number:ElectricPotential  Wattpilot_Garage_Phase_3_Voltage             "Phase 3 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-voltage", unit="V"}
-Number:ElectricCurrent    Wattpilot_Garage_Phase_3_Current             "Phase 3 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-current", unit="A"}
+Number:ElectricCurrent    Wattpilot_Garage_Phase_3_Current             "Phase 3 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Measurement", "Current"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-current", unit="A"}
 ```

--- a/bundles/org.openhab.binding.froniuswattpilot/README.md
+++ b/bundles/org.openhab.binding.froniuswattpilot/README.md
@@ -5,6 +5,7 @@ through their unofficial WebSocket API, which is also used by the [Fronius Solar
 
 It should support all Fronius Wattpilot wallboxes and has been tested with the following models:
 
+- Fronius Wattpilot Home 11J
 - Fronius Wattpilot Home 22J
 
 ## Supported Things

--- a/bundles/org.openhab.binding.froniuswattpilot/README.md
+++ b/bundles/org.openhab.binding.froniuswattpilot/README.md
@@ -66,30 +66,30 @@ Thing froniuswattpilot:wattpilot:garage "Wattpilot Garage" [hostname="xxx.xxx.xx
 Group                     Wattpilot_Garage                             "Wattpilot Garage"                                                          ["Equipment"]
 
 // Control
-String                    Wattpilot_Garage_Enforced_Charging_State     "Enforced Charging State"               <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#enforced-charging-state"}
+Switch                    Wattpilot_Garage_Charging_Allowed            "Charging Allowed"                      <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#charging-allowed"}
 String                    Wattpilot_Garage_Charging_Mode               "Charging Mode"                         <BatteryLevel>  (Wattpilot_Garage)  ["Control"]                 {channel="froniuswattpilot:wattpilot:garage:control#charging-mode"}
 Number:ElectricCurrent    Wattpilot_Garage_Charging_Current            "Charging Current [%d A]"               <Energy>        (Wattpilot_Garage)  ["Current", "Setpoint"]     {channel="froniuswattpilot:wattpilot:garage:control#charging-current", unit="A"}
-Number:Power              Wattpilot_Garage_PV_Surplus_Power_Threshold  "PV Surplus Power Threshold [%.1f kW]"  <SolarPlant>    (Wattpilot_Garage)  ["Power", "Setpoint"]       {channel="froniuswattpilot:wattpilot:garage:control#pv-surplus-threshold", unit="W"}
+Number:Power              Wattpilot_Garage_PV_Surplus_Power_Threshold  "PV Surplus Power Threshold [%.1f kW]"  <SolarPlant>    (Wattpilot_Garage)  ["Power", "Setpoint"]       {channel="froniuswattpilot:wattpilot:garage:control#pv-surplus-threshold", unit="kW"}
 
 // Status
-Switch                    Wattpilot_Garage_Charging_Allowed            "Charging Allowed"                      <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#charging-allowed"}
+Switch                    Wattpilot_Garage_Charging_Possible           "Charging Possible"                     <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#charging-possible"}
 String                    Wattpilot_Garage_Charging_State              "Charging State"                        <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#charging-state"}
 Switch                    Wattpilot_Garage_Single_Phase_Charging       "Single Phase Charging"                 <BatteryLevel>  (Wattpilot_Garage)  ["Status"]                  {channel="froniuswattpilot:wattpilot:garage:status#single-phase"}
 
 // Metrics total
-Number:Power              Wattpilot_Garage_Total_Power                 "Total Power [%.2f kW]"                 <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#power", unit="W"}
+Number:Power              Wattpilot_Garage_Total_Power                 "Total Power [%.2f kW]"                 <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#power", unit="kW"}
 Number:Energy             Wattpilot_Garage_Charged_Energy              "Charged Energy [%.2f kWh]"             <Energy>        (Wattpilot_Garage)  ["Energy", "Measurement"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-session", unit="kWh"}
 Number:Energy             Wattpilot_Garage_Total_Charged_Energy        "Total Charged Energy [%.0f kWh]"       <Energy>        (Wattpilot_Garage)  ["Energy", "Measurement"]   {channel="froniuswattpilot:wattpilot:garage:metrics#energy-total", unit="kWh"}
 // Metrics phase 1
-Number:Power              Wattpilot_Garage_Phase_1_Power               "Phase 1 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l1-power", unit="W"}
+Number:Power              Wattpilot_Garage_Phase_1_Power               "Phase 1 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l1-power", unit="kW"}
 Number:ElectricPotential  Wattpilot_Garage_Phase_1_Voltage             "Phase 1 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-voltage", unit="V"}
 Number:ElectricCurrent    Wattpilot_Garage_Phase_1_Current             "Phase 1 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l1-current", unit="A"}
 // Metrics phase 2
-Number:Power              Wattpilot_Garage_Phase_2_Power               "Phase 2 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l2-power", unit="W"}
+Number:Power              Wattpilot_Garage_Phase_2_Power               "Phase 2 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l2-power", unit="kW"}
 Number:ElectricPotential  Wattpilot_Garage_Phase_2_Voltage             "Phase 2 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-voltage", unit="V"}
 Number:ElectricCurrent    Wattpilot_Garage_Phase_2_Current             "Phase 2 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l2-current", unit="A"}
 // Metrics phase 3
-Number:Power              Wattpilot_Garage_Phase_3_Power               "Phase 3 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l3-power", unit="W"}
+Number:Power              Wattpilot_Garage_Phase_3_Power               "Phase 3 Power [%.2f kW]"               <Energy>        (Wattpilot_Garage)  ["Measurement", "Power"]    {channel="froniuswattpilot:wattpilot:garage:metrics#l3-power", unit="kW"}
 Number:ElectricPotential  Wattpilot_Garage_Phase_3_Voltage             "Phase 3 Voltage [%d V]"                <Energy>        (Wattpilot_Garage)  ["Measurement", "Voltage"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-voltage", unit="V"}
 Number:ElectricCurrent    Wattpilot_Garage_Phase_3_Current             "Phase 3 Current [%.1f A]"              <Energy>        (Wattpilot_Garage)  ["Current", "Measurement"]  {channel="froniuswattpilot:wattpilot:garage:metrics#l3-current", unit="A"}
 ```

--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -18,7 +18,8 @@
     <dependency>
       <groupId>com.florianhotze.sdk</groupId>
       <artifactId>wattpilot4j</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>1.0.0</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.florianhotze.sdk</groupId>
       <artifactId>wattpilot4j</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.florianhotze.sdk</groupId>
       <artifactId>wattpilot4j</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.froniuswattpilot</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Fronius Wattpilot Binding</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.florianhotze.sdk</groupId>
+      <artifactId>wattpilot4j</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.froniuswattpilot-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.1.0</bundle>
+		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.2.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.0.0</bundle>
+		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.1.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
 
 	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.0.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.froniuswattpilot.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link FroniusWattpilotBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class FroniusWattpilotBindingConstants {
+
+    private static final String BINDING_ID = "froniuswattpilot";
+
+    // Wattpilot Thing Type UID
+    public static final ThingTypeUID THING_TYPE = new ThingTypeUID(BINDING_ID, "wattpilot");
+
+    // Wattpilot channel groups
+    public static final String CHANNEL_GROUP_ID_CONTROL = "control";
+    public static final String CHANNEL_GROUP_ID_STATUS = "status";
+    public static final String CHANNEL_GROUP_ID_METRICS = "metrics";
+
+    // Wattpilot metrics channel prefixes
+    public static final String PREFIX_PHASE_1 = "l1-";
+    public static final String PREFIX_PHASE_2 = "l2-";
+    public static final String PREFIX_PHASE_3 = "l3-";
+
+    // Wattpilot status channels
+    public static final String CHANNEL_CHARGING_STATE = "charging-state";
+    public static final String CHANNEL_CHARGING_ALLOWED = "charging-allowed";
+    public static final String CHANNEL_CHARGING_SINGLE_PHASE = "single-phase";
+
+    // Wattpilot metrics channels
+    public static final String CHANNEL_POWER = "power";
+    public static final String CHANNEL_CHARGED_ENERGY = "energy-session";
+    public static final String CHANNEL_VOLTAGE = "voltage";
+    public static final String CHANNEL_CURRENT = "current";
+}

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -28,6 +28,8 @@ public class FroniusWattpilotBindingConstants {
 
     private static final String BINDING_ID = "froniuswattpilot";
 
+    public static final String HOSTNAME_CONFIGURATION_KEY = "hostname";
+
     // Wattpilot Thing Type UID
     public static final ThingTypeUID THING_TYPE_WATTPILOT = new ThingTypeUID(BINDING_ID, "wattpilot");
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -23,7 +23,8 @@ import org.openhab.core.thing.ThingTypeUID;
  */
 @NonNullByDefault
 public class FroniusWattpilotBindingConstants {
-    private FroniusWattpilotBindingConstants() {}
+    private FroniusWattpilotBindingConstants() {
+    }
 
     private static final String BINDING_ID = "froniuswattpilot";
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -29,7 +29,7 @@ public class FroniusWattpilotBindingConstants {
     private static final String BINDING_ID = "froniuswattpilot";
 
     // Wattpilot Thing Type UID
-    public static final ThingTypeUID THING_TYPE = new ThingTypeUID(BINDING_ID, "wattpilot");
+    public static final ThingTypeUID THING_TYPE_WATTPILOT = new ThingTypeUID(BINDING_ID, "wattpilot");
 
     // Wattpilot channel groups
     public static final String CHANNEL_GROUP_ID_CONTROL = "control";

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -23,6 +23,7 @@ import org.openhab.core.thing.ThingTypeUID;
  */
 @NonNullByDefault
 public class FroniusWattpilotBindingConstants {
+    private FroniusWattpilotBindingConstants() {}
 
     private static final String BINDING_ID = "froniuswattpilot";
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -37,14 +37,14 @@ public class FroniusWattpilotBindingConstants {
     public static final String CHANNEL_GROUP_ID_METRICS = "metrics";
 
     // Wattpilot control channels
-    public static final String CHANNEL_ENFORCED_CHARGING_STATE = "enforced-charging-state";
+    public static final String CHANNEL_CHARGING_ALLOWED = "charging-allowed";
     public static final String CHANNEL_CHARGING_MODE = "charging-mode";
     public static final String CHANNEL_CHARGING_CURRENT = "charging-current";
     public static final String CHANNEL_PV_SURPLUS_THRESHOLD = "pv-surplus-threshold";
 
     // Wattpilot status channels
     public static final String CHANNEL_CHARGING_STATE = "charging-state";
-    public static final String CHANNEL_CHARGING_ALLOWED = "charging-allowed";
+    public static final String CHANNEL_CHARGING_POSSIBLE = "charging-possible";
     public static final String CHANNEL_CHARGING_SINGLE_PHASE = "single-phase";
 
     // Wattpilot metrics channel prefixes

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotBindingConstants.java
@@ -34,19 +34,26 @@ public class FroniusWattpilotBindingConstants {
     public static final String CHANNEL_GROUP_ID_STATUS = "status";
     public static final String CHANNEL_GROUP_ID_METRICS = "metrics";
 
-    // Wattpilot metrics channel prefixes
-    public static final String PREFIX_PHASE_1 = "l1-";
-    public static final String PREFIX_PHASE_2 = "l2-";
-    public static final String PREFIX_PHASE_3 = "l3-";
+    // Wattpilot control channels
+    public static final String CHANNEL_ENFORCED_CHARGING_STATE = "enforced-charging-state";
+    public static final String CHANNEL_CHARGING_MODE = "charging-mode";
+    public static final String CHANNEL_CHARGING_CURRENT = "charging-current";
+    public static final String CHANNEL_PV_SURPLUS_THRESHOLD = "pv-surplus-threshold";
 
     // Wattpilot status channels
     public static final String CHANNEL_CHARGING_STATE = "charging-state";
     public static final String CHANNEL_CHARGING_ALLOWED = "charging-allowed";
     public static final String CHANNEL_CHARGING_SINGLE_PHASE = "single-phase";
 
+    // Wattpilot metrics channel prefixes
+    public static final String PREFIX_PHASE_1 = "l1-";
+    public static final String PREFIX_PHASE_2 = "l2-";
+    public static final String PREFIX_PHASE_3 = "l3-";
+
     // Wattpilot metrics channels
     public static final String CHANNEL_POWER = "power";
-    public static final String CHANNEL_CHARGED_ENERGY = "energy-session";
+    public static final String CHANNEL_CHARGED_ENERGY_SESSION = "energy-session";
+    public static final String CHANNEL_CHARGED_ENERGY_TOTAL = "energy-total";
     public static final String CHANNEL_VOLTAGE = "voltage";
     public static final String CHANNEL_CURRENT = "current";
 }

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotConfiguration.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotConfiguration.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.froniuswattpilot.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link FroniusWattpilotConfiguration} class contains fields mapping thing configuration parameters.
@@ -22,6 +21,6 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 public class FroniusWattpilotConfiguration {
-    public @Nullable String hostname = "";
-    public @Nullable String password = "";
+    public String hostname = "";
+    public String password = "";
 }

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotConfiguration.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.froniuswattpilot.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link FroniusWattpilotConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class FroniusWattpilotConfiguration {
+    public @Nullable String hostname = "";
+    public @Nullable String password = "";
+}

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.froniuswattpilot.internal;
 import static org.openhab.binding.froniuswattpilot.internal.FroniusWattpilotBindingConstants.*;
 
 import java.io.IOException;
+import java.net.NoRouteToHostException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -24,6 +25,7 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.io.EofException;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
@@ -206,9 +208,10 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
             awaitDisconnect.complete(null);
         }
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
-        if (cause instanceof TimeoutException) {
-            logger.debug("Connection to Wattpilot timed out, scheduling reconnection attempt.");
-            scheduler.schedule(this::initialize, 30, TimeUnit.SECONDS);
+        if (cause instanceof TimeoutException || cause instanceof NoRouteToHostException
+                || cause instanceof EofException) {
+            this.logger.debug("Connection to Wattpilot lost, scheduling reconnection attempt.");
+            this.scheduler.schedule(this::initialize, 30L, TimeUnit.SECONDS);
         }
     }
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -91,25 +91,39 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
                     break;
                 case CHANNEL_CHARGING_CURRENT:
                     int ampere;
-                    if (command instanceof QuantityType<?> qt) {
-                        ampere = qt.toUnit(Units.AMPERE).intValue();
-                    } else if (command instanceof DecimalType dt) {
-                        ampere = dt.intValue();
-                    } else {
-                        logger.debug("Command has wrong type, QuantityType or DecimalType required!");
-                        return;
+                    switch (command) {
+                        case QuantityType<?> qt -> {
+                            qt = qt.toUnit(Units.AMPERE);
+                            if (qt == null) {
+                                logger.debug("Failed to convert QuantityType to AMPERE!");
+                                return;
+                            }
+                            ampere = qt.intValue();
+                        }
+                        case DecimalType dt -> ampere = dt.intValue();
+                        default -> {
+                            logger.debug("Command has wrong type, QuantityType or DecimalType required!");
+                            return;
+                        }
                     }
                     client.sendCommand(new SetChargingCurrentCommand(ampere));
                     break;
                 case CHANNEL_PV_SURPLUS_THRESHOLD:
                     int watts;
-                    if (command instanceof QuantityType<?> qt) {
-                        watts = qt.toUnit(Units.WATT).intValue();
-                    } else if (command instanceof DecimalType dt) {
-                        watts = dt.intValue();
-                    } else {
-                        logger.debug("Command has wrong type, QuantityType or DecimalType required!");
-                        return;
+                    switch (command) {
+                        case QuantityType<?> qt -> {
+                            qt = qt.toUnit(Units.WATT);
+                            if (qt == null) {
+                                logger.debug("Failed to convert QuantityType to WATT!");
+                                return;
+                            }
+                            watts = qt.intValue();
+                        }
+                        case DecimalType dt -> watts = dt.intValue();
+                        default -> {
+                            logger.debug("Command has wrong type, QuantityType or DecimalType required!");
+                            return;
+                        }
                     }
                     client.sendCommand(new SetSurplusPowerThresholdCommand(watts));
                     break;
@@ -177,10 +191,8 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
     @Override
     public void disconnected(@Nullable String reason, @Nullable Throwable cause) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
-        if (cause instanceof Exception e) {
-            if (e.getCause() instanceof TimeoutException) {
-                // TODO: Handle timeout
-            }
+        if (cause instanceof Exception e && e.getCause() instanceof TimeoutException) {
+            // TODO: Handle timeout
         }
     }
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import com.florianhotze.wattpilot.WattpilotClient;
 import com.florianhotze.wattpilot.WattpilotClientListener;
+import com.florianhotze.wattpilot.WattpilotInfo;
 import com.florianhotze.wattpilot.WattpilotStatus;
 import com.florianhotze.wattpilot.commands.SetChargingCurrentCommand;
 import com.florianhotze.wattpilot.commands.SetChargingModeCommand;
@@ -188,6 +189,7 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
     @Override
     public void connected() {
         updateStatus(ThingStatus.ONLINE);
+        updateDeviceProperties(client.getDeviceInfo());
     }
 
     @Override
@@ -206,6 +208,13 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         updateChannelsControl(status);
         updateChannelsStatus(status);
         updateChannelsMetrics(status);
+    }
+
+    private void updateDeviceProperties(WattpilotInfo deviceInfo) {
+        Map<String, String> properties = editProperties();
+        properties.put(Thing.PROPERTY_SERIAL_NUMBER, deviceInfo.serial());
+        properties.put(Thing.PROPERTY_FIRMWARE_VERSION, deviceInfo.firmwareVersion());
+        updateProperties(properties);
     }
 
     private void updateChannelsControl(WattpilotStatus status) {

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -152,7 +152,6 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
     @Override
     public void initialize() {
         config = getConfigAs(FroniusWattpilotConfiguration.class);
-        updateStatus(ThingStatus.UNKNOWN);
 
         FroniusWattpilotConfiguration config = this.config;
         if (config == null) {
@@ -172,6 +171,7 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
             return;
         }
 
+        updateStatus(ThingStatus.UNKNOWN);
         try {
             client.connect(config.hostname, config.password);
         } catch (IOException e) {

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.froniuswattpilot.internal.FroniusWattpilotBind
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -109,8 +110,13 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
     }
 
     @Override
-    public void disconnected(@Nullable String reason) {
+    public void disconnected(@Nullable String reason, @Nullable Throwable cause) {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
+        if (cause instanceof Exception e) {
+            if (e.getCause() instanceof TimeoutException) {
+                // TODO: Handle timeout
+            }
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.froniuswattpilot.internal;
+
+import static org.openhab.binding.froniuswattpilot.internal.FroniusWattpilotBindingConstants.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.florianhotze.wattpilot.WattpilotClient;
+import com.florianhotze.wattpilot.WattpilotClientListener;
+import com.florianhotze.wattpilot.WattpilotStatus;
+
+/**
+ * The {@link FroniusWattpilotHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class FroniusWattpilotHandler extends BaseThingHandler implements WattpilotClientListener {
+    private final Logger logger = LoggerFactory.getLogger(FroniusWattpilotHandler.class);
+    private final WattpilotClient client;
+
+    private @Nullable FroniusWattpilotConfiguration config;
+
+    public FroniusWattpilotHandler(Thing thing, HttpClient httpClient) {
+        super(thing);
+        client = new WattpilotClient(httpClient);
+        client.addListener(this);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(FroniusWattpilotConfiguration.class);
+        updateStatus(ThingStatus.UNKNOWN);
+
+        String hostname = config.hostname;
+        String password = config.password;
+
+        if (hostname == null || hostname.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Hostname is missing");
+            return;
+        }
+
+        if (password == null || password.isBlank()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Password is missing");
+            return;
+        }
+
+        try {
+            client.connect(config.hostname, config.password);
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (client.isConnected()) {
+            client.disconnect();
+        }
+    }
+
+    @Override
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+        super.handleConfigurationUpdate(configurationParameters);
+
+        if (client.isConnected()) {
+            client.disconnect();
+        }
+        initialize();
+    }
+
+    @Override
+    public void connected() {
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void disconnected(@Nullable String reason) {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
+    }
+
+    @Override
+    public void statusChanged(@Nullable WattpilotStatus status) {
+        if (status == null) {
+            return;
+        }
+        updateChannelsStatus(status);
+        updateChannelsMetrics(status);
+    }
+
+    private void updateChannelsStatus(WattpilotStatus status) {
+        final ThingUID uid = getThing().getUID();
+        ChannelUID channel;
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_STATE);
+        updateState(channel, new StringType(status.getChargingState().toString()));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_ALLOWED);
+        updateState(channel, status.isChargingAllowed() ? OnOffType.ON : OnOffType.OFF);
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_SINGLE_PHASE);
+        updateState(channel, status.isChargingSinglePhase() ? OnOffType.ON : OnOffType.OFF);
+    }
+
+    private void updateChannelsMetrics(WattpilotStatus status) {
+        final ThingUID uid = getThing().getUID();
+        ChannelUID channel;
+
+        // total
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, CHANNEL_POWER);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().power(), Units.WATT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, CHANNEL_CHARGED_ENERGY);
+        updateState(channel, new QuantityType<>(status.getEnergyCounterSinceStart(), Units.WATT_HOUR));
+
+        // phase 1
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_1 + CHANNEL_POWER);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().power1(), Units.WATT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_1 + CHANNEL_VOLTAGE);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().voltage1(), Units.VOLT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_1 + CHANNEL_CURRENT);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().amperage1(), Units.AMPERE));
+
+        // phase 2
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_2 + CHANNEL_POWER);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().power2(), Units.WATT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_2 + CHANNEL_VOLTAGE);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().voltage2(), Units.VOLT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_2 + CHANNEL_CURRENT);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().amperage2(), Units.AMPERE));
+
+        // phase 3
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_3 + CHANNEL_POWER);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().power3(), Units.WATT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_3 + CHANNEL_VOLTAGE);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().voltage3(), Units.VOLT));
+
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_METRICS, PREFIX_PHASE_3 + CHANNEL_CURRENT);
+        updateState(channel, new QuantityType<>(status.getChargingMetrics().amperage3(), Units.AMPERE));
+    }
+}

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -80,12 +80,12 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         String channelId = channelUID.getIdWithoutGroup();
         try {
             switch (channelId) {
-                case CHANNEL_ENFORCED_CHARGING_STATE:
-                    if (command instanceof StringType st) {
-                        client.sendCommand(
-                                new SetEnforcedChargingStateCommand(EnforcedChargingState.valueOf(st.toString())));
+                case CHANNEL_CHARGING_ALLOWED:
+                    if (command instanceof OnOffType oft) {
+                        client.sendCommand(new SetEnforcedChargingStateCommand(
+                                oft == OnOffType.OFF ? EnforcedChargingState.OFF : EnforcedChargingState.NEUTRAL));
                     } else {
-                        logger.debug("Command has wrong type, StringType required!");
+                        logger.debug("Command has wrong type, OnOffType required!");
                     }
                     break;
                 case CHANNEL_CHARGING_MODE:
@@ -233,8 +233,9 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         final ThingUID uid = getThing().getUID();
         ChannelUID channel;
 
-        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_CONTROL, CHANNEL_ENFORCED_CHARGING_STATE);
-        updateState(channel, new StringType(status.getEnforcedChargingState().toString()));
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_CONTROL, CHANNEL_CHARGING_ALLOWED);
+        updateState(channel,
+                status.getEnforcedChargingState() == EnforcedChargingState.OFF ? OnOffType.OFF : OnOffType.ON);
 
         channel = new ChannelUID(uid, CHANNEL_GROUP_ID_CONTROL, CHANNEL_CHARGING_MODE);
         updateState(channel, new StringType(status.getChargingMode().toString()));
@@ -253,7 +254,7 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_STATE);
         updateState(channel, new StringType(status.getChargingState().toString()));
 
-        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_ALLOWED);
+        channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_POSSIBLE);
         updateState(channel, status.isChargingAllowed() ? OnOffType.ON : OnOffType.OFF);
 
         channel = new ChannelUID(uid, CHANNEL_GROUP_ID_STATUS, CHANNEL_CHARGING_SINGLE_PHASE);

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -147,16 +147,19 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         config = getConfigAs(FroniusWattpilotConfiguration.class);
         updateStatus(ThingStatus.UNKNOWN);
 
-        String hostname = config.hostname;
-        String password = config.password;
+        FroniusWattpilotConfiguration config = this.config;
+        if (config == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
+            return;
+        }
 
-        if (hostname == null || hostname.isBlank()) {
+        if (config.hostname.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.configuration-error.no-host");
             return;
         }
 
-        if (password == null || password.isBlank()) {
+        if (config.password.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.configuration-error.no-password");
             return;

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.util.Utf8Appendable;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
@@ -210,7 +211,7 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         }
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
         if (cause instanceof TimeoutException || cause instanceof NoRouteToHostException
-                || cause instanceof EofException) {
+                || cause instanceof EofException || cause instanceof Utf8Appendable.NotUtf8Exception) {
             this.logger.debug("Connection to Wattpilot lost, scheduling reconnection attempt.");
             this.scheduler.schedule(this::initialize, 30L, TimeUnit.SECONDS);
         }

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -63,7 +63,7 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
     private final Logger logger = LoggerFactory.getLogger(FroniusWattpilotHandler.class);
     private final WattpilotClient client;
 
-    private @Nullable CompletableFuture<?> awaitDisconnect;
+    private @Nullable CompletableFuture<@Nullable Void> awaitDisconnect;
 
     private @Nullable FroniusWattpilotConfiguration config;
 
@@ -182,11 +182,11 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
     @Override
     public void dispose() {
         if (client.isConnected()) {
+            CompletableFuture<@Nullable Void> awaitDisconnect = this.awaitDisconnect;
             if (awaitDisconnect != null) {
                 awaitDisconnect.cancel(true);
-                awaitDisconnect = null;
             }
-            awaitDisconnect = new CompletableFuture<>();
+            awaitDisconnect = this.awaitDisconnect = new CompletableFuture<>();
             client.disconnect();
             try {
                 awaitDisconnect.get(3, TimeUnit.SECONDS);
@@ -204,6 +204,7 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
 
     @Override
     public void disconnected(@Nullable String reason, @Nullable Throwable cause) {
+        CompletableFuture<@Nullable Void> awaitDisconnect = this.awaitDisconnect;
         if (awaitDisconnect != null) {
             awaitDisconnect.complete(null);
         }

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -150,12 +150,14 @@ public class FroniusWattpilotHandler extends BaseThingHandler implements Wattpil
         String password = config.password;
 
         if (hostname == null || hostname.isBlank()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Hostname is missing");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.no-host");
             return;
         }
 
         if (password == null || password.isBlank()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Password is missing");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.no-password");
             return;
         }
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
@@ -44,8 +44,7 @@ public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
 
     @Activate
     public FroniusWattpilotHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
-        this.httpClient = httpClientFactory.createHttpClient("fronius-wattpilot");
-        httpClient.setIdleTimeout(30L * 1000);
+        this.httpClient = httpClientFactory.createHttpClient("openhab-fronius-wattpilot");
     }
 
     @Override

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
@@ -45,7 +45,7 @@ public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
     @Activate
     public FroniusWattpilotHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
         this.httpClient = httpClientFactory.createHttpClient("fronius-wattpilot");
-        httpClient.setIdleTimeout(30 * 1000);
+        httpClient.setIdleTimeout(30L * 1000);
     }
 
     @Override

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
@@ -44,7 +44,7 @@ public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
 
     @Activate
     public FroniusWattpilotHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
-        this.httpClient = httpClientFactory.createHttpClient("openhab-fronius-wattpilot");
+        this.httpClient = httpClientFactory.createHttpClient("fronius-wattpilot");
     }
 
     @Override

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.froniuswattpilot.internal;
+
+import static org.openhab.binding.froniuswattpilot.internal.FroniusWattpilotBindingConstants.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link FroniusWattpilotHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.froniuswattpilot", service = ThingHandlerFactory.class)
+public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE);
+
+    private final HttpClient httpClient;
+
+    @Activate
+    public FroniusWattpilotHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.createHttpClient("fronius-wattpilot");
+        httpClient.setIdleTimeout(30 * 1000);
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE.equals(thingTypeUID)) {
+            return new FroniusWattpilotHandler(thing, httpClient);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandlerFactory.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 @Component(configurationPid = "binding.froniuswattpilot", service = ThingHandlerFactory.class)
 public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE);
+    static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_WATTPILOT);
 
     private final HttpClient httpClient;
 
@@ -57,7 +57,7 @@ public class FroniusWattpilotHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (THING_TYPE.equals(thingTypeUID)) {
+        if (THING_TYPE_WATTPILOT.equals(thingTypeUID)) {
             return new FroniusWattpilotHandler(thing, httpClient);
         }
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotMDNSDiscoveryServiceParticipant.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotMDNSDiscoveryServiceParticipant.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.froniuswattpilot.internal;
+
+import static org.openhab.binding.froniuswattpilot.internal.FroniusWattpilotBindingConstants.*;
+import static org.openhab.binding.froniuswattpilot.internal.FroniusWattpilotHandlerFactory.SUPPORTED_THING_TYPES_UIDS;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * The {@link FroniusWattpilotMDNSDiscoveryServiceParticipant} is responsible for discovering new and removed Wattpilot
+ * wallboxes through mDNS. It uses the central
+ * {@link org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@Component(service = MDNSDiscoveryParticipant.class, configurationPid = "discovery.froniuswattpilot")
+@NonNullByDefault
+public class FroniusWattpilotMDNSDiscoveryServiceParticipant implements MDNSDiscoveryParticipant {
+
+    private static final String SERVICE_TYPE = "_Fronius-SE-Wattpilot._tcp.local.";
+
+    private boolean isAutoDiscoveryEnabled = true;
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        activateOrModifyService(componentContext);
+    }
+
+    @Modified
+    protected void modified(ComponentContext componentContext) {
+        activateOrModifyService(componentContext);
+    }
+
+    private void activateOrModifyService(ComponentContext componentContext) {
+        Dictionary<String, @Nullable Object> properties = componentContext.getProperties();
+        String autoDiscoveryPropertyValue = (String) properties
+                .get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
+        if (autoDiscoveryPropertyValue != null && !autoDiscoveryPropertyValue.isBlank()) {
+            isAutoDiscoveryEnabled = Boolean.valueOf(autoDiscoveryPropertyValue);
+        }
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override
+    public String getServiceType() {
+        return SERVICE_TYPE;
+    }
+
+    @Override
+    public @Nullable DiscoveryResult createResult(ServiceInfo service) {
+        if (isAutoDiscoveryEnabled) {
+            ThingUID uid = getThingUID(service);
+            if (uid != null) {
+                String[] addresses = service.getHostAddresses();
+                if (addresses == null || addresses.length == 0) {
+                    return null;
+                }
+                String ip = addresses[0];
+                return DiscoveryResultBuilder.create(uid) //
+                        .withProperties(Map.of( //
+                                "hostname", ip)) //
+                        .withLabel(service.getName()) //
+                        .withRepresentationProperty("hostname") //
+                        .build();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable ThingUID getThingUID(ServiceInfo service) {
+        String name = service.getName();
+        if (name != null && !name.isBlank()) {
+            return new ThingUID(THING_TYPE_WATTPILOT, name.replace("_", "-").replace(" ", "-").toLowerCase());
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotMDNSDiscoveryServiceParticipant.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotMDNSDiscoveryServiceParticipant.java
@@ -90,9 +90,9 @@ public class FroniusWattpilotMDNSDiscoveryServiceParticipant implements MDNSDisc
                 String ip = addresses[0];
                 return DiscoveryResultBuilder.create(uid) //
                         .withProperties(Map.of( //
-                                "hostname", ip)) //
+                                FroniusWattpilotBindingConstants.HOSTNAME_CONFIGURATION_KEY, ip)) //
                         .withLabel(service.getName()) //
-                        .withRepresentationProperty("hostname") //
+                        .withRepresentationProperty(FroniusWattpilotBindingConstants.HOSTNAME_CONFIGURATION_KEY) //
                         .build();
             }
         }

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/addon/addon.xml
@@ -6,5 +6,17 @@
 	<type>binding</type>
 	<name>Fronius Wattpilot Binding</name>
 	<description>This is the binding for Fronius Wattpilot wallboxes.</description>
+	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>mdns</service-type>
+			<discovery-parameters>
+				<discovery-parameter>
+					<name>mdnsServiceType</name>
+					<value>_Fronius-SE-Wattpilot._tcp.local.</value>
+				</discovery-parameter>
+			</discovery-parameters>
+		</discovery-method>
+	</discovery-methods>
 </addon:addon>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="froniuswattpilot" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>binding</type>
+	<name>Fronius Wattpilot Binding</name>
+	<description>This is the binding for Fronius Wattpilot wallboxes.</description>
+
+</addon:addon>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
@@ -1,0 +1,3 @@
+# FIXME: please add all English translations to this file so the texts can be translated using Crowdin
+# FIXME: to generate the content of this file run: mvn i18n:generate-default-translations
+# FIXME: see also: https://www.openhab.org/docs/developer/utils/i18n.html

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
@@ -1,3 +1,72 @@
-# FIXME: please add all English translations to this file so the texts can be translated using Crowdin
-# FIXME: to generate the content of this file run: mvn i18n:generate-default-translations
-# FIXME: see also: https://www.openhab.org/docs/developer/utils/i18n.html
+# add-on
+
+addon.froniuswattpilot.name = Fronius Wattpilot Binding
+addon.froniuswattpilot.description = This is the binding for Fronius Wattpilot wallboxes.
+
+# thing types
+
+thing-type.froniuswattpilot.wattpilot.label = Fronius Wattpilot
+thing-type.froniuswattpilot.wattpilot.description = Fronius Wattpilot wallbox
+
+# thing types config
+
+thing-type.config.froniuswattpilot.wattpilot.hostname.label = Hostname
+thing-type.config.froniuswattpilot.wattpilot.hostname.description = Hostname or IP address of the device
+thing-type.config.froniuswattpilot.wattpilot.password.label = Password
+thing-type.config.froniuswattpilot.wattpilot.password.description = Password to access the device (the same password as required by the Solar.Wattpilot app)
+
+# channel group types
+
+channel-group-type.froniuswattpilot.control.label = Charging Control
+channel-group-type.froniuswattpilot.metrics.label = Charging Metrics
+channel-group-type.froniuswattpilot.metrics.channel.energy-session.label = Charged Energy
+channel-group-type.froniuswattpilot.metrics.channel.energy-session.description = Energy charged in the current/last session
+channel-group-type.froniuswattpilot.metrics.channel.energy-total.label = Total Charged Energy
+channel-group-type.froniuswattpilot.metrics.channel.energy-total.description = Energy charged in total
+channel-group-type.froniuswattpilot.metrics.channel.l1-current.label = Phase 1 Current
+channel-group-type.froniuswattpilot.metrics.channel.l1-power.label = Phase 1 Power
+channel-group-type.froniuswattpilot.metrics.channel.l1-voltage.label = Phase 1 Voltage
+channel-group-type.froniuswattpilot.metrics.channel.l2-current.label = Phase 2 Current
+channel-group-type.froniuswattpilot.metrics.channel.l2-power.label = Phase 2 Power
+channel-group-type.froniuswattpilot.metrics.channel.l2-voltage.label = Phase 2 Voltage
+channel-group-type.froniuswattpilot.metrics.channel.l3-current.label = Phase 3 Current
+channel-group-type.froniuswattpilot.metrics.channel.l3-power.label = Phase 3 Power
+channel-group-type.froniuswattpilot.metrics.channel.l3-voltage.label = Phase 3 Voltage
+channel-group-type.froniuswattpilot.metrics.channel.power.label = Total Power
+channel-group-type.froniuswattpilot.status.label = Charging Status
+
+# channel types
+
+channel-type.froniuswattpilot.charging-allowed.label = Charging Allowed
+channel-type.froniuswattpilot.charging-allowed.description = Whether charging is currently allowed, e.g. when using eco mode too low solar sur-plus can forbid charging
+channel-type.froniuswattpilot.charging-allowed.state.option.ON = Allowed
+channel-type.froniuswattpilot.charging-allowed.state.option.OFF = Not Allowed
+channel-type.froniuswattpilot.charging-current.label = Charging Current
+channel-type.froniuswattpilot.charging-current.description = The current to charge with
+channel-type.froniuswattpilot.charging-mode.label = Charging Mode
+channel-type.froniuswattpilot.charging-mode.description = The mode of charging
+channel-type.froniuswattpilot.charging-mode.state.option.DEFAULT = Default
+channel-type.froniuswattpilot.charging-mode.state.option.ECO = Eco
+channel-type.froniuswattpilot.charging-mode.state.option.NEXT_TRIP = Next Trip
+channel-type.froniuswattpilot.charging-single-phase.label = Single Phase Charging
+channel-type.froniuswattpilot.charging-single-phase.description = Whether the wallbox is charging single phase only
+channel-type.froniuswattpilot.charging-single-phase.state.option.ON = Single Phase
+channel-type.froniuswattpilot.charging-single-phase.state.option.OFF = Three Phases
+channel-type.froniuswattpilot.charging-state.label = Charging State
+channel-type.froniuswattpilot.charging-state.description = Current Charging State of the wallbox
+channel-type.froniuswattpilot.charging-state.state.option.NO_CAR = No car connected
+channel-type.froniuswattpilot.charging-state.state.option.CHARGING = Charging
+channel-type.froniuswattpilot.charging-state.state.option.READY = Ready to charge
+channel-type.froniuswattpilot.charging-state.state.option.COMPLETE = Charging completed
+channel-type.froniuswattpilot.enforced-charging-state.label = Enforced Charging State
+channel-type.froniuswattpilot.enforced-charging-state.description = Enforced charging state, i.e. force/forbid charging or let the wallbox decide
+channel-type.froniuswattpilot.enforced-charging-state.state.option.NEUTRAL = Wallbox decides
+channel-type.froniuswattpilot.enforced-charging-state.state.option.ON = Force charging
+channel-type.froniuswattpilot.enforced-charging-state.state.option.OFF = Forbid charging
+channel-type.froniuswattpilot.pv-surplus-threshold.label = PV Surplus Power Threshold
+channel-type.froniuswattpilot.pv-surplus-threshold.description = The PV Surplus power at which surplus charging starts
+
+# thing status description
+
+offline.configuration-error.no-host = No host configured
+offline.configuration-error.no-password = No password configured

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
@@ -64,16 +64,3 @@ channel-type.froniuswattpilot.charging-state.state.option.READY = Ready to charg
 channel-type.froniuswattpilot.charging-state.state.option.COMPLETE = Charging completed
 channel-type.froniuswattpilot.pv-surplus-threshold.label = PV Surplus Power Threshold
 channel-type.froniuswattpilot.pv-surplus-threshold.description = The PV Surplus power at which surplus charging starts
-
-# channel types
-
-channel-type.froniuswattpilot.enforced-charging-state.label = Enforced Charging State
-channel-type.froniuswattpilot.enforced-charging-state.description = Force or forbid charging, or let the wallbox decide
-channel-type.froniuswattpilot.enforced-charging-state.state.option.NEUTRAL = Wallbox decides
-channel-type.froniuswattpilot.enforced-charging-state.state.option.ON = Force charging
-channel-type.froniuswattpilot.enforced-charging-state.state.option.OFF = Forbid charging
-
-# thing status description
-
-offline.configuration-error.no-host = No host configured
-offline.configuration-error.no-password = No password configured

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
@@ -38,7 +38,7 @@ channel-group-type.froniuswattpilot.status.label = Charging Status
 # channel types
 
 channel-type.froniuswattpilot.charging-allowed.label = Charging Allowed
-channel-type.froniuswattpilot.charging-allowed.description = Whether charging is currently allowed, e.g. when using eco mode too low solar sur-plus can forbid charging
+channel-type.froniuswattpilot.charging-allowed.description = Whether charging is currently allowed, e.g. when using eco mode too low PV surplus can forbid charging
 channel-type.froniuswattpilot.charging-allowed.state.option.ON = Allowed
 channel-type.froniuswattpilot.charging-allowed.state.option.OFF = Not Allowed
 channel-type.froniuswattpilot.charging-current.label = Charging Current
@@ -53,13 +53,13 @@ channel-type.froniuswattpilot.charging-single-phase.description = Whether the wa
 channel-type.froniuswattpilot.charging-single-phase.state.option.ON = Single Phase
 channel-type.froniuswattpilot.charging-single-phase.state.option.OFF = Three Phases
 channel-type.froniuswattpilot.charging-state.label = Charging State
-channel-type.froniuswattpilot.charging-state.description = Current Charging State of the wallbox
+channel-type.froniuswattpilot.charging-state.description = Charging State of the wallbox
 channel-type.froniuswattpilot.charging-state.state.option.NO_CAR = No car connected
 channel-type.froniuswattpilot.charging-state.state.option.CHARGING = Charging
 channel-type.froniuswattpilot.charging-state.state.option.READY = Ready to charge
 channel-type.froniuswattpilot.charging-state.state.option.COMPLETE = Charging completed
 channel-type.froniuswattpilot.enforced-charging-state.label = Enforced Charging State
-channel-type.froniuswattpilot.enforced-charging-state.description = Enforced charging state, i.e. force/forbid charging or let the wallbox decide
+channel-type.froniuswattpilot.enforced-charging-state.description = Force or forbid charging, or let the wallbox decide
 channel-type.froniuswattpilot.enforced-charging-state.state.option.NEUTRAL = Wallbox decides
 channel-type.froniuswattpilot.enforced-charging-state.state.option.ON = Force charging
 channel-type.froniuswattpilot.enforced-charging-state.state.option.OFF = Forbid charging

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
@@ -38,9 +38,9 @@ channel-group-type.froniuswattpilot.status.label = Charging Status
 # channel types
 
 channel-type.froniuswattpilot.charging-allowed.label = Charging Allowed
-channel-type.froniuswattpilot.charging-allowed.description = Whether charging is currently allowed, e.g. when using eco mode too low PV surplus can forbid charging
-channel-type.froniuswattpilot.charging-allowed.state.option.ON = Allowed
-channel-type.froniuswattpilot.charging-allowed.state.option.OFF = Not Allowed
+channel-type.froniuswattpilot.charging-allowed.description = Allow or forbid charging
+channel-type.froniuswattpilot.charging-allowed.state.option.ON = Allow charging
+channel-type.froniuswattpilot.charging-allowed.state.option.OFF = Forbid charging
 channel-type.froniuswattpilot.charging-current.label = Charging Current
 channel-type.froniuswattpilot.charging-current.description = The current to charge with
 channel-type.froniuswattpilot.charging-mode.label = Charging Mode
@@ -48,6 +48,10 @@ channel-type.froniuswattpilot.charging-mode.description = The mode of charging
 channel-type.froniuswattpilot.charging-mode.state.option.DEFAULT = Default
 channel-type.froniuswattpilot.charging-mode.state.option.ECO = Eco
 channel-type.froniuswattpilot.charging-mode.state.option.NEXT_TRIP = Next Trip
+channel-type.froniuswattpilot.charging-possible.label = Charging Possible
+channel-type.froniuswattpilot.charging-possible.description = Whether charging is currently possible, e.g. when using ECO mode, too low PV surplus can block charging
+channel-type.froniuswattpilot.charging-possible.state.option.ON = Possible
+channel-type.froniuswattpilot.charging-possible.state.option.OFF = Not Possible
 channel-type.froniuswattpilot.charging-single-phase.label = Single Phase Charging
 channel-type.froniuswattpilot.charging-single-phase.description = Whether the wallbox is charging single phase only
 channel-type.froniuswattpilot.charging-single-phase.state.option.ON = Single Phase
@@ -58,13 +62,16 @@ channel-type.froniuswattpilot.charging-state.state.option.NO_CAR = No car connec
 channel-type.froniuswattpilot.charging-state.state.option.CHARGING = Charging
 channel-type.froniuswattpilot.charging-state.state.option.READY = Ready to charge
 channel-type.froniuswattpilot.charging-state.state.option.COMPLETE = Charging completed
+channel-type.froniuswattpilot.pv-surplus-threshold.label = PV Surplus Power Threshold
+channel-type.froniuswattpilot.pv-surplus-threshold.description = The PV Surplus power at which surplus charging starts
+
+# channel types
+
 channel-type.froniuswattpilot.enforced-charging-state.label = Enforced Charging State
 channel-type.froniuswattpilot.enforced-charging-state.description = Force or forbid charging, or let the wallbox decide
 channel-type.froniuswattpilot.enforced-charging-state.state.option.NEUTRAL = Wallbox decides
 channel-type.froniuswattpilot.enforced-charging-state.state.option.ON = Force charging
 channel-type.froniuswattpilot.enforced-charging-state.state.option.OFF = Forbid charging
-channel-type.froniuswattpilot.pv-surplus-threshold.label = PV Surplus Power Threshold
-channel-type.froniuswattpilot.pv-surplus-threshold.description = The PV Surplus power at which surplus charging starts
 
 # thing status description
 

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/i18n/froniuswattpilot.properties
@@ -24,15 +24,25 @@ channel-group-type.froniuswattpilot.metrics.channel.energy-session.description =
 channel-group-type.froniuswattpilot.metrics.channel.energy-total.label = Total Charged Energy
 channel-group-type.froniuswattpilot.metrics.channel.energy-total.description = Energy charged in total
 channel-group-type.froniuswattpilot.metrics.channel.l1-current.label = Phase 1 Current
+channel-group-type.froniuswattpilot.metrics.channel.l1-current.description = Charging current on phase 1
 channel-group-type.froniuswattpilot.metrics.channel.l1-power.label = Phase 1 Power
+channel-group-type.froniuswattpilot.metrics.channel.l1-power.description = Charging power on phase 1
 channel-group-type.froniuswattpilot.metrics.channel.l1-voltage.label = Phase 1 Voltage
+channel-group-type.froniuswattpilot.metrics.channel.l1-voltage.description = Current voltage on phase 1
 channel-group-type.froniuswattpilot.metrics.channel.l2-current.label = Phase 2 Current
+channel-group-type.froniuswattpilot.metrics.channel.l2-current.description = Charging current on phase 2
 channel-group-type.froniuswattpilot.metrics.channel.l2-power.label = Phase 2 Power
+channel-group-type.froniuswattpilot.metrics.channel.l2-power.description = Charging power on phase 2
 channel-group-type.froniuswattpilot.metrics.channel.l2-voltage.label = Phase 2 Voltage
+channel-group-type.froniuswattpilot.metrics.channel.l2-voltage.description = Current voltage on phase 2
 channel-group-type.froniuswattpilot.metrics.channel.l3-current.label = Phase 3 Current
+channel-group-type.froniuswattpilot.metrics.channel.l3-current.description = Charging current on phase 3
 channel-group-type.froniuswattpilot.metrics.channel.l3-power.label = Phase 3 Power
+channel-group-type.froniuswattpilot.metrics.channel.l3-power.description = Charging power on phase 3
 channel-group-type.froniuswattpilot.metrics.channel.l3-voltage.label = Phase 3 Voltage
+channel-group-type.froniuswattpilot.metrics.channel.l3-voltage.description = Current voltage on phase 3
 channel-group-type.froniuswattpilot.metrics.channel.power.label = Total Power
+channel-group-type.froniuswattpilot.metrics.channel.power.description = Total charging power
 channel-group-type.froniuswattpilot.status.label = Charging Status
 
 # channel types

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -99,6 +99,9 @@
 		<label>Charging State</label>
 		<description>Current Charging State of the wallbox</description>
 		<category>BatteryLevel</category>
+		<tags>
+			<tag>Status</tag>
+		</tags>
 		<state readOnly="true">
 			<options>
 				<option value="NO_CAR">No car connected</option>
@@ -114,6 +117,9 @@
 		<description>Whether charging is currently allowed, e.g. when using eco mode too low solar sur-plus can forbid
 			charging</description>
 		<category>BatteryLevel</category>
+		<tags>
+			<tag>Status</tag>
+		</tags>
 		<state readOnly="true">
 			<options>
 				<option value="ON">Allowed</option>
@@ -126,6 +132,9 @@
 		<label>Single Phase Charging</label>
 		<description>Whether the wallbox is charging single phase only</description>
 		<category>BatteryLevel</category>
+		<tags>
+			<tag>Status</tag>
+		</tags>
 		<state readOnly="true">
 			<options>
 				<option value="ON">Single Phase</option>
@@ -138,6 +147,9 @@
 		<label>Enforced Charging State</label>
 		<description>Enforced charging state, i.e. force/forbid charging or let the wallbox decide</description>
 		<category>BatteryLevel</category>
+		<tags>
+			<tag>Control</tag>
+		</tags>
 		<state>
 			<options>
 				<option value="NEUTRAL">Wallbox decides</option>
@@ -152,6 +164,9 @@
 		<label>Charging Mode</label>
 		<description>The mode of charging</description>
 		<category>BatteryLevel</category>
+		<tags>
+			<tag>Control</tag>
+		</tags>
 		<state>
 			<options>
 				<option value="DEFAULT">Default</option>
@@ -166,6 +181,10 @@
 		<label>Charging Current</label>
 		<description>The current to charge with</description>
 		<category>Energy</category>
+		<tags>
+			<tag>Setpoint</tag>
+			<tag>Current</tag>
+		</tags>
 		<state pattern="%d A" min="6" max="32" step="1"/>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
@@ -174,6 +193,10 @@
 		<label>PV Surplus Power Threshold</label>
 		<description>The PV Surplus power at which surplus charging starts</description>
 		<category>SolarPlant</category>
+		<tags>
+			<tag>Setpoint</tag>
+			<tag>Power</tag>
+		</tags>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -63,6 +63,7 @@
 		<channels>
 			<channel id="power" typeId="system.electric-power">
 				<label>Total Power</label>
+				<description>Total charging power</description>
 			</channel>
 			<channel id="energy-session" typeId="system.electric-energy">
 				<label>Charged Energy</label>
@@ -74,30 +75,39 @@
 			</channel>
 			<channel id="l1-power" typeId="system.electric-power">
 				<label>Phase 1 Power</label>
+				<description>Charging power on phase 1</description>
 			</channel>
 			<channel id="l2-power" typeId="system.electric-power">
 				<label>Phase 2 Power</label>
+				<description>Charging power on phase 2</description>
 			</channel>
 			<channel id="l3-power" typeId="system.electric-power">
 				<label>Phase 3 Power</label>
+				<description>Charging power on phase 3</description>
 			</channel>
 			<channel id="l1-voltage" typeId="system.electric-voltage">
 				<label>Phase 1 Voltage</label>
+				<description>Current voltage on phase 1</description>
 			</channel>
 			<channel id="l2-voltage" typeId="system.electric-voltage">
 				<label>Phase 2 Voltage</label>
+				<description>Current voltage on phase 2</description>
 			</channel>
 			<channel id="l3-voltage" typeId="system.electric-voltage">
 				<label>Phase 3 Voltage</label>
+				<description>Current voltage on phase 3</description>
 			</channel>
 			<channel id="l1-current" typeId="system.electric-current">
 				<label>Phase 1 Current</label>
+				<description>Charging current on phase 1</description>
 			</channel>
 			<channel id="l2-current" typeId="system.electric-current">
 				<label>Phase 2 Current</label>
+				<description>Charging current on phase 2</description>
 			</channel>
 			<channel id="l3-current" typeId="system.electric-current">
 				<label>Phase 3 Current</label>
+				<description>Charging current on phase 3</description>
 			</channel>
 		</channels>
 	</channel-group-type>
@@ -107,7 +117,7 @@
 		<item-type>Switch</item-type>
 		<label>Charging Allowed</label>
 		<description>Allow or forbid charging</description>
-		<category>BatteryLevel</category>
+		<category>Battery</category>
 		<tags>
 			<tag>Control</tag>
 		</tags>
@@ -123,9 +133,10 @@
 		<item-type>String</item-type>
 		<label>Charging Mode</label>
 		<description>The mode of charging</description>
-		<category>BatteryLevel</category>
+		<category>Battery</category>
 		<tags>
 			<tag>Control</tag>
+			<tag>Mode</tag>
 		</tags>
 		<state>
 			<options>
@@ -164,7 +175,7 @@
 		<item-type>String</item-type>
 		<label>Charging State</label>
 		<description>Charging State of the wallbox</description>
-		<category>BatteryLevel</category>
+		<category>Battery</category>
 		<tags>
 			<tag>Status</tag>
 		</tags>
@@ -181,7 +192,7 @@
 		<item-type>Switch</item-type>
 		<label>Charging Possible</label>
 		<description>Whether charging is currently possible, e.g. when using ECO mode, too low PV surplus can block charging</description>
-		<category>BatteryLevel</category>
+		<category>Battery</category>
 		<tags>
 			<tag>Status</tag>
 		</tags>
@@ -196,7 +207,7 @@
 		<item-type>Switch</item-type>
 		<label>Single Phase Charging</label>
 		<description>Whether the wallbox is charging single phase only</description>
-		<category>BatteryLevel</category>
+		<category>Battery</category>
 		<tags>
 			<tag>Status</tag>
 		</tags>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -18,6 +18,7 @@
 		<properties>
 			<property name="serialNumber"/>
 			<property name="firmwareVersion"/>
+			<property name="thingTypeVersion">1</property>
 		</properties>
 
 		<representation-property>hostname</representation-property>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -104,7 +104,7 @@
 	<channel-type id="charging-state">
 		<item-type>String</item-type>
 		<label>Charging State</label>
-		<description>Current Charging State of the wallbox</description>
+		<description>Charging State of the wallbox</description>
 		<category>BatteryLevel</category>
 		<tags>
 			<tag>Status</tag>
@@ -121,8 +121,7 @@
 	<channel-type id="charging-allowed">
 		<item-type>Switch</item-type>
 		<label>Charging Allowed</label>
-		<description>Whether charging is currently allowed, e.g. when using eco mode too low solar sur-plus can forbid
-			charging</description>
+		<description>Whether charging is currently allowed, e.g. when using eco mode too low PV surplus can forbid charging</description>
 		<category>BatteryLevel</category>
 		<tags>
 			<tag>Status</tag>
@@ -152,7 +151,7 @@
 	<channel-type id="enforced-charging-state">
 		<item-type>String</item-type>
 		<label>Enforced Charging State</label>
-		<description>Enforced charging state, i.e. force/forbid charging or let the wallbox decide</description>
+		<description>Force or forbid charging, or let the wallbox decide</description>
 		<category>BatteryLevel</category>
 		<tags>
 			<tag>Control</tag>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -101,54 +101,7 @@
 		</channels>
 	</channel-group-type>
 
-	<!-- Channel Types -->
-	<channel-type id="charging-state">
-		<item-type>String</item-type>
-		<label>Charging State</label>
-		<description>Charging State of the wallbox</description>
-		<category>BatteryLevel</category>
-		<tags>
-			<tag>Status</tag>
-		</tags>
-		<state readOnly="true">
-			<options>
-				<option value="NO_CAR">No car connected</option>
-				<option value="CHARGING">Charging</option>
-				<option value="READY">Ready to charge</option>
-				<option value="COMPLETE">Charging completed</option>
-			</options>
-		</state>
-	</channel-type>
-	<channel-type id="charging-possible">
-		<item-type>Switch</item-type>
-		<label>Charging Possible</label>
-		<description>Whether charging is currently possible, e.g. when using ECO mode, too low PV surplus can block charging</description>
-		<category>BatteryLevel</category>
-		<tags>
-			<tag>Status</tag>
-		</tags>
-		<state readOnly="true">
-			<options>
-				<option value="ON">Possible</option>
-				<option value="OFF">Not Possible</option>
-			</options>
-		</state>
-	</channel-type>
-	<channel-type id="charging-single-phase">
-		<item-type>Switch</item-type>
-		<label>Single Phase Charging</label>
-		<description>Whether the wallbox is charging single phase only</description>
-		<category>BatteryLevel</category>
-		<tags>
-			<tag>Status</tag>
-		</tags>
-		<state readOnly="true">
-			<options>
-				<option value="ON">Single Phase</option>
-				<option value="OFF">Three Phases</option>
-			</options>
-		</state>
-	</channel-type>
+	<!-- Control Channel Types -->
 	<channel-type id="charging-allowed">
 		<item-type>Switch</item-type>
 		<label>Charging Allowed</label>
@@ -204,5 +157,53 @@
 			<tag>Power</tag>
 		</tags>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+	<!-- Status Channel Types -->
+	<channel-type id="charging-state">
+		<item-type>String</item-type>
+		<label>Charging State</label>
+		<description>Charging State of the wallbox</description>
+		<category>BatteryLevel</category>
+		<tags>
+			<tag>Status</tag>
+		</tags>
+		<state readOnly="true">
+			<options>
+				<option value="NO_CAR">No car connected</option>
+				<option value="CHARGING">Charging</option>
+				<option value="READY">Ready to charge</option>
+				<option value="COMPLETE">Charging completed</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="charging-possible">
+		<item-type>Switch</item-type>
+		<label>Charging Possible</label>
+		<description>Whether charging is currently possible, e.g. when using ECO mode, too low PV surplus can block charging</description>
+		<category>BatteryLevel</category>
+		<tags>
+			<tag>Status</tag>
+		</tags>
+		<state readOnly="true">
+			<options>
+				<option value="ON">Possible</option>
+				<option value="OFF">Not Possible</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="charging-single-phase">
+		<item-type>Switch</item-type>
+		<label>Single Phase Charging</label>
+		<description>Whether the wallbox is charging single phase only</description>
+		<category>BatteryLevel</category>
+		<tags>
+			<tag>Status</tag>
+		</tags>
+		<state readOnly="true">
+			<options>
+				<option value="ON">Single Phase</option>
+				<option value="OFF">Three Phases</option>
+			</options>
+		</state>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -41,7 +41,7 @@
 	<channel-group-type id="control">
 		<label>Charging Control</label>
 		<channels>
-			<channel id="enforced-charging-state" typeId="enforced-charging-state"/>
+			<channel id="charging-allowed" typeId="charging-allowed"/>
 			<channel id="charging-mode" typeId="charging-mode"/>
 			<channel id="charging-current" typeId="charging-current"/>
 			<channel id="pv-surplus-threshold" typeId="pv-surplus-threshold"/>
@@ -52,7 +52,7 @@
 		<label>Charging Status</label>
 		<channels>
 			<channel id="charging-state" typeId="charging-state"/>
-			<channel id="charging-allowed" typeId="charging-allowed"/>
+			<channel id="charging-possible" typeId="charging-possible"/>
 			<channel id="single-phase" typeId="charging-single-phase"/>
 		</channels>
 	</channel-group-type>
@@ -119,18 +119,18 @@
 			</options>
 		</state>
 	</channel-type>
-	<channel-type id="charging-allowed">
+	<channel-type id="charging-possible">
 		<item-type>Switch</item-type>
-		<label>Charging Allowed</label>
-		<description>Whether charging is currently allowed, e.g. when using eco mode too low PV surplus can forbid charging</description>
+		<label>Charging Possible</label>
+		<description>Whether charging is currently possible, e.g. when using ECO mode, too low PV surplus can block charging</description>
 		<category>BatteryLevel</category>
 		<tags>
 			<tag>Status</tag>
 		</tags>
 		<state readOnly="true">
 			<options>
-				<option value="ON">Allowed</option>
-				<option value="OFF">Not Allowed</option>
+				<option value="ON">Possible</option>
+				<option value="OFF">Not Possible</option>
 			</options>
 		</state>
 	</channel-type>
@@ -149,18 +149,17 @@
 			</options>
 		</state>
 	</channel-type>
-	<channel-type id="enforced-charging-state">
-		<item-type>String</item-type>
-		<label>Enforced Charging State</label>
-		<description>Force or forbid charging, or let the wallbox decide</description>
+	<channel-type id="charging-allowed">
+		<item-type>Switch</item-type>
+		<label>Charging Allowed</label>
+		<description>Allow or forbid charging</description>
 		<category>BatteryLevel</category>
 		<tags>
 			<tag>Control</tag>
 		</tags>
 		<state>
 			<options>
-				<option value="NEUTRAL">Wallbox decides</option>
-				<option value="ON">Force charging</option>
+				<option value="ON">Allow charging</option>
 				<option value="OFF">Forbid charging</option>
 			</options>
 		</state>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="froniuswattpilot"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Thing Types -->
+	<thing-type id="wattpilot">
+		<label>Fronius Wattpilot</label>
+		<description>Fronius Wattpilot wallbox</description>
+
+		<channel-groups>
+			<channel-group id="status" typeId="status"/>
+			<channel-group id="metrics" typeId="metrics"/>
+		</channel-groups>
+
+		<config-description>
+			<parameter name="hostname" type="text" required="true">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="password" type="text" required="true">
+				<context>password</context>
+				<label>Password</label>
+				<description>Password to access the device (the same password as required by the Solar.Wattpilot app)</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<!-- Channel Group Types -->
+	<channel-group-type id="status">
+		<label>Charging Status</label>
+		<channels>
+			<channel id="charging-state" typeId="charging-state"/>
+			<channel id="charging-allowed" typeId="charging-allowed"/>
+			<channel id="single-phase" typeId="charging-single-phase"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="metrics">
+		<label>Charging Metrics</label>
+		<channels>
+			<channel id="power" typeId="system.electric-power">
+				<label>Total Power</label>
+			</channel>
+			<channel id="energy-session" typeId="system.electric-energy">
+				<label>Charged Energy</label>
+				<description>Energy charged in the current/last session</description>
+			</channel>
+			<channel id="l1-power" typeId="system.electric-power">
+				<label>Phase 1 Power</label>
+			</channel>
+			<channel id="l2-power" typeId="system.electric-power">
+				<label>Phase 2 Power</label>
+			</channel>
+			<channel id="l3-power" typeId="system.electric-power">
+				<label>Phase 3 Power</label>
+			</channel>
+			<channel id="l1-voltage" typeId="system.electric-voltage">
+				<label>Phase 1 Voltage</label>
+			</channel>
+			<channel id="l2-voltage" typeId="system.electric-voltage">
+				<label>Phase 2 Voltage</label>
+			</channel>
+			<channel id="l3-voltage" typeId="system.electric-voltage">
+				<label>Phase 3 Voltage</label>
+			</channel>
+			<channel id="l1-current" typeId="system.electric-current">
+				<label>Phase 1 Current</label>
+			</channel>
+			<channel id="l2-current" typeId="system.electric-current">
+				<label>Phase 2 Current</label>
+			</channel>
+			<channel id="l3-current" typeId="system.electric-current">
+				<label>Phase 3 Current</label>
+			</channel>
+		</channels>
+	</channel-group-type>
+
+	<!-- Channel Types -->
+	<channel-type id="charging-state">
+		<item-type>String</item-type>
+		<label>Charging State</label>
+		<description>Current Charging State of the wallbox</description>
+		<state readOnly="true">
+			<options>
+				<option value="NO_CAR">No car connected</option>
+				<option value="CHARGING">Charging</option>
+				<option value="READY">Ready to charge</option>
+				<option value="COMPLETE">Charging completed</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="charging-allowed">
+		<item-type>Switch</item-type>
+		<label>Charging Allowed</label>
+		<description>Whether charging is currently allowed, e.g. when using eco mode too low solar sur-plus can forbid
+			charging</description>
+		<state readOnly="true">
+			<options>
+				<option value="ON">Allowed</option>
+				<option value="OFF">Not Allowed</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="charging-single-phase">
+		<item-type>Switch</item-type>
+		<label>Single Phase Charging</label>
+		<description>Whether the wallbox is charging single phase only</description>
+		<state readOnly="true">
+			<options>
+				<option value="ON">Single Phase</option>
+				<option value="OFF">Three Phase</option>
+			</options>
+		</state>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -15,6 +15,11 @@
 			<channel-group id="metrics" typeId="metrics"/>
 		</channel-groups>
 
+		<properties>
+			<property name="serialNumber"/>
+			<property name="firmwareVersion"/>
+		</properties>
+
 		<config-description>
 			<parameter name="hostname" type="text" required="true">
 				<context>network-address</context>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -10,6 +10,7 @@
 		<description>Fronius Wattpilot wallbox</description>
 
 		<channel-groups>
+			<channel-group id="control" typeId="control"/>
 			<channel-group id="status" typeId="status"/>
 			<channel-group id="metrics" typeId="metrics"/>
 		</channel-groups>
@@ -29,6 +30,16 @@
 	</thing-type>
 
 	<!-- Channel Group Types -->
+	<channel-group-type id="control">
+		<label>Charging Control</label>
+		<channels>
+			<channel id="enforced-charging-state" typeId="enforced-charging-state"/>
+			<channel id="charging-mode" typeId="charging-mode"/>
+			<channel id="charging-current" typeId="charging-current"/>
+			<channel id="pv-surplus-threshold" typeId="pv-surplus-threshold"/>
+		</channels>
+	</channel-group-type>
+
 	<channel-group-type id="status">
 		<label>Charging Status</label>
 		<channels>
@@ -47,6 +58,10 @@
 			<channel id="energy-session" typeId="system.electric-energy">
 				<label>Charged Energy</label>
 				<description>Energy charged in the current/last session</description>
+			</channel>
+			<channel id="energy-total" typeId="system.electric-energy">
+				<label>Total Charged Energy</label>
+				<description>Energy charged in total</description>
 			</channel>
 			<channel id="l1-power" typeId="system.electric-power">
 				<label>Phase 1 Power</label>
@@ -83,6 +98,7 @@
 		<item-type>String</item-type>
 		<label>Charging State</label>
 		<description>Current Charging State of the wallbox</description>
+		<category>BatteryLevel</category>
 		<state readOnly="true">
 			<options>
 				<option value="NO_CAR">No car connected</option>
@@ -97,6 +113,7 @@
 		<label>Charging Allowed</label>
 		<description>Whether charging is currently allowed, e.g. when using eco mode too low solar sur-plus can forbid
 			charging</description>
+		<category>BatteryLevel</category>
 		<state readOnly="true">
 			<options>
 				<option value="ON">Allowed</option>
@@ -108,11 +125,55 @@
 		<item-type>Switch</item-type>
 		<label>Single Phase Charging</label>
 		<description>Whether the wallbox is charging single phase only</description>
+		<category>BatteryLevel</category>
 		<state readOnly="true">
 			<options>
 				<option value="ON">Single Phase</option>
-				<option value="OFF">Three Phase</option>
+				<option value="OFF">Three Phases</option>
 			</options>
 		</state>
+	</channel-type>
+	<channel-type id="enforced-charging-state">
+		<item-type>String</item-type>
+		<label>Enforced Charging State</label>
+		<description>Enforced charging state, i.e. force/forbid charging or let the wallbox decide</description>
+		<category>BatteryLevel</category>
+		<state>
+			<options>
+				<option value="NEUTRAL">Wallbox decides</option>
+				<option value="ON">Force charging</option>
+				<option value="OFF">Forbid charging</option>
+			</options>
+		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+	<channel-type id="charging-mode">
+		<item-type>String</item-type>
+		<label>Charging Mode</label>
+		<description>The mode of charging</description>
+		<category>BatteryLevel</category>
+		<state>
+			<options>
+				<option value="DEFAULT">Default</option>
+				<option value="ECO">Eco</option>
+				<option value="NEXT_TRIP">Next Trip</option>
+			</options>
+		</state>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+	<channel-type id="charging-current">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Charging Current</label>
+		<description>The current to charge with</description>
+		<category>Energy</category>
+		<state pattern="%d A" min="6" max="32" step="1"/>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
+	</channel-type>
+	<channel-type id="pv-surplus-threshold">
+		<item-type>Number:Power</item-type>
+		<label>PV Surplus Power Threshold</label>
+		<description>The PV Surplus power at which surplus charging starts</description>
+		<category>SolarPlant</category>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -20,6 +20,8 @@
 			<property name="firmwareVersion"/>
 		</properties>
 
+		<representation-property>hostname</representation-property>
+
 		<config-description>
 			<parameter name="hostname" type="text" required="true">
 				<context>network-address</context>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 	<thing-type id="wattpilot">
 		<label>Fronius Wattpilot</label>
 		<description>Fronius Wattpilot wallbox</description>
+		<semantic-equipment-tag>EVSE</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control"/>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -166,6 +166,7 @@
     <module>org.openhab.binding.freecurrency</module>
     <module>org.openhab.binding.frenchgovtenergydata</module>
     <module>org.openhab.binding.fronius</module>
+    <module>org.openhab.binding.froniuswattpilot</module>
     <module>org.openhab.binding.fsinternetradio</module>
     <module>org.openhab.binding.ftpupload</module>
     <module>org.openhab.binding.gardena</module>


### PR DESCRIPTION
This adds a new binding that allows to integrate Fronius Wattpilot wallboxes into openHAB.

It has been tested with the following models:

- Fronius Wattpilot Home 11J (tested by @sihui62)
- Fronius Wattpilot Home 22J (tested myself)