### PR TITLE
[jdbc] Upgrade Yank to 3.5.0

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -20,9 +20,9 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <hikari.version>2.4.7</hikari.version>
-    <dbutils.version>1.6</dbutils.version>
-    <yank.version>3.4.0</yank.version>
+    <hikari.version>5.1.0</hikari.version>
+    <dbutils.version>1.8.1</dbutils.version>
+    <yank.version>3.5.0</yank.version>
 
     <!-- JDBC database driver versions -->
     <derby.version>10.17.1.0</derby.version>

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -266,7 +266,7 @@ public class JdbcPersistenceService extends JdbcMapper implements ModifiablePers
         }
     }
 
-    public void updateConfig(Map<Object, Object> configuration) {
+    private void updateConfig(Map<Object, Object> configuration) {
         logger.debug("JDBC::updateConfig");
 
         conf = new JdbcConfiguration(configuration);

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/db/JdbcBaseDAO.java
@@ -247,7 +247,9 @@ public class JdbcBaseDAO {
     }
 
     public Properties getConnectionProperties() {
-        return new Properties(this.databaseProps);
+        Properties properties = new Properties(databaseProps.size());
+        properties.putAll(databaseProps);
+        return properties;
     }
 
     /**************


### PR DESCRIPTION
Upgrade Yank with related dependencies:
- Updated to [Hikari-CP 5.1.0](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES).
- Updated to [commons-dbutils 1.8.1](https://commons.apache.org/proper/commons-dbutils/changes-report.html).

brettwooldridge/HikariCP@5f3c97702facbdd09e91632324d26e952b4cc62c dropped support for `Properties` defaults in HikariCP 2.4.9, therefore `getConnectionProperties` had to be adapted.