### PR TITLE
[various] Fix xml validation errors

### DIFF
--- a/bundles/org.openhab.binding.argoclima/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.argoclima/src/main/resources/OH-INF/thing/thing-types.xml
@@ -316,7 +316,7 @@
 		<category>Climate</category>
 		<tags>
 			<tag>Control</tag>
-			<tag>Climate</tag>
+			<tag>Mode</tag>
 		</tags>
 		<state readOnly="false">
 			<options>

--- a/bundles/org.openhab.binding.casokitchen/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.casokitchen/src/main/resources/OH-INF/thing/channel-types.xml
@@ -9,8 +9,8 @@
 		<label>Temperature</label>
 		<description>Current Zone Temperature</description>
 		<tags>
-			<tag>Temperature</tag>
 			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
@@ -19,8 +19,8 @@
 		<label>Target Temperature</label>
 		<description>Target Zone Temperature</description>
 		<tags>
+			<tag>Setpoint</tag>
 			<tag>Temperature</tag>
-			<tag>SetPoint</tag>
 		</tags>
 		<state pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/group-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/group-thing-types.xml
@@ -33,7 +33,8 @@
 		<label>All On</label>
 		<description>"On" if all lights in this group are "On", otherwise "Off".</description>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Switch</tag>
+			<tag>Light</tag>
 		</tags>
 		<state readOnly="true"/>
 	</channel-type>
@@ -43,7 +44,8 @@
 		<label>Any On</label>
 		<description>"On" if any light in this group is "On", otherwise "Off".</description>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Switch</tag>
+			<tag>Light</tag>
 		</tags>
 		<state readOnly="true"/>
 	</channel-type>
@@ -52,7 +54,8 @@
 		<item-type>String</item-type>
 		<label>Recall Scene</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Mode</tag>
 		</tags>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
@@ -180,7 +180,8 @@
 		<item-type>String</item-type>
 		<label>Effect Channel</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Status</tag>
+			<tag>Mode</tag>
 		</tags>
 	</channel-type>
 
@@ -188,7 +189,8 @@
 		<item-type>Number</item-type>
 		<label>Effect Speed Channel</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Speed</tag>
 		</tags>
 		<state min="0" max="10" step="1"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
@@ -69,7 +69,7 @@
 		<category>Moisture</category>
 		<tags>
 			<tag>Measurement</tag>
-			<tag>Rain</tag>
+			<tag>Humidity</tag>
 		</tags>
 		<state pattern="%.0f %%" readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
@@ -69,7 +69,7 @@
 		<category>Moisture</category>
 		<tags>
 			<tag>Measurement</tag>
-			<tag>Moisture</tag>
+			<tag>Rain</tag>
 		</tags>
 		<state pattern="%.0f %%" readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
@@ -69,7 +69,6 @@
 		<category>Moisture</category>
 		<tags>
 			<tag>Measurement</tag>
-			<tag>Humidity</tag>
 		</tags>
 		<state pattern="%.0f %%" readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
+++ b/bundles/org.openhab.binding.fineoffsetweatherstation/src/main/resources/OH-INF/thing/gateway.xml
@@ -67,9 +67,6 @@
 		<item-type>Number:Dimensionless</item-type>
 		<label>Moisture</label>
 		<category>Moisture</category>
-		<tags>
-			<tag>Measurement</tag>
-		</tags>
 		<state pattern="%.0f %%" readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/OH-INF/thing/channels.xml
@@ -159,7 +159,7 @@
 	</channel-type>
 
 	<channel-type id="modulationLevel">
-		<item-type>Number:DimensionLess</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Modulelation Level</label>
 		<description>Gets the modulation level of this boiler</description>
 		<category>heating</category>
@@ -263,7 +263,7 @@
 	</channel-type>
 
 	<channel-type id="valvePosition">
-		<item-type>Number:DimensionLess</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Valve Position</label>
 		<description>Gets the position of the valve (0% closed, 100% open)</description>
 		<category>heating</category>

--- a/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wiz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -115,7 +115,8 @@
 		<item-type>String</item-type>
 		<label>Light Mode</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Mode</tag>
 		</tags>
 		<state>
 			<options>
@@ -160,7 +161,8 @@
 		<label>Dynamic Light Mode Speed</label>
 		<description>Speed of color/intensity changes in dynamic light modes</description>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Speed</tag>
 		</tags>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-types.xml
@@ -10,7 +10,7 @@
 		<description>The date and time of the last update.</description>
 		<category>Time</category>
 		<tags>
-			<tag>Point</tag>
+			<tag>Status</tag>
 			<tag>Timestamp</tag>
 		</tags>
 		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
@@ -22,7 +22,8 @@
 		<description>The date and time of the last update in UTC as submitted by the device. This can be 'now'.</description>
 		<category>Time</category>
 		<tags>
-			<tag>Point</tag>
+			<tag>Status</tag>
+			<tag>Timestamp</tag>
 		</tags>
 		<state readOnly="true"/>
 	</channel-type>
@@ -35,7 +36,7 @@
 			case of 'now', the current time is used.</description>
 		<category>Time</category>
 		<tags>
-			<tag>Point</tag>
+			<tag>Status</tag>
 			<tag>Timestamp</tag>
 		</tags>
 		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>


### PR DESCRIPTION
This PR fixes some xml schema validation errors in several addons as follows:

- ArgoClima
- CasoKitchen
- Deconz
- FineOffsetWeatherStation
- PlugWiseHA
- Wiz
- WunderGroundUpdateReceiver

See https://github.com/openhab/openhab-core/pull/4615#issuecomment-2776036635

Note: it depends on two other PRs  to add some missing PROPERTY tags `Speed` and `AirQuality` 
- https://github.com/openhab/openhab-core/pull/4695 to add the missing tags
- https://github.com/openhab/openhab-core/pull/4626 to inject the tags into the XSD file

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>