### PR TITLE
[lutron] Provides device location and names during discovery

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
@@ -68,11 +68,24 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
         thingHandler.queryDiscoveryData();
     }
 
-    public void processDeviceDefinitions(List<Device> deviceList) {
+    public void processDeviceDefinitions(List<Device> deviceList, Map<Integer, String> zoneIdToName,
+            Map<Integer, String> areaIdToName) {
         for (Device device : deviceList) {
-            // Integer zoneid = device.getZone();
+            Integer zoneId = device.getZone();
             Integer deviceId = device.getDevice();
+            Integer areaId = device.getArea();
+
             String label = device.getFullyQualifiedName();
+            // RA3 doesn't provide a name for the above instead you
+            // need to get the Area and Zone name to have it make sense
+            if (label.isEmpty()) {
+                String areaName = areaIdToName.getOrDefault(areaId, "");
+                if (areaName.isEmpty()) {
+                    label = zoneIdToName.getOrDefault(zoneId, "");
+                } else {
+                    label = String.format("%s - %s", areaName, zoneIdToName.getOrDefault(zoneId, ""));
+                }
+            }
             if (deviceId > 0) {
                 logger.debug("Discovered device: {} type: {} id: {}", label, device.deviceType, deviceId);
                 if (device.deviceType != null) {
@@ -116,6 +129,11 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                         case "TriathlonHoneycombShade":
                         case "QsWirelessShade":
                             notifyDiscovery(THING_TYPE_SHADE, deviceId, label);
+                            break;
+                        case "RPSWallMountedOccupancySensor":
+                            // Handle ra3 OccupancySensors, will need to get area
+                            // that the sensor is associated with to get at the sensor
+                            // status
                             break;
                         case "RPSOccupancySensor":
                             // Don't discover sensors. Using occupancy groups instead.

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LeapDeviceDiscoveryService.java
@@ -131,7 +131,7 @@ public class LeapDeviceDiscoveryService extends AbstractThingHandlerDiscoverySer
                             notifyDiscovery(THING_TYPE_SHADE, deviceId, label);
                             break;
                         case "RPSWallMountedOccupancySensor":
-                            // Handle ra3 OccupancySensors, will need to get area
+                            // TODO: Handle ra3 OccupancySensors, will need to get area
                             // that the sensor is associated with to get at the sensor
                             // status
                             break;

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/LeapMessageParser.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/LeapMessageParser.java
@@ -27,6 +27,7 @@ import org.openhab.binding.lutron.internal.protocol.leap.dto.Header;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.OccupancyGroup;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.OccupancyGroupStatus;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.Project;
+import org.openhab.binding.lutron.internal.protocol.leap.dto.ZoneExpanded;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.ZoneStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -213,6 +214,9 @@ public class LeapMessageParser {
                 case "MultipleZoneStatus":
                     parseMultipleZoneStatus(body);
                     break;
+                case "MultipleZoneExpandedStatus":
+                    parseMultipleZoneExpandedStatus(body);
+                    break;
                 default:
                     logger.debug("Unknown MessageBodyType received: {}", messageBodyType);
                     break;
@@ -328,6 +332,12 @@ public class LeapMessageParser {
             logger.debug("Setting zone {} to level: {}", status.href, status.level);
             callback.handleZoneUpdate(status);
         }
+    }
+
+    private void parseMultipleZoneExpandedStatus(JsonObject messageBody) {
+        List<ZoneExpanded> zoneExpandedList = parseBodyMultiple(messageBody, "ZoneExpandedStatuses",
+                ZoneExpanded.class);
+        callback.handleMultipleZoneExpandedUpdate(zoneExpandedList);
     }
 
     /**

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/LeapMessageParserCallbacks.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/LeapMessageParserCallbacks.java
@@ -21,6 +21,7 @@ import org.openhab.binding.lutron.internal.protocol.leap.dto.ButtonStatus;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.Device;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.OccupancyGroup;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.Project;
+import org.openhab.binding.lutron.internal.protocol.leap.dto.ZoneExpanded;
 import org.openhab.binding.lutron.internal.protocol.leap.dto.ZoneStatus;
 
 /**
@@ -40,6 +41,8 @@ public interface LeapMessageParserCallbacks {
     void handleEmptyButtonGroupDefinition();
 
     void handleZoneUpdate(ZoneStatus zoneStatus);
+
+    void handleMultipleZoneExpandedUpdate(List<ZoneExpanded> expandedZones);
 
     void handleGroupUpdate(int groupNumber, String occupancyStatus);
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/Request.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/Request.java
@@ -14,6 +14,9 @@ package org.openhab.binding.lutron.internal.protocol.leap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.lutron.internal.protocol.FanSpeedType;
+import org.openhab.binding.lutron.internal.protocol.leap.dto.LeapRequest;
+
+import com.google.gson.Gson;
 
 /**
  * Contains static methods for constructing LEAP messages
@@ -99,8 +102,13 @@ public class Request {
     }
 
     public static String request(CommuniqueType cType, String url) {
-        String request = "{\"CommuniqueType\": \"%s\",\"Header\": {\"Url\": \"%s\"}}";
-        return String.format(request, cType.toString(), url);
+        LeapRequest leapRequest = new LeapRequest();
+        leapRequest.communiqueType = cType.toString();
+        leapRequest.header = new LeapRequest.Header();
+        leapRequest.header.url = url;
+
+        Gson gson = new Gson();
+        return gson.toJson(leapRequest);
     }
 
     public static String ping() {
@@ -150,6 +158,11 @@ public class Request {
         return request(CommuniqueType.READREQUEST, String.format("/zone/%d/status", zone));
     }
 
+    public static String getZoneStatuses() {
+        return request(CommuniqueType.READREQUEST,
+                "/zone/status/expanded?where=Zone.ControlType:\"Dimmed\"|\"Switched\"|\"CCO\"|\"Shade\"");
+    }
+
     public static String getOccupancyGroupStatus() {
         return request(CommuniqueType.READREQUEST, "/occupancygroup/status");
     }
@@ -164,5 +177,9 @@ public class Request {
 
     public static String subscribeZoneStatus() {
         return request(CommuniqueType.SUBSCRIBEREQUEST, "/zone/status");
+    }
+
+    public static String subscribeAreaStatus() {
+        return request(CommuniqueType.SUBSCRIBEREQUEST, "/area/status");
     }
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/Device.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/Device.java
@@ -26,6 +26,7 @@ import com.google.gson.annotations.SerializedName;
 public class Device extends AbstractMessageBody {
     public static final Pattern DEVICE_HREF_PATTERN = Pattern.compile("/device/([0-9]+)");
     private static final Pattern ZONE_HREF_PATTERN = Pattern.compile("/zone/([0-9]+)");
+    private static final Pattern AREA_HREF_PATTERN = Pattern.compile("/area/([0-9]+)");
 
     @SerializedName("href")
     public String href;
@@ -103,6 +104,14 @@ public class Device extends AbstractMessageBody {
     public int getZone() {
         if (localZones != null && localZones.length > 0) {
             return hrefNumber(ZONE_HREF_PATTERN, localZones[0].href);
+        } else {
+            return 0;
+        }
+    }
+
+    public int getArea() {
+        if (associatedArea != null && !associatedArea.href.isEmpty()) {
+            return hrefNumber(AREA_HREF_PATTERN, associatedArea.href);
         } else {
             return 0;
         }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/LeapRequest.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/LeapRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.protocol.leap.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * LeapRequest object
+ *
+ * @author Peter J Wojciechowski - initial
+ */
+public class LeapRequest {
+    @SerializedName("CommuniqueType")
+    public String communiqueType = "";
+    @SerializedName("Header")
+    public Header header;
+    @SerializedName("Body")
+    public Body body;
+
+    public static class Body {
+        @SerializedName("Command")
+        public Command command;
+    }
+
+    public static class Command {
+        @SerializedName("CommandType")
+        public String commandType;
+        @SerializedName("Parameter")
+        public CommandParameter commandParameter;
+
+        public static class CommandParameter {
+            @SerializedName("Type")
+            public String type;
+            @SerializedName("Value")
+            public String value;
+        }
+    }
+
+    public static class Header {
+        @SerializedName("Url")
+        public String url;
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/Zone.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/Zone.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.protocol.leap.dto;
+
+import java.util.regex.Pattern;
+
+import org.openhab.binding.lutron.internal.protocol.leap.AbstractMessageBody;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * LEAP Zone Object
+ *
+ * @author Peter J Wojciechowski - Initial contribution
+ */
+
+public class Zone extends AbstractMessageBody {
+    public static final Pattern ZONE_HREF_PATTERN = Pattern.compile("/zone/([0-9]+)");
+
+    @SerializedName("href")
+    public String href = "";
+    @SerializedName("XID")
+    public String xid = "";
+    @SerializedName("Name")
+    public String name = "";
+    @SerializedName("AvailableControlTypes")
+    public String[] controlTypes = {};
+    @SerializedName("Category")
+    public ZoneCategory zoneCategory = new ZoneCategory();
+    @SerializedName("AssociatedArea")
+    public Href associatedArea = new Href();
+    @SerializedName("SortOrder")
+    public int sortOrder;
+    @SerializedName("ControlType")
+    public String controlType = "";
+
+    public int getZone() {
+        if (href != null) {
+            return hrefNumber(ZONE_HREF_PATTERN, href);
+        } else {
+            return 0;
+        }
+    }
+
+    public class ZoneCategory {
+        @SerializedName("Type")
+        public String type = "";
+        @SerializedName("IsLight")
+        public boolean isLight = false;
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/ZoneExpanded.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/leap/dto/ZoneExpanded.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.protocol.leap.dto;
+
+import org.openhab.binding.lutron.internal.protocol.leap.AbstractMessageBody;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * ZoneExpanded object
+ *
+ * @author Peter J Wojciechowski - initial
+ */
+public class ZoneExpanded extends AbstractMessageBody {
+    @SerializedName("href")
+    public String href;
+    @SerializedName("Level")
+    public int level;
+    @SerializedName("StatusAccuracy")
+    public String statusAccuracy;
+    @SerializedName("Zone")
+    public Zone zone;
+}


### PR DESCRIPTION
<!--
Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.
-->
# [lutron] Improve RA3 discovery - add names to Things

# Description

The current implementation would discover and add Things to the "Inbox" using only the integration ID.  For RA3 devices the name is buried with the Area & Zone.  This provides the ability to see what has been discovered based on the names of the Area, if defined, and Zone.  

# Testing

I have this currently running on my home system with Dimmer, Switches and Occupancy Sensors.  The binding currently doesn't support RA2 RadioSavr Sensors working outside of OccupancyGroups.


