### PR TITLE
[energidataservice] Add tariff filter for Forsyning Elnet

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/config/config.xml
@@ -36,6 +36,7 @@
 				<option value="5790001095277">Elinord</option>
 				<option value="5790001100520">Elnet Midt</option>
 				<option value="5790000392551">FLOW Elnet</option>
+				<option value="5790001088309">Forsyning Elnet</option>
 				<option value="5790001090166">Hammel Elforsyning Net</option>
 				<option value="5790000610839">Hurup Elværk Net</option>
 				<option value="5790000682102">Ikast El Net</option>

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/OH-INF/i18n/energidataservice.properties
@@ -26,6 +26,7 @@ thing-type.config.energidataservice.service.gridCompanyGLN.option.5790000836239 
 thing-type.config.energidataservice.service.gridCompanyGLN.option.5790001095277 = Elinord
 thing-type.config.energidataservice.service.gridCompanyGLN.option.5790001100520 = Elnet Midt
 thing-type.config.energidataservice.service.gridCompanyGLN.option.5790000392551 = FLOW Elnet
+thing-type.config.energidataservice.service.gridCompanyGLN.option.5790001088309 = Forsyning Elnet
 thing-type.config.energidataservice.service.gridCompanyGLN.option.5790001090166 = Hammel Elforsyning Net
 thing-type.config.energidataservice.service.gridCompanyGLN.option.5790000610839 = Hurup Elværk Net
 thing-type.config.energidataservice.service.gridCompanyGLN.option.5790000682102 = Ikast El Net

--- a/bundles/org.openhab.binding.energidataservice/src/main/resources/filters/grid_tariffs.yaml
+++ b/bundles/org.openhab.binding.energidataservice/src/main/resources/filters/grid_tariffs.yaml
@@ -52,6 +52,12 @@
   notes:
     - "Nettarif C"
   start: "StartOfDay"
+# Forsyning Elnet
+- gln: "5790001088309"
+  chargeTypeCodes:
+    - "STR-NT-03"
+  notes:
+    - "Nettarif C"
 # Hammel Elforsyning Net
 - gln: "5790001090166"
   chargeTypeCodes:


### PR DESCRIPTION
Price list as PDF here: https://www.forsyningelnet.dk/wp-content/uploads/2025/02/1_januar_til_31_december_2025_-_aarsforbrug_0_-_50000_kWh.pdf

Query: https://api.energidataservice.dk/dataset/DatahubPricelist?offset=0&filter=%7B%22GLN_Number%22:[%225790001088309%22],%22ChargeType%22:[%22D03%22],%22ChargeTypeCode%22:[%22STR-NT-03%22],%22Note%22:[%22Nettarif%20C%22]%7D&sort=ValidFrom%20DESC

![image](https://github.com/user-attachments/assets/ad3c54f7-14e2-4218-99f2-b3ab94e857e0)
