### PR TITLE
[danfossairunit] Add semantic equipment tag

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 	<thing-type id="airunit">
 		<label>Danfoss Air Unit</label>
 		<description>The Danfoss Air Unit Heat Exchanger, CCM and Air Dial</description>
+		<semantic-equipment-tag>HeatRecovery</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="main" typeId="main"/>


### PR DESCRIPTION
Awaiting new XSD for validation (openhab/website#511) and Main UI support for testing (openhab/openhab-webui#3124).