### PR TITLE
[asuswrt] Fixed issue where reconnectJob does not try to reconnect (#18456)

### DIFF
--- a/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/api/AsuswrtConnector.java
+++ b/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/api/AsuswrtConnector.java
@@ -167,10 +167,10 @@ public class AsuswrtConnector extends AsuswrtHttpClient {
             router.setState(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorMessage);
         } else if (e instanceof InterruptedException) {
             router.errorHandler.raiseError(new Exception(e), payload);
-            router.setState(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR, errorMessage);
+            router.setState(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorMessage);
         } else {
             router.errorHandler.raiseError(new Exception(e), errorMessage);
-            router.setState(ThingStatus.UNKNOWN, ThingStatusDetail.COMMUNICATION_ERROR, errorMessage);
+            router.setState(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorMessage);
         }
     }
 


### PR DESCRIPTION
Router does not recover when if there are issues with the network.  When a connection failure happens, the router status was set to UNKOWN and the "reconnectJob" only attempts to reconnect if the status is OFFLINE.

This PR sets the status to OFFLINE in the event of a network failure (instead of UNKNWOWN).  This could have also been fixed by attempting to reconnect if the status was either OFFLINE or UNKNOWN, however I chose this change as I thought  it was less intrusive since the UNKOWN state is used as the initial state on init.

@wildcs, could you provide feedback.