### PR TITLE
[jrubyscripting] Move console instance check from Java to Ruby code

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -26,12 +26,6 @@
       <version>${jruby.version}</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.io.console.karaf</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
@@ -288,21 +288,24 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
         final String consoleScript = script.contains("/") ? script : DEFAULT_CONSOLE_PATH + script;
         final String[] argv = args;
 
-        // Use full class name here to avoid ambiguity against other OSGiConsole implementations
-        if (console instanceof org.openhab.core.io.console.karaf.OSGiConsole) {
-            logger.debug("Starting JRuby console with script: {}", consoleScript);
+        logger.debug("Starting JRuby console with script: {}", consoleScript);
 
-            executeWithFullJRuby(console, engine -> {
-                // Resolve console.getSession().getTerminal() in Ruby to avoid having to add
-                // org.apache.karaf.shell.core as a dependency in pom.xml
-                engine.put("$console", console);
-                engine.put(ScriptEngine.ARGV, argv);
-                engine.eval(String.format("$terminal = $console.session.terminal; require '%s'", consoleScript));
-                return null;
-            });
-        } else {
-            console.println("JRuby Console is not supported in this environment.");
-        }
+        executeWithFullJRuby(console, engine -> {
+            // Resolve console.getSession().getTerminal() in Ruby to avoid having to add
+            // org.apache.karaf.shell.core as a dependency in pom.xml
+            engine.put("$console", console);
+            engine.put(ScriptEngine.ARGV, argv);
+            engine.eval("""
+                    begin
+                      $terminal = $console.session.terminal
+                    rescue NoMethodError
+                      puts "Error: Unable to resolve terminal. JRuby Console is not supported in this environment."
+                      exit
+                    end
+                    """ + String.format("require '%s'", consoleScript));
+
+            return null;
+        });
     }
 
     synchronized private void bundler(Console console, String[] args) {

--- a/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
+++ b/bundles/org.openhab.automation.jrubyscripting/src/main/java/org/openhab/automation/jrubyscripting/internal/JRubyConsoleCommandExtension.java
@@ -295,14 +295,7 @@ public class JRubyConsoleCommandExtension extends AbstractConsoleCommandExtensio
             // org.apache.karaf.shell.core as a dependency in pom.xml
             engine.put("$console", console);
             engine.put(ScriptEngine.ARGV, argv);
-            engine.eval("""
-                    begin
-                      $terminal = $console.session.terminal
-                    rescue NoMethodError
-                      puts "Error: Unable to resolve terminal. JRuby Console is not supported in this environment."
-                      exit
-                    end
-                    """ + String.format("require '%s'", consoleScript));
+            engine.eval(String.format("require '%s'", consoleScript));
 
             return null;
         });


### PR DESCRIPTION
I'm not sure why the distro addon failed to detect `console instanceof org.openhab.core.io.console.karaf.OSGiConsole`. 

I didn't experience this issue with a custom built jar.

Trying a different approach by moving this into Ruby.