### PR TITLE
Bindings G thru L: Add equipment tags

### DIFF
--- a/bundles/org.openhab.binding.generacmobilelink/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.generacmobilelink/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="account">
 		<label>MobileLink Account</label>
 		<description>MobileLink Cloud Account</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<config-description-ref uri="thing-type:generacmobilelink:account"/>
 	</bridge-type>
 
@@ -16,6 +17,7 @@
 		</supported-bridge-type-refs>
 		<label>MobileLink Generator</label>
 		<description>MobileLink Generator</description>
+		<semantic-equipment-tag>Generator</semantic-equipment-tag>
 		<channels>
 			<channel id="heroImageUrl" typeId="heroImageUrl"/>
 			<channel id="statusLabel" typeId="statusLabel"/>

--- a/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.goecharger/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,7 @@
 	<thing-type id="goe">
 		<label>Go-eCharger</label>
 		<description>Go-eCharger thing that represents the wallbox configuration and readings</description>
-
+		<semantic-equipment-tag>EVSE</semantic-equipment-tag>
 		<channels>
 			<channel id="awattarMaxPrice" typeId="awp"/>
 			<channel id="maxCurrent" typeId="current"/>

--- a/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
+++ b/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
@@ -8,7 +8,7 @@
 	<thing-type id="pigpio-remote" extensible="pigpio-digital-input,pigpio-digital-output">
 		<label>Pigpio Remote</label>
 		<description>The remote pigpio thing represents a remote raspberry pi with pigpio installed. Pins are channels.</description>
-
+		<semantic-equipment-tag>Computer</semantic-equipment-tag>
 		<properties>
 			<property name="vendor">Raspberry Pi Foundation</property>
 		</properties>

--- a/bundles/org.openhab.binding.gpstracker/src/main/resources/OH-INF/thing/tracker.xml
+++ b/bundles/org.openhab.binding.gpstracker/src/main/resources/OH-INF/thing/tracker.xml
@@ -7,7 +7,7 @@
 	<thing-type id="tracker" extensible="regionDistance">
 		<label>Tracker Device</label>
 		<description>Device running tracker application</description>
-
+		<semantic-equipment-tag>Tracker</semantic-equipment-tag>
 		<channels>
 			<channel id="lastLocation" typeId="system.location"/>
 			<channel id="batteryLevel" typeId="system.battery-level"/>

--- a/bundles/org.openhab.binding.gree/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/OH-INF/thing/thing-types.xml
@@ -6,6 +6,7 @@
 
 	<thing-type id="airconditioner">
 		<label>@text/thing-type.gree.airconditioner.label</label>
+		<semantic-equipment-tag>AirConditioner</semantic-equipment-tag>
 		<channels>
 			<channel id="power" typeId="system.power"/>
 			<channel id="mode" typeId="mode"/>

--- a/bundles/org.openhab.binding.gridbox/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gridbox/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,7 +8,7 @@
 
 		<label>GridBox</label>
 		<description>GridBox Thing</description>
-
+		<semantic-equipment-tag>PowerSupply</semantic-equipment-tag>
 		<channels>
 			<channel id="battery-capacity" typeId="system.electric-energy"/>
 			<channel id="battery-nominal-capacity" typeId="system.electric-energy"/>

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/OH-INF/thing/thing-types.xml
@@ -9,7 +9,7 @@
 		<description>This is an interface to the GROHE ONDUS Account as it is used by the app. If username and password are
 			not set, you can configure to use a `refreshToken` to login. Read the README to get more info.
 		</description>
-
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<config-description>
 			<parameter name="username" type="text" required="false">
 				<label>Username</label>
@@ -30,7 +30,7 @@
 
 		<label>GROHE SENSE GUARD Appliance</label>
 		<description>A SENSE GUARD device</description>
-
+		<semantic-equipment-tag>HotWaterFaucet</semantic-equipment-tag>
 		<channels>
 			<channel id="name" typeId="name"/>
 			<channel id="pressure" typeId="pressure"/>
@@ -71,6 +71,7 @@
 
 		<label>GROHE SENSE Appliance</label>
 		<description>A SENSE device</description>
+		<semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
 		<channels>
 			<channel id="name" typeId="name"/>

--- a/bundles/org.openhab.binding.groupepsa/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groupepsa/src/main/resources/OH-INF/thing/thing-types.xml
@@ -62,7 +62,7 @@
 
 		<label>Groupe PSA Car</label>
 		<description>Car connected via Groupe PSA (Peugeot, Citroen, Vauxhall, Opel, DS) Bridge</description>
-
+		<semantic-equipment-tag>Vehicle</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="battery" typeId="battery"/>
 			<channel-group id="doors" typeId="doors"/>

--- a/bundles/org.openhab.binding.guntamatic/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.guntamatic/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="biostar">
 		<label>Guntamatic Biostar</label>
 		<description>Guntamatic Biostar Pellets Heating System</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type"/>
@@ -27,6 +28,7 @@
 	<thing-type id="biosmart">
 		<label>Guntamatic Biosmart</label>
 		<description>Guntamatic Biosmart Log Heating System</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type-wo-boiler-app"/>
@@ -46,6 +48,7 @@
 	<thing-type id="powerchip">
 		<label>Guntamatic Powerchip</label>
 		<description>Guntamatic Powerchip WoodChip Heating System</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type"/>
@@ -66,6 +69,7 @@
 	<thing-type id="powercorn">
 		<label>Guntamatic Powercorn</label>
 		<description>Guntamatic Powercorn EnergyGrain Heating System. Untested! Please provide Feedback!</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type"/>
@@ -86,6 +90,7 @@
 	<thing-type id="biocom">
 		<label>Guntamatic Biocom</label>
 		<description>Guntamatic Biocom Pellets Heating System. Untested! Please provide Feedback!</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type"/>
@@ -106,6 +111,7 @@
 	<thing-type id="pro">
 		<label>Guntamatic Pro</label>
 		<description>Guntamatic Pro Pellets or WoodChip Heating System. Untested! Please provide Feedback!</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type"/>
@@ -126,6 +132,7 @@
 	<thing-type id="therm">
 		<label>Guntamatic Therm</label>
 		<description>Guntamatic Therm Pellets Heating System. Untested! Please provide Feedback!</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type"/>
@@ -147,6 +154,7 @@
 		<label>Guntamatic Generic</label>
 		<description>Generic Guntamatic Heating System. Use this type, if your Heating System is none of the others. Please
 			provide Feedback!</description>
+		<semantic-equipment-tag>Boiler</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="control" typeId="control-group-type-wo-boiler-app"/>

--- a/bundles/org.openhab.binding.haassohnpelletstove/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.haassohnpelletstove/src/main/resources/OH-INF/thing/thing-types.xml
@@ -11,7 +11,7 @@
 			optional
 			WLAN-Modul. More information can be found here: https://www.haassohn.com/de/ihr-plus/WLAN-Funktion. It allows
 			to power on/off the stove as well as receiving different operation information about the stove.</description>
-
+		<semantic-equipment-tag>Oven</semantic-equipment-tag>
 
 		<channels>
 			<channel id="channelIsTemp" typeId="isTemp"/>

--- a/bundles/org.openhab.binding.haassohnpelletstove/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.haassohnpelletstove/src/main/resources/OH-INF/thing/thing-types.xml
@@ -11,7 +11,7 @@
 			optional
 			WLAN-Modul. More information can be found here: https://www.haassohn.com/de/ihr-plus/WLAN-Funktion. It allows
 			to power on/off the stove as well as receiving different operation information about the stove.</description>
-		<semantic-equipment-tag>Oven</semantic-equipment-tag>
+		<semantic-equipment-tag>Furnace</semantic-equipment-tag>
 
 		<channels>
 			<channel id="channelIsTemp" typeId="isTemp"/>

--- a/bundles/org.openhab.binding.harmonyhub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.harmonyhub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,6 @@
 	<bridge-type id="hub">
 		<label>Harmony Hub</label>
 		<description>A Logitech Harmony Hub</description>
-		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
 		<channels>
 			<channel id="currentActivity" typeId="currentActivity"/>
 			<channel id="activityStarting" typeId="eventTrigger">
@@ -49,7 +48,6 @@
 		</supported-bridge-type-refs>
 		<label>Harmony Device</label>
 		<description>Logitech Harmony Hub Device</description>
-		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
 		<channels>
 			<channel id="buttonPress" typeId="buttonPress"/>
 		</channels>

--- a/bundles/org.openhab.binding.harmonyhub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.harmonyhub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="hub">
 		<label>Harmony Hub</label>
 		<description>A Logitech Harmony Hub</description>
+		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
 		<channels>
 			<channel id="currentActivity" typeId="currentActivity"/>
 			<channel id="activityStarting" typeId="eventTrigger">
@@ -48,6 +49,7 @@
 		</supported-bridge-type-refs>
 		<label>Harmony Device</label>
 		<description>Logitech Harmony Hub Device</description>
+		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
 		<channels>
 			<channel id="buttonPress" typeId="buttonPress"/>
 		</channels>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
@@ -8,7 +8,7 @@
 	<bridge-type id="bridge">
 		<label>Hayward OmniLogix Connection</label>
 		<description>Connection to Hayward's Server</description>
-
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<config-description>
 			<parameter name="endpointUrl" type="text" required="true">
 				<context>url</context>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Chlorinator</label>
+		<semantic-equipment-tag>Chlorinator</semantic-equipment-tag>
 		<channels>
 			<channel id="chlorEnable" typeId="system.power"/>
 			<channel id="chlorOperatingMode" typeId="chlorOperatingMode"/>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/colorlogic.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/colorlogic.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Color Logic Light</label>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="colorLogicLightEnable" typeId="system.power"/>
 			<channel id="colorLogicLightState" typeId="lightState"/>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Filter</label>
+		<semantic-equipment-tag>WaterFilter</semantic-equipment-tag>
 		<channels>
 			<channel id="filterEnable" typeId="system.power"/>
 			<channel id="filterValvePosition" typeId="valvePosition"/>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/heater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/heater.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Heater</label>
+		<semantic-equipment-tag>WaterHeater</semantic-equipment-tag>
 		<channels>
 			<channel id="heaterState" typeId="state"/>
 			<channel id="heaterEnable" typeId="enable"/>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Pump</label>
+		<semantic-equipment-tag>Pump</semantic-equipment-tag>
 		<channels>
 			<channel id="pumpEnable" typeId="system.power"/>
 			<channel id="pumpSpeedPercent" typeId="pumpSpeedPercent"/>

--- a/bundles/org.openhab.binding.hccrubbishcollection/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.hccrubbishcollection/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="collection">
 		<label>HCC NZ Rubbish Collection</label>
 		<description>Rubbish collection days for Hamilton City Council (NZ).</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<channels>
 			<channel id="day" typeId="day"/>

--- a/bundles/org.openhab.binding.helios/src/main/resources/OH-INF/thing/ipvario221.xml
+++ b/bundles/org.openhab.binding.helios/src/main/resources/OH-INF/thing/ipvario221.xml
@@ -7,6 +7,7 @@
 	<thing-type id="ipvario221">
 		<label>Helios IP Vario</label>
 		<description>Helios IP Vario Door Station / Intercom with Firmware v2.21</description>
+		<semantic-equipment-tag>Doorbell</semantic-equipment-tag>
 
 		<channels>
 			<channel id="audiolooptest" typeId="audiolooptest"/>

--- a/bundles/org.openhab.binding.heliosventilation/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.heliosventilation/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 	<thing-type id="ventilation">
 		<label>HeliosVentilation (KWL)</label>
 		<description>A domestic ventilation system (KWL) from Helios.</description>
+		<semantic-equipment-tag>HVAC</semantic-equipment-tag>
 
 		<channels>
 			<channel id="outsideTemp" typeId="outside_temperature"/>

--- a/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/thing/HeosGroup.xml
+++ b/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/thing/HeosGroup.xml
@@ -10,6 +10,8 @@
 		</supported-bridge-type-refs>
 		<label>HEOS Group</label>
 		<description>A group of HEOS Player</description>
+		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
+
 		<channels>
 			<channel id="Control" typeId="system.media-control"/>
 			<channel id="Volume" typeId="system.volume"/>

--- a/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/thing/HeosPlayer.xml
+++ b/bundles/org.openhab.binding.heos/src/main/resources/OH-INF/thing/HeosPlayer.xml
@@ -11,6 +11,7 @@
 		</supported-bridge-type-refs>
 		<label>HEOS Player</label>
 		<description>A HEOS Player of the HEOS Network</description>
+		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 
 		<channels>
 			<channel id="Control" typeId="system.media-control"/>

--- a/bundles/org.openhab.binding.herzborg/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.herzborg/src/main/resources/OH-INF/thing/thing-types.xml
@@ -6,6 +6,7 @@
 	<bridge-type id="serialBus">
 		<label>Herzborg Serial Bus</label>
 		<description>RS485 bus</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 		<config-description>
 			<parameter name="port" type="text" required="true">
 				<label>Serial Port</label>
@@ -22,6 +23,8 @@
 		</supported-bridge-type-refs>
 		<label>Herzborg Curtain Motor</label>
 		<description>Curtain motor</description>
+		<semantic-equipment-tag>Drapes</semantic-equipment-tag>
+
 		<channels>
 			<channel id="position" typeId="position"/>
 			<channel id="mode" typeId="mode"/>

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-bat.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-bat.xml
@@ -8,7 +8,7 @@
 		<label>HomeWizard Plug-In Battery</label>
 		<description>This thing provides the measurement data that is available through the API of a HomeWizard Plug-In
 			Battery.</description>
-
+		<semantic-equipment-tag>Battery</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="energy" typeId="bat-energy-group"/>
 		</channel-groups>

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-kwh.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-kwh.xml
@@ -8,7 +8,7 @@
 		<label>HomeWizard kWh Meter</label>
 		<description>This thing provides the measurement data that is available through the API of a HomeWizard
 			kWh Meter.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="energy" typeId="kwh-energy-group"/>
 		</channel-groups>

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-p1.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-p1.xml
@@ -8,7 +8,7 @@
 		<label>HomeWizard P1 Meter</label>
 		<description>This thing provides the measurement data that is available through the API of a HomeWizard
 			P1 Meter.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="energy" typeId="p1-energy-group"/>
 		</channel-groups>

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-skt.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-skt.xml
@@ -8,7 +8,7 @@
 		<label>HomeWizard Energy Socket</label>
 		<description>This thing provides the measurement data that is available through the API of a HomeWizard
 			Energy Socket.</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="energy" typeId="skt-energy-group"/>
 			<channel-group id="control" typeId="skt-control-group"/>

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-wtr.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/hwe-wtr.xml
@@ -8,7 +8,7 @@
 		<label>HomeWizard Watermeter</label>
 		<description>This thing provides the measurement data that is available through the API of a HomeWizard
 			Watermeter.</description>
-
+		<semantic-equipment-tag>WaterMeter</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="water" typeId="es-water-group"/>
 		</channel-groups>

--- a/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.homewizard/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,7 +8,7 @@
 		<label>HomeWizard Wi-Fi P1 Meter</label>
 		<description>This thing provides the measurement data that is available through the http interface of the HomeWizard
 			Wi-Fi P1 Meter.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="active_current" typeId="system.electric-current">
 				<label>Current</label>

--- a/bundles/org.openhab.binding.huesync/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.huesync/src/main/resources/OH-INF/thing/thing-types.xml
@@ -13,6 +13,7 @@
 		</description>
 
 		<category>receiver</category>
+		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="device-firmware" typeId="device-firmware"></channel-group>

--- a/bundles/org.openhab.binding.hydrawise/src/main/resources/OH-INF/thing/things.xml
+++ b/bundles/org.openhab.binding.hydrawise/src/main/resources/OH-INF/thing/things.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="account">
 		<label>Hydrawise Account Thing</label>
 		<description>Hydrawise account</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<config-description>
 			<parameter name="userName" type="text" required="true">
 				<label>User Name</label>
@@ -37,6 +38,7 @@
 		</supported-bridge-type-refs>
 		<label>Hydrawise Controller Thing</label>
 		<description>Hydrawise connected irrigation controller</description>
+		<semantic-equipment-tag>Irrigation</semantic-equipment-tag>
 
 		<!-- Until we have https://github.com/eclipse/smarthome/issues/1118 fixed, we need to list
 			all possible channel groups.
@@ -316,6 +318,7 @@
 	<thing-type id="local">
 		<label>Hydrawise Local Thing</label>
 		<description>Hydrawise local connected irrigation controller</description>
+		<semantic-equipment-tag>Irrigation</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="zone1" typeId="zone">
 				<label>Zone 1</label>

--- a/bundles/org.openhab.binding.iammeter/src/main/resources/OH-INF/thing/3080.xml
+++ b/bundles/org.openhab.binding.iammeter/src/main/resources/OH-INF/thing/3080.xml
@@ -7,6 +7,7 @@
 	<thing-type id="powermeter">
 		<label>Iammeter Power Meter 3162/3080</label>
 		<description>Single phase PowerMeter for Iammeter Binding</description>
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="voltage" typeId="voltage"/>
 			<channel id="current" typeId="current"/>

--- a/bundles/org.openhab.binding.iammeter/src/main/resources/OH-INF/thing/3080T.xml
+++ b/bundles/org.openhab.binding.iammeter/src/main/resources/OH-INF/thing/3080T.xml
@@ -7,6 +7,7 @@
 	<thing-type id="powermeter3080T">
 		<label>Iammeter Power Meter 3080T</label>
 		<description>3 phases PowerMeter for Iammeter 3080T Binding</description>
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="powerPhaseA" typeId="powerPhaseGroup">
 				<label>Power Phase A</label>

--- a/bundles/org.openhab.binding.iaqualink/src/main/resources/OH-INF/thing/iAqualink.xml
+++ b/bundles/org.openhab.binding.iaqualink/src/main/resources/OH-INF/thing/iAqualink.xml
@@ -7,6 +7,7 @@
 		<label>iAquaLink Pool Controller</label>
 		<description>An iAquaLink pool control thing represents an iAquaLink pool controller for Jandy/Zodiac systems
 		</description>
+		<semantic-equipment-tag>SwimmingPool</semantic-equipment-tag>
 		<channels>
 			<channel id="status" typeId="status"/>
 			<channel id="system_type" typeId="system_type"/>

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/device.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/device.xml
@@ -13,7 +13,7 @@
 
 		<label>Insteon Device</label>
 		<description>An Insteon device such as a switch, dimmer, keypad, sensor, etc.</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<representation-property>address</representation-property>
 
 		<config-description>

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/hub1.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/hub1.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="hub1">
 		<label>Insteon Hub</label>
 		<description>An Insteon Hub Legacy that communicates with Insteon devices.</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="hostname" type="text" required="true">

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/hub2.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/hub2.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="hub2">
 		<label>Insteon Hub 2</label>
 		<description>An Insteon Hub 2 that communicates with Insteon devices.</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="hostname" type="text" required="true">

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/legacy-thing-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/legacy-thing-types.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="network">
 		<label>Insteon Network (Legacy)</label>
 		<description>An Insteon PLM or Hub that communicates with Insteon devices.</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="port" type="text" required="true">

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/legacy-thing-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/legacy-thing-types.xml
@@ -43,7 +43,7 @@
 
 		<label>Insteon Device (Legacy)</label>
 		<description>An Insteon or X10 device such as a switch, dimmer, keypad, sensor, etc.</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<representation-property>address</representation-property>
 
 		<config-description>

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/plm.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/plm.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="plm">
 		<label>Insteon PLM</label>
 		<description>An Insteon PLM that communicates with Insteon devices.</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="serialPort" type="text" required="true">

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/x10.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/x10.xml
@@ -13,7 +13,6 @@
 
 		<label>X10 Device</label>
 		<description>An X10 device such as a switch, dimmer or sensor.</description>
-		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="houseCode" type="text" pattern="[A-P]" required="true">

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/x10.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/x10.xml
@@ -13,6 +13,7 @@
 
 		<label>X10 Device</label>
 		<description>An X10 device such as a switch, dimmer or sensor.</description>
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="houseCode" type="text" pattern="[A-P]" required="true">

--- a/bundles/org.openhab.binding.intesis/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.intesis/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="intesisHome">
 		<label>IntesisHome WiFi Adapter</label>
 		<description>Represents a single IntesisHome WiFi adapter on the network, connected to an A/C unit.</description>
+		<semantic-equipment-tag>WirelessAccessPoint</semantic-equipment-tag>
 		<channels>
 			<channel id="power" typeId="system.power"/>
 			<channel id="wifiSignal" typeId="system.signal-strength"/>
@@ -37,6 +38,7 @@
 	<thing-type id="intesisBox">
 		<label>IntesisBox Adapter</label>
 		<description>Represents a single IntesisBox WiFi adapter on the network, connected to an A/C unit.</description>
+		<semantic-equipment-tag>WirelessAccessPoint</semantic-equipment-tag>
 		<channels>
 			<channel id="power" typeId="system.power"/>
 			<channel id="wifiSignal" typeId="system.signal-strength"/>

--- a/bundles/org.openhab.binding.iotawatt/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.iotawatt/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,7 +8,7 @@
 	<thing-type id="iotawatt">
 		<label>IoTaWatt Binding Thing</label>
 		<description>An IoTaWatt devices</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<config-description>
 			<parameter name="hostname" type="text" required="true">
 				<context>network-address</context>

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,7 @@
 	<thing-type id="group">
 		<label>Group Multiple Cameras</label>
 		<description>Show multiple cameras as a single rotating feed</description>
-		<semantic-equipment-tag>Display</semantic-equipment-tag>
+
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="mjpegUrl" typeId="mjpegUrl"/>

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="group">
 		<label>Group Multiple Cameras</label>
 		<description>Show multiple cameras as a single rotating feed</description>
+		<semantic-equipment-tag>Display</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="mjpegUrl" typeId="mjpegUrl"/>
@@ -97,6 +98,7 @@
 	<thing-type id="generic">
 		<label>RTSP/HTTP IP Camera</label>
 		<description>Use when your camera is not ONVIF compatible.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -322,6 +324,7 @@
 	<thing-type id="onvif">
 		<label>ONVIF IP Camera</label>
 		<description>Use when the binding does not list your brand of ONVIF camera.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -612,6 +615,7 @@
 	<thing-type id="amcrest">
 		<label>Amcrest Camera with API</label>
 		<description>Use for older Amcrest Cameras, that wont work as dahua thing type.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -887,6 +891,7 @@
 	<thing-type id="dahua">
 		<label>Dahua Camera with API</label>
 		<description>Use for all current Dahua cameras, as they support an API as well as ONVIF.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -1195,6 +1200,7 @@
 	<thing-type id="doorbird">
 		<label>Doorbird Camera with API</label>
 		<description>Use for all current Doorbird Cameras, as they support an API as well as ONVIF.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -1456,6 +1462,7 @@
 	<thing-type id="foscam">
 		<label>Foscam Camera with API</label>
 		<description>Use for all current HD FOSCAM Cameras as they support an API as well as ONVIF.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -1742,6 +1749,7 @@
 	<thing-type id="hikvision">
 		<label>Hikvision Camera with API</label>
 		<description>Use for all current Hikvision Cameras as they support an API as well as ONVIF.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -2029,6 +2037,7 @@
 	<thing-type id="instar">
 		<label>Instar Camera with API</label>
 		<description>Use for all current INSTAR HD Cameras, as they support an API as well as ONVIF.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>
@@ -2300,6 +2309,7 @@
 	<thing-type id="reolink">
 		<label>Reolink Camera with API</label>
 		<description>Use for all Reolink cameras, as they support an API as well as ONVIF.</description>
+		<semantic-equipment-tag>Camera</semantic-equipment-tag>
 		<channels>
 			<channel id="startStream" typeId="startStream"/>
 			<channel id="pollImage" typeId="pollImage"/>

--- a/bundles/org.openhab.binding.ipobserver/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipobserver/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="weatherstation">
 		<label>Weather Station</label>
 		<description>Use for any weather station sold under multiple brands that come with an IP Observer unit.</description>
+		<semantic-equipment-tag>WeatherStation</semantic-equipment-tag>
 		<channels>
 			<channel id="temperatureIndoor" typeId="temperatureIndoor"/>
 			<channel id="temperatureOutdoor" typeId="system.outdoor-temperature"/>

--- a/bundles/org.openhab.binding.ipp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -5,6 +5,7 @@
 	<thing-type id="printer">
 		<label>Printer</label>
 		<description>An IPP Printer</description>
+		<semantic-equipment-tag>Printer</semantic-equipment-tag>
 
 		<channels>
 			<channel id="jobs" typeId="jobs"/>

--- a/bundles/org.openhab.binding.irobot/src/main/resources/OH-INF/thing/thing.xml
+++ b/bundles/org.openhab.binding.irobot/src/main/resources/OH-INF/thing/thing.xml
@@ -8,6 +8,7 @@
 		<label>Roomba</label>
 		<description>A Roomba vacuum robot</description>
 		<category>CleaningRobot</category>
+		<semantic-equipment-tag>CleaningRobot</semantic-equipment-tag>
 
 		<channels>
 			<channel id="command" typeId="command"/>

--- a/bundles/org.openhab.binding.irtrans/src/main/resources/OH-INF/thing/blaster.xml
+++ b/bundles/org.openhab.binding.irtrans/src/main/resources/OH-INF/thing/blaster.xml
@@ -12,6 +12,7 @@
 
 		<label>Blaster</label>
 		<description>This is an infrared transmitter that can send infrared commands</description>
+		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
 
 		<channels>
 			<channel id="io" typeId="io"/>

--- a/bundles/org.openhab.binding.irtrans/src/main/resources/OH-INF/thing/blaster.xml
+++ b/bundles/org.openhab.binding.irtrans/src/main/resources/OH-INF/thing/blaster.xml
@@ -12,7 +12,7 @@
 
 		<label>Blaster</label>
 		<description>This is an infrared transmitter that can send infrared commands</description>
-		<semantic-equipment-tag>AudioVisual</semantic-equipment-tag>
+		<semantic-equipment-tag>RemoteControl</semantic-equipment-tag>
 
 		<channels>
 			<channel id="io" typeId="io"/>

--- a/bundles/org.openhab.binding.irtrans/src/main/resources/OH-INF/thing/ethernetbridge.xml
+++ b/bundles/org.openhab.binding.irtrans/src/main/resources/OH-INF/thing/ethernetbridge.xml
@@ -8,6 +8,7 @@
 	<bridge-type id="ethernet">
 		<label>IRtrans Ethernet Bridge</label>
 		<description>This is an Ethernet (PoE) IRtrans transceiver equipped with an on-board IRDB database</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">

--- a/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/bridge.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="bridge">
 		<label>Jablonet Bridge</label>
 		<description>A bridge to the Jablonet cloud service.</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<config-description-ref uri="bridge-type:jablotron:bridge"/>
 	</bridge-type>

--- a/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/ja100.xml
+++ b/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/ja100.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 		<label>JA100 Alarm</label>
 		<description>A Jablotron JA100 alarm device.</description>
+		<semantic-equipment-tag>AlarmDevice</semantic-equipment-tag>
 
 		<channels>
 			<channel id="lastEvent" typeId="lastEvent"/>

--- a/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/ja100f.xml
+++ b/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/ja100f.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 		<label>JA100F Alarm</label>
 		<description>A Jablotron JA100F alarm device.</description>
+		<semantic-equipment-tag>AlarmDevice</semantic-equipment-tag>
 
 		<channels>
 			<channel id="lastEvent" typeId="lastEvent"/>

--- a/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/oasis.xml
+++ b/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/oasis.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 		<label>Oasis Alarm</label>
 		<description>A Jablotron Oasis alarm device.</description>
+		<semantic-equipment-tag>AlarmDevice</semantic-equipment-tag>
 
 		<channels>
 			<channel id="statusA" typeId="statusA"/>

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/OH-INF/thing/thing-types.xml
@@ -162,7 +162,7 @@
 
 		<label>@text/thing-type.lacrosse.label</label>
 		<description>@text/thing-type.lacrosse.description</description>
-
+		<semantic-equipment-tag>Sensor</semantic-equipment-tag>
 		<channels>
 			<channel id="temperature" typeId="temperature"/>
 			<channel id="humidity" typeId="humidity"/>
@@ -221,7 +221,7 @@
 
 		<label>@text/thing-type.ec3k.label</label>
 		<description>@text/thing-type.ec3k.description</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channels>
 			<channel id="currentPower" typeId="current-power"/>
 			<channel id="maxPower" typeId="max-power"/>
@@ -266,7 +266,7 @@
 
 		<label>@text/thing-type.pca301.label</label>
 		<description>@text/thing-type.pca301.description</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channels>
 			<channel id="switchingState" typeId="switching-state"/>
 			<channel id="currentPower" typeId="current-power"/>
@@ -302,7 +302,7 @@
 
 		<label>@text/thing-type.emt7110.label</label>
 		<description>@text/thing-type.emt7110.description</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channels>
 			<channel id="currentPower" typeId="current-power"/>
 			<channel id="consumptionTotal" typeId="consumption-total"/>
@@ -334,7 +334,7 @@
 
 		<label>@text/thing-type.revolt.label</label>
 		<description>@text/thing-type.revolt.description</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="currentPower" typeId="current-power"/>
 			<channel id="consumptionTotal" typeId="consumption-total"/>
@@ -368,7 +368,7 @@
 
 		<label>@text/thing-type.tx22.label</label>
 		<description>@text/thing-type.tx22.description</description>
-
+		<semantic-equipment-tag>Sensor</semantic-equipment-tag>
 		<channels>
 			<channel id="temperature" typeId="temperature"/>
 			<channel id="humidity" typeId="humidity"/>
@@ -408,7 +408,7 @@
 
 		<label>@text/thing-type.lgw.label</label>
 		<description>@text/thing-type.lgw.description</description>
-
+		<semantic-equipment-tag>TemperatureSensor</semantic-equipment-tag>
 		<channels>
 			<channel id="temperature" typeId="temperature"/>
 		</channels>

--- a/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/thing/channels.xml
@@ -10,7 +10,7 @@
 		<description>
 			A Kaleidescape Movie Player (KPlayer, M Class [M300, M500, M700] or Cinema One 1st Gen)
 		</description>
-
+		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="ui" typeId="ui">
 				<label>User Interface</label>
@@ -45,7 +45,7 @@
 		<description>
 			A Kaleidescape Cinema One (2nd Generation) Player
 		</description>
-
+		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="ui" typeId="c1-alto_ui">
 				<label>User Interface</label>
@@ -80,7 +80,7 @@
 		<description>
 			A Kaleidescape Alto Player
 		</description>
-
+		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="ui" typeId="c1-alto_ui">
 				<label>User Interface</label>
@@ -111,7 +111,7 @@
 		<description>
 			A Kaleidescape Strato Player
 		</description>
-
+		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="ui" typeId="strato_ui">
 				<label>User Interface</label>

--- a/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.kaleidescape/src/main/resources/OH-INF/thing/channels.xml
@@ -10,7 +10,6 @@
 		<description>
 			A Kaleidescape Movie Player (KPlayer, M Class [M300, M500, M700] or Cinema One 1st Gen)
 		</description>
-		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="ui" typeId="ui">
@@ -46,7 +45,6 @@
 		<description>
 			A Kaleidescape Cinema One (2nd Generation) Player
 		</description>
-		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="ui" typeId="c1-alto_ui">
@@ -82,7 +80,6 @@
 		<description>
 			A Kaleidescape Alto Player
 		</description>
-		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="ui" typeId="c1-alto_ui">
@@ -114,7 +111,6 @@
 		<description>
 			A Kaleidescape Strato Player
 		</description>
-		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group id="ui" typeId="strato_ui">

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
@@ -7,7 +7,7 @@
 	<thing-type id="kecontact">
 		<label>KeContact EV Charging Station</label>
 		<description>A KeContact EV Charging Station</description>
-
+		<semantic-equipment-tag>EVSE</semantic-equipment-tag>
 		<channels>
 			<channel id="enabledsystem" typeId="enabledsystem"/>
 			<channel id="enableduser" typeId="enableduser"/>

--- a/bundles/org.openhab.binding.kodi/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.kodi/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 	<thing-type id="kodi" extensible="shownotification">
 		<label>Kodi Mediacenter</label>
 		<description>Kodi Mediacenter Binding</description>
+		<semantic-equipment-tag>MediaPlayer</semantic-equipment-tag>
 
 		<channels>
 			<channel id="volume" typeId="system.volume"/>

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,12 +7,14 @@
 	<thing-type id="wifi-module" extensible="switch-wifi,actuator-wifi,temperature-wifi,humidity-wifi">
 		<label>The Konnected Alarm Panel</label>
 		<description>The Konnected Wi-Fi Alarm Panel</description>
+		<semantic-equipment-tag>AlarmSystem</semantic-equipment-tag>
 		<config-description-ref uri="thing-type:konnected:module"/>
 	</thing-type>
 	<!-- This is the Konnected Alarm Panel Pro Thing-Type -->
 	<thing-type id="pro-module" extensible="switch-pro,actuator-pro,temperature-pro,humidity-pro">
 		<label>The Konnected Alarm Panel Pro</label>
 		<description>The Konnected Alarm Panel Pro</description>
+		<semantic-equipment-tag>AlarmSystem</semantic-equipment-tag>
 		<config-description-ref uri="thing-type:konnected:module"/>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKO1020.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKO1020.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PIKO 10-20</label>
 		<description>Bindings for the KOSTAL PIKO 10-20</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel typeId="device-local-grid-output-power" id="gridOutputPower"/>
 			<channel typeId="statistic-yield-day-second-gen" id="yieldDaySecondGen"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ100.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ100.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PIKO IQ 10.0</label>
 		<description>Bindings for the KOSTAL PIKO IQ 10.0 solar inverter</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ42.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ42.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PIKO IQ 4.2</label>
 		<description>Bindings for the KOSTAL PIKO IQ 4.2 solar inverter</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ55.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ55.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PIKO IQ 5.5</label>
 		<description>Bindings for the KOSTAL PIKO IQ 5.5 solar inverter</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ70.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ70.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PIKO IQ 7.0</label>
 		<description>Bindings for the KOSTAL PIKO IQ 7.0 solar inverter</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ85.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ85.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PIKO IQ 8.5</label>
 		<description>Bindings for the KOSTAL PIKO IQ 8.5 solar inverter</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 10.0 (with Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 10.0 solar inverter (with battery attached on PV string 3)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromBattery" typeId="device-local-homeconsumption-from-battery"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHOUTBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 10.0 (no Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 10.0 solar inverter (no battery attached)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 4.2 (with Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 4.2 solar inverter (with battery attached on PV string 3)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromBattery" typeId="device-local-homeconsumption-from-battery"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHOUTBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 4.2 (no Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 4.2 solar inverter (no battery attached)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 5.5 (with Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 5.5 solar inverter (with battery attached on PV string 3)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromBattery" typeId="device-local-homeconsumption-from-battery"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHOUTBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 5.5 (no Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 5.5 solar inverter (no battery attached)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 7.0 (with Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 7.0 solar inverter (with battery attached on PV string 3)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromBattery" typeId="device-local-homeconsumption-from-battery"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHOUTBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 7.0 (no Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 7.0 solar inverter (no battery attached)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 8.5 (with Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 8.5 solar inverter (with battery attached on PV string 3)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromBattery" typeId="device-local-homeconsumption-from-battery"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHOUTBATTERY.xml
@@ -7,6 +7,7 @@
 		<label>KOSTAL PLENTICORE Plus 8.5 (no Battery)</label>
 		<description>Bindings for the KOSTAL PIKO PLENTICORE plus 8.5 solar inverter (no battery attached)</description>
 		<category>Inverter</category>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel id="deviceLocalDCPower" typeId="device-local-dc-power"/>
 			<channel id="deviceLocalHomeconsumptionFromGrid" typeId="device-local-homeconsumption-from-grid"/>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="kostalinverter">
 		<label>Kostal Inverter</label>
 		<description>Kostal Inverter</description>
+		<semantic-equipment-tag>Inverter</semantic-equipment-tag>
 		<channels>
 			<channel typeId="device-local-ac-current-power" id="acPower"/>
 			<channel typeId="statistic-yield-total" id="totalEnergy"/>

--- a/bundles/org.openhab.binding.leapmotion/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.leapmotion/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,7 @@
 	<thing-type id="controller">
 		<label>Leap Motion Controller</label>
 		<description>A Leap Motion Gesture Sensor</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="gesture" typeId="gesture"/>
 		</channels>

--- a/bundles/org.openhab.binding.lghombot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lghombot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,7 +8,7 @@
 		<label>LG HomBot</label>
 		<description>HomBot vacuum robot.</description>
 		<category>CleaningRobot</category>
-
+		<semantic-equipment-tag>CleaningRobot</semantic-equipment-tag>
 		<channels>
 			<channel id="state" typeId="stateType"/>
 			<channel id="battery" typeId="batteryType"/>

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/air-conditioner.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/air-conditioner.xml
@@ -11,7 +11,7 @@
 
 		<label>Air Conditioner</label>
 		<description>LG ThinQ Air Conditioner</description>
-
+		<semantic-equipment-tag>AirConditioner</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="dashboard" typeId="ac-dashboard"/>
 			<channel-group id="extended-information" typeId="ac-extended-info"/>

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/bridge.xml
@@ -6,6 +6,7 @@
 	<bridge-type id="cloud-account">
 		<label>LG ThinQ Gateway</label>
 		<description>A connection to a LG ThinQ Gateway</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<config-description>
 			<parameter name="language" type="text" required="true">

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/dish-washer.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/dish-washer.xml
@@ -11,6 +11,7 @@
 
 		<label>Dish Washer</label>
 		<description>LG ThinQ Dish Washer</description>
+		<semantic-equipment-tag>Dishwasher</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="dashboard" typeId="dw-dashboard"/>
 		</channel-groups>

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/dryer.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/dryer.xml
@@ -11,6 +11,7 @@
 
 		<label>Dryer</label>
 		<description>LG ThinQ Dryer</description>
+		<semantic-equipment-tag>Dryer</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="dashboard" typeId="dr-dashboard"/>
 			<channel-group id="rs-grp" typeId="dr-rs-grp"/>

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/fridge.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/fridge.xml
@@ -11,7 +11,7 @@
 
 		<label>Fridge</label>
 		<description>LG ThinQ Fridge</description>
-
+		<semantic-equipment-tag>Refrigerator</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="dashboard" typeId="fr-dashboard"/>
 			<channel-group id="extended-information" typeId="fr-extra-info"/>

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/heat-pump.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/heat-pump.xml
@@ -11,7 +11,7 @@
 
 		<label>Heat Pump</label>
 		<description>LG ThinQ Heat Pump</description>
-
+		<semantic-equipment-tag>HeatPump</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="dashboard" typeId="hp-dashboard"/>
 			<channel-group id="extended-information" typeId="hp-extra-info"/>

--- a/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/washer-dryer.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/resources/OH-INF/thing/washer-dryer.xml
@@ -11,6 +11,7 @@
 
 		<label>LGThinQ Washer</label>
 		<description>LG ThinQ Washing Machine</description>
+		<semantic-equipment-tag>WashingMachine</semantic-equipment-tag>
 		<channel-groups>
 			<channel-group id="dashboard" typeId="wm-dashboard"/>
 			<channel-group id="rs-grp" typeId="wm-rs-grp"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-M6503C.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-M6503C.xml
@@ -9,7 +9,7 @@
 	<thing-type id="lgtv-M6503C">
 		<label>M6503C Model</label>
 		<description>This thing supports the M6503C monitor</description>
-
+		<semantic-equipment-tag>Display</semantic-equipment-tag>
 		<channels>
 			<channel id="aspect-ratio" typeId="aspect-ratio-M6503C"/>
 			<channel id="auto-sleep" typeId="auto-sleep"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
@@ -11,7 +11,7 @@
 	<thing-type id="lgtv-LV-series">
 		<label>LV/LW Series</label>
 		<description>This thing supports the LED LCD TV models LV and LW except *LV255C, *LV355B, *LV355C</description>
-
+		<semantic-equipment-tag>Television</semantic-equipment-tag>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types-SAC34134216.xml
@@ -44,6 +44,7 @@
 	<thing-type id="lgtv-LVx55-series">
 		<label>LV/LW Series</label>
 		<description>This thing supports the *LV255C, *LV355B, *LV355C models</description>
+		<semantic-equipment-tag>Television</semantic-equipment-tag>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>
@@ -77,7 +78,7 @@
 	<thing-type id="lgtv-LK-series">
 		<label>LK Series</label>
 		<description>This thing supports the LCD TV models LK</description>
-
+		<semantic-equipment-tag>Television</semantic-equipment-tag>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>
@@ -109,7 +110,7 @@
 	<thing-type id="lgtv-PW-series">
 		<label>PW Series</label>
 		<description>This thing supports the PLASMA TV models PW</description>
-
+		<semantic-equipment-tag>Television</semantic-equipment-tag>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/OH-INF/thing/thing-types.xml
@@ -11,7 +11,7 @@
 		<label>Generic LG TV</label>
 		<description>Generic LG television connected through a serial interface. This thing should be used only when there is
 			no proper thing defined for your TV model as it has most existing channels for most known commands.</description>
-
+		<semantic-equipment-tag>Television</semantic-equipment-tag>
 		<channels>
 			<channel id="3d" typeId="3d"/>
 			<channel id="3d-extended" typeId="3d-extended"/>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorhevlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorhevlight.xml
@@ -6,6 +6,7 @@
 
 	<thing-type id="colorhevlight">
 		<label>LIFX Color HEV Light</label>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorirlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorirlight.xml
@@ -6,6 +6,7 @@
 
 	<thing-type id="colorirlight">
 		<label>LIFX Color IR Light</label>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorlight.xml
@@ -6,6 +6,7 @@
 
 	<thing-type id="colorlight">
 		<label>LIFX Color Light</label>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colormzlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colormzlight.xml
@@ -6,6 +6,7 @@
 
 	<thing-type id="colormzlight">
 		<label>LIFX Color MultiZone Light</label>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/tilelight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/tilelight.xml
@@ -6,6 +6,7 @@
 
 	<thing-type id="tilelight">
 		<label>LIFX Tile Light</label>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>

--- a/bundles/org.openhab.binding.linktap/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.linktap/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="gateway">
 		<label>LinkTap Gateway</label>
 		<description>This represents a LinkTap gateway</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<properties>
 			<property name="gatewayId"/>
@@ -63,6 +64,7 @@
 
 		<label>LinkTap Binding Thing</label>
 		<description>LinkTap Binding Device</description>
+		<semantic-equipment-tag>Irrigation</semantic-equipment-tag>
 
 		<channels>
 			<channel id="mode" typeId="mode-type"/>

--- a/bundles/org.openhab.binding.linky/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.linky/src/main/resources/OH-INF/thing/thing-types.xml
@@ -11,6 +11,7 @@
 			In order to receive the data, you must activate your account at
 			https://espace-client-particuliers.enedis.fr/web/espace-particuliers/compteur-linky.
 		</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
 		<channel-groups>
 			<channel-group typeId="daily" id="daily"/>

--- a/bundles/org.openhab.binding.liquidcheck/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.liquidcheck/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<thing-type id="liquidCheckDevice">
 		<label>Liquid Check Device</label>
 		<category>Sensor</category>
+		<semantic-equipment-tag>Sensor</semantic-equipment-tag>
 
 		<channels>
 			<channel id="content" typeId="content-channel"/>

--- a/bundles/org.openhab.binding.lirc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lirc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,7 +8,7 @@
 	<thing-type id="remote" listed="false">
 		<label>Remote Control</label>
 		<description>An IR remote control</description>
-		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
+		<semantic-equipment-tag>RemoteControl</semantic-equipment-tag>
 
 		<channels>
 			<channel id="event" typeId="event"/>

--- a/bundles/org.openhab.binding.lirc/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lirc/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 	<thing-type id="remote" listed="false">
 		<label>Remote Control</label>
 		<description>An IR remote control</description>
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 
 		<channels>
 			<channel id="event" typeId="event"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/AnalogMeter.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/AnalogMeter.xml
@@ -11,7 +11,7 @@
 
 		<label>Analog Meter</label>
 		<description>The Analog Meter from the LIVISI EnergyControl product.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="absoluteEnergyConsumption" typeId="absoluteEnergyConsumption"/>
 			<channel id="energyConsumptionDayKwh" typeId="energyConsumptionDayKwh"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/BRC8.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/BRC8.xml
@@ -11,7 +11,7 @@
 
 		<label>Basic Remote Controller (BRC8)</label>
 		<description>A battery powered remote controller with eight push buttons.</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="button1" typeId="system.button"/>
 			<channel id="button2" typeId="system.button"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/BT-PSS.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/BT-PSS.xml
@@ -11,7 +11,7 @@
 
 		<label>Bluetooth Pluggable Smart Switch (BT-PSS)</label>
 		<description>A pluggable switch that can be switched on and off and which can measure the current energy consumption.</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channels>
 			<channel id="switch" typeId="switchActuator"/>
 		</channels>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/GenerationMeter.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/GenerationMeter.xml
@@ -11,7 +11,7 @@
 
 		<label>Generation Meter</label>
 		<description>The Generation Meter from the LIVISI PowerControlSolar product, that measures the generated energy.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="powerGenerationWatt" typeId="powerGenerationWatt"/>
 			<channel id="totalEnergyGeneration" typeId="totalEnergyGeneration"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISC2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISC2.xml
@@ -11,7 +11,7 @@
 
 		<label>In Wall Smart Controller (ISC2)</label>
 		<description>A smart controller with two push buttons.</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="button1" typeId="system.button"/>
 			<channel id="button2" typeId="system.button"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISD2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISD2.xml
@@ -11,7 +11,7 @@
 
 		<label>In Wall Smart Dimmer (ISD2)</label>
 		<description>An in wall dimmer with push buttons.</description>
-
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="dimmer" typeId="dimmerActuator"/>
 			<channel id="button1" typeId="system.button"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISR2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISR2.xml
@@ -11,7 +11,7 @@
 
 		<label>In Wall Smart Roller Shutter (ISR2)</label>
 		<description>An in wall rollershutter with two push buttons.</description>
-
+		<semantic-equipment-tag>Blinds</semantic-equipment-tag>
 		<channels>
 			<channel id="rollershutter" typeId="rollershutterActuator"/>
 			<channel id="button1" typeId="system.button"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISS2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/ISS2.xml
@@ -11,7 +11,7 @@
 
 		<label>In Wall Smart Switch (ISS2)</label>
 		<description>An in wall switch with push buttons that can be switched on and off.</description>
-
+		<semantic-equipment-tag>Button</semantic-equipment-tag>
 		<channels>
 			<channel id="switch" typeId="switchActuator"/>
 			<channel id="button1" typeId="system.button"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/PSD.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/PSD.xml
@@ -11,7 +11,7 @@
 
 		<label>Pluggable Smart Dimmer (PSD)</label>
 		<description>A pluggable dimmer.</description>
-
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="dimmer" typeId="dimmerActuator"/>
 		</channels>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/PSS.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/PSS.xml
@@ -11,7 +11,7 @@
 
 		<label>Pluggable Smart Switch (PSS)</label>
 		<description>A pluggable switch that can be switched on and off.</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channels>
 			<channel id="switch" typeId="switchActuator"/>
 		</channels>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/PSSO.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/PSSO.xml
@@ -11,7 +11,7 @@
 
 		<label>Pluggable Smart Switch Outdoor (PSSO)</label>
 		<description>A pluggable outdoor switch that can be switched on and off.</description>
-
+		<semantic-equipment-tag>PowerOutlet</semantic-equipment-tag>
 		<channels>
 			<channel id="switch" typeId="switchActuator"/>
 		</channels>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/RST.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/RST.xml
@@ -11,7 +11,7 @@
 
 		<label>Radiator Mounted Smart Thermostat (RST)</label>
 		<description>A thermostat, that supports setting the temperature and measuring the current temperature and humidity.</description>
-
+		<semantic-equipment-tag>Thermostat</semantic-equipment-tag>
 		<channels>
 			<channel id="targetTemperature" typeId="thermostatActuatorPointTemperature"/>
 			<channel id="currentTemperature" typeId="temperatureSensorTemperature"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/RST2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/RST2.xml
@@ -12,7 +12,7 @@
 		<label>Radiator Mounted Smart Thermostat (RST2)</label>
 		<description>A thermostat, that supports setting the temperature and measuring the current temperature and humidity (2
 			battery version since 2018)</description>
-
+		<semantic-equipment-tag>Thermostat</semantic-equipment-tag>
 		<channels>
 			<channel id="targetTemperature" typeId="thermostatActuatorPointTemperature"/>
 			<channel id="currentTemperature" typeId="temperatureSensorTemperature"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/SIR.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/SIR.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Siren Indoor (SIR)</label>
 		<description>A battery powered indoor siren.</description>
-
+		<semantic-equipment-tag>Siren</semantic-equipment-tag>
 		<channels>
 			<channel id="sirenAlarm" typeId="sirenAlarmActuator"/>
 			<channel id="sirenNotification" typeId="sirenNotificationActuator"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/SmartMeter.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/SmartMeter.xml
@@ -11,7 +11,7 @@
 
 		<label>Smart Meter</label>
 		<description>The Smart Meter from the LIVISI PowerControl product.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="powerConsumptionWatt" typeId="powerConsumptionWatt"/>
 			<channel id="absoluteEnergyConsumption" typeId="absoluteEnergyConsumption"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/TwoWayMeter.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/TwoWayMeter.xml
@@ -11,7 +11,7 @@
 
 		<label>Two-Way-Meter</label>
 		<description>The Two-Way-Meter from the LIVISI PowerControlSolar product.</description>
-
+		<semantic-equipment-tag>ElectricMeter</semantic-equipment-tag>
 		<channels>
 			<channel id="powerWatt" typeId="powerConsumptionWatt"/>
 			<channel id="totalEnergy" typeId="totalEnergyConsumption"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WDS.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WDS.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Door/Window Sensor (WDS)</label>
 		<description>A window/door sensor, that provides the open/close state.</description>
-
+		<semantic-equipment-tag>ContactSensor</semantic-equipment-tag>
 		<channels>
 			<channel id="contact" typeId="windowDoorSensor"/>
 			<channel id="batteryLow" typeId="system.low-battery"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WMD.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WMD.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Motion Detector Indoor (WMD)</label>
 		<description>A battery powered motion detector, that also measures luminance.</description>
-
+		<semantic-equipment-tag>MotionDetector</semantic-equipment-tag>
 		<channels>
 			<channel id="motionCount" typeId="motionDetectionSensor"/>
 			<channel id="luminance" typeId="luminanceSensor"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WMDO.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WMDO.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Motion Detector Outdoor (WMDO)</label>
 		<description>A battery powered motion detector for outdoors, that also measures luminance.</description>
-
+		<semantic-equipment-tag>MotionDetector</semantic-equipment-tag>
 		<channels>
 			<channel id="motionCount" typeId="motionDetectionSensor"/>
 			<channel id="luminance" typeId="luminanceSensor"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WRT.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WRT.xml
@@ -12,7 +12,7 @@
 		<label>Wall Mounted Room Thermostat (WRT)</label>
 		<description>A wall thermostat, that supports setting the temperature and measuring the current temperature and
 			humidity.</description>
-
+		<semantic-equipment-tag>Thermostat</semantic-equipment-tag>
 		<channels>
 			<channel id="targetTemperature" typeId="thermostatActuatorPointTemperature"/>
 			<channel id="currentTemperature" typeId="temperatureSensorTemperature"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WSC2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WSC2.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Smart Controller (WSC2)</label>
 		<description>A battery powered smart controller with two push buttons.</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="button1" typeId="system.button"/>
 			<channel id="button2" typeId="system.button"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WSD.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WSD.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Smoke Detector (WSD)</label>
 		<description>A battery powered smoke detector sensor with integrated alarm (first version).</description>
-
+		<semantic-equipment-tag>SmokeDetector</semantic-equipment-tag>
 		<channels>
 			<channel id="smoke" typeId="smokeDetectorSensor"/>
 			<channel id="alarm" typeId="alarmActuator"/>

--- a/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WSD2.xml
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/resources/OH-INF/thing/WSD2.xml
@@ -11,7 +11,7 @@
 
 		<label>Wall Mounted Smoke Detector (WSD2)</label>
 		<description>A battery powered smoke detector sensor with integrated alarm (2nd version with long-life battery).</description>
-
+		<semantic-equipment-tag>SmokeDetector</semantic-equipment-tag>
 		<channels>
 			<channel id="smoke" typeId="smokeDetectorSensor"/>
 			<channel id="alarm" typeId="alarmActuator"/>

--- a/bundles/org.openhab.binding.loxone/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.loxone/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,6 +8,7 @@
 
 		<label>Loxone Miniserver</label>
 		<description>IP gateway for Loxone Smarthome system</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 
 		<config-description>
 

--- a/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="ipbridge">
 		<label>Lutron IP Access Point</label>
 		<description>Lutron controller using Lutron Integration Protocol (LIP) over TCP/IP</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 		<properties>
 			<property name="vendor">Lutron</property>
 		</properties>
@@ -135,6 +136,7 @@
 		<label>Lutron Dimmer</label>
 		<description>Controls dimmable loads</description>
 		<category>Lightbulb</category>
+		<semantic-equipment-tag>Dial</semantic-equipment-tag>
 
 		<channels>
 			<channel id="lightlevel" typeId="lightDimmer"/>
@@ -181,7 +183,7 @@
 
 		<label>Fan Speed Controller</label>
 		<description>Controls ceiling fans</description>
-
+		<semantic-equipment-tag>Fan</semantic-equipment-tag>
 		<channels>
 			<channel id="fanspeed" typeId="fanControl"/>
 			<channel id="fanlevel" typeId="lightDimmer"/>
@@ -206,7 +208,7 @@
 		<label>Lutron Shade</label>
 		<description>Controls roller shades, drapes, and motor controllers</description>
 		<category>Blinds</category>
-
+		<semantic-equipment-tag>Blinds</semantic-equipment-tag>
 		<channels>
 			<channel id="shadelevel" typeId="shadeControl"/>
 		</channels>
@@ -229,7 +231,7 @@
 		<label>Lutron Blind</label>
 		<description>Controls venetian and horizontal sheer blinds</description>
 		<category>Blinds</category>
-
+		<semantic-equipment-tag>Blinds</semantic-equipment-tag>
 		<channels>
 			<channel id="blindliftlevel" typeId="blindLift"/>
 			<channel id="blindtiltlevel" typeId="blindTilt"/>
@@ -263,7 +265,7 @@
 		<label>Lutron Switch</label>
 		<description>On/off switch</description>
 		<category>WallSwitch</category>
-
+		<semantic-equipment-tag>WallSwitch</semantic-equipment-tag>
 		<channels>
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>
@@ -372,7 +374,7 @@
 		<label>Radio Powr Savr Sensor</label>
 		<description>Motion sensor to detect occupancy status</description>
 		<category>MotionDetector</category>
-
+		<semantic-equipment-tag>OccupancySensor</semantic-equipment-tag>
 		<channels>
 			<channel id="occupancystatus" typeId="occupiedState"/>
 		</channels>
@@ -416,7 +418,7 @@
 		<label>Occupancy Group</label>
 		<description>Shows state of occupancy sensor group</description>
 		<category>MotionDetector</category>
-
+		<semantic-equipment-tag>OccupancySensor</semantic-equipment-tag>
 		<channels>
 			<channel id="groupstate" typeId="groupState"/>
 		</channels>
@@ -438,7 +440,7 @@
 
 		<label>seeTouch Keypad</label>
 		<description>Lutron seeTouch/Hybrid seeTouch wall keypad</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -494,7 +496,7 @@
 
 		<label>Tabletop seeTouch Keypad</label>
 		<description>Lutron wireless tabletop keypad</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -531,7 +533,7 @@
 
 		<label>International seeTouch Keypad</label>
 		<description>Lutron International seeTouch keypad (HomeWorks QS Only)</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -570,7 +572,7 @@
 
 		<label>Palladiom Keypad</label>
 		<description>Lutron Palladiom keypad (HomeWorks QS Only)</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -613,7 +615,7 @@
 
 		<label>Pico Keypad</label>
 		<description>Lutron wireless Pico keypad</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -649,7 +651,7 @@
 
 		<label>GRAFIK Eye QS Keypad</label>
 		<description>Lutron GRAFIK Eye QS for RadioRA 2/HomeWorks QS</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -683,7 +685,7 @@
 
 		<label>VCRX</label>
 		<description>Lutron visor control receiver</description>
-
+		<semantic-equipment-tag>Sensor</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -730,7 +732,7 @@
 
 		<label>Virtual Keypad</label>
 		<description>Virtual integration keypad on repeater</description>
-
+		<semantic-equipment-tag>Keypad</semantic-equipment-tag>
 		<representation-property>integrationId</representation-property>
 
 		<config-description>
@@ -843,7 +845,7 @@
 	<bridge-type id="prgbridge">
 		<label>Lutron GRX-PRG or GRX-CI-PRG Bridge</label>
 		<description>Ethernet access point to Lutron GRAFIK Eye 3x/4x Systems</description>
-
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 		<channels>
 			<channel id="buttonpress" typeId="buttonpress"/>
 			<channel id="zonelowerstop" typeId="button">
@@ -918,7 +920,7 @@
 
 		<label>GRAFIK Eye</label>
 		<description>Controls a GRAFIK Eye</description>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="scene" typeId="scene"/>
 			<channel id="scenelock" typeId="scenelock"/>
@@ -1145,7 +1147,7 @@
 		<label>Lutron Dimmer (Legacy HomeWorks)</label>
 		<description>Controls dimmable loads for legacy HomeWorks systems</description>
 		<category>Lightbulb</category>
-
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="lightlevel" typeId="lightDimmer"/>
 		</channels>
@@ -1193,7 +1195,7 @@
 		<label>Lutron Dimmer (Legacy RadioRA)</label>
 		<description>Controls dimmable loads for legacy RadioRA systems</description>
 		<category>Lightbulb</category>
-
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 		<channels>
 			<channel id="lightlevel" typeId="lightDimmer"/>
 		</channels>
@@ -1226,7 +1228,7 @@
 		<label>Lutron Switch (Legacy RadioRA)</label>
 		<description>On/off switch for Legacy RadioRA systems</description>
 		<category>WallSwitch</category>
-
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>
@@ -1250,7 +1252,7 @@
 		</supported-bridge-type-refs>
 		<label>Phantom Button (Legacy RadioRA)</label>
 		<description>Phantom Button for Legacy RadioRA systems</description>
-
+		<semantic-equipment-tag>Button</semantic-equipment-tag>
 		<channels>
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>

--- a/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/OH-INF/thing/thing-types.xml
@@ -136,7 +136,7 @@
 		<label>Lutron Dimmer</label>
 		<description>Controls dimmable loads</description>
 		<category>Lightbulb</category>
-		<semantic-equipment-tag>Dial</semantic-equipment-tag>
+		<semantic-equipment-tag>LightSource</semantic-equipment-tag>
 
 		<channels>
 			<channel id="lightlevel" typeId="lightDimmer"/>

--- a/bundles/org.openhab.binding.luxom/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.luxom/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,7 @@
 	<bridge-type id="bridge">
 		<label>Luxom Bridge</label>
 		<description>This bridge represents a Luxom IP-interface (for example a DS-65L).</description>
+		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">
 				<context>network-address</context>
@@ -35,6 +36,7 @@
 		</supported-bridge-type-refs>
 		<label>Switch</label>
 		<description>Switch type action in Luxom</description>
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="switch" typeId="switchState"/>
 		</channels>
@@ -54,6 +56,7 @@
 		</supported-bridge-type-refs>
 		<label>Dimmer</label>
 		<description>Dimmer type action in Luxom</description>
+		<semantic-equipment-tag>ControlDevice</semantic-equipment-tag>
 		<channels>
 			<channel id="brightness" typeId="system.brightness"/>
 		</channels>

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
@@ -6,6 +6,7 @@
 	<thing-type id="heatpump">
 		<label>Heatpump with Luxtronik Control</label>
 		<description>Integrates a heatpump with a Luxtronik control.</description>
+		<semantic-equipment-tag>HeatPump</semantic-equipment-tag>
 		<channels>
 			<channel id="temperatureHeatingCircuitFlow" typeId="temperatureHeatingCircuitFlow"/>
 			<channel id="temperatureHeatingCircuitReturn" typeId="temperatureHeatingCircuitReturn"/>


### PR DESCRIPTION
This PR adds Equipment tags (only) to bindings G thru L.

- It adds Equipment tags where it is relatively easy to determine the type of Equipment from the context.
- It does NOT add any Point or Property tags => I am hoping that you code contributors will provide these.
- See Equipment tags in this [table](https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.semantics/model/SemanticTags.csv) for reference.

Signed-off-by: Andrew Fiddian-Green [software@whitebear.ch](mailto:software@whitebear.ch)