### PR TITLE
[homematic] Fix HM-IP long press button handling

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonVirtualDatapointHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonVirtualDatapointHandler.java
@@ -80,10 +80,10 @@ public class ButtonVirtualDatapointHandler extends AbstractVirtualDatapointHandl
                 }
                 case "LONG":
                     if (usesLongStart) {
-                        // HM-IP devices do long press repetitions via LONG instead of CONT events,
-                        // so clear previous value to force re-triggering of event
+                        // HM-IP devices do long press repetitions via LONG instead of CONT events;
+                        // besides that the logic is the same as in the CONT handling below
+                        vdp.setValue(null);
                         if (isLongPressActive) {
-                            vdp.setValue(null);
                             vdp.setValue(LONG_REPEATED_EVENT);
                         }
                     } else {

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
@@ -80,6 +80,12 @@ public class ButtonDatapointTest extends JavaTest {
         HmDatapoint releaseDp = createPressDatapointFrom(longPressDp, "PRESS_LONG_RELEASE", Boolean.TRUE);
         mockEventReceiver.eventReceived(releaseDp);
         assertThat(buttonVirtualDatapoint.getValue(), is("LONG_RELEASED"));
+
+        // A CONT event right after a SHORT event should not trigger another SHORT_PRESSED event
+        HmDatapoint shortPressDp = createPressDatapointFrom(longPressDp, "PRESS_SHORT", Boolean.TRUE);
+        mockEventReceiver.eventReceived(shortPressDp);
+        mockEventReceiver.eventReceived(contPressDp);
+        assertThat(buttonVirtualDatapoint.getValue(), nullValue());
     }
 
     @Test
@@ -98,6 +104,12 @@ public class ButtonDatapointTest extends JavaTest {
         HmDatapoint releaseDp = createPressDatapointFrom(longPressDp, "PRESS_LONG_RELEASE", Boolean.TRUE);
         mockEventReceiver.eventReceived(releaseDp);
         assertThat(buttonVirtualDatapoint.getValue(), is("LONG_RELEASED"));
+
+        // A LONG event right after a SHORT event should not trigger another SHORT_PRESSED event
+        HmDatapoint shortPressDp = createPressDatapointFrom(longPressDp, "PRESS_SHORT", Boolean.TRUE);
+        mockEventReceiver.eventReceived(shortPressDp);
+        mockEventReceiver.eventReceived(contPressDp);
+        assertThat(buttonVirtualDatapoint.getValue(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
When starting a long press right after a short press, the short press wrongly was emitted twice.

Reported in the forum: https://community.openhab.org/t/homematic-ip-wired-virtual-datapoints-of-buttons-long-press-fires-short-pressed-command/163673