### PR TITLE
[rrd4j] Fix NaN check

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -589,8 +589,8 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             // First get the last update state and time
             currentValue = db.getLastDatasourceValue(DATASOURCE_STATE);
             lastUpdate = db.getLastArchiveUpdateTime();
-            if (currentValue == Double.NaN) {
-                logger.debug("Could not find persisted value for item '{}' in rrjd4j database", itemName);
+            if (Double.isNaN(currentValue)) {
+                logger.debug("Could not find persisted value for item '{}' in rrd4j database", itemName);
                 return null;
             }
 


### PR DESCRIPTION
I had plenty of these errors in my log:

```
15:01:05.012 [ERROR] [rnal.common.AbstractInvocationHandler] - An error occurred while calling method 'QueryablePersistenceService.persistedItem()' on 'org.openhab.persistence.rrd4j.internal.RRD4jPersistenceService@4e3eeda0': Character N is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
java.lang.NumberFormatException: Character N is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
        at java.math.BigDecimal.<init>(BigDecimal.java:608) ~[?:?]
        at java.math.BigDecimal.<init>(BigDecimal.java:497) ~[?:?]
        at java.math.BigDecimal.<init>(BigDecimal.java:903) ~[?:?]
        at org.openhab.core.library.types.DecimalType.<init>(DecimalType.java:66) ~[?:?]
        at org.openhab.persistence.rrd4j.internal.RRD4jPersistenceService.persistedItem(RRD4jPersistenceService.java:645) ~[?:?]
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
        at org.openhab.core.internal.common.AbstractInvocationHandler.invokeDirect(AbstractInvocationHandler.java:149) ~[?:?]
        at org.openhab.core.internal.common.Invocation.call(Invocation.java:52) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
```
This PR fixes it by correctly implementing the `NaN` check.