### PR TITLE
[bluetooth.bluegiga] Fix NoSuchElementException during initialization

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
@@ -244,6 +244,13 @@ public class BlueGigaBridgeHandler extends AbstractBluetoothBridgeHandler<BlueGi
                             closeSerialPort(sp);
                         }
                     });
+
+                    if (inputStream.isEmpty() || outputStream.isEmpty()) {
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
+                                "Serial Error: Communication stream not available");
+                        throw new RetryException(INITIALIZATION_INTERVAL_SEC, TimeUnit.SECONDS);
+                    }
+
                     return sp;
                 } catch (PortInUseException e) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,


### PR DESCRIPTION
I had the following exception in my logs during startup:
```
16:10:36.282 [WARN ] [luegiga.handler.BlueGigaBridgeHandler] - Error initializing bluegiga
java.util.concurrent.CompletionException: java.util.NoSuchElementException: No value present
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
        at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
        at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2179) ~[?:?]
        at org.openhab.binding.bluetooth.util.RetryFuture$CallableTask.run(RetryFuture.java:67) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.util.NoSuchElementException: No value present
        at java.util.Optional.get(Optional.java:143) ~[?:?]
        at org.openhab.binding.bluetooth.bluegiga.handler.BlueGigaBridgeHandler.lambda$3(BlueGigaBridgeHandler.java:263) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646) ~[?:?]
        ... 9 more
```
This PR should hopefully fix it.