### PR TITLE
Maven Build: Validate Thing-type XML against schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,8 @@ Import-Package: \\
         <configuration>
           <validationSets>
             <validationSet>
-              <dir>src/main/resources/OH-INF/thing/</dir>
+              <dir>${session.executionRootDirectory}</dir>
+              <includes>**/src/main/resources/OH-INF/thing/*.xml</includes>
               <systemId>https://openhab.org/schemas/thing-description-1.0.0.xsd</systemId>
             </validationSet>
           </validationSets>

--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,29 @@ Import-Package: \\
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>src/main/resources/OH-INF/thing/</dir>
+              <systemId>https://openhab.org/schemas/thing-description-1.0.0.xsd</systemId>
+            </validationSet>
+          </validationSets>
+          <catalogs>
+            <catalog>${session.executionRootDirectory}/src/thing-type-xml-validation-catalog.xml</catalog>
+          </catalogs>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <extensions>
       <extension>

--- a/src/thing-type-xml-validation-catalog.xml
+++ b/src/thing-type-xml-validation-catalog.xml
@@ -1,0 +1,6 @@
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+	<public publicId="https://openhab.org/schemas/thing-description/v1.0.0"
+		uri="thing-description-schema.xsd"/>
+	<system systemId="https://openhab.org/schemas/thing-description-1.0.0.xsd"
+		uri="thing-description-schema.xsd"/>
+</catalog>

--- a/src/thing-type-xml-validation-catalog.xml
+++ b/src/thing-type-xml-validation-catalog.xml
@@ -1,6 +1,4 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-	<public publicId="https://openhab.org/schemas/thing-description/v1.0.0"
-		uri="thing-description-schema.xsd"/>
-	<system systemId="https://openhab.org/schemas/thing-description-1.0.0.xsd"
-		uri="thing-description-schema.xsd"/>
+	<public publicId="https://openhab.org/schemas/thing-description/v1.0.0" uri="thing-description-schema.xsd"/>
+	<system systemId="https://openhab.org/schemas/thing-description-1.0.0.xsd" uri="thing-description-schema.xsd"/>
 </catalog>


### PR DESCRIPTION
I went to great extents to modify the thing-description xml schema to be stricter in validating semantic tags against pre-defined allowed values. But then I discovered that the standard Maven build process does not actually do any xml schema validation at all. Maybe it was deleted at some time? Anyway this PR adds back the schema validation.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>