### PR TITLE
[mqtt.homeassistant] Clear internal data when stopping

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -247,6 +247,12 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
                     // we need to join all the stops, otherwise they might not be done when start is called
                     .collect(FutureCollector.allOf()).join();
 
+            haComponents.clear();
+            haComponentsByUniqueId.clear();
+            haComponentsByHaId.clear();
+            channelStates.clear();
+            discoveryHomeAssistantIDs.clear();
+            updateComponent = null;
             started = false;
         }
         super.stop();


### PR DESCRIPTION
When the thing config changes, core will dispose of the handler, and then immediately initialize the exact same object again. If we don't clear the internal data, we'll find conflicts, and cause channels to be renamed unnecessarily. I believe this also fixes an issue that I'm never able to remove topics from the config, even though they no longer exist.

Closes #18278 and #18494
