### PR TITLE
[energidataservice] Fix `NullPointerException`

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/provider/cache/SpotPriceSubscriptionCache.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/provider/cache/SpotPriceSubscriptionCache.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.energidataservice.internal.api.dto.ElspotpriceRecord;
@@ -57,8 +58,11 @@ public class SpotPriceSubscriptionCache extends ElectricityPriceSubscriptionCach
         boolean anyChanges = false;
         int oldSize = priceMap.size();
         for (ElspotpriceRecord record : records) {
-            BigDecimal newValue = (isDKK ? record.spotPriceDKK() : record.spotPriceEUR())
-                    .divide(BigDecimal.valueOf(1000));
+            BigDecimal spotPrice = isDKK ? record.spotPriceDKK() : record.spotPriceEUR();
+            if (Objects.isNull(spotPrice)) {
+                continue;
+            }
+            BigDecimal newValue = spotPrice.divide(BigDecimal.valueOf(1000));
             BigDecimal oldValue = priceMap.put(record.hour(), newValue);
             if (oldValue == null || newValue.compareTo(oldValue) != 0) {
                 anyChanges = true;


### PR DESCRIPTION
I noticed missing prices today and found this in my logs:
```
2025-04-22 13:10:30.039 [TRACE] [gidataservice.internal.ApiController] - GET request for https://api.energidataservice.dk/dataset/Elspotprices?start=utcnow&filter=%7B%22PriceArea%22%3A%22DK1%22%7D&columns=HourUTC%2CSpotPriceDKK
2025-04-22 13:10:30.202 [TRACE] [gidataservice.internal.ApiController] - Response content: '{"total":36,"filters":"{\"PriceArea\":\"DK1\"}","dataset":"Elspotprices","records":[{"HourUTC":"2025-04-23T21:00:00","SpotPriceDKK":null},{"HourUTC>
2025-04-22 13:10:30.206 [WARN ] [ore.internal.scheduler.SchedulerImpl] - Scheduled job '<unknown>' failed and stopped
java.lang.NullPointerException: Cannot invoke "java.math.BigDecimal.divide(java.math.BigDecimal)"
        at org.openhab.binding.energidataservice.internal.provider.cache.SpotPriceSubscriptionCache.put(SpotPriceSubscriptionCache.java:61) ~[?:?]
        at org.openhab.binding.energidataservice.internal.provider.ElectricityPriceProvider.downloadSpotPrices(ElectricityPriceProvider.java:285) ~[?:?]
        at org.openhab.binding.energidataservice.internal.provider.ElectricityPriceProvider.downloadPrices(ElectricityPriceProvider.java:258) ~[?:?]
        at org.openhab.binding.energidataservice.internal.provider.ElectricityPriceProvider.refreshElectricityPrices(ElectricityPriceProvider.java:152) ~[?:?]
        at org.openhab.core.scheduler.Scheduler.lambda$0(Scheduler.java:75) ~[bundleFile:?]
        at org.openhab.core.internal.scheduler.SchedulerImpl.lambda$1(SchedulerImpl.java:88) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:840) [?:?]
```

For some reason the Danish prices are missing, the full payload with all columns starts (and continues) like this:
```xml
{
  "total": 32,
  "filters": "{\"PriceArea\":\"DK1\"}",
  "dataset": "Elspotprices",
  "records": [
    {
      "HourUTC": "2025-04-23T21:00:00",
      "HourDK": "2025-04-23T23:00:00",
      "PriceArea": "DK1",
      "SpotPriceDKK": null,
      "SpotPriceEUR": 97.150002
    },
```

This is probably caused by their [new implementation](https://energidataservice.dk/tso-electricity/Elspotprices):
> From February 1st, 2025, the Spot Price (DKK) is calculated based on the Spot Price (EUR) and the Euro exchange rate from Danmarks Nationalbank. It may therefore deviate from Danish spot prices seen elsewhere.

In any case, validation is missing in the binding, so this has been added. It will now be detected that prices are missing, and the retry mechanism will kick in.