### PR TITLE
Fix xml-maven-plugin error in Eclipse since #18579

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -763,6 +763,19 @@ Import-Package: \\
                         <execute/>
                       </action>
                     </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <versionRange>[1.0.0,)</versionRange>
+                        <goals>
+                          <goal>validate</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore/>
+                      </action>
+                    </pluginExecution>
                   </pluginExecutions>
                 </lifecycleMappingMetadata>
               </configuration>


### PR DESCRIPTION
As [discussed here](https://community.openhab.org/t/californium-removed/163625/40) there's an error preventing building from Eclipse since #18579.

`xml-maven-plugin` doesn't seem to have its own M2E "configuration", which leads to an error from M2E when encountering this plugin. Since the plugin is used for XML validation, which isn't needed for Eclipse builds, the solution here is to simply tell M2E to ignore the plugin.

According to my testing, this solves the issue.