### PR TITLE
[grundfosalpha] Add myself as code owner for Alpha3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,7 +52,7 @@
 /bundles/org.openhab.binding.bluetooth.enoceanble/ @pfink
 /bundles/org.openhab.binding.bluetooth.generic/ @cpmeister
 /bundles/org.openhab.binding.bluetooth.govee/ @cpmeister
-/bundles/org.openhab.binding.bluetooth.grundfosalpha/ @tisoft
+/bundles/org.openhab.binding.bluetooth.grundfosalpha/ @tisoft @jlaur
 /bundles/org.openhab.binding.bluetooth.hdpowerview/ @andrewfg
 /bundles/org.openhab.binding.bluetooth.radoneye/ @petero-dk
 /bundles/org.openhab.binding.bluetooth.roaming/ @cpmeister


### PR DESCRIPTION
I'm proposing to add myself as maintainer of the Grundfos binding after contributing support for the Alpha3 pump: #18187

Please do not merge without approval from @tisoft who originally contributed the binding: #15907