### PR TITLE
[jsscriptingnashorn] Upgrade Nashorn to 15.6

### DIFF
--- a/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
+++ b/bundles/org.openhab.automation.jsscriptingnashorn/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.openjdk.nashorn</groupId>
       <artifactId>nashorn-core</artifactId>
-      <version>15.4</version>
+      <version>15.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrades Nashorn from 15.4 to 15.6.

For release notes, see:

https://github.com/openjdk/nashorn/blob/main/CHANGELOG.md