### PR TITLE
[lgtvserial] Fix inverted Volume Mute switch

### DIFF
--- a/bundles/org.openhab.binding.lgtvserial/README.md
+++ b/bundles/org.openhab.binding.lgtvserial/README.md
@@ -134,7 +134,7 @@ Here is the list of all the LG TV commands added to the binding, in channel type
 
 ## Not added or linked commands
 
-The following commands/channels are not currently implemented in the binding but the commands could be sent via the `raw` channel.
+The following commands/channels are not currently implemented in the binding but the commands could be [sent via the raw channel](#using-raw-channel-via-rules-example).
 
 | Channel ID         | Command | Description
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|

--- a/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/commands/BaseOnOffInvertCommand.java
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/commands/BaseOnOffInvertCommand.java
@@ -17,24 +17,25 @@ import org.openhab.binding.lgtvserial.internal.protocol.serial.responses.OnOffRe
 import org.openhab.core.library.types.OnOffType;
 
 /**
- * This command is the base command for the On/Off type command which translates to 00/01 on the wire.
+ * This command is the base command for the On/Off type command where the state is inverted.
+ * I.e. The volume mute command that reports on mute on as 00, mute off as 01.
  *
  * @author Richard Lavoie - Initial contribution
  *
  */
-public abstract class BaseOnOffCommand extends BaseLGSerialCommand {
+public abstract class BaseOnOffInvertCommand extends BaseLGSerialCommand {
 
-    protected BaseOnOffCommand(char command1, char command2, int setId) {
+    protected BaseOnOffInvertCommand(char command1, char command2, int setId) {
         super(command1, command2, setId, true);
     }
 
     @Override
     protected String computeSerialDataFrom(Object data) {
-        return data == OnOffType.ON ? "01" : "00";
+        return data == OnOffType.ON ? "00" : "01";
     }
 
     @Override
     protected LGSerialResponse createResponse(int set, boolean success, String data) {
-        return new OnOffResponse(set, success, data, false);
+        return new OnOffResponse(set, success, data, true);
     }
 }

--- a/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/commands/VolumeMuteCommand.java
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/commands/VolumeMuteCommand.java
@@ -18,7 +18,7 @@ package org.openhab.binding.lgtvserial.internal.protocol.serial.commands;
  * @author Richard Lavoie - Initial contribution
  *
  */
-public class VolumeMuteCommand extends BaseOnOffCommand {
+public class VolumeMuteCommand extends BaseOnOffInvertCommand {
 
     protected VolumeMuteCommand(int setId) {
         super('k', 'e', setId);

--- a/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/responses/OnOffResponse.java
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/java/org/openhab/binding/lgtvserial/internal/protocol/serial/responses/OnOffResponse.java
@@ -31,12 +31,13 @@ public class OnOffResponse implements LGSerialResponse {
 
     private State state;
 
-    public OnOffResponse(int setId, boolean success, String data) {
+    public OnOffResponse(int setId, boolean success, String data, boolean invert) {
         this.setId = setId;
         this.success = success;
 
         if (success) {
-            state = OnOffType.from("01".equals(data));
+            // inverted "00" == on, not inverted "01" == on
+            state = OnOffType.from((invert ? "00" : "01").equals(data));
         } else {
             state = new StringType(data);
         }


### PR DESCRIPTION
Fix the issue with the `volume-mute` channel being inverted relative to the actual mute state on the TV. Confusingly the API reports a state of 00 when the mute is on and 01 when the mute is off. This is opposite to how other states such as the power state are reported. With this change the volume is muted when the switch is on and not muted when the switch is off.

![LG Mute](https://github.com/user-attachments/assets/ab47e741-29ba-4823-8ca7-51ce771ebd4f)
