### PR TITLE
[energidataservice] Fix `DAY_AHEAD_AVAILABLE` event

### DIFF
--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/handler/EnergiDataServiceHandler.java
@@ -129,11 +129,7 @@ public class EnergiDataServiceHandler extends BaseThingHandler
 
         String channelId = channelUID.getId();
         if (ELECTRICITY_CHANNELS.contains(channelId)) {
-            if (!electricityPriceProvider.forceRefreshPrices(getChannelSubscription(channelId))) {
-                // All subscriptions are automatically notified upon actual changes after download.
-                // If cached values are the same, we will update the requested channel directly.
-                updateChannelFromCache(getChannelSubscription(channelId), channelId);
-            }
+            updateChannelFromCache(getChannelSubscription(channelId), channelId);
         } else if (CO2_EMISSION_CHANNELS.contains(channelId)) {
             Subscription subscription = getChannelSubscription(channelId);
             unsubscribe(subscription);

--- a/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/provider/ElectricityPriceProvider.java
+++ b/bundles/org.openhab.binding.energidataservice/src/main/java/org/openhab/binding/energidataservice/internal/provider/ElectricityPriceProvider.java
@@ -90,6 +90,13 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
         this.apiController = new ApiController(httpClientFactory.getCommonHttpClient(), timeZoneProvider);
     }
 
+    protected ElectricityPriceProvider(final Scheduler scheduler, final ApiController apiController,
+            final TimeZoneProvider timeZoneProvider) {
+        this.scheduler = scheduler;
+        this.timeZoneProvider = timeZoneProvider;
+        this.apiController = apiController;
+    }
+
     @Deactivate
     public void deactivate() {
         stopJobs();
@@ -147,10 +154,15 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
                 Subscription subscription = subscriptionListener.getKey();
                 Set<ElectricityPriceListener> listeners = subscriptionListener.getValue();
 
-                downloadPrices(subscription, false);
+                boolean spotPricesUpdated = downloadPricesIfNotCached(subscription)
+                        && subscription instanceof SpotPriceSubscription;
 
                 updateCurrentPrices(subscription);
                 publishPricesFromCache(subscription, listeners);
+
+                if (spotPricesUpdated && getSpotPriceSubscriptionDataCache(subscription).arePricesFullyCached()) {
+                    listeners.forEach(listener -> listener.onDayAheadAvailable());
+                }
             }
 
             reschedulePriceUpdateJob();
@@ -224,30 +236,10 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
     }
 
     /**
-     * Force refresh prices for {@link Subscription} even if already cached.
-     * The prices are not returned, but will be stored in the cache and can
-     * be obtained by {@link #getCurrentPriceIfCached(Subscription)}
-     * or {@link #getPricesIfCached(Subscription)}.
-     *
-     * @return true if cached values were changed as a result of the refresh
-     */
-    public boolean forceRefreshPrices(Subscription subscription) {
-        try {
-            return downloadPrices(subscription, true);
-        } catch (DataServiceException e) {
-            logger.debug("Error force retrieving prices", e);
-            return false;
-        } catch (InterruptedException e) {
-            logger.debug("Force refresh interrupted");
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
-
-    /**
      * Get all prices for given {@link Subscription}.
      * If the prices are not already cached, they will be fetched
-     * from the service.
+     * from the service unless there are active listeners.
+     * In that case a retry policy should already be in effect.
      *
      * @param subscription Subscription for which to get prices
      * @return Map of available prices
@@ -256,36 +248,57 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
      */
     public Map<Instant, BigDecimal> getPrices(Subscription subscription)
             throws InterruptedException, DataServiceException {
-        downloadPrices(subscription, false);
+        if (getListeners(subscription).isEmpty()) {
+            logger.debug("{} has no listeners, trigger download if not cached", subscription);
+            downloadPricesIfNotCached(subscription);
+        }
 
+        // If there are listeners for the subscription, do not short-circuit
+        // the download flow; Just return what is already cached.
+        // Method refreshElectricityPrices is responsible for downloading new
+        // prices and notifying listeners when new spot proces are available.
         return getSubscriptionDataCache(subscription).get();
     }
 
-    private boolean downloadPrices(Subscription subscription, boolean force)
+    /**
+     * PLEASE NOTE: This method should only be called when there are no listeners
+     * or by {@link #refreshElectricityPrices}, because it will manage the retry
+     * policy and notify listeners when new day-ahead prices are available.
+     */
+    private boolean downloadPricesIfNotCached(Subscription subscription)
             throws InterruptedException, DataServiceException {
         if (subscription instanceof SpotPriceSubscription spotPriceSubscription) {
-            return downloadSpotPrices(spotPriceSubscription, false);
+            return downloadSpotPricesIfNotCached(spotPriceSubscription);
         } else if (subscription instanceof DatahubPriceSubscription datahubPriceSubscription) {
-            return downloadTariffs(datahubPriceSubscription, false);
+            return downloadTariffsIfNotCached(datahubPriceSubscription);
         }
         throw new IllegalArgumentException("Subscription " + subscription + " is not supported");
     }
 
-    private boolean downloadSpotPrices(SpotPriceSubscription subscription, boolean force)
+    private boolean downloadSpotPricesIfNotCached(SpotPriceSubscription subscription)
             throws InterruptedException, DataServiceException {
         SpotPriceSubscriptionCache cache = getSpotPriceSubscriptionDataCache(subscription);
 
-        if (!force && cache.arePricesFullyCached()) {
+        if (cache.arePricesFullyCached()) {
             logger.debug("Cached spot prices still valid, skipping download.");
             return false;
         }
+
         DateQueryParameter start;
-        if (!force && cache.areHistoricPricesCached()) {
+        if (cache.areHistoricPricesCached()) {
             start = DateQueryParameter.of(DateQueryParameterType.UTC_NOW);
         } else {
             start = DateQueryParameter.of(DateQueryParameterType.UTC_NOW,
                     Duration.ofHours(-ElectricityPriceSubscriptionCache.NUMBER_OF_HISTORIC_HOURS));
         }
+
+        return downloadSpotPrices(subscription, start);
+    }
+
+    private boolean downloadSpotPrices(SpotPriceSubscription subscription, DateQueryParameter start)
+            throws InterruptedException, DataServiceException {
+        SpotPriceSubscriptionCache cache = getSpotPriceSubscriptionDataCache(subscription);
+
         Map<String, String> properties = new HashMap<>();
         boolean isUpdated = false;
         try {
@@ -294,28 +307,34 @@ public class ElectricityPriceProvider extends AbstractProvider<ElectricityPriceL
             isUpdated = cache.put(spotPriceRecords);
         } finally {
             listenerToSubscriptions.keySet().forEach(listener -> listener.onPropertiesUpdated(properties));
-
-            if (isUpdated && cache.arePricesFullyCached()) {
-                getListeners(subscription).forEach(listener -> listener.onDayAheadAvailable());
-            }
         }
         return isUpdated;
     }
 
-    private boolean downloadTariffs(DatahubPriceSubscription subscription, boolean force)
+    private boolean downloadTariffsIfNotCached(DatahubPriceSubscription subscription)
             throws InterruptedException, DataServiceException {
         GlobalLocationNumber globalLocationNumber = subscription.getGlobalLocationNumber();
         if (globalLocationNumber.isEmpty()) {
             return false;
         }
         DatahubPriceSubscriptionCache cache = getDatahubPriceSubscriptionDataCache(subscription);
-        if (!force && cache.areTariffsValidTomorrow()) {
+        if (cache.areTariffsValidTomorrow()) {
             logger.debug("Cached tariffs of type {} still valid, skipping download.", subscription.getDatahubTariff());
             cache.update();
             return false;
-        } else {
-            return cache.put(downloadPriceLists(subscription));
         }
+
+        return downloadTariffs(subscription);
+    }
+
+    private boolean downloadTariffs(DatahubPriceSubscription subscription)
+            throws InterruptedException, DataServiceException {
+        GlobalLocationNumber globalLocationNumber = subscription.getGlobalLocationNumber();
+        if (globalLocationNumber.isEmpty()) {
+            return false;
+        }
+        DatahubPriceSubscriptionCache cache = getDatahubPriceSubscriptionDataCache(subscription);
+        return cache.put(downloadPriceLists(subscription));
     }
 
     private Collection<DatahubPricelistRecord> downloadPriceLists(DatahubPriceSubscription subscription)

--- a/bundles/org.openhab.binding.energidataservice/src/test/java/org/openhab/binding/energidataservice/internal/provider/ElectricityPriceProviderTest.java
+++ b/bundles/org.openhab.binding.energidataservice/src/test/java/org/openhab/binding/energidataservice/internal/provider/ElectricityPriceProviderTest.java
@@ -15,7 +15,10 @@ package org.openhab.binding.energidataservice.internal.provider;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +27,8 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Currency;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -31,16 +36,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.binding.energidataservice.internal.ApiController;
 import org.openhab.binding.energidataservice.internal.DatahubTariff;
+import org.openhab.binding.energidataservice.internal.api.DateQueryParameter;
+import org.openhab.binding.energidataservice.internal.api.dto.ElspotpriceRecord;
+import org.openhab.binding.energidataservice.internal.exception.DataServiceException;
 import org.openhab.binding.energidataservice.internal.provider.listener.ElectricityPriceListener;
 import org.openhab.binding.energidataservice.internal.provider.subscription.SpotPriceSubscription;
 import org.openhab.binding.energidataservice.internal.provider.subscription.Subscription;
 import org.openhab.core.i18n.TimeZoneProvider;
-import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
 import org.openhab.core.scheduler.Scheduler;
 import org.openhab.core.scheduler.SchedulerRunnable;
@@ -56,7 +65,7 @@ import org.openhab.core.scheduler.SchedulerRunnable;
 public class ElectricityPriceProviderTest {
 
     private @NonNullByDefault({}) @Mock Scheduler scheduler;
-    private @NonNullByDefault({}) @Mock HttpClientFactory httpClientFactory;
+    private @NonNullByDefault({}) @Mock ApiController apiController;
     private @NonNullByDefault({}) @Mock TimeZoneProvider timeZoneProvider;
     private @NonNullByDefault({}) @Mock MockedListener listener1;
     private @NonNullByDefault({}) @Mock MockedListener listener2;
@@ -68,7 +77,7 @@ public class ElectricityPriceProviderTest {
         ScheduledCompletableFuture<@Nullable Void> futureMock = (ScheduledCompletableFuture<@Nullable Void>) mock(
                 ScheduledCompletableFuture.class);
         when(scheduler.at(any(SchedulerRunnable.class), any(Instant.class))).thenReturn(futureMock);
-        provider = new ElectricityPriceProvider(scheduler, httpClientFactory, timeZoneProvider);
+        provider = new ElectricityPriceProvider(scheduler, apiController, timeZoneProvider);
     }
 
     @AfterEach
@@ -127,6 +136,30 @@ public class ElectricityPriceProviderTest {
         assertThrows(IllegalArgumentException.class, () -> {
             provider.unsubscribe(listener1, SpotPriceSubscription.of("DK1", Currency.getInstance("DKK")));
         });
+    }
+
+    @Test
+    void getPricesDownloadsPricesWhenNotCachedAndHavingNoListeners()
+            throws InterruptedException, TimeoutException, ExecutionException, DataServiceException {
+        when(apiController.getSpotPrices(any(String.class), any(Currency.class), any(DateQueryParameter.class),
+                any(DateQueryParameter.class), ArgumentMatchers.<Map<String, String>> any()))
+                .thenReturn(new ElspotpriceRecord[] {});
+        provider.getPrices(SpotPriceSubscription.of("DK1", Currency.getInstance("DKK")));
+        verify(apiController).getSpotPrices(eq("DK1"), eq(Currency.getInstance("DKK")), any(DateQueryParameter.class),
+                any(DateQueryParameter.class), anyMap());
+    }
+
+    @Test
+    void getPricesDoesNotDownloadPricesWhenNotCachedAndHavingListeners()
+            throws InterruptedException, TimeoutException, ExecutionException, DataServiceException {
+        when(apiController.getSpotPrices(any(String.class), any(Currency.class), any(DateQueryParameter.class),
+                any(DateQueryParameter.class), ArgumentMatchers.<Map<String, String>> any()))
+                .thenReturn(new ElspotpriceRecord[] {});
+        Subscription subscription = SpotPriceSubscription.of("DK1", Currency.getInstance("DKK"));
+        provider.subscribe(listener1, subscription);
+        provider.getPrices(SpotPriceSubscription.of("DK1", Currency.getInstance("DKK")));
+        verify(apiController, never()).getSpotPrices(eq("DK1"), eq(Currency.getInstance("DKK")),
+                any(DateQueryParameter.class), any(DateQueryParameter.class), anyMap());
     }
 
     private class MockedListener implements ElectricityPriceListener {


### PR DESCRIPTION
Fixes the underlying issue of #18583.

The previously provided fix caused the event to be triggered before updating the time series. Additionally, although it fixed the event in the specific scenario where a Thing action would trigger successful spot price updates, it did not make sure to update the time series in this case.

Now, Thing actions will not cause any unplanned requests, unless they are made for a subscription without any listeners. Otherwise only already cached prices will be returned, and the already applied retry policy will make sure to request prices when appropriate, and notify all listeners on success.