### PR TITLE
[tuya] Order Channels using DP order in schemas

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaBindingConstants.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaBindingConstants.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -72,7 +73,8 @@ public class TuyaBindingConstants {
 
         try (InputStreamReader reader = new InputStreamReader(resource)) {
             Gson gson = new Gson();
-            Type schemaListType = TypeToken.getParameterized(Map.class, String.class, SchemaDp.class).getType();
+            Type schemaListType = TypeToken.getParameterized(LinkedHashMap.class, String.class, SchemaDp.class)
+                    .getType();
             Type schemaType = TypeToken.getParameterized(Map.class, String.class, schemaListType).getType();
             return Objects.requireNonNull(gson.fromJson(reader, schemaType));
         } catch (IOException e) {

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -419,7 +420,8 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             if (schema == null) {
                 if (!schemaDps.isEmpty()) {
                     // fallback to retrieved schema
-                    schema = schemaDps.stream().collect(Collectors.toMap(s -> s.code, s -> s));
+                    schema = schemaDps.stream()
+                            .collect(Collectors.toMap(s -> s.code, s -> s, (e1, e2) -> e1, LinkedHashMap::new));
                 } else {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                             "No channels added and schema not found.");
@@ -466,7 +468,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             return;
         }
 
-        Map<String, Channel> channels = new HashMap<>(schema.entrySet().stream().map(e -> {
+        Map<String, Channel> channels = new LinkedHashMap<>(schema.entrySet().stream().map(e -> {
             String channelId = e.getKey();
             SchemaDp schemaDp = e.getValue();
 


### PR DESCRIPTION
Retain the order of DPs in schemas so that Channels are created in consistent order. Remote schemas seem to be ordered by DP id, local schemas are ordered however whoever added them thought was logical.