### PR TITLE
[pythonscripting] Fix helper lib deployment on Windows

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -73,6 +74,8 @@ public class PythonScriptEngine
         extends InvocationInterceptingScriptEngineWithInvocableAndCompilableAndAutoCloseable<GraalPythonScriptEngine>
         implements Lock {
     private final Logger logger = LoggerFactory.getLogger(PythonScriptEngine.class);
+
+    private static final String SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION = "polyglotimpl.AttachLibraryFailureAction";
 
     private static final String PYTHON_OPTION_EXECUTABLE = "python.Executable";
     private static final String PYTHON_OPTION_PYTHONHOME = "python.PythonHome";
@@ -163,6 +166,10 @@ public class PythonScriptEngine
 
         lifecycleTracker = new LifecycleTracker();
         scriptExtensionModuleProvider = new ScriptExtensionModuleProvider();
+
+        // disable warning about missing TruffleAttach library (is only available in graalvm)
+        Properties props = System.getProperties();
+        props.setProperty(SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION, "ignore");
 
         Context.Builder contextConfig = Context.newBuilder(GraalPythonScriptEngine.LANGUAGE_ID) //
                 .out(scriptOutputStream) //

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -66,6 +66,8 @@ import org.slf4j.LoggerFactory;
 public class PythonScriptEngineFactory implements ScriptEngineFactory {
     private final Logger logger = LoggerFactory.getLogger(PythonScriptEngineFactory.class);
 
+    private static final String RESOURCE_SEPARATOR = "/";
+
     public static final Path PYTHON_DEFAULT_PATH = Paths.get(OpenHAB.getConfigFolder(), "automation", "python");
     public static final Path PYTHON_LIB_PATH = PYTHON_DEFAULT_PATH.resolve("lib");
 
@@ -132,12 +134,11 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
 
     private void initHelperLib() {
         try {
-            String resourceSeparator = "/";
             String pathSeparator = FileSystems.getDefault().getSeparator();
             String resourceLibPath = PYTHON_OPENHAB_LIB_PATH.toString()
                     .substring(PYTHON_DEFAULT_PATH.toString().length()) + pathSeparator;
-            if (!resourceSeparator.equals(pathSeparator)) {
-                resourceLibPath = resourceLibPath.replace(pathSeparator, resourceSeparator);
+            if (!RESOURCE_SEPARATOR.equals(pathSeparator)) {
+                resourceLibPath = resourceLibPath.replace(pathSeparator, RESOURCE_SEPARATOR);
             }
 
             if (Files.exists(PythonScriptEngineFactory.PYTHON_OPENHAB_LIB_PATH)) {
@@ -202,7 +203,7 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
                 try (InputStream is = PythonScriptEngineFactory.class.getClassLoader()
                         .getResourceAsStream(resourcePath)) {
                     Path target = PythonScriptEngineFactory.PYTHON_OPENHAB_LIB_PATH
-                            .resolve(resourcePath.substring(resourcePath.lastIndexOf(resourceSeparator) + 1));
+                            .resolve(resourcePath.substring(resourcePath.lastIndexOf(RESOURCE_SEPARATOR) + 1));
 
                     Files.copy(is, target);
                     File file = target.toFile();

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -132,9 +132,13 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
 
     private void initHelperLib() {
         try {
+            String resourceSeparator = "/";
             String pathSeparator = FileSystems.getDefault().getSeparator();
             String resourceLibPath = PYTHON_OPENHAB_LIB_PATH.toString()
                     .substring(PYTHON_DEFAULT_PATH.toString().length()) + pathSeparator;
+            if (!resourceSeparator.equals(pathSeparator)) {
+                resourceLibPath = resourceLibPath.replace(pathSeparator, resourceSeparator);
+            }
 
             if (Files.exists(PythonScriptEngineFactory.PYTHON_OPENHAB_LIB_PATH)) {
                 try (Stream<Path> files = Files.list(PYTHON_OPENHAB_LIB_PATH)) {
@@ -190,6 +194,7 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
 
             Enumeration<URL> resourceFiles = FrameworkUtil.getBundle(PythonScriptEngineFactory.class)
                     .findEntries(resourceLibPath, "*.py", true);
+
             while (resourceFiles.hasMoreElements()) {
                 URL resourceFile = resourceFiles.nextElement();
                 String resourcePath = resourceFile.getPath();
@@ -197,7 +202,7 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
                 try (InputStream is = PythonScriptEngineFactory.class.getClassLoader()
                         .getResourceAsStream(resourcePath)) {
                     Path target = PythonScriptEngineFactory.PYTHON_OPENHAB_LIB_PATH
-                            .resolve(resourcePath.substring(resourcePath.lastIndexOf(pathSeparator) + 1));
+                            .resolve(resourcePath.substring(resourcePath.lastIndexOf(resourceSeparator) + 1));
 
                     Files.copy(is, target);
                     File file = target.toFile();


### PR DESCRIPTION
The goal of this pull request is to fix the helper lib deployment on windows.

The main problem was the usage of PosixPermissions before. Now, everything is handled in a more generic way.

In addition, a warning about missing TruffleAttachLibrary is ignored. It will never be available, except we are using the graalvm directly.

The fix was already tested by @jlaur 

@wborn &  @florian-h05 could one of you please review and approve please?