### PR TITLE
[pythonscripting] Fix python timedelta to java duration mapping

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/pom.xml
+++ b/bundles/org.openhab.automation.pythonscripting/pom.xml
@@ -80,7 +80,7 @@
             <configuration>
               <connectionUrl>scm:git:https://github.com/openhab/openhab-python</connectionUrl>
               <checkoutDirectory>${project.build.directory}/python</checkoutDirectory>
-              <scmVersion>v1.0.0-rc1</scmVersion>
+              <scmVersion>v1.0.0-rc2</scmVersion>
               <scmVersionType>tag</scmVersionType>
             </configuration>
           </execution>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -121,7 +121,7 @@ public class PythonScriptEngine
             .targetTypeMapping(Value.class, Duration.class,
                     // picking two members to check as Duration has many common function names
                     v -> v.hasMember("total_seconds") && v.hasMember("total_seconds"),
-                    v -> Duration.ofNanos(v.invokeMember("total_seconds").asLong() * 10000000),
+                    v -> Duration.ofNanos(v.invokeMember("total_seconds").asLong() * 1000000000),
                     HostAccess.TargetMappingPrecedence.LOW)
 
             // Translate python item to org.openhab.core.items.Item

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -121,7 +121,7 @@ public class PythonScriptEngine
             .targetTypeMapping(Value.class, Duration.class,
                     // picking two members to check as Duration has many common function names
                     v -> v.hasMember("total_seconds") && v.hasMember("total_seconds"),
-                    v -> Duration.ofNanos(v.invokeMember("total_seconds").asLong() * 1000000000),
+                    v -> Duration.ofNanos(Math.round(v.invokeMember("total_seconds").asDouble() * 1000000000)),
                     HostAccess.TargetMappingPrecedence.LOW)
 
             // Translate python item to org.openhab.core.items.Item


### PR DESCRIPTION
This fixes the mapping between a python timedelta to java Duration mapping

@jlaur can you please review?