### PR TITLE
[weatherunderground] Fix equipment tag

### DIFF
--- a/bundles/org.openhab.binding.weatherunderground/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/resources/OH-INF/thing/bridge.xml
@@ -7,7 +7,7 @@
 	<bridge-type id="bridge">
 		<label>Weatherunderground Bridge</label>
 		<description>The Weather Underground bridge represents a connection to the Weather Underground service</description>
-		<semantic-equipment-tag>NetworkAppliance</semantic-equipment-tag>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 		<config-description>
 			<parameter name="apikey" type="text" required="true">
 				<context>password</context>


### PR DESCRIPTION
Make it consistent with openweathermap binding.
