### PR TITLE
[insteon] Improve message transport control flow

### DIFF
--- a/bundles/org.openhab.binding.insteon/README.md
+++ b/bundles/org.openhab.binding.insteon/README.md
@@ -16,7 +16,8 @@ Other tools can be used to managed Insteon devices, such as the [Insteon Termina
 
 At startup, the binding will download the modem database along with each configured device all-link database if not previously downloaded and currently awake.
 Therefore, the initialization on the first start may take some additional time to complete depending on the number of devices configured.
-The modem and device link databases are only downloaded once unless the binding receives an indication that a database was updated or marked to be refreshed via the [openHAB console](#console-commands).
+The modem and device link databases information is then cached and updated accordingly based on relevant messages the binding receives.
+To force a database redownload, use the [openHAB console](#console-commands).
 
 **Important note as of openHAB 4.3.0**
 
@@ -108,8 +109,8 @@ The default poll interval of 300 seconds has been tested and found to be a good 
 
 The device type is automatically determined by the binding using the device product data.
 For a [battery powered device](#battery-powered-devices) that was never configured previously, it may take until the next time that device sends a broadcast message to be modeled properly.
-To speed up the process for this case, it is recommended to force the device to become awake after the associated bridge is online.
-Likewise, for a device that wasn't accessible during the binding initialization phase, press on its SET button once powered on to notify the binding that it is available.
+To speed up the process for this case, it is recommended to force the device to become awake after the associated bridge is online by pressing on its SET button.
+Likewise, for a wired device that wasn't connected during the first binding initialization, press on its on/off button once powered on to notify the binding that it is available.
 
 ### `scene`
 
@@ -669,7 +670,7 @@ By default, the binding only sends direct messages to the intended device to upd
 Whenever the bridge related device synchronization parameter `deviceSyncEnabled` is set to `true`, broadcast messages for supported Insteon commands (e.g. on/off, bright/dim, manual change) are sent to all responders of a given group, updating all related devices in one request.
 If no broadcast group is determined or for Insteon commands that don't support broadcasting (e.g. percent), direct messages are sent to each related device instead, to adjust their level based on their all-link database.
 
-## Insteon Binding Process
+## Insteon Linking Process
 
 Before Insteon devices communicate with one another, they must be linked.
 During the linking process, one of the devices will be the "Controller", the other the "Responder".
@@ -1600,8 +1601,15 @@ This will automatically disable the legacy network bridge with the same configur
 - For battery powered devices, press on their SET button to speed up the discovery process.
 Otherwise you may have to wait until the next time these devices send a heartbeat message which can take up to 24 hours.
 
+- For wired devices that weren't available during the first binding initialization, once connected, press on their on/off button.
+This will notify the binding to retrieve the product information from these devices.
+
 - For scenes, you can either enable scene discovery and add the discovered things, or just manually add specific scene things based on your existing environment.
 Enabling scene discovery might generate a considerable amount of things in your inbox depending on the number of scenes configured in your modem.
+
+- If some unknown devices are showing in your inbox, it could be due corrupt messages the binding received during the modem database download phase.
+Since the modem database is cached after the first download, it will need to be reloaded using the `insteon modem reloadDatabase` console command.
+Otherwise, these devices will keep appearing in your inbox.
 
 - If you have rules to send commands to synchronize the state between related devices, you can enable the device synchronization feature on the bridge instead.
 This will synchronize related devices automatically based on their all-link database.

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonLegacyBinding.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonLegacyBinding.java
@@ -440,7 +440,7 @@ public class InsteonLegacyBinding implements LegacyDriverListener, LegacyPortLis
 
     @Override
     public void msg(Msg msg) {
-        if (msg.isEcho() || msg.isPureNack()) {
+        if (msg.isPureNack() || msg.isReply()) {
             return;
         }
         messagesReceived++;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/command/DebugCommand.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/command/DebugCommand.java
@@ -390,8 +390,6 @@ public class DebugCommand extends InsteonCommand implements PortListener {
                 console.println(msg.toString());
             } catch (FieldException | InvalidMessageTypeException | NumberFormatException e) {
                 console.println("Error while trying to create message.");
-            } catch (IOException e) {
-                console.println("Failed to send message.");
             }
         }
     }
@@ -425,8 +423,6 @@ public class DebugCommand extends InsteonCommand implements PortListener {
                 console.println(msg.toString());
             } catch (FieldException | InvalidMessageTypeException | NumberFormatException e) {
                 console.println("Error while trying to create message.");
-            } catch (IOException e) {
-                console.println("Failed to send message.");
             }
         }
     }
@@ -451,8 +447,6 @@ public class DebugCommand extends InsteonCommand implements PortListener {
                 console.println(mcmd.toString());
             } catch (FieldException | InvalidMessageTypeException | NumberFormatException e) {
                 console.println("Error while trying to create message.");
-            } catch (IOException e) {
-                console.println("Failed to send message.");
             }
         }
     }
@@ -477,8 +471,6 @@ public class DebugCommand extends InsteonCommand implements PortListener {
                 console.println("Too many data bytes provided.");
             } catch (InvalidMessageTypeException e) {
                 console.println("Error while trying to create message.");
-            } catch (IOException e) {
-                console.println("Failed to send message.");
             }
         }
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/command/DeviceCommand.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/command/DeviceCommand.java
@@ -722,7 +722,7 @@ public class DeviceCommand extends InsteonCommand {
                         + (device.isBatteryPowered() ? "awake" : !device.isResponding() ? "online" : "polled") + ".");
             } else {
                 console.println("Refreshing device " + device.getAddress() + "...");
-                device.doPoll(0L);
+                device.poll(0L);
             }
         }
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
@@ -540,7 +540,7 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
                 case QUERY_QUEUED:
                     // wait for feature queried request to be sent unless next request has higher priority
                     DeviceRequest request = peekNextRequest();
-                    if (request == null || request.getMessage().hasHigherPriorityThan(feature.getQueryMessage())) {
+                    if (request == null || !request.getMessage().hasHigherPriorityThan(feature.getQueryMessage())) {
                         logger.trace("still waiting for {} query to be sent to {}", feature.getName(), address);
                         return now + 1000L; // retry in 1000 ms
                     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.insteon.internal.device;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -42,7 +41,6 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S extends InsteonThingHandler>
         implements Device {
     private static final int DIRECT_ACK_TIMEOUT = 6000; // in milliseconds
-    private static final int REQUEST_QUEUE_TIMEOUT = 30000; // in milliseconds
     private static final int FAILED_REQUEST_THRESHOLD = 5;
 
     protected static enum DeviceStatus {
@@ -65,7 +63,6 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
     private @Nullable DeviceFeature featureQueried;
     private long pollInterval = -1L; // in milliseconds
     private volatile int failedRequestCount = 0;
-    private volatile long lastRequestQueued = 0L;
     private volatile long lastRequestSent = 0L;
 
     public BaseDevice(T address) {
@@ -141,9 +138,15 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
         }
     }
 
-    public @Nullable DeviceFeature getFeatureQueried() {
+    protected @Nullable DeviceFeature getFeatureQueried() {
         synchronized (requestQueue) {
             return featureQueried;
+        }
+    }
+
+    protected boolean isFeatureQueried(DeviceFeature feature) {
+        synchronized (requestQueue) {
+            return feature.equals(featureQueried);
         }
     }
 
@@ -275,7 +278,7 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
      * @param delay scheduling delay (in milliseconds)
      */
     @Override
-    public void doPoll(long delay) {
+    public void poll(long delay) {
         schedulePoll(delay, feature -> true);
     }
 
@@ -286,8 +289,8 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
      * @param delay scheduling delay (in milliseconds)
      * @return poll message
      */
-    public @Nullable Msg pollFeature(String name, long delay) {
-        return Optional.ofNullable(getFeature(name)).map(feature -> feature.doPoll(delay)).orElse(null);
+    protected @Nullable Msg pollFeature(String name, long delay) {
+        return Optional.ofNullable(getFeature(name)).map(feature -> feature.poll(delay)).orElse(null);
     }
 
     /**
@@ -306,7 +309,7 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
             }
             // poll feature with listeners or never queried before
             if (feature.hasListeners() || feature.getQueryStatus() == QueryStatus.NEVER_QUERIED) {
-                Msg msg = feature.doPoll(delay + spacing);
+                Msg msg = feature.poll(delay + spacing);
                 if (msg != null) {
                     spacing += msg.getQuietTime();
                 }
@@ -423,7 +426,7 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
      */
     @Override
     public void sendMessage(Msg msg, DeviceFeature feature, long delay) {
-        addDeviceRequest(msg, feature, delay);
+        addRequest(msg, feature, delay);
     }
 
     /**
@@ -433,7 +436,7 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
      * @param feature device feature that sent this message
      * @param delay time (in milliseconds) to delay before sending message
      */
-    protected void addDeviceRequest(Msg msg, DeviceFeature feature, long delay) {
+    protected void addRequest(Msg msg, DeviceFeature feature, long delay) {
         logger.trace("enqueuing request with delay {} msec", delay);
 
         synchronized (requestQueue) {
@@ -461,53 +464,73 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
     @Override
     public long handleNextRequest() {
         long now = System.currentTimeMillis();
-        // wait for feature queried to complete
-        long waitTime = checkFeatureQueried(now);
+        // wait for feature queried to be processed or next request to be scheduled
+        long waitTime = Optional.of(checkFeatureQueriedStatus(now)).filter(time -> time > 0)
+                .orElseGet(() -> checkNextRequestScheduledTime(now));
         if (waitTime > 0) {
             return waitTime;
         }
+        // poll next request from queue
+        DeviceRequest request = pollNextRequest();
+        if (request == null) {
+            return 0L;
+        }
+        // get request feature and message
+        DeviceFeature feature = request.getFeature();
+        Msg msg = request.getMessage();
+        // update message timestamp
+        msg.setTimestamp(now);
+        // set feature queried for non-broadcast request message
+        if (!msg.isAllLinkBroadcast()) {
+            logger.trace("request taken off direct for {}: {}", feature.getName(), msg);
+            // mark requested feature query status as queued
+            feature.setQueryStatus(QueryStatus.QUERY_QUEUED);
+            // store requested feature query message
+            feature.setQueryMessage(msg);
+            // set feature queried
+            setFeatureQueried(feature);
+        } else {
+            logger.trace("request taken off bcast for {}: {}", feature.getName(), msg);
+        }
+        // write message
+        InsteonModem modem = getModem();
+        if (modem != null) {
+            modem.writeMessage(msg);
+        }
+        // determine the wait time for the next request
+        DeviceRequest nextRequest = peekNextRequest();
+        waitTime = now + msg.getQuietTime();
+        if (nextRequest != null) {
+            waitTime = Math.max(waitTime, nextRequest.getScheduledTime());
+            nextRequest.setScheduledTime(waitTime);
+        }
+        logger.trace("next request scheduled in {} msec", waitTime - now);
+        return waitTime;
+    }
 
+    /**
+     * Polls next request for this device
+     *
+     * @return next request or null if queue is empty
+     */
+    private @Nullable DeviceRequest pollNextRequest() {
         synchronized (requestQueue) {
-            // take the next request off the queue
             DeviceRequest request = requestQueue.poll();
-            if (request == null) {
-                return 0L;
+            if (request != null) {
+                requestQueueHash.remove(request.getMessage());
             }
-            // get requested feature and message
-            DeviceFeature feature = request.getFeature();
-            Msg msg = request.getMessage();
-            // remove request from queue hash
-            requestQueueHash.remove(msg);
-            // set last request queued time
-            lastRequestQueued = now;
-            // set feature queried for non-broadcast request message
-            if (!msg.isAllLinkBroadcast()) {
-                logger.trace("request taken off direct for {}: {}", feature.getName(), msg);
-                // mark requested feature query status as queued
-                feature.setQueryStatus(QueryStatus.QUERY_QUEUED);
-                // store requested feature query message
-                feature.setQueryMessage(msg);
-                // set feature queried
-                setFeatureQueried(feature);
-            } else {
-                logger.trace("request taken off bcast for {}: {}", feature.getName(), msg);
-            }
-            // write message
-            InsteonModem modem = getModem();
-            if (modem != null) {
-                try {
-                    modem.writeMessage(msg);
-                } catch (IOException e) {
-                    logger.warn("message write failed for msg: {}", msg, e);
-                }
-            }
-            // determine the wait time for the next request
-            long quietTime = msg.getQuietTime();
-            long nextExpTime = Optional.ofNullable(requestQueue.peek()).map(DeviceRequest::getExpirationTime)
-                    .orElse(0L);
-            long nextTime = Math.max(now + quietTime, nextExpTime);
-            logger.trace("next request queue processed in {} msec, quiettime {} msec", nextTime - now, quietTime);
-            return nextTime;
+            return request;
+        }
+    }
+
+    /**
+     * Peeks next request for this device
+     *
+     * @return next request or null if queue is empty
+     */
+    private @Nullable DeviceRequest peekNextRequest() {
+        synchronized (requestQueue) {
+            return requestQueue.peek();
         }
     }
 
@@ -517,26 +540,25 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
      * @param now the current time
      * @return wait time if necessary otherwise 0
      */
-    private long checkFeatureQueried(long now) {
+    private long checkFeatureQueriedStatus(long now) {
         DeviceFeature feature = getFeatureQueried();
         if (feature != null) {
             QueryStatus queryStatus = feature.getQueryStatus();
             switch (queryStatus) {
                 case QUERY_QUEUED:
-                    // wait for feature queried request to be sent
-                    long maxQueueTime = lastRequestQueued + REQUEST_QUEUE_TIMEOUT;
-                    if (maxQueueTime > now) {
-                        logger.trace("still waiting for {} query to be sent to {} for another {} msec",
-                                feature.getName(), address, maxQueueTime - now);
+                    // wait for feature queried request to be sent unless next request has higher priority
+                    DeviceRequest request = peekNextRequest();
+                    if (request == null || request.getMessage().hasHigherPriorityThan(feature.getQueryMessage())) {
+                        logger.trace("still waiting for {} query to be sent to {}", feature.getName(), address);
                         return now + 1000L; // retry in 1000 ms
                     }
                     logger.debug("gave up waiting for {} query to be sent to {}", feature.getName(), address);
-                    // notify feature queried failed
-                    featureQueriedFailed(feature);
+                    // notify feature queried expired
+                    featureQueriedExpired(feature);
                     break;
                 case QUERY_SENT:
                 case QUERY_ACKED:
-                    // wait for the feature queried to be answered
+                    // wait for the feature queried to be answered unless timed out
                     long maxAckTime = lastRequestSent + DIRECT_ACK_TIMEOUT;
                     if (maxAckTime > now) {
                         logger.trace("still waiting for {} query reply from {} for another {} msec", feature.getName(),
@@ -553,6 +575,21 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
                     // reset feature queried
                     setFeatureQueried(null);
             }
+        }
+        return 0L;
+    }
+
+    /**
+     * Checks next request scheduled time
+     *
+     * @param now the current time
+     * @return wait time if necessary otherwise 0
+     */
+    private long checkNextRequestScheduledTime(long now) {
+        DeviceRequest request = peekNextRequest();
+        // wait for next request scheduled time if necessary
+        if (request != null && request.getScheduledTime() > now) {
+            return request.getScheduledTime() - now;
         }
         return 0L;
     }
@@ -577,15 +614,15 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
     }
 
     /**
-     * Notifies that the feature queried failed
+     * Notifies that the feature queried has expired
      *
      * @param feature the feature queried
      */
-    protected void featureQueriedFailed(DeviceFeature feature) {
-        QueryStatus queryStatus = feature.getQueryStatus();
-        // increase failed request count if in sent or acked status
-        if (queryStatus == QueryStatus.QUERY_SENT || queryStatus == QueryStatus.QUERY_ACKED) {
-            failedRequestCount++;
+    protected void featureQueriedExpired(DeviceFeature feature) {
+        Msg msg = feature.getQueryMessage();
+        // set feature query message as expired if defined
+        if (msg != null) {
+            msg.setExpired(true);
         }
         // mark feature queried as processed and never queried
         setFeatureQueried(null);
@@ -593,8 +630,20 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
         feature.setQueryStatus(QueryStatus.NEVER_QUERIED);
         // poll feature again if device is responding
         if (isResponding()) {
-            feature.doPoll(0L);
+            feature.poll(0L);
         }
+    }
+
+    /**
+     * Notifies that the feature queried has failed
+     *
+     * @param feature the feature queried
+     */
+    protected void featureQueriedFailed(DeviceFeature feature) {
+        // increase failed request count
+        failedRequestCount++;
+        // notify feature queried expired
+        featureQueriedExpired(feature);
         // notify status changed if failed request count at threshold
         if (failedRequestCount == FAILED_REQUEST_THRESHOLD) {
             statusChanged();
@@ -634,7 +683,7 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
     public void requestSent(Msg msg, long time) {
         DeviceFeature feature = getFeatureQueried();
         if (feature != null && msg.equals(feature.getQueryMessage())) {
-            // mark feature queried as pending
+            // mark feature queried as sent
             feature.setQueryStatus(QueryStatus.QUERY_SENT);
             // set last request sent time
             lastRequestSent = time;
@@ -672,12 +721,12 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
     protected static class DeviceRequest implements Comparable<DeviceRequest> {
         private DeviceFeature feature;
         private Msg msg;
-        private long expirationTime;
+        private long scheduledTime;
 
         public DeviceRequest(DeviceFeature feature, Msg msg, long delay) {
             this.feature = feature;
             this.msg = msg;
-            setExpirationTime(delay);
+            setScheduledDelay(delay);
         }
 
         public DeviceFeature getFeature() {
@@ -688,17 +737,25 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
             return msg;
         }
 
-        public long getExpirationTime() {
-            return expirationTime;
+        public long getScheduledTime() {
+            return scheduledTime;
         }
 
-        public void setExpirationTime(long delay) {
-            this.expirationTime = System.currentTimeMillis() + delay;
+        public void setScheduledDelay(long delay) {
+            this.scheduledTime = System.currentTimeMillis() + delay;
+        }
+
+        public void setScheduledTime(long scheduledTime) {
+            this.scheduledTime = scheduledTime;
         }
 
         @Override
         public int compareTo(DeviceRequest other) {
-            return (int) (expirationTime - other.expirationTime);
+            int result = msg.getPriority().compareTo(other.msg.getPriority());
+            if (result == 0) {
+                result = Long.compare(scheduledTime, other.scheduledTime);
+            }
+            return result;
         }
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/BaseDevice.java
@@ -620,9 +620,9 @@ public abstract class BaseDevice<@NonNull T extends DeviceAddress, @NonNull S ex
         setFeatureQueried(null);
         feature.setQueryMessage(null);
         feature.setQueryStatus(QueryStatus.NEVER_QUERIED);
-        // poll feature again if device is responding
-        if (isResponding()) {
-            feature.poll(0L);
+        // resend feature query message if defined and device is responding
+        if (msg != null && isResponding()) {
+            sendMessage(msg.copy(), feature, 0L);
         }
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/Device.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/Device.java
@@ -66,7 +66,7 @@ public interface Device {
      *
      * @param delay scheduling delay (in milliseconds)
      */
-    public void doPoll(long delay);
+    public void poll(long delay);
 
     /**
      * Handles an incoming message for this device

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceCache.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceCache.java
@@ -114,8 +114,8 @@ public class DeviceCache {
         }
 
         public Builder withDatabase(ModemDB modemDB) {
-            cache.database = DatabaseCache.builder().withProducts(modemDB.getProducts())
-                    .withRecords(modemDB.getRecords()).build();
+            cache.database = DatabaseCache.builder().withComplete(modemDB.isComplete())
+                    .withProducts(modemDB.getProducts()).withRecords(modemDB.getRecords()).build();
             return this;
         }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceFeature.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceFeature.java
@@ -37,6 +37,7 @@ import org.openhab.binding.insteon.internal.device.feature.MessageHandler;
 import org.openhab.binding.insteon.internal.device.feature.PollHandler;
 import org.openhab.binding.insteon.internal.transport.message.FieldException;
 import org.openhab.binding.insteon.internal.transport.message.Msg;
+import org.openhab.binding.insteon.internal.transport.message.Priority;
 import org.openhab.binding.insteon.internal.utils.ParameterParser;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
@@ -284,7 +285,7 @@ public class DeviceFeature {
 
     public boolean isPollable() {
         PollHandler pollHandler = getPollHandler();
-        return pollHandler != null && pollHandler.makeMsg() != null;
+        return pollHandler != null && pollHandler.getMessage() != null;
     }
 
     public @Nullable DeviceFeature getGroupFeature() {
@@ -519,18 +520,18 @@ public class DeviceFeature {
     }
 
     /**
-     * Makes a poll message using the configured poll message handler
+     * Returns poll message using the configured poll handler
      *
      * @return the poll message
      */
-    public @Nullable Msg makePollMsg() {
+    public @Nullable Msg getPollMessage() {
         PollHandler pollHandler = getPollHandler();
         if (pollHandler == null) {
             return null;
         }
         logger.trace("{}:{} making poll msg using handler {}", device.getAddress(), name,
                 pollHandler.getClass().getSimpleName());
-        return pollHandler.makeMsg();
+        return pollHandler.getMessage();
     }
 
     /**
@@ -577,13 +578,13 @@ public class DeviceFeature {
             delay = getPollDelay();
         }
         // trigger feature poll if pollable
-        if (doPoll(delay) != null) {
+        if (poll(delay, Priority.TRIGGER_POLL) != null) {
             logger.trace("{}:{} triggered poll on this feature", device.getAddress(), name);
             return;
         }
         // trigger group feature poll if defined and pollable, as fallback
         DeviceFeature groupFeature = getGroupFeature();
-        if (groupFeature != null && groupFeature.doPoll(delay) != null) {
+        if (groupFeature != null && groupFeature.poll(delay, Priority.TRIGGER_POLL) != null) {
             logger.trace("{}:{} triggered poll on group feature {}", device.getAddress(), name, groupFeature.getName());
             return;
         }
@@ -614,14 +615,26 @@ public class DeviceFeature {
     }
 
     /**
-     * Executes the polling of this feature
+     * Polls this feature with standard priority
      *
      * @param delay scheduling delay (in milliseconds)
      * @return poll message
      */
-    public @Nullable Msg doPoll(long delay) {
-        Msg msg = makePollMsg();
+    public @Nullable Msg poll(long delay) {
+        return poll(delay, Priority.STANDARD_POLL);
+    }
+
+    /**
+     * Polls this feature with a specific priority
+     *
+     * @param delay scheduling delay (in milliseconds)
+     * @param priority priority of the poll message
+     * @return poll message
+     */
+    public @Nullable Msg poll(long delay, Priority priority) {
+        Msg msg = getPollMessage();
         if (msg != null) {
+            msg.setPriority(priority);
             device.sendMessage(msg, this, delay);
         }
         return msg;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
@@ -254,14 +254,14 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
      * @param delay scheduling delay (in milliseconds)
      */
     @Override
-    public void doPoll(long delay) {
+    public void poll(long delay) {
         // process deferred queue
         processDeferredQueue(delay);
         // poll insteon engine if unknown or its feature never queried
         DeviceFeature engineFeature = getFeature(FEATURE_INSTEON_ENGINE);
         if (engineFeature != null
                 && (engine == InsteonEngine.UNKNOWN || engineFeature.getQueryStatus() == QueryStatus.NEVER_QUERIED)) {
-            engineFeature.doPoll(delay);
+            engineFeature.poll(delay);
             return; // insteon engine needs to be known before enqueueing more messages
         }
         // load this device link db if not complete or should be reloaded
@@ -274,7 +274,7 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
             linkDB.update(delay);
         }
 
-        super.doPoll(delay);
+        super.poll(delay);
     }
 
     /**
@@ -459,7 +459,7 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
                 && !isDuplicateMsg(msg)) {
             // add poll delay for non-replayed all link broadcast allowing cleanup msg to be be processed beforehand
             long delay = msg.isAllLinkBroadcast() && !msg.isAllLinkSuccessReport() && !msg.isReplayed() ? 1500L : 0L;
-            doPoll(delay);
+            poll(delay);
         }
     }
 
@@ -473,12 +473,12 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
     @Override
     public void sendMessage(Msg msg, DeviceFeature feature, long delay) {
         if (isAwake()) {
-            addDeviceRequest(msg, feature, delay);
+            addRequest(msg, feature, delay);
         } else {
             addDeferredRequest(msg, feature);
         }
         // mark feature query status as scheduled for non-broadcast request message
-        if (!msg.isAllLinkBroadcast()) {
+        if (!msg.isAllLinkBroadcast() && !isFeatureQueried(feature)) {
             feature.setQueryStatus(QueryStatus.QUERY_SCHEDULED);
         }
     }
@@ -496,9 +496,9 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
                     Msg msg = request.getMessage();
                     DeviceFeature feature = request.getFeature();
                     deferredQueueHash.remove(msg);
-                    request.setExpirationTime(delay);
+                    request.setScheduledDelay(delay);
                     logger.trace("enqueuing deferred request for {}", feature.getName());
-                    addDeviceRequest(msg, feature, delay);
+                    addRequest(msg, feature, delay);
                 }
             }
         }
@@ -840,7 +840,7 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
                 // poll database delta feature
                 pollFeature(FEATURE_DATABASE_DELTA, 0L);
                 // poll remaining features for this device
-                doPoll(0L);
+                poll(500L);
             }
             // log missing links
             logMissingLinks();

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonModem.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonModem.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.insteon.internal.device;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -183,7 +182,7 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
         return initialized;
     }
 
-    public void writeMessage(Msg msg) throws IOException {
+    public void writeMessage(Msg msg) {
         port.writeMessage(msg);
     }
 
@@ -205,12 +204,9 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
 
     public void disconnect() {
         logger.debug("disconnecting from modem");
-        if (linker.isRunning()) {
-            linker.stop();
-        }
-
-        dbm.stop();
         port.stop();
+        dbm.stop();
+        linker.stop();
         requester.stop();
         poller.stop();
     }
@@ -234,10 +230,8 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
         try {
             Msg msg = Msg.makeMessage("GetIMInfo");
             writeMessage(msg);
-        } catch (IOException e) {
-            logger.warn("error sending modem info query ", e);
         } catch (InvalidMessageTypeException e) {
-            logger.warn("invalid message ", e);
+            logger.warn("error creating message", e);
         }
     }
 
@@ -274,10 +268,8 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
         try {
             Msg msg = Msg.makeMessage("ResetIM");
             writeMessage(msg);
-        } catch (IOException e) {
-            logger.warn("error sending modem reset query", e);
         } catch (InvalidMessageTypeException e) {
-            logger.warn("invalid message ", e);
+            logger.warn("error creating message", e);
         }
     }
 
@@ -504,7 +496,7 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
     private void handleMessage(DeviceAddress address, Msg msg) throws FieldException {
         Device device = getDevice(address);
         if (device == null) {
-            logger.debug("unknown device with address {}, dropping message", address);
+            logger.trace("unknown device with address {}, dropping message", address);
         } else if (msg.isReply()) {
             device.requestReplied(msg);
         } else {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyDevice.java
@@ -519,7 +519,7 @@ public class LegacyDevice {
 
         @Override
         public int compareTo(QEntry qe) {
-            return (int) (expirationTime - qe.expirationTime);
+            return Long.compare(expirationTime, qe.expirationTime);
         }
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyPollManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyPollManager.java
@@ -269,7 +269,7 @@ public class LegacyPollManager {
 
         @Override
         public int compareTo(PQEntry pqe) {
-            return (int) (expirationTime - pqe.expirationTime);
+            return Long.compare(expirationTime, pqe.expirationTime);
         }
 
         @Override

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyRequestManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LegacyRequestManager.java
@@ -181,7 +181,7 @@ public class LegacyRequestManager {
 
         @Override
         public int compareTo(RequestQueue queue) {
-            return (int) (expirationTime - queue.expirationTime);
+            return Long.compare(expirationTime, queue.expirationTime);
         }
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LinkManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/LinkManager.java
@@ -118,6 +118,7 @@ public class LinkManager implements PortListener {
 
         modem.getPort().registerListener(this);
         modem.getRequestManager().pause();
+        modem.getPollManager().pause();
 
         setAddress(address);
         setGroup(-1);
@@ -147,6 +148,7 @@ public class LinkManager implements PortListener {
         }
 
         modem.getRequestManager().resume();
+        modem.getPollManager().resume();
         modem.getPort().unregisterListener(this);
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/PollManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/PollManager.java
@@ -12,32 +12,20 @@
  */
 package org.openhab.binding.insteon.internal.device;
 
-import java.sql.Date;
 import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class manages the polling of all devices.
- * Between successive polls of any device there is a quiet time of
- * at least MIN_MSEC_BETWEEN_POLLS. This avoids bunching up of poll messages
- * and keeps the network bandwidth open for other messages.
- *
- * - An entry in the poll queue corresponds to a single device, i.e. each device should
- * have exactly one entry in the poll queue. That entry is created when startPolling()
- * is called, and then re-enqueued whenever it expires.
- * - When a device comes up for polling, its poll() method is called, which in turn
- * puts an entry into that devices request queue. So the Poller class actually never
- * sends out messages directly. That is done by the device itself via its request
- * queue. The poller just reminds the device to poll.
+ * Class that manages device poll scheduling
  *
  * @author Bernd Pfrommer - Initial contribution
  * @author Rob Nielsen - Port to openHAB 2 insteon binding
@@ -49,236 +37,128 @@ public class PollManager {
 
     private final Logger logger = LoggerFactory.getLogger(PollManager.class);
 
-    private ScheduledExecutorService scheduler;
-    private @Nullable ScheduledFuture<?> job;
-    private TreeSet<PQEntry> pollQueue = new TreeSet<>();
+    private final long pollInterval;
+    private final ScheduledExecutorService scheduler;
+    private final Map<Device, ScheduledFuture<?>> polls = new ConcurrentHashMap<>();
+    private final AtomicBoolean paused = new AtomicBoolean(false);
+    private volatile int deviceCount = 0;
 
-    /**
-     * Constructor
-     */
-    public PollManager(ScheduledExecutorService scheduler) {
+    public PollManager(long pollInterval, ScheduledExecutorService scheduler) {
+        this.pollInterval = pollInterval;
         this.scheduler = scheduler;
     }
 
-    /**
-     * Returns if poller is running
-     *
-     * @return true if poll queue reader job is defined
-     */
-    private boolean isRunning() {
-        return job != null;
+    public int getPollCount() {
+        return polls.size();
+    }
+
+    public void setDeviceCount(int deviceCount) {
+        this.deviceCount = deviceCount;
     }
 
     /**
-     * Get size of poll queue
-     *
-     * @return number of devices being polled
+     * Pauses poll manager
      */
-    public int getSizeOfQueue() {
-        return pollQueue.size();
-    }
-
-    /**
-     * Register a device for polling.
-     *
-     * @param device device to register for polling
-     * @param pollInterval device poll interval
-     * @param numDev approximate number of total devices
-     */
-    public void startPolling(Device device, long pollInterval, int numDev) {
-        logger.debug("start polling device {}", device.getAddress());
-
-        synchronized (pollQueue) {
-            // try to spread out the scheduling when starting up
-            long pollDelay = pollQueue.size() * pollInterval / (numDev + 1);
-            addToPollQueue(device, pollInterval, System.currentTimeMillis() + pollDelay);
-            pollQueue.notify();
+    public void pause() {
+        if (!paused.getAndSet(true)) {
+            logger.debug("pausing poll manager");
         }
+    }
+
+    /**
+     * Resumes poll manager
+     */
+    public void resume() {
+        if (paused.getAndSet(false)) {
+            logger.debug("resuming poll manager");
+        }
+    }
+
+    /**
+     * Stops poll manager
+     */
+    public void stop() {
+        logger.debug("stopping poll manager");
+        paused.set(false);
+        polls.values().forEach(job -> job.cancel(false));
+        polls.clear();
+    }
+
+    /**
+     * Starts polling a given device
+     *
+     * @param device the device to start polling
+     * @return true if polling is scheduled, otherwise false
+     */
+    public boolean startPolling(Device device) {
+        if (polls.containsKey(device)) {
+            logger.trace("device {} already being polled", device.getAddress());
+            return true;
+        }
+
+        long pollDelay = getNextPollDelay();
+        if (pollDelay > pollInterval) {
+            logger.warn("device {} cannot be polled, increase the poll interval to allow for more devices to be polled",
+                    device.getAddress());
+            return false;
+        }
+
+        logger.debug("start polling device {} in {} msec", device.getAddress(), pollDelay);
+
+        ScheduledFuture<?> job = scheduler.scheduleWithFixedDelay(() -> pollDevice(device), pollDelay, pollInterval,
+                TimeUnit.MILLISECONDS);
+
+        polls.put(device, job);
+
+        return true;
     }
 
     /**
      * Stops polling a given device
      *
-     * @param device reference to the device to be polled
+     * @param device the device to stop polling
      */
     public void stopPolling(Device device) {
-        synchronized (pollQueue) {
-            for (Iterator<PQEntry> it = pollQueue.iterator(); it.hasNext();) {
-                if (it.next().getDevice().getAddress().equals(device.getAddress())) {
-                    it.remove();
-                    logger.debug("stopped polling device {}", device.getAddress());
-                }
-            }
-        }
-    }
-
-    /**
-     * Starts the poller thread
-     */
-    public void start() {
-        if (isRunning()) {
-            logger.debug("poll manager already running, not started again");
-            return;
-        }
-        job = scheduler.schedule(new PollQueueReader(), 0, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Stops the poller thread
-     */
-    public void stop() {
-        ScheduledFuture<?> job = this.job;
+        ScheduledFuture<?> job = polls.remove(device);
         if (job != null) {
-            job.cancel(true);
-            this.job = null;
+            job.cancel(false);
+            logger.debug("stopped polling device {}", device.getAddress());
         }
     }
 
     /**
-     * Adds a device to the poll queue. After this call, the device's poll() method
-     * will be called according to the polling frequency set.
+     * Returns the next poll delay
      *
-     * @param device the device to poll periodically
-     * @param pollInterval the device poll interval
-     * @param time the target time for the next poll to happen. Note that this time is merely
-     *            a suggestion, and may be adjusted, because there must be at least a minimum gap in polling.
+     * @return the next poll delay
      */
+    private long getNextPollDelay() {
+        long desiredDelay = polls.size() * pollInterval / (deviceCount + 1);
+        Iterator<Long> iterator = polls.values().stream().map(job -> job.getDelay(TimeUnit.MILLISECONDS))
+                .filter(delay -> delay >= desiredDelay - MIN_MSEC_BETWEEN_POLLS).sorted().iterator();
 
-    private void addToPollQueue(Device device, long pollInterval, long time) {
-        long expTime = findNextExpirationTime(device, pollInterval, time);
-        PQEntry entry = new PQEntry(device, pollInterval, expTime);
-        logger.trace("added entry {}", entry);
-        pollQueue.add(entry);
+        long pollDelay = desiredDelay;
+        while (iterator.hasNext()) {
+            long delay = iterator.next();
+            if (delay >= pollDelay + MIN_MSEC_BETWEEN_POLLS) {
+                break;
+            }
+            pollDelay = delay + MIN_MSEC_BETWEEN_POLLS;
+        }
+        return pollDelay;
     }
 
     /**
-     * Finds the best expiration time for a poll queue, i.e. a time slot that is after the
-     * desired expiration time, but does not collide with any of the already scheduled
-     * polls.
+     * Polls a device
      *
-     * @param device device to poll (for logging)
-     * @param pollInterval device poll interval
-     * @param time desired time after which the device should be polled
-     * @return the suggested time to poll
+     * @param device the device to poll
      */
-
-    private long findNextExpirationTime(Device device, long pollInterval, long time) {
-        long expTime;
-        // find all poll queue entries that expire after time - buffer
-        PQEntry entry = new PQEntry(device, pollInterval, time - MIN_MSEC_BETWEEN_POLLS);
-        Set<PQEntry> expEntries = pollQueue.tailSet(entry);
-        if (expEntries.isEmpty()) {
-            // all entries in the poll queue are ahead of the new element,
-            // go ahead and simply add it to the end
-            expTime = time;
+    private void pollDevice(Device device) {
+        if (paused.get()) {
+            logger.trace("poll manager paused, skipping poll for {}", device.getAddress());
         } else {
-            Iterator<PQEntry> it = expEntries.iterator();
-            PQEntry prevEntry = it.next();
-            if (prevEntry.getExpirationTime() > time + MIN_MSEC_BETWEEN_POLLS) {
-                // there is a time slot free before the head of the tail set
-                expTime = time;
-            } else {
-                // look for a gap where we can squeeze in
-                // a new poll while maintaining MIN_MSEC_BETWEEN_POLLS
-                while (it.hasNext()) {
-                    PQEntry currEntry = it.next();
-                    long currTime = currEntry.getExpirationTime();
-                    long prevTime = prevEntry.getExpirationTime();
-                    if (currTime - prevTime >= 2 * MIN_MSEC_BETWEEN_POLLS) {
-                        // found gap
-                        logger.trace("device {} time {} found slot between {} and {}", device.getAddress(), time,
-                                prevTime, currTime);
-                        break;
-                    }
-                    prevEntry = currEntry;
-                }
-                expTime = prevEntry.getExpirationTime() + MIN_MSEC_BETWEEN_POLLS;
-            }
-        }
-        return expTime;
-    }
-
-    private class PollQueueReader implements Runnable {
-        @Override
-        public void run() {
-            logger.debug("starting poll queue thread");
-            try {
-                while (!Thread.interrupted()) {
-                    synchronized (pollQueue) {
-                        if (pollQueue.isEmpty()) {
-                            logger.trace("waiting for poll queue to fill");
-                            pollQueue.wait();
-                            continue;
-                        }
-                        // something is in the queue
-                        long now = System.currentTimeMillis();
-                        PQEntry entry = pollQueue.first();
-                        long delay = entry.getExpirationTime() - now;
-                        if (delay > 0) { // must wait for this item to expire
-                            logger.trace("waiting for {} msec until {} comes due", delay, entry);
-                            pollQueue.wait(delay);
-                        } else { // queue entry has expired, process it!
-                            logger.trace("poll queue entry {} has expired", entry);
-                            processQueueEntry(now);
-                        }
-                    }
-                }
-            } catch (InterruptedException e) {
-                logger.trace("poll queue thread interrupted!");
-            }
-            logger.debug("exiting poll queue thread!");
-        }
-
-        /**
-         * Takes first element off the poll queue, polls the corresponding device,
-         * and puts the device back into the poll queue to be polled again later.
-         *
-         * @param now the current time
-         */
-        private void processQueueEntry(long now) {
-            PQEntry entry = pollQueue.pollFirst();
-            if (entry != null) {
-                entry.getDevice().poll(0L);
-                addToPollQueue(entry.getDevice(), entry.getPollInterval(), now + entry.getPollInterval());
-            }
-        }
-    }
-
-    /**
-     * A poll queue entry corresponds to a single device that needs
-     * to be polled.
-     */
-    private static class PQEntry implements Comparable<PQEntry> {
-        private Device device;
-        private long pollInterval;
-        private long expirationTime;
-
-        PQEntry(Device device, long pollInterval, long expirationTime) {
-            this.device = device;
-            this.pollInterval = pollInterval;
-            this.expirationTime = expirationTime;
-        }
-
-        long getExpirationTime() {
-            return expirationTime;
-        }
-
-        long getPollInterval() {
-            return pollInterval;
-        }
-
-        Device getDevice() {
-            return device;
-        }
-
-        @Override
-        public int compareTo(PQEntry other) {
-            return (int) (expirationTime - other.expirationTime);
-        }
-
-        @Override
-        public String toString() {
-            return String.format("%s/%tc", device.getAddress(), new Date(expirationTime));
+            logger.debug("polling device {}", device.getAddress());
+            device.poll(0L);
+            logger.trace("next poll for {} scheduled in {} msec", device.getAddress(), pollInterval);
         }
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/RequestManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/RequestManager.java
@@ -83,12 +83,12 @@ public class RequestManager {
                 queue = new RequestQueue(device, time);
                 requestQueues.add(queue);
                 requestQueueHash.put(device, queue);
-                requestQueues.notify();
             } else if (queue.getExpirationTime() > time) {
                 logger.trace("rescheduling request for device {} from {} to {} msec", device.getAddress(),
                         queue.getExpirationTime() - now, delay);
                 queue.setExpirationTime(time);
             }
+            requestQueues.notify();
         }
     }
 
@@ -98,7 +98,6 @@ public class RequestManager {
     public void pause() {
         if (isRunning() && !paused.getAndSet(true)) {
             logger.debug("pausing request queue thread");
-
             synchronized (requestQueues) {
                 requestQueues.notify();
             }
@@ -111,7 +110,6 @@ public class RequestManager {
     public void resume() {
         if (isRunning() && paused.getAndSet(false)) {
             logger.debug("resuming request queue thread");
-
             synchronized (paused) {
                 paused.notify();
             }
@@ -170,11 +168,11 @@ public class RequestManager {
                             Device device = queue.getDevice();
                             if (delay > 0) {
                                 // The head of the queue is not up for processing yet, wait().
-                                logger.trace("request queue head: {} must wait for {} msec", device.getAddress(),
-                                        delay);
+                                logger.trace("request queue for {} must wait for {} msec", device.getAddress(), delay);
                                 requestQueues.wait(delay);
                             } else {
                                 // The head of the queue has expired and can be processed!
+                                logger.trace("processing request queue for {}", device.getAddress());
                                 processRequestQueue(now);
                             }
                         }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/RequestManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/RequestManager.java
@@ -12,10 +12,8 @@
  */
 package org.openhab.binding.insteon.internal.device;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -27,15 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Class that manages all the per-device request queues using a single thread.
- *
- * - Each device has its own request queue, and the RequestQueueManager keeps a
- * queue of queues.
- * - Each entry in requestQueues corresponds to a single device's request queue.
- * A device should never be more than once in requestQueues.
- * - A hash map (requestQueueHash) is kept in sync with requestQueues for
- * faster lookup in case a request queue is modified and needs to be
- * rescheduled.
+ * Class that manages per-device request scheduling
  *
  * @author Bernd Pfrommer - Initial contribution
  * @author Rob Nielsen - Port to openHAB 2 insteon binding
@@ -45,196 +35,133 @@ import org.slf4j.LoggerFactory;
 public class RequestManager {
     private final Logger logger = LoggerFactory.getLogger(RequestManager.class);
 
-    private ScheduledExecutorService scheduler;
-    private @Nullable ScheduledFuture<?> job;
-    private Queue<RequestQueue> requestQueues = new PriorityQueue<>();
-    private Map<Device, RequestQueue> requestQueueHash = new HashMap<>();
-    private AtomicBoolean paused = new AtomicBoolean(false);
+    private final ScheduledExecutorService scheduler;
+    private final Map<Device, RequestEntry> requests = new ConcurrentHashMap<>();
+    private final AtomicBoolean paused = new AtomicBoolean(false);
 
-    /**
-     * Constructor
-     */
     public RequestManager(ScheduledExecutorService scheduler) {
         this.scheduler = scheduler;
     }
 
     /**
-     * Returns if request manager is running
-     *
-     * @return true if request queue reader job is defined
-     */
-    private boolean isRunning() {
-        return job != null;
-    }
-
-    /**
-     * Adds device to global request queue.
-     *
-     * @param device the device to add
-     * @param time (in milliseconds) to delay queue processing
-     */
-    public void addQueue(Device device, long delay) {
-        synchronized (requestQueues) {
-            long now = System.currentTimeMillis();
-            long time = now + delay;
-            RequestQueue queue = requestQueueHash.get(device);
-            if (queue == null) {
-                logger.trace("scheduling request for device {} in {} msec", device.getAddress(), delay);
-                queue = new RequestQueue(device, time);
-                requestQueues.add(queue);
-                requestQueueHash.put(device, queue);
-            } else if (queue.getExpirationTime() > time) {
-                logger.trace("rescheduling request for device {} from {} to {} msec", device.getAddress(),
-                        queue.getExpirationTime() - now, delay);
-                queue.setExpirationTime(time);
-            }
-            requestQueues.notify();
-        }
-    }
-
-    /**
-     * Pauses request manager thread
+     * Pauses request manager
      */
     public void pause() {
-        if (isRunning() && !paused.getAndSet(true)) {
-            logger.debug("pausing request queue thread");
-            synchronized (requestQueues) {
-                requestQueues.notify();
-            }
+        if (!paused.getAndSet(true)) {
+            logger.debug("pausing request manager");
+            requests.values().forEach(this::cancelRequest);
         }
     }
 
     /**
-     * Resumes request queue thread
+     * Resumes request manager
      */
     public void resume() {
-        if (isRunning() && paused.getAndSet(false)) {
-            logger.debug("resuming request queue thread");
-            synchronized (paused) {
-                paused.notify();
-            }
+        if (paused.getAndSet(false)) {
+            logger.debug("resuming request manager");
+            requests.values().forEach(this::scheduleRequest);
         }
     }
 
     /**
-     * Starts request queue thread
-     */
-    public void start() {
-        if (isRunning()) {
-            logger.debug("request manager already running, not started again");
-            return;
-        }
-        job = scheduler.schedule(new RequestQueueReader(), 0, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Stops request queue thread
+     * Stops request manager
      */
     public void stop() {
-        ScheduledFuture<?> job = this.job;
-        if (job != null) {
-            job.cancel(true);
-            this.job = null;
+        logger.debug("stopping request manager");
+        paused.set(false);
+        requests.values().forEach(this::cancelRequest);
+        requests.clear();
+    }
+
+    /**
+     * Adds a request for a device
+     *
+     * @param device the device to add
+     * @param time (in milliseconds) to delay handling
+     */
+    public void addRequest(Device device, long delay) {
+        long now = System.currentTimeMillis();
+        long scheduledTime = now + delay;
+
+        requests.compute(device, (key, request) -> {
+            if (request == null) {
+                logger.trace("scheduling request for {} in {} msec", device.getAddress(), delay);
+                request = new RequestEntry(device, scheduledTime);
+                scheduleRequest(request);
+            } else if (request.scheduledTime > scheduledTime) {
+                logger.trace("rescheduling request for {} from {} to {} msec", device.getAddress(),
+                        request.scheduledTime - now, delay);
+                request.scheduledTime = scheduledTime;
+                cancelRequest(request);
+                scheduleRequest(request);
+            }
+            return request;
+        });
+    }
+
+    /**
+     * Cancels a request
+     *
+     * @param request the request to cancel
+     */
+    private void cancelRequest(RequestEntry request) {
+        ScheduledFuture<?> job = request.job;
+        if (job != null && !job.isDone()) {
+            job.cancel(false);
+            request.job = null;
         }
     }
 
     /**
-     * Request queue reader class
+     * Schedules a request
+     *
+     * @param request the request to schedule
      */
-    private class RequestQueueReader implements Runnable {
-        @Override
-        public void run() {
-            logger.debug("starting request queue thread");
-            try {
-                while (!Thread.interrupted()) {
-                    synchronized (paused) {
-                        if (paused.get()) {
-                            logger.trace("waiting for request queue thread to resume");
-                            paused.wait();
-                            continue;
-                        }
-                    }
-                    synchronized (requestQueues) {
-                        if (requestQueues.isEmpty()) {
-                            logger.trace("waiting for request queues to fill");
-                            requestQueues.wait();
-                            continue;
-                        }
-                        RequestQueue queue = requestQueues.peek();
-                        if (queue != null) {
-                            long now = System.currentTimeMillis();
-                            long expTime = queue.getExpirationTime();
-                            long delay = expTime - now;
-                            Device device = queue.getDevice();
-                            if (delay > 0) {
-                                // The head of the queue is not up for processing yet, wait().
-                                logger.trace("request queue for {} must wait for {} msec", device.getAddress(), delay);
-                                requestQueues.wait(delay);
-                            } else {
-                                // The head of the queue has expired and can be processed!
-                                logger.trace("processing request queue for {}", device.getAddress());
-                                processRequestQueue(now);
-                            }
-                        }
-                    }
-                }
-            } catch (InterruptedException e) {
-                logger.trace("request queue thread interrupted!");
-            }
-            logger.debug("exiting request queue thread!");
+    private void scheduleRequest(RequestEntry request) {
+        if (paused.get()) {
+            logger.trace("request manager paused, request for {} to be scheduled later", request.device.getAddress());
+            return;
         }
 
-        /**
-         * Processes the head of the queue
-         *
-         * @param now the current time
-         */
-        private void processRequestQueue(long now) {
-            RequestQueue queue = requestQueues.poll(); // remove front element
-            if (queue != null) {
-                Device device = queue.getDevice();
-                requestQueueHash.remove(device); // and remove from hash map
-                long nextExp = device.handleNextRequest();
-                if (nextExp > 0) {
-                    queue = new RequestQueue(device, nextExp);
-                    requestQueues.add(queue);
-                    requestQueueHash.put(device, queue);
-                    logger.trace("device queue for {} rescheduled in {} msec", device.getAddress(), nextExp - now);
-                } else {
-                    // remove from hash since queue is no longer scheduled
-                    logger.trace("device queue for {} is empty!", device.getAddress());
-                }
-            }
+        long delay = Math.max(0, request.scheduledTime - System.currentTimeMillis());
+        request.job = scheduler.schedule(() -> handleRequest(request.device), delay, TimeUnit.MILLISECONDS);
+
+        logger.trace("request for {} scheduled in {} msec", request.device.getAddress(), delay);
+    }
+
+    /**
+     * Handles a request for a device
+     *
+     * @param device the device to handle the request for
+     */
+    private void handleRequest(Device device) {
+        RequestEntry request = requests.remove(device);
+        if (request == null) {
+            logger.trace("no request to handle for {}", device.getAddress());
+            return;
+        }
+
+        logger.trace("handling request for {}", device.getAddress());
+
+        long delay = device.handleNextRequest() - System.currentTimeMillis();
+        if (delay > 0) {
+            addRequest(device, delay);
+        } else {
+            logger.trace("no more pending requests for {}", device.getAddress());
         }
     }
 
     /**
-     * Class that represents a request queue
+     * Class that represents a request entry
      */
-    private static class RequestQueue implements Comparable<RequestQueue> {
-        private Device device;
-        private long expirationTime;
+    private static class RequestEntry {
+        private final Device device;
+        private volatile long scheduledTime;
+        private volatile @Nullable ScheduledFuture<?> job;
 
-        RequestQueue(Device device, long expirationTime) {
+        RequestEntry(Device device, long scheduledTime) {
             this.device = device;
-            this.expirationTime = expirationTime;
-        }
-
-        public Device getDevice() {
-            return device;
-        }
-
-        public long getExpirationTime() {
-            return expirationTime;
-        }
-
-        public void setExpirationTime(long expirationTime) {
-            this.expirationTime = expirationTime;
-        }
-
-        @Override
-        public int compareTo(RequestQueue other) {
-            return (int) (expirationTime - other.expirationTime);
+            this.scheduledTime = scheduledTime;
         }
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/DatabaseCache.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/DatabaseCache.java
@@ -30,10 +30,15 @@ import org.openhab.binding.insteon.internal.device.ProductData;
  */
 @NonNullByDefault
 public class DatabaseCache {
+    private @Nullable Boolean complete;
     private @Nullable Integer delta;
     private @Nullable Boolean reload;
     private @Nullable List<DatabaseRecord> records;
     private @Nullable Map<String, ProductData> products;
+
+    public boolean getComplete() {
+        return Objects.requireNonNullElse(complete, false);
+    }
 
     public int getDelta() {
         return Objects.requireNonNullElse(delta, -1);
@@ -94,6 +99,12 @@ public class DatabaseCache {
         if (!records.isEmpty()) {
             modemDB.loadRecords(records);
         }
+
+        // set modem db complete if true
+        boolean complete = getComplete();
+        if (complete) {
+            modemDB.setIsComplete(complete);
+        }
     }
 
     /**
@@ -103,6 +114,11 @@ public class DatabaseCache {
         private final DatabaseCache cache = new DatabaseCache();
 
         private Builder() {
+        }
+
+        public Builder withComplete(boolean complete) {
+            cache.complete = complete;
+            return this;
         }
 
         public Builder withDatabaseDelta(int delta) {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/DatabaseManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/DatabaseManager.java
@@ -96,6 +96,7 @@ public class DatabaseManager {
         if (job == null && !terminated) {
             job = scheduler.schedule(() -> {
                 modem.getRequestManager().pause();
+                modem.getPollManager().pause();
 
                 handleNextOperation();
             }, delay, TimeUnit.MILLISECONDS);
@@ -109,6 +110,7 @@ public class DatabaseManager {
         DatabaseOperation operation = operationQueue.poll();
         if (operation == null || terminated) {
             modem.getRequestManager().resume();
+            modem.getPollManager().resume();
             job = null;
             return;
         }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/DatabaseManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/DatabaseManager.java
@@ -74,21 +74,10 @@ public class DatabaseManager {
             this.job = null;
         }
 
-        if (ldbr.isRunning()) {
-            ldbr.stop();
-        }
-
-        if (ldbw.isRunning()) {
-            ldbw.stop();
-        }
-
-        if (mdbr.isRunning()) {
-            mdbr.stop();
-        }
-
-        if (mdbw.isRunning()) {
-            mdbw.stop();
-        }
+        ldbr.stop();
+        ldbw.stop();
+        mdbr.stop();
+        mdbw.stop();
     }
 
     /**

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
@@ -304,7 +304,6 @@ public class LinkDB {
         } else if (dbm == null) {
             logger.debug("unable to load link db for {}, database manager not available", device.getAddress());
         } else {
-            clear();
             setStatus(DatabaseStatus.LOADING);
             dbm.read(device, delay);
         }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBReader.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBReader.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.insteon.internal.device.database;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +25,7 @@ import org.openhab.binding.insteon.internal.transport.PortListener;
 import org.openhab.binding.insteon.internal.transport.message.FieldException;
 import org.openhab.binding.insteon.internal.transport.message.InvalidMessageTypeException;
 import org.openhab.binding.insteon.internal.transport.message.Msg;
+import org.openhab.binding.insteon.internal.transport.message.Priority;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,20 +43,16 @@ public class LinkDBReader implements PortListener {
     private ScheduledExecutorService scheduler;
     private @Nullable ScheduledFuture<?> job;
     private ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    private boolean done = true;
-    private boolean standardMode = true;
-    private long lastMsgReceived;
-    private int location;
-    private int lastMSB;
-    private int recordCount;
+    private volatile boolean done = true;
+    private volatile boolean standardMode = true;
+    private volatile long lastMsgReceived;
+    private volatile int location;
+    private volatile int lastMSB;
+    private volatile int recordCount;
 
     public LinkDBReader(InsteonModem modem, ScheduledExecutorService scheduler) {
         this.modem = modem;
         this.scheduler = scheduler;
-    }
-
-    public boolean isRunning() {
-        return job != null;
     }
 
     public void read(InsteonDevice device) {
@@ -65,26 +61,13 @@ public class LinkDBReader implements PortListener {
         this.device = device;
 
         getAllRecords();
-
-        job = scheduler.scheduleWithFixedDelay(() -> {
-            if (System.currentTimeMillis() - lastMsgReceived > DatabaseManager.MESSAGE_TIMEOUT) {
-                if (standardMode && recordCount == 0 && device.isAwake()) {
-                    logger.debug("all link database request timed out for {}, trying peek method instead",
-                            device.getAddress());
-                    getPeekRecords();
-                } else {
-                    logger.debug("link database reader timed out for {}, aborting", device.getAddress());
-                    done();
-                }
-            }
-        }, 0, 1000, TimeUnit.MILLISECONDS);
     }
 
     private void getAllRecords() {
-        lastMsgReceived = System.currentTimeMillis();
         done = false;
         standardMode = true;
         recordCount = 0;
+        device.getLinkDB().clear();
 
         modem.getPort().registerListener(this);
 
@@ -102,8 +85,6 @@ public class LinkDBReader implements PortListener {
     }
 
     public void stop() {
-        logger.debug("link database reader finished for {}", device.getAddress());
-
         ScheduledFuture<?> job = this.job;
         if (job != null) {
             job.cancel(true);
@@ -111,13 +92,14 @@ public class LinkDBReader implements PortListener {
         }
 
         modem.getPort().unregisterListener(this);
-        modem.getDBM().operationCompleted();
     }
 
     private void done() {
-        device.getLinkDB().recordsLoaded();
+        logger.debug("link database reader finished for {}", device.getAddress());
         done = true;
         stop();
+        device.getLinkDB().recordsLoaded();
+        modem.getDBM().operationCompleted();
     }
 
     private void getPeekRecords() {
@@ -149,26 +131,20 @@ public class LinkDBReader implements PortListener {
     private void setMSBAddress(int msb) {
         try {
             Msg msg = Msg.makeStandardMessage(device.getAddress(), (byte) 0x28, (byte) msb);
+            msg.setPriority(Priority.DATABASE);
             modem.writeMessage(msg);
-        } catch (IOException e) {
-            logger.warn("error sending set msb address query ", e);
-        } catch (InvalidMessageTypeException e) {
-            logger.warn("invalid message ", e);
-        } catch (FieldException e) {
-            logger.warn("error parsing message ", e);
+        } catch (FieldException | InvalidMessageTypeException e) {
+            logger.warn("error creating message", e);
         }
     }
 
     private void getPeekByte(int lsb) {
         try {
             Msg msg = Msg.makeStandardMessage(device.getAddress(), (byte) 0x2B, (byte) lsb);
+            msg.setPriority(Priority.DATABASE);
             modem.writeMessage(msg);
-        } catch (IOException e) {
-            logger.warn("error sending peek query ", e);
-        } catch (InvalidMessageTypeException e) {
-            logger.warn("invalid message ", e);
-        } catch (FieldException e) {
-            logger.warn("error parsing message ", e);
+        } catch (FieldException | InvalidMessageTypeException e) {
+            logger.warn("error creating message", e);
         }
     }
 
@@ -176,14 +152,30 @@ public class LinkDBReader implements PortListener {
         try {
             Msg msg = Msg.makeExtendedMessage(device.getAddress(), (byte) 0x2F, (byte) 0x00,
                     device.getInsteonEngine().supportsChecksum());
+            msg.setPriority(Priority.DATABASE);
             modem.writeMessage(msg);
-        } catch (IOException e) {
-            logger.warn("error sending get all link record query ", e);
-        } catch (InvalidMessageTypeException e) {
-            logger.warn("invalid message ", e);
-        } catch (FieldException e) {
-            logger.warn("error parsing message ", e);
+        } catch (FieldException | InvalidMessageTypeException e) {
+            logger.warn("error creating message", e);
         }
+    }
+
+    private void startAbortTimer() {
+        logger.trace("starting abort timer for {}", device.getAddress());
+
+        lastMsgReceived = System.currentTimeMillis();
+
+        job = scheduler.scheduleWithFixedDelay(() -> {
+            if (System.currentTimeMillis() - lastMsgReceived > DatabaseManager.MESSAGE_TIMEOUT) {
+                if (standardMode && recordCount == 0 && device.isAwake()) {
+                    logger.debug("all link database request timed out for {}, trying peek method instead",
+                            device.getAddress());
+                    getPeekRecords();
+                } else {
+                    logger.debug("link database reader timed out for {}, aborting", device.getAddress());
+                    done();
+                }
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -196,12 +188,12 @@ public class LinkDBReader implements PortListener {
 
     @Override
     public void messageReceived(Msg msg) {
-        try {
-            if (!msg.isFromAddress(device.getAddress())) {
-                return;
-            }
-            lastMsgReceived = msg.getTimestamp();
+        if (!msg.isFromAddress(device.getAddress())) {
+            return;
+        }
+        lastMsgReceived = msg.getTimestamp();
 
+        try {
             if (msg.getCommand() == 0x50 && msg.getByte("command1") == 0x28) {
                 // we got a set msb address response
                 getNextPeekByte();
@@ -213,13 +205,26 @@ public class LinkDBReader implements PortListener {
                 handleRecordMsg(msg);
             }
         } catch (FieldException e) {
-            logger.warn("error parsing link db info reply field ", e);
+            logger.warn("error parsing message", e);
         }
     }
 
     @Override
     public void messageSent(Msg msg) {
-        // ignore outbound message
+        if (!msg.isToAddress(device.getAddress())) {
+            return;
+        }
+
+        try {
+            if (msg.getCommand() == 0x62 && (msg.getByte("command1") == 0x28 || msg.getByte("command1") == 0x2F)) {
+                // we sent a set msb address or get aldb record message
+                if (!done && job == null) {
+                    startAbortTimer();
+                }
+            }
+        } catch (FieldException e) {
+            logger.warn("error parsing message", e);
+        }
     }
 
     private void addRecord(LinkDBRecord record) {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/CommandHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/CommandHandler.java
@@ -243,10 +243,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                     logger.debug("{}: sent {} {} request to {}", nm(), feature.getName(), HexUtils.getHexString(value),
                             address);
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -508,10 +506,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                         feature.adjustRelatedDevices(config, cmd);
                     }
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -781,10 +777,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 if (config.isOriginal() && getInsteonDevice().isDeviceSyncEnabled()) {
                     feature.adjustRelatedDevices(config, cmd);
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -1231,10 +1225,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                             HexUtils.getHexString(alwaysOnOffMask), address);
                 }
                 feature.sendRequest(alwaysOnOffMaskMsg);
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
     }
@@ -1302,10 +1294,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                                 HexUtils.getHexString(heartbeatInterval), address);
                     }
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
     }
@@ -1445,10 +1435,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 } else {
                     logger.warn("{}: no d2 parameter specified in command handler", nm());
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -1503,10 +1491,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 } else {
                     logger.warn("{}: no cmd1 field specified", nm());
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
     }
@@ -1541,10 +1527,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 } else {
                     logger.warn("{}: unable to determine op flags command, ignoring request", nm());
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -1594,10 +1578,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                     logger.debug("{}: sent op flag {} request to {}", nm(), entry.getValue(),
                             getInsteonDevice().getAddress());
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -1631,10 +1613,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 } else {
                     logger.warn("{}: got unexpected ramp rate command {}, ignoreing request", nm(), cmd);
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -1769,10 +1749,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 } else {
                     logger.warn("{}: got unexpected momentary duration command {}, ignoring request", nm(), cmd);
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -2137,10 +2115,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 Msg msg = Msg.makeExtendedMessageCRC2(address, (byte) 0x2E, (byte) 0x02, data);
                 feature.sendRequest(msg);
                 logger.debug("{}: sent set time data request to {}", nm(), address);
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
     }
@@ -2159,10 +2135,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 Msg msg = getIMMessage(cmd);
                 feature.sendRequest(msg);
                 logger.debug("{}: sent {} request to {}", nm(), cmd, getInsteonModem().getAddress());
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 
@@ -2242,10 +2216,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                     feature.sendRequest(msg);
                     logger.debug("{}: sent {} request to {}", nm(), cmd, getInsteonModem().getAddress());
                 }
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
     }
@@ -2268,10 +2240,8 @@ public abstract class CommandHandler extends BaseFeatureHandler {
                 Msg cmdMsg = Msg.makeX10CommandMessage((byte) cmdCode);
                 feature.sendRequest(cmdMsg);
                 logger.debug("{}: sent {} request to {}", nm(), cmd, address);
-            } catch (InvalidMessageTypeException e) {
-                logger.warn("{}: invalid message: ", nm(), e);
-            } catch (FieldException e) {
-                logger.warn("{}: command send message creation error ", nm(), e);
+            } catch (FieldException | InvalidMessageTypeException e) {
+                logger.warn("{}: error creating message", nm(), e);
             }
         }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/feature/MessageHandler.java
@@ -552,7 +552,7 @@ public abstract class MessageHandler extends BaseFeatureHandler {
                 // set device insteon engine
                 getInsteonDevice().setInsteonEngine(engine);
                 // continue device polling
-                getInsteonDevice().doPoll(0L);
+                getInsteonDevice().poll(500L);
             } catch (FieldException e) {
                 logger.warn("{}: error parsing msg: {}", nm(), msg, e);
             }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonBridgeHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonBridgeHandler.java
@@ -343,8 +343,6 @@ public class InsteonBridgeHandler extends InsteonBaseThingHandler implements Bri
      * @param modem the discovered modem
      */
     public void modemDiscovered(InsteonModem modem) {
-        modem.setPollInterval(getDevicePollInterval());
-
         initializeChannels(modem);
         updateProperties(modem);
         loadDeviceCache(modem);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
@@ -122,7 +122,6 @@ public class InsteonDeviceHandler extends InsteonBaseThingHandler {
         InsteonBridgeHandler handler = getInsteonBridgeHandler();
         if (handler != null) {
             device = InsteonDevice.makeDevice(address, modem, handler.getProductData(address));
-            device.setPollInterval(handler.getDevicePollInterval());
             device.setIsDeviceSyncEnabled(handler.isDeviceSyncEnabled());
             handler.loadDeviceCache(device);
         } else {
@@ -213,7 +212,6 @@ public class InsteonDeviceHandler extends InsteonBaseThingHandler {
     public void bridgeThingUpdated(InsteonBridgeConfiguration config, InsteonModem modem) {
         InsteonDevice device = getDevice();
         if (device != null) {
-            device.setPollInterval(config.getDevicePollInterval());
             device.setIsDeviceSyncEnabled(config.isDeviceSyncEnabled());
             device.setModem(modem);
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/HubIOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/HubIOStream.java
@@ -46,6 +46,7 @@ import org.openhab.binding.insteon.internal.utils.HexUtils;
 public class HubIOStream extends IOStream {
     private static final String BUFFER_TAG_START = "<BS>";
     private static final String BUFFER_TAG_END = "</BS>";
+    private static final int RATE_LIMIT_TIME = 500; // in milliseconds
     private static final int REQUEST_TIMEOUT = 30; // in seconds
 
     private String host;
@@ -71,6 +72,7 @@ public class HubIOStream extends IOStream {
      */
     public HubIOStream(String host, int port, String username, String password, int pollInterval, HttpClient httpClient,
             ScheduledExecutorService scheduler) {
+        super(RATE_LIMIT_TIME);
         this.host = host;
         this.port = port;
         this.auth = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/IOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/IOStream.java
@@ -44,6 +44,15 @@ public abstract class IOStream {
 
     protected @Nullable InputStream in;
     protected @Nullable OutputStream out;
+    private final int rateLimitTime;
+
+    protected IOStream(int rateLimitTime) {
+        this.rateLimitTime = rateLimitTime;
+    }
+
+    public int getRateLimitTime() {
+        return rateLimitTime;
+    }
 
     /**
      * Reads data from IOStream

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/LegacyPort.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/LegacyPort.java
@@ -37,6 +37,7 @@ import org.openhab.binding.insteon.internal.transport.message.FieldException;
 import org.openhab.binding.insteon.internal.transport.message.InvalidMessageTypeException;
 import org.openhab.binding.insteon.internal.transport.message.Msg;
 import org.openhab.binding.insteon.internal.transport.message.MsgFactory;
+import org.openhab.binding.insteon.internal.transport.stream.IOStream;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/Port.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/Port.java
@@ -12,25 +12,22 @@
  */
 package org.openhab.binding.insteon.internal.transport;
 
-import java.io.IOException;
-import java.util.Comparator;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.insteon.internal.config.InsteonBridgeConfiguration;
 import org.openhab.binding.insteon.internal.transport.message.Msg;
-import org.openhab.binding.insteon.internal.transport.message.MsgFactory;
-import org.openhab.binding.insteon.internal.transport.message.Priority;
+import org.openhab.binding.insteon.internal.transport.stream.IOStream;
+import org.openhab.binding.insteon.internal.transport.stream.IOStreamListener;
+import org.openhab.binding.insteon.internal.transport.stream.IOStreamReader;
+import org.openhab.binding.insteon.internal.transport.stream.IOStreamWriter;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,15 +35,6 @@ import org.slf4j.LoggerFactory;
 /**
  * The Port class represents a port, that is a connection to either an Insteon modem either through
  * a serial or USB port, or via an Insteon Hub.
- * It does the initialization of the port, and (via its inner classes IOStreamReader and IOStreamWriter)
- * manages the reading/writing of messages on the Insteon network.
- *
- * The IOStreamReader and IOStreamWriter class combined implement the somewhat tricky flow control protocol.
- * In combination with the MsgFactory class, the incoming data stream is turned into a Msg structure
- * for further processing by the upper layers (PortListener).
- *
- * A write queue is maintained to pace the flow of outgoing messages. Sending messages back-to-back
- * can lead to dropped messages.
  *
  * @author Bernd Pfrommer - Initial contribution
  * @author Daniel Pfrommer - openHAB 1 insteonplm binding
@@ -54,26 +42,26 @@ import org.slf4j.LoggerFactory;
  * @author Jeremy Setton - Rewrite insteon binding
  */
 @NonNullByDefault
-public class Port {
+public class Port implements IOStreamListener {
     private final Logger logger = LoggerFactory.getLogger(Port.class);
 
-    private String name;
-    private ScheduledExecutorService scheduler;
-    private IOStream ioStream;
-    private IOStreamReader reader = new IOStreamReader();
-    private IOStreamWriter writer = new IOStreamWriter();
+    private final String name;
+    private final ScheduledExecutorService scheduler;
+    private final IOStream stream;
+    private final IOStreamReader reader;
+    private final IOStreamWriter writer;
     private @Nullable ScheduledFuture<?> readJob;
     private @Nullable ScheduledFuture<?> writeJob;
-    private Set<PortListener> listeners = new CopyOnWriteArraySet<>();
-    private PriorityBlockingQueue<Msg> writeQueue = new PriorityBlockingQueue<>(10,
-            Comparator.comparing(Msg::getPriority).thenComparingLong(Msg::getTimestamp));
-    private AtomicBoolean connected = new AtomicBoolean(false);
+    private final Set<PortListener> listeners = new CopyOnWriteArraySet<>();
+    private final AtomicBoolean connected = new AtomicBoolean(false);
 
     public Port(InsteonBridgeConfiguration config, HttpClient httpClient, ScheduledExecutorService scheduler,
             SerialPortManager serialPortManager) {
         this.name = config.getId();
         this.scheduler = scheduler;
-        this.ioStream = IOStream.create(config, httpClient, scheduler, serialPortManager);
+        this.stream = IOStream.create(config, httpClient, scheduler, serialPortManager);
+        this.reader = new IOStreamReader(stream, this);
+        this.writer = new IOStreamWriter(stream, this);
     }
 
     public String getName() {
@@ -105,9 +93,9 @@ public class Port {
 
         logger.debug("starting port {}", name);
 
-        writeQueue.clear();
+        writer.clearQueue();
 
-        if (!ioStream.open()) {
+        if (!stream.open()) {
             logger.debug("failed to open port {}", name);
             return false;
         }
@@ -130,7 +118,7 @@ public class Port {
 
         connected.set(false);
 
-        ioStream.close();
+        stream.close();
 
         ScheduledFuture<?> readJob = this.readJob;
         if (readJob != null) {
@@ -154,17 +142,18 @@ public class Port {
      */
     public void writeMessage(Msg msg) {
         try {
-            writeQueue.add(msg);
-            logger.trace("enqueued msg ({}): {}", writeQueue.size(), msg);
+            writer.addMessage(msg);
+            logger.trace("enqueued msg ({}): {}", writer.getQueueSize(), msg);
         } catch (IllegalStateException e) {
             logger.debug("cannot write message {}, write queue is full!", msg);
         }
     }
 
     /**
-     * Notifies that the port has disconnected
+     * Notifies that the io stream has disconnected
      */
-    private void disconnected() {
+    @Override
+    public void disconnected() {
         if (connected.getAndSet(false)) {
             logger.warn("port {} disconnected", name);
             listeners.forEach(PortListener::disconnected);
@@ -172,181 +161,34 @@ public class Port {
     }
 
     /**
-     * Notifies that the port has received a message
+     * Notifies that the io stream has received a message
      *
-     * @param msg the message received
+     * @param msg the message received if valid, otherwise null
      */
-    private void messageReceived(Msg msg) {
+    @Override
+    public void messageReceived(Msg msg) {
+        logger.debug("got msg: {}", msg);
         listeners.forEach(listener -> listener.messageReceived(msg));
+        writer.messageReceived(msg);
     }
 
     /**
-     * Notifies that the port has sent a message
+     * Notifies that the io stream has received bad data
+     */
+    @Override
+    public void invalidMessageReceived() {
+        logger.debug("got bad data back");
+        writer.invalidMessageReceived();
+    }
+
+    /**
+     * Notifies that the io stream has sent a message
      *
      * @param msg the message sent
      */
-    private void messageSent(Msg msg) {
+    @Override
+    public void messageSent(Msg msg) {
+        logger.debug("sent msg: {}", msg);
         listeners.forEach(listener -> listener.messageSent(msg));
-    }
-
-    /**
-     * The IOStreamReader uses the MsgFactory to turn the incoming bytes into
-     * Msgs for the listeners. It also communicates with the IOStreamWriter
-     * to implement flow control.
-     */
-    private class IOStreamReader implements Runnable {
-        private static final int READ_BUFFER_SIZE = 1024;
-
-        private final MsgFactory msgFactory = new MsgFactory();
-
-        @Override
-        public void run() {
-            logger.debug("starting reader thread");
-            byte[] buffer = new byte[READ_BUFFER_SIZE];
-            try {
-                while (!Thread.interrupted()) {
-                    logger.trace("reader checking for input data");
-                    // this call blocks until input data is available
-                    int len = ioStream.read(buffer);
-                    if (len > 0) {
-                        msgFactory.addData(buffer, len);
-                        processMessages();
-                    }
-                }
-            } catch (InterruptedException e) {
-                logger.trace("reader thread got interrupted!");
-            } catch (IOException e) {
-                logger.trace("reader thread got an io exception", e);
-                disconnected();
-            }
-            logger.debug("exiting reader thread!");
-        }
-
-        private void processMessages() {
-            // call msgFactory.processData() until it is done processing buffer
-            while (!msgFactory.isDone()) {
-                try {
-                    Msg msg = msgFactory.processData();
-                    if (msg != null) {
-                        logger.debug("got msg: {}", msg);
-                        messageReceived(msg);
-                        writer.messageReceived(msg);
-                    }
-                } catch (IOException e) {
-                    // got bad data from modem,
-                    // unblock those waiting for ack
-                    writer.invalidMessageReceived();
-                }
-            }
-        }
-    }
-
-    /**
-     * Writes messages to the port. Flow control is implemented following Insteon
-     * documents to avoid overloading the modem.
-     */
-    private class IOStreamWriter implements Runnable {
-        private static final int REPLY_TIMEOUT_TIME = 8000; // milliseconds
-
-        private static enum ReplyStatus {
-            GOT_ACK,
-            GOT_NACK,
-            WAITING_FOR_ACK
-        }
-
-        private final ReentrantLock lock = new ReentrantLock();
-        private final Condition messageReceived = lock.newCondition();
-        private final Condition replyReceived = lock.newCondition();
-        private ReplyStatus replyStatus = ReplyStatus.GOT_ACK;
-        private @Nullable Msg lastMsg;
-
-        @Override
-        public void run() {
-            logger.debug("starting writer thread");
-            try {
-                while (!Thread.interrupted()) {
-                    logger.trace("writer checking message queue");
-                    Msg msg = writeQueue.take();
-                    if (msg.isExpired()) {
-                        logger.trace("skipping expired message: {}", msg);
-                    } else {
-                        logger.debug("writing: {}", msg);
-                        ioStream.write(msg.getData());
-                        messageSent(msg);
-                        waitForReply(msg);
-                        limitRate(ioStream.getRateLimitTime());
-                    }
-                }
-            } catch (InterruptedException e) {
-                logger.trace("writer thread got interrupted!");
-            } catch (IOException e) {
-                logger.trace("writer thread got an io exception", e);
-                disconnected();
-            }
-            logger.debug("exiting writer thread!");
-        }
-
-        private void messageReceived(Msg msg) {
-            lock.lock();
-            try {
-                if (replyStatus == ReplyStatus.WAITING_FOR_ACK) {
-                    if (msg.isPureNack() || msg.isReplyOf(lastMsg)) {
-                        replyStatus = msg.isPureNack() ? ReplyStatus.GOT_NACK : ReplyStatus.GOT_ACK;
-                        logger.trace("signaling receipt of ack: {}", replyStatus == ReplyStatus.GOT_ACK);
-                        replyReceived.signal();
-                    }
-                }
-                messageReceived.signal();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        private void invalidMessageReceived() {
-            lock.lock();
-            try {
-                if (replyStatus == ReplyStatus.WAITING_FOR_ACK) {
-                    logger.debug("got bad data back, must assume message was acked.");
-                    replyStatus = ReplyStatus.GOT_ACK;
-                    replyReceived.signal();
-                }
-                messageReceived.signal();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        private void waitForReply(Msg msg) throws InterruptedException {
-            lock.lock();
-            try {
-                lastMsg = msg;
-                replyStatus = ReplyStatus.WAITING_FOR_ACK;
-                logger.trace("waiting for reply ack");
-                if (replyReceived.await(REPLY_TIMEOUT_TIME, TimeUnit.MILLISECONDS)) {
-                    logger.trace("got reply ack: {}", replyStatus == ReplyStatus.GOT_ACK);
-                } else {
-                    logger.trace("reply ack timeout expired");
-                    replyStatus = ReplyStatus.GOT_NACK;
-                }
-                if (replyStatus == ReplyStatus.GOT_NACK) {
-                    logger.trace("retransmitting msg: {}", msg);
-                    msg.setPriority(Priority.RETRANSMIT);
-                    writeMessage(msg);
-                }
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        private void limitRate(int time) throws InterruptedException {
-            lock.lock();
-            try {
-                do {
-                    logger.trace("writer rate limited for {} msec", time);
-                } while (messageReceived.await(time, TimeUnit.MILLISECONDS));
-            } finally {
-                lock.unlock();
-            }
-        }
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/SerialIOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/SerialIOStream.java
@@ -33,12 +33,15 @@ import org.openhab.core.io.transport.serial.UnsupportedCommOperationException;
  */
 @NonNullByDefault
 public class SerialIOStream extends IOStream {
+    private static final int RATE_LIMIT_TIME = 800; // in milliseconds
+
     private String name;
     private int baudRate;
     private SerialPortManager serialPortManager;
     private @Nullable SerialPort port;
 
     public SerialIOStream(String name, int baudRate, SerialPortManager serialPortManager) {
+        super(RATE_LIMIT_TIME);
         this.name = name;
         this.baudRate = baudRate;
         this.serialPortManager = serialPortManager;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/TcpIOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/TcpIOStream.java
@@ -29,6 +29,8 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 public class TcpIOStream extends IOStream {
+    private static final int RATE_LIMIT_TIME = 800; // in milliseconds
+
     private String host;
     private int port;
     private @Nullable Socket socket;
@@ -40,6 +42,7 @@ public class TcpIOStream extends IOStream {
      * @param port port to connect to
      */
     public TcpIOStream(String host, int port) {
+        super(RATE_LIMIT_TIME);
         this.host = host;
         this.port = port;
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/message/Msg.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/message/Msg.java
@@ -608,6 +608,18 @@ public class Msg {
         return priority.compareTo(msg.priority) < 0;
     }
 
+    /**
+     * Returns a copy of this message
+     *
+     * @return the copied message
+     */
+    public Msg copy() {
+        Msg msg = new Msg(data, definition);
+        msg.priority = priority;
+        msg.quietTime = quietTime;
+        return msg;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (obj == this) {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/message/Msg.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/message/Msg.java
@@ -42,13 +42,16 @@ public class Msg {
 
     private final byte[] data;
     private final MsgDefinition definition;
-    private long quietTime = 0;
+    private Priority priority;
+    private long quietTime = 500L;
+    private boolean expired = false;
     private boolean replayed = false;
     private long timestamp = System.currentTimeMillis();
 
     public Msg(byte[] data, MsgDefinition definition) {
         this.data = Arrays.copyOf(data, definition.getLength());
         this.definition = definition;
+        this.priority = isOutbound() ? Priority.COMMAND : Priority.NULL;
     }
 
     public Msg(MsgDefinition definition) {
@@ -69,6 +72,10 @@ public class Msg {
 
     public Direction getDirection() {
         return definition.getDirection();
+    }
+
+    public Priority getPriority() {
+        return priority;
     }
 
     public long getQuietTime() {
@@ -107,16 +114,20 @@ public class Msg {
         }
     }
 
+    public boolean isToAddress(@Nullable InsteonAddress address) {
+        try {
+            return getInsteonAddress("toAddress").equals(address);
+        } catch (FieldException e) {
+            return false;
+        }
+    }
+
     public boolean isInbound() {
         return getDirection() == Direction.FROM_MODEM;
     }
 
     public boolean isOutbound() {
         return getDirection() == Direction.TO_MODEM;
-    }
-
-    public boolean isEcho() {
-        return isPureNack() || isReply();
     }
 
     public boolean isReply() {
@@ -139,8 +150,8 @@ public class Msg {
         }
     }
 
-    public boolean isReplyOf(Msg msg) {
-        return isReply() && Arrays.equals(msg.getData(), Arrays.copyOf(data, msg.getLength()));
+    public boolean isReplyOf(@Nullable Msg msg) {
+        return msg != null && isReply() && Arrays.equals(msg.getData(), Arrays.copyOf(data, msg.getLength()));
     }
 
     public boolean isFailureReport() {
@@ -219,16 +230,32 @@ public class Msg {
         }
     }
 
+    public boolean isExpired() {
+        return expired;
+    }
+
     public boolean isReplayed() {
         return replayed;
+    }
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
     }
 
     public void setQuietTime(long quietTime) {
         this.quietTime = quietTime;
     }
 
+    public void setExpired(boolean expired) {
+        this.expired = expired;
+    }
+
     public void setIsReplayed(boolean replayed) {
         this.replayed = replayed;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
     }
 
     public boolean containsField(String key) {
@@ -568,6 +595,19 @@ public class Msg {
         }
     }
 
+    /**
+     * Checks if message has a higher priority than another one
+     *
+     * @param msg the message to compare to
+     * @return true if this message has a higher priority, otherwise false
+     */
+    public boolean hasHigherPriorityThan(@Nullable Msg msg) {
+        if (msg == null) {
+            return true;
+        }
+        return priority.compareTo(msg.priority) < 0;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (obj == this) {
@@ -706,7 +746,6 @@ public class Msg {
         msg.setByte("messageFlags", (byte) 0xCF);
         msg.setByte("command1", cmd1);
         msg.setByte("command2", cmd2);
-        msg.setQuietTime(0L);
         return msg;
     }
 
@@ -841,7 +880,6 @@ public class Msg {
         Msg msg = makeMessage("SendX10Message");
         msg.setByte("rawX10", cmd);
         msg.setByte("X10Flag", flag);
-        msg.setQuietTime(300L);
         return msg;
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/message/Priority.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/message/Priority.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.insteon.internal.transport.message;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link Priority} represents a message priority
+ *
+ * @author Jeremy Setton - Initial contribution
+ */
+@NonNullByDefault
+public enum Priority {
+    RETRANSMIT,
+    COMMAND,
+    TRIGGER_POLL,
+    STANDARD_POLL,
+    DATABASE,
+    NULL
+}

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/HubIOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/HubIOStream.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.insteon.internal.transport;
+package org.openhab.binding.insteon.internal.transport.stream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStream.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.insteon.internal.transport;
+package org.openhab.binding.insteon.internal.transport.stream;
 
 import java.io.EOFException;
 import java.io.IOException;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStreamListener.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStreamListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.insteon.internal.transport.stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.insteon.internal.transport.message.Msg;
+
+/**
+ * Interface for classes that want to listen to notifications from the port io stream
+ *
+ * @author Jeremy Setton - Initial contribution
+ */
+@NonNullByDefault
+public interface IOStreamListener {
+    /**
+     * Notifies that the io stream has disconnected
+     */
+    public void disconnected();
+
+    /**
+     * Notifies that the io stream has received a message
+     *
+     * @param msg the message received
+     */
+    public void messageReceived(Msg msg);
+
+    /**
+     * Notifies that the io stream has received bad data
+     */
+    public void invalidMessageReceived();
+
+    /**
+     * Notifies that the io stream has sent a message
+     *
+     * @param msg the message sent
+     */
+    public void messageSent(Msg msg);
+}

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStreamReader.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStreamReader.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.insteon.internal.transport.stream;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.insteon.internal.transport.message.Msg;
+import org.openhab.binding.insteon.internal.transport.message.MsgFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link IOStreamReader} represents an io stream reader
+ *
+ * @author Jeremy Setton - Initial contribution
+ */
+@NonNullByDefault
+public class IOStreamReader implements Runnable {
+    private static final int READ_BUFFER_SIZE = 1024;
+
+    private final Logger logger = LoggerFactory.getLogger(IOStreamReader.class);
+
+    private final IOStream stream;
+    private final IOStreamListener listener;
+    private final MsgFactory msgFactory = new MsgFactory();
+
+    public IOStreamReader(IOStream stream, IOStreamListener listener) {
+        this.stream = stream;
+        this.listener = listener;
+    }
+
+    @Override
+    public void run() {
+        logger.trace("starting thread");
+        byte[] buffer = new byte[READ_BUFFER_SIZE];
+        try {
+            while (!Thread.interrupted()) {
+                logger.trace("checking for input data");
+                // this call blocks until input data is available
+                int len = stream.read(buffer);
+                if (len > 0) {
+                    msgFactory.addData(buffer, len);
+                    processMessages();
+                }
+            }
+        } catch (InterruptedException e) {
+            logger.trace("got interrupted!");
+        } catch (IOException e) {
+            logger.trace("got an io exception", e);
+            listener.disconnected();
+        }
+        logger.trace("exiting thread!");
+    }
+
+    private void processMessages() {
+        // call msgFactory.processData() until it is done processing buffer
+        while (!msgFactory.isDone()) {
+            try {
+                Msg msg = msgFactory.processData();
+                if (msg != null) {
+                    listener.messageReceived(msg);
+                }
+            } catch (IOException e) {
+                // got bad data from modem,
+                // unblock those waiting for ack
+                listener.invalidMessageReceived();
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStreamWriter.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/IOStreamWriter.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.insteon.internal.transport.stream;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.insteon.internal.transport.message.Msg;
+import org.openhab.binding.insteon.internal.transport.message.Priority;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link IOStreamWriter} represents an io stream writer
+ *
+ * @author Jeremy Setton - Initial contribution
+ */
+@NonNullByDefault
+public class IOStreamWriter implements Runnable {
+    private static final int REPLY_TIMEOUT_TIME = 8000; // milliseconds
+
+    private final Logger logger = LoggerFactory.getLogger(IOStreamWriter.class);
+
+    private static enum ReplyStatus {
+        GOT_ACK,
+        GOT_NACK,
+        WAITING_FOR_ACK
+    }
+
+    private final IOStream stream;
+    private final IOStreamListener listener;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition messageReceived = lock.newCondition();
+    private final Condition replyReceived = lock.newCondition();
+    private final PriorityBlockingQueue<Msg> messageQueue = new PriorityBlockingQueue<>(10,
+            Comparator.comparing(Msg::getPriority).thenComparingLong(Msg::getTimestamp));
+    private ReplyStatus replyStatus = ReplyStatus.GOT_ACK;
+    private @Nullable Msg lastMsg;
+
+    public IOStreamWriter(IOStream stream, IOStreamListener listener) {
+        this.stream = stream;
+        this.listener = listener;
+    }
+
+    @Override
+    public void run() {
+        logger.trace("starting thread");
+        try {
+            while (!Thread.interrupted()) {
+                logger.trace("checking message queue");
+                Msg msg = messageQueue.take();
+                if (msg.isExpired()) {
+                    logger.trace("skipping expired message: {}", msg);
+                } else {
+                    stream.write(msg.getData());
+                    listener.messageSent(msg);
+                    waitForReply(msg);
+                    limitRate(stream.getRateLimitTime());
+                }
+            }
+        } catch (InterruptedException e) {
+            logger.trace("got interrupted!");
+        } catch (IOException e) {
+            logger.trace("got an io exception", e);
+            listener.disconnected();
+        }
+        logger.trace("exiting thread!");
+    }
+
+    public int getQueueSize() {
+        return messageQueue.size();
+    }
+
+    public void addMessage(Msg msg) {
+        messageQueue.add(msg);
+    }
+
+    public void clearQueue() {
+        messageQueue.clear();
+    }
+
+    public void messageReceived(Msg msg) {
+        lock.lock();
+        try {
+            if (replyStatus == ReplyStatus.WAITING_FOR_ACK) {
+                if (msg.isPureNack() || msg.isReplyOf(lastMsg)) {
+                    replyStatus = msg.isPureNack() ? ReplyStatus.GOT_NACK : ReplyStatus.GOT_ACK;
+                    logger.trace("signaling receipt of ack: {}", replyStatus == ReplyStatus.GOT_ACK);
+                    replyReceived.signal();
+                }
+            }
+            messageReceived.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void invalidMessageReceived() {
+        lock.lock();
+        try {
+            if (replyStatus == ReplyStatus.WAITING_FOR_ACK) {
+                logger.trace("got bad data back, must assume message was acked.");
+                replyStatus = ReplyStatus.GOT_ACK;
+                replyReceived.signal();
+            }
+            messageReceived.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void waitForReply(Msg msg) throws InterruptedException {
+        lock.lock();
+        try {
+            lastMsg = msg;
+            replyStatus = ReplyStatus.WAITING_FOR_ACK;
+            logger.trace("waiting for reply ack");
+            if (replyReceived.await(REPLY_TIMEOUT_TIME, TimeUnit.MILLISECONDS)) {
+                logger.trace("got reply ack: {}", replyStatus == ReplyStatus.GOT_ACK);
+            } else {
+                logger.trace("reply ack timeout expired");
+                replyStatus = ReplyStatus.GOT_NACK;
+            }
+            if (replyStatus == ReplyStatus.GOT_NACK) {
+                logger.trace("retransmitting msg: {}", msg);
+                msg.setPriority(Priority.RETRANSMIT);
+                messageQueue.add(msg);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void limitRate(int time) throws InterruptedException {
+        lock.lock();
+        try {
+            do {
+                logger.trace("rate limited for {} msec", time);
+            } while (messageReceived.await(time, TimeUnit.MILLISECONDS));
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/ReadByteBuffer.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/ReadByteBuffer.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.insteon.internal.transport;
+package org.openhab.binding.insteon.internal.transport.stream;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/SerialIOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/SerialIOStream.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.insteon.internal.transport;
+package org.openhab.binding.insteon.internal.transport.stream;
 
 import java.io.IOException;
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/TcpIOStream.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/transport/stream/TcpIOStream.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.insteon.internal.transport;
+package org.openhab.binding.insteon.internal.transport.stream;
 
 import java.io.IOException;
 import java.net.Socket;


### PR DESCRIPTION
This change improves the message transport control flow by slowing it down and introducing message priority. The new implementation is retrieving a lot more information than the legacy one causing high latency in environment with serial PLMs and high amount of linked devices.

It also includes refactoring request and poll managers to use `ScheduleFuture` jobs and allow the poll manager along with refactoring the transport port io stream reader and writer classes to handle the new message properties and add a rate limit after the last message received by the io stream based on its type.

This has been tested for a few months by different users.

I would advocated to have this change back ported since affected users on OH 4.3 have to use a beta release but since OH 5.0 is around the corner, it may not be necessary.