### PR TITLE
[jsscripting] Upgrade openhab-js to 5.11.1

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -22,7 +22,7 @@
       !jdk.vm.ci.services</bnd.importpackage>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
     <graaljs.version>24.2.0</graaljs.version>
-    <ohjs.version>openhab@5.11.0</ohjs.version>
+    <ohjs.version>openhab@5.11.1</ohjs.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This includes a fix for a regression from 5.11.0.