### PR TITLE
Accommodate change to RuleRegistry in Core

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/mocks/DummyRuleRegistry.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/mocks/DummyRuleRegistry.java
@@ -99,4 +99,8 @@ public class DummyRuleRegistry implements RuleRegistry {
     public Collection<Rule> getByTags(String... tags) {
         return Collections.emptyList();
     }
+
+    @Override
+    public void regenerateFromTemplate(String ruleUID) {
+    }
 }


### PR DESCRIPTION
This PR depends on https://github.com/openhab/openhab-core/pull/4718, and should only be merged if https://github.com/openhab/openhab-core/pull/4718 is merged.

It corrects for a small change in `RuleRegistry`. Builds of this PR will fail as long as https://github.com/openhab/openhab-core/pull/4718 isn't in Core.

