### PR TITLE
[insteon] Set device type for usb adapter as plm network bridge

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonModem.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonModem.java
@@ -31,6 +31,7 @@ import org.openhab.binding.insteon.internal.transport.PortListener;
 import org.openhab.binding.insteon.internal.transport.message.FieldException;
 import org.openhab.binding.insteon.internal.transport.message.InvalidMessageTypeException;
 import org.openhab.binding.insteon.internal.transport.message.Msg;
+import org.openhab.binding.insteon.internal.utils.HexUtils;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 
 /**
@@ -251,8 +252,8 @@ public class InsteonModem extends BaseDevice<InsteonAddress, InsteonBridgeHandle
 
         DeviceType deviceType = productData.getDeviceType();
         if (deviceType == null) {
-            logger.warn("unsupported product data for modem {} devCat:{} subCat:{}", address, deviceCategory,
-                    subCategory);
+            logger.warn("unsupported product data for modem {} devCat:{} subCat:{}", address,
+                    HexUtils.getHexString(deviceCategory), HexUtils.getHexString(subCategory));
             return;
         }
         setAddress(address);

--- a/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device-products.xml
@@ -1054,16 +1054,19 @@
 		<description>USB Adapter</description>
 		<model>2448A7</model>
 		<vendor>Insteon</vendor>
+		<device-type>NetworkBridge_PLM</device-type>
 	</product>
 	<product devCat="0x03" subCat="0x20" productKey="0x00007E">
 		<description>USB Adapter</description>
 		<model>2448A7</model>
 		<vendor>Insteon</vendor>
+		<device-type>NetworkBridge_PLM</device-type>
 	</product>
 	<product devCat="0x03" subCat="0x21" productKey="0x00008E">
 		<description>USB Adapter (HouseLinc)</description>
 		<model>2448A7H</model>
 		<vendor>Insteon</vendor>
+		<device-type>NetworkBridge_PLM</device-type>
 	</product>
 	<product devCat="0x03" subCat="0x22" productKey="0x00008F">
 		<description>Central Controller Interface</description>
@@ -1074,6 +1077,7 @@
 		<description>USB Adapter (HouseLinc)</description>
 		<model>2448A7H</model>
 		<vendor>Insteon</vendor>
+		<device-type>NetworkBridge_PLM</device-type>
 	</product>
 	<product devCat="0x03" subCat="0x24" productKey="0x0000A2">
 		<description>TouchLinc</description>


### PR DESCRIPTION
This change adds support for Insteon 2448A7 USB adapter (different versions) by setting its device type to `NetworkBridge_PLM`.

Fixes: #18649 