### PR TITLE
[tuya] Add support for protocol version 3.5

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
@@ -34,6 +34,7 @@ import org.openhab.binding.tuya.internal.cloud.TuyaOpenAPI;
 import org.openhab.binding.tuya.internal.cloud.dto.DeviceListInfo;
 import org.openhab.binding.tuya.internal.cloud.dto.DeviceSchema;
 import org.openhab.binding.tuya.internal.handler.ProjectHandler;
+import org.openhab.binding.tuya.internal.local.UdpDiscoverySender;
 import org.openhab.binding.tuya.internal.util.SchemaDp;
 import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -64,6 +65,9 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
     private final Gson gson = new Gson();
     private @NonNullByDefault({}) Storage<String> storage;
     private @Nullable ScheduledFuture<?> discoveryJob;
+    private @Nullable ScheduledFuture<?> broadcastJob;
+
+    private final UdpDiscoverySender udpDiscoverySender = new UdpDiscoverySender();
 
     public TuyaDiscoveryService() {
         super(ProjectHandler.class, SUPPORTED_THING_TYPES, SEARCH_TIME);
@@ -136,6 +140,11 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
 
     @Override
     protected synchronized void stopScan() {
+        ScheduledFuture<?> broadcastJob = this.broadcastJob;
+        if (broadcastJob != null) {
+            broadcastJob.cancel(true);
+            this.broadcastJob = null;
+        }
         removeOlderResults(getTimestampOfLastScan());
         super.stopScan();
     }
@@ -163,6 +172,12 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
         if (discoveryJob == null || discoveryJob.isCancelled()) {
             this.discoveryJob = scheduler.scheduleWithFixedDelay(this::startScan, 1, 5, TimeUnit.MINUTES);
         }
+
+        ScheduledFuture<?> broadcastJob = this.broadcastJob;
+        if (broadcastJob == null || broadcastJob.isDone() || broadcastJob.isCancelled()) {
+            this.broadcastJob = scheduler.scheduleWithFixedDelay(udpDiscoverySender::sendMessage, 5, 10,
+                    TimeUnit.SECONDS);
+        }
     }
 
     @Override
@@ -171,6 +186,11 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
         if (discoveryJob != null) {
             discoveryJob.cancel(true);
             this.discoveryJob = null;
+        }
+        ScheduledFuture<?> broadcastJob = this.broadcastJob;
+        if (broadcastJob != null) {
+            broadcastJob.cancel(true);
+            this.broadcastJob = null;
         }
     }
 }

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/CommandType.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/CommandType.java
@@ -44,6 +44,7 @@ public enum CommandType {
     UDP_NEW(19),
     AP_CONFIG_NEW(20),
     BROADCAST_LPV34(35),
+    REQ_DEVINFO(37),
     LAN_EXT_STREAM(40),
     LAN_GW_ACTIVE(240),
     LAN_SUB_DEV_REQUEST(241),

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/ProtocolVersion.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/ProtocolVersion.java
@@ -26,7 +26,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public enum ProtocolVersion {
     V3_1("3.1"),
     V3_3("3.3"),
-    V3_4("3.4");
+    V3_4("3.4"),
+    V3_5("3.5");
 
     private final String versionString;
 

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/TuyaDevice.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.tuya.internal.local.CommandType.DP_QUERY;
 import static org.openhab.binding.tuya.internal.local.CommandType.DP_REFRESH;
 import static org.openhab.binding.tuya.internal.local.CommandType.SESS_KEY_NEG_START;
 import static org.openhab.binding.tuya.internal.local.ProtocolVersion.V3_4;
+import static org.openhab.binding.tuya.internal.local.ProtocolVersion.V3_5;
 
 import java.util.List;
 import java.util.Map;
@@ -112,7 +113,7 @@ public class TuyaDevice implements ChannelFutureListener {
     }
 
     public void set(Map<Integer, @Nullable Object> command) {
-        CommandType commandType = (protocolVersion == V3_4) ? CONTROL_NEW : CONTROL;
+        CommandType commandType = (protocolVersion == V3_4 || protocolVersion == V3_5) ? CONTROL_NEW : CONTROL;
         MessageWrapper<?> m = new MessageWrapper<>(commandType, Map.of("dps", command));
         Channel channel = this.channel;
         if (channel != null) {
@@ -156,7 +157,7 @@ public class TuyaDevice implements ChannelFutureListener {
             // session key is device key before negotiation
             channel.attr(SESSION_KEY_ATTR).set(deviceKey);
 
-            if (protocolVersion == V3_4) {
+            if (protocolVersion == V3_4 || protocolVersion == V3_5) {
                 byte[] sessionRandom = CryptoUtil.generateRandom(16);
                 channel.attr(SESSION_RANDOM_ATTR).set(sessionRandom);
                 this.channel = channel;

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoverySender.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/UdpDiscoverySender.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.local;
+
+import static org.openhab.binding.tuya.internal.local.CommandType.REQ_DEVINFO;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.tuya.internal.local.handlers.TuyaEncoder;
+import org.openhab.binding.tuya.internal.local.handlers.UdpBroadcastHandler;
+import org.openhab.binding.tuya.internal.util.CryptoUtil;
+import org.openhab.binding.tuya.internal.util.NetworkUtil;
+import org.openhab.core.util.HexUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+
+/**
+ * The {@link UdpDiscoverySender} sends device v3.5 discovery UDP broadcast message
+ *
+ * @author Andriy Yemets - Initial contribution
+ */
+@NonNullByDefault
+public class UdpDiscoverySender {
+    private static final byte[] TUYA_UDP_KEY = HexUtils.hexToBytes(CryptoUtil.md5("yGAdlopoPVldABfn"));
+
+    private final Logger logger = LoggerFactory.getLogger(UdpDiscoverySender.class);
+
+    private final Gson gson = new Gson();
+
+    private final String broadcastAddress = "255.255.255.255";
+    private final int broadcastPort = 7000;
+
+    public UdpDiscoverySender() {
+        //
+    }
+
+    public void sendMessage() {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group).channel(NioDatagramChannel.class).option(ChannelOption.SO_BROADCAST, true)
+                    .handler(new ChannelInitializer<DatagramChannel>() {
+                        @Override
+                        protected void initChannel(DatagramChannel ch) throws Exception {
+                            ChannelPipeline pipeline = ch.pipeline();
+                            pipeline.addLast("broadcastHandler",
+                                    new UdpBroadcastHandler(broadcastAddress, broadcastPort));
+                            pipeline.addLast("messageEncoder", new TuyaEncoder(gson));
+                        }
+                    });
+
+            ChannelFuture futureChannel = b.bind(0).sync();
+            Channel broadcastChannel = futureChannel.channel();
+            broadcastChannel.attr(TuyaDevice.DEVICE_ID_ATTR).set("udpDiscoverySender");
+            broadcastChannel.attr(TuyaDevice.PROTOCOL_ATTR).set(ProtocolVersion.V3_5);
+            broadcastChannel.attr(TuyaDevice.SESSION_KEY_ATTR).set(TUYA_UDP_KEY);
+
+            MessageWrapper<?> m = new MessageWrapper<>(REQ_DEVINFO,
+                    Map.of("from", "app", "ip", NetworkUtil.getLocalIPAddress()));
+            broadcastChannel.writeAndFlush(m).addListener(ChannelFutureListener.CLOSE);
+        } catch (Exception e) {
+            logger.error("Error during sending UDP Discovery message. {}", e.getMessage());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/UdpBroadcastHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/local/handlers/UdpBroadcastHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.local.handlers;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.socket.DatagramPacket;
+
+/**
+ * The {@link UdpBroadcastHandler} is a Netty handler for create UDP broadcast message
+ *
+ * @author Andriy Yemets - Initial contribution
+ */
+@NonNullByDefault
+public class UdpBroadcastHandler extends ChannelOutboundHandlerAdapter {
+
+    private final String broadcastAddress;
+    private final int broadcastPort;
+
+    public UdpBroadcastHandler(String broadcastAddress, int broadcastPort) {
+        this.broadcastAddress = broadcastAddress;
+        this.broadcastPort = broadcastPort;
+    }
+
+    @Override
+    public void write(@NonNullByDefault({}) ChannelHandlerContext ctx, @NonNullByDefault({}) Object msg,
+            @NonNullByDefault({}) ChannelPromise promise) throws Exception {
+        if (msg instanceof ByteBuf) {
+            ByteBuf buf = (ByteBuf) msg;
+            DatagramPacket packet = new DatagramPacket(buf, new InetSocketAddress(broadcastAddress, broadcastPort));
+            ctx.write(packet, promise);
+        } else {
+            super.write(ctx, msg, promise);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/util/NetworkUtil.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/util/NetworkUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tuya.internal.util;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link NetworkUtil} is a support class for retrieving network related information.
+ *
+ * Parts of this code are inspired by the TuyAPI project (see notice file)
+ *
+ * @author Andriy Yemets - Initial contribution
+ */
+@NonNullByDefault
+public class NetworkUtil {
+    private static final Logger logger = LoggerFactory.getLogger(NetworkUtil.class);
+
+    private NetworkUtil() {
+        // prevent instantiation
+    }
+
+    /**
+     * Get host local IPv4 address
+     *
+     * @return the resulting IPv4 address as String
+     */
+    public static String getLocalIPAddress() {
+        try {
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements()) {
+                NetworkInterface netInterface = networkInterfaces.nextElement();
+                if (!netInterface.isLoopback() && netInterface.isUp()) {
+                    Enumeration<InetAddress> inetAddresses = netInterface.getInetAddresses();
+                    while (inetAddresses.hasMoreElements()) {
+                        InetAddress inetAddress = inetAddresses.nextElement();
+                        if (inetAddress.isSiteLocalAddress() && inetAddress instanceof Inet4Address) {
+                            logger.trace("Local IPv4 address is: {}", inetAddress.getHostAddress());
+                            return inetAddress.getHostAddress();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to get local IPv4 address. {}", e.getMessage());
+        }
+        return "";
+    }
+}

--- a/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
@@ -84,6 +84,7 @@
 					<option value="3.1">3.1</option>
 					<option value="3.3">3.3</option>
 					<option value="3.4">3.4</option>
+					<option value="3.5">3.5</option>
 				</options>
 				<limitToOptions>true</limitToOptions>
 				<advanced>true</advanced>

--- a/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/util/CryptoUtilTest.java
+++ b/bundles/org.openhab.binding.tuya/src/test/java/org/openhab/binding/tuya/internal/util/CryptoUtilTest.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.tuya.internal.local.ProtocolVersion;
 import org.openhab.core.util.HexUtils;
 
 /**
@@ -37,7 +38,7 @@ public class CryptoUtilTest {
         byte[] remoteKey = HexUtils.hexToBytes("30633665666638323536343733353036");
         byte[] expectedSessionKey = HexUtils.hexToBytes("afe2349b17e2cc833247ccb1a52e8aae");
 
-        byte[] sessionKey = CryptoUtil.generateSessionKey(localKey, remoteKey, deviceKey);
+        byte[] sessionKey = CryptoUtil.generateSessionKey(localKey, remoteKey, deviceKey, ProtocolVersion.V3_4);
 
         assertThat(sessionKey, is(expectedSessionKey));
     }


### PR DESCRIPTION
Add support for the 3.5 protocol version. This was merged into the Smarthome/J version of the Tuya binding but only after the openhab-addons version had been created. Since Tuya has been removed from Smarthome/J in favour of the openhab-addons version it's kind of important that we don't lose this!
