### PR TITLE
[teslapowerwall] Code cleanups, and fix degradation being based on a single powerwall

### DIFF
--- a/bundles/org.openhab.binding.teslapowerwall/README.md
+++ b/bundles/org.openhab.binding.teslapowerwall/README.md
@@ -12,12 +12,13 @@ The binding does not support auto discovery.
 
 ## Thing Configuration
 
-As a minimum, the hostname is needed:
+| Thing Parameter | Default Value | Required | Advanced | Description                                                                          |
+|-----------------|---------------|----------|----------|--------------------------------------------------------------------------------------|
+| hostname        | N/A           | Yes      | No       | The IP or hostname of the Tesla Powerwall                                            |
+| email           | N/A           | Yes      | No       | the email of the local account on the Powerwall that the installer provided          |
+| password        | N/A           | Yes      | No       | the password of the local account on the Powerwall that the installer provided       |
+| refresh         | 10            | No       | Yes      | The frequency with which to refresh information from the Powerwall (in seconds)      |
 
-- hostname - The hostname of the Tesla Powerwall 2. Defaults to powerwall to avoid SSL certificate issues
-- email - the email of the local account on the Powerwall that the installer provided
-- password - the password of the local account on the Powerwall that the installer provided
-- refresh - The frequency with which to refresh information from the Tesla Powerwall2 specified in seconds. Defaults to 10 seconds.
 
 ## Channels
 
@@ -39,7 +40,7 @@ As a minimum, the hostname is needed:
 | battery-energy-imported   | Number:Energy        | Total Battery Energy Imported                                |
 | home-energy-imported      | Number:Energy        | Total Home Energy Imported                                   |
 | solar-energy-imported     | Number:Energy        | Total Solar Energy Imported                                  |
-| degradation               | Number:Dimensionless | Current battery degradation % (Based on single battery)      |
+| degradation               | Number:Dimensionless | Current battery degradation %                                |
 | full-pack-energy          | Number:Energy        | Reported battery capacity at full                            |
 
 ## Full Example

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
@@ -124,50 +124,65 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
             return;
         }
 
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_MODE, new StringType(operations.mode));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_RESERVE,
-                new QuantityType<>(((operations.reserve / 0.95) - (5 / 0.95)), Units.PERCENT));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_SOE,
-                new QuantityType<>(((batterySOE.soe / 0.95) - (5 / 0.95)), Units.PERCENT));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_STATUS,
-                new StringType(gridStatus.gridStatus));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_SERVICES,
-                (gridStatus.gridServices ? OnOffType.ON : OnOffType.OFF));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_FULL_PACK_ENERGY,
-                new QuantityType<>(systemStatus.fullPackEnergy, Units.WATT_HOUR));
-        if (systemStatus.fullPackEnergy < TeslaPowerwallBindingConstants.TESLA_POWERWALL_CAPACITY) {
-            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_DEGRADATION,
-                    new QuantityType<>(
-                            (TeslaPowerwallBindingConstants.TESLA_POWERWALL_CAPACITY - systemStatus.fullPackEnergy)
-                                    / TeslaPowerwallBindingConstants.TESLA_POWERWALL_CAPACITY * 100,
-                            Units.PERCENT));
-        } else {
-            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_DEGRADATION,
-                    new QuantityType<>(0, Units.PERCENT));
+        if (operations != null) {
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_MODE,
+                    new StringType(operations.realMode));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_RESERVE,
+                    new QuantityType<>(((operations.backupReservePercent / 0.95) - (5 / 0.95)), Units.PERCENT));
         }
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_INST_POWER,
-                new QuantityType<>(meterAggregates.gridInstpower, MetricPrefix.KILO(Units.WATT)));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_ENERGY_EXPORTED,
-                new QuantityType<>(meterAggregates.gridEnergyexported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_ENERGY_IMPORTED,
-                new QuantityType<>(meterAggregates.gridEnergyimported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_INST_POWER,
-                new QuantityType<>(meterAggregates.batteryInstpower, MetricPrefix.KILO(Units.WATT)));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGY_EXPORTED,
-                new QuantityType<>(meterAggregates.batteryEnergyexported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGY_IMPORTED,
-                new QuantityType<>(meterAggregates.batteryEnergyimported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_HOME_INST_POWER,
-                new QuantityType<>(meterAggregates.homeInstpower, MetricPrefix.KILO(Units.WATT)));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_HOME_ENERGY_EXPORTED,
-                new QuantityType<>(meterAggregates.homeEnergyexported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_HOME_ENERGY_IMPORTED,
-                new QuantityType<>(meterAggregates.homeEnergyimported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_SOLAR_INST_POWER,
-                new QuantityType<>(meterAggregates.solarInstpower, MetricPrefix.KILO(Units.WATT)));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_SOLAR_ENERGY_EXPORTED,
-                new QuantityType<>(meterAggregates.solarEnergyexported, Units.KILOWATT_HOUR));
-        updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_SOLAR_ENERGY_IMPORTED,
-                new QuantityType<>(meterAggregates.solarEnergyimported, Units.KILOWATT_HOUR));
+        if (batterySOE != null) {
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_SOE,
+                    new QuantityType<>(((batterySOE.soe / 0.95) - (5 / 0.95)), Units.PERCENT));
+        }
+        if (gridStatus != null) {
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_STATUS,
+                    new StringType(gridStatus.gridStatus));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_SERVICES,
+                    (gridStatus.gridServicesActive ? OnOffType.ON : OnOffType.OFF));
+        }
+        if (systemStatus != null) {
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_FULL_PACK_ENERGY,
+                    new QuantityType<>(systemStatus.nominalFullPackEnergy, Units.WATT_HOUR));
+            if (systemStatus.nominalFullPackEnergy < systemStatus.availableBlocks
+                    * TeslaPowerwallBindingConstants.TESLA_POWERWALL_CAPACITY) {
+                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_DEGRADATION,
+                        new QuantityType<>(
+                                (systemStatus.availableBlocks * TeslaPowerwallBindingConstants.TESLA_POWERWALL_CAPACITY
+                                        - systemStatus.nominalFullPackEnergy)
+                                        / (systemStatus.availableBlocks
+                                                * TeslaPowerwallBindingConstants.TESLA_POWERWALL_CAPACITY)
+                                        * 100,
+                                Units.PERCENT));
+            } else {
+                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_DEGRADATION,
+                        new QuantityType<>(0, Units.PERCENT));
+            }
+        }
+        if (meterAggregates != null) {
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_INST_POWER,
+                    new QuantityType<>(meterAggregates.siteMeterDetails.instantPower, MetricPrefix.KILO(Units.WATT)));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_ENERGY_EXPORTED,
+                    new QuantityType<>(meterAggregates.siteMeterDetails.energyExported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_ENERGY_IMPORTED,
+                    new QuantityType<>(meterAggregates.siteMeterDetails.energyImported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_INST_POWER, new QuantityType<>(
+                    meterAggregates.batteryMeterDetails.instantPower, MetricPrefix.KILO(Units.WATT)));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGY_EXPORTED,
+                    new QuantityType<>(meterAggregates.batteryMeterDetails.energyExported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGY_IMPORTED,
+                    new QuantityType<>(meterAggregates.batteryMeterDetails.energyImported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_HOME_INST_POWER,
+                    new QuantityType<>(meterAggregates.loadMeterDetails.instantPower, MetricPrefix.KILO(Units.WATT)));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_HOME_ENERGY_EXPORTED,
+                    new QuantityType<>(meterAggregates.loadMeterDetails.energyExported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_HOME_ENERGY_IMPORTED,
+                    new QuantityType<>(meterAggregates.loadMeterDetails.energyImported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_SOLAR_INST_POWER,
+                    new QuantityType<>(meterAggregates.solarMeterDetails.instantPower, MetricPrefix.KILO(Units.WATT)));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_SOLAR_ENERGY_EXPORTED,
+                    new QuantityType<>(meterAggregates.solarMeterDetails.energyExported, Units.KILOWATT_HOUR));
+            updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_SOLAR_ENERGY_IMPORTED,
+                    new QuantityType<>(meterAggregates.solarMeterDetails.energyImported, Units.KILOWATT_HOUR));
+        }
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallWebTargets.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallWebTargets.java
@@ -73,36 +73,35 @@ public class TeslaPowerwallWebTargets {
     public BatterySOE getBatterySOE(String email, String password)
             throws TeslaPowerwallCommunicationException, TeslaPowerwallAuthenticationException {
         String response = invoke(getBatterySOEUri, email, password);
-        logger.trace("getBatterySOE response = {}", response);
         return gson.fromJson(response, BatterySOE.class);
     }
 
+    @Nullable
     public GridStatus getGridStatus(String email, String password)
             throws TeslaPowerwallCommunicationException, TeslaPowerwallAuthenticationException {
         String response = invoke(getGridStatusUri, email, password);
-        logger.trace("getGridStatus response = {}", response);
-        return GridStatus.parse(response);
+        return gson.fromJson(response, GridStatus.class);
     }
 
+    @Nullable
     public SystemStatus getSystemStatus(String email, String password)
             throws TeslaPowerwallCommunicationException, TeslaPowerwallAuthenticationException {
         String response = invoke(getSystemStatusUri, email, password);
-        logger.trace("getSystemStatus response = {}", response);
-        return SystemStatus.parse(response);
+        return gson.fromJson(response, SystemStatus.class);
     }
 
+    @Nullable
     public MeterAggregates getMeterAggregates(String email, String password)
             throws TeslaPowerwallCommunicationException, TeslaPowerwallAuthenticationException {
         String response = invoke(getMeterAggregatesUri, email, password);
-        logger.trace("getMeterAggregates response = {}", response);
-        return MeterAggregates.parse(response);
+        return gson.fromJson(response, MeterAggregates.class);
     }
 
+    @Nullable
     public Operations getOperations(String email, String password)
             throws TeslaPowerwallCommunicationException, TeslaPowerwallAuthenticationException {
         String response = invoke(getOperationUri, email, password);
-        logger.trace("getOperations response = {}", response);
-        return Operations.parse(response);
+        return gson.fromJson(response, Operations.class);
     }
 
     public String getToken(String email, String password)

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallWebTargets.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallWebTargets.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
@@ -31,6 +32,7 @@ import org.openhab.binding.teslapowerwall.internal.api.SystemStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -54,6 +56,8 @@ public class TeslaPowerwallWebTargets {
     private final Logger logger = LoggerFactory.getLogger(TeslaPowerwallWebTargets.class);
     private HttpClient httpClient;
 
+    private final Gson gson = new Gson();
+
     public TeslaPowerwallWebTargets(String hostname, HttpClient httpClient) {
         this.httpClient = httpClient;
         String baseUri = "https://" + hostname + "/";
@@ -65,11 +69,12 @@ public class TeslaPowerwallWebTargets {
         getOperationUri = baseUri + "api/operation";
     }
 
+    @Nullable
     public BatterySOE getBatterySOE(String email, String password)
             throws TeslaPowerwallCommunicationException, TeslaPowerwallAuthenticationException {
         String response = invoke(getBatterySOEUri, email, password);
         logger.trace("getBatterySOE response = {}", response);
-        return BatterySOE.parse(response);
+        return gson.fromJson(response, BatterySOE.class);
     }
 
     public GridStatus getGridStatus(String email, String password)

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/BatterySOE.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/BatterySOE.java
@@ -14,8 +14,6 @@ package org.openhab.binding.teslapowerwall.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -30,13 +28,5 @@ public class BatterySOE {
     public float soe = 0;
 
     private BatterySOE() {
-    }
-
-    public static BatterySOE parse(String response) {
-        /* parse json string */
-        JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-        BatterySOE info = new BatterySOE();
-        info.soe = jsonObject.get("percentage").getAsFloat();
-        return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/BatterySOE.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/BatterySOE.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Class for holding the set of parameters used to read the battery soe.
@@ -25,7 +26,8 @@ import com.google.gson.JsonParser;
  */
 @NonNullByDefault
 public class BatterySOE {
-    public double soe;
+    @SerializedName("percentage")
+    public float soe = 0;
 
     private BatterySOE() {
     }
@@ -34,7 +36,7 @@ public class BatterySOE {
         /* parse json string */
         JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
         BatterySOE info = new BatterySOE();
-        info.soe = jsonObject.get("percentage").getAsDouble();
+        info.soe = jsonObject.get("percentage").getAsFloat();
         return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
@@ -14,8 +14,7 @@ package org.openhab.binding.teslapowerwall.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Class for holding the set of parameters used to read the battery soe.
@@ -26,18 +25,12 @@ import com.google.gson.JsonParser;
 @NonNullByDefault
 public class GridStatus {
 
+    @SerializedName("grid_status")
     public String gridStatus = "";
-    public Boolean gridServices = false;
+
+    @SerializedName("grid_services_active")
+    public boolean gridServicesActive;
 
     private GridStatus() {
-    }
-
-    public static GridStatus parse(String response) {
-        /* parse json string */
-        JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-        GridStatus info = new GridStatus();
-        info.gridStatus = jsonObject.get("grid_status").getAsString();
-        info.gridServices = jsonObject.get("grid_services_active").getAsString().equalsIgnoreCase("true");
-        return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
@@ -14,8 +14,7 @@ package org.openhab.binding.teslapowerwall.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Class for holding the set of parameters used to read the battery soe.
@@ -25,47 +24,71 @@ import com.google.gson.JsonParser;
  */
 @NonNullByDefault
 public class MeterAggregates {
-    public double gridInstpower;
-    public double batteryInstpower;
-    public double homeInstpower;
-    public double solarInstpower;
-    public double gridEnergyexported;
-    public double batteryEnergyexported;
-    public double homeEnergyexported;
-    public double solarEnergyexported;
-    public double gridEnergyimported;
-    public double batteryEnergyimported;
-    public double homeEnergyimported;
-    public double solarEnergyimported;
+    @SerializedName("site")
+    public @NonNullByDefault({}) MeterDetails siteMeterDetails;
 
-    private MeterAggregates() {
+    @SerializedName("battery")
+    public @NonNullByDefault({}) MeterDetails batteryMeterDetails;
+
+    @SerializedName("load")
+    public @NonNullByDefault({}) MeterDetails loadMeterDetails;
+
+    @SerializedName("solar")
+    public @NonNullByDefault({}) MeterDetails solarMeterDetails;
+
+    public class MeterDetails {
+        @SerializedName("last_communication_time")
+        public String lastCommunicationTime = "";
+
+        @SerializedName("instant_power")
+        public float instantPower;
+
+        @SerializedName("instant_reactive_power")
+        public float instantReactivePower;
+
+        @SerializedName("instant_apparent_power")
+        public float instantApparentPower;
+
+        @SerializedName("frequency")
+        public float frequency;
+
+        @SerializedName("energy_exported")
+        public int energyExported;
+
+        @SerializedName("energy_imported")
+        public float energyImported;
+
+        @SerializedName("instant_average_voltage")
+        public float instantAverageVoltage;
+
+        @SerializedName("instant_average_current")
+        public float instantAverageCurrent;
+
+        @SerializedName("i_a_current")
+        public int iaCurrent;
+
+        @SerializedName("i_b_current")
+        public int ibCurrent;
+
+        @SerializedName("i_c_current")
+        public int icCurrent;
+
+        @SerializedName("last_phase_voltage_communication_time")
+        public String lastPhaseVoltageCommunicationTime = "";
+
+        @SerializedName("last_phase_power_communication_time")
+        public String lastPhasePowerCommunicationTime = "";
+
+        @SerializedName("last_phase_energy_communication_time")
+        public String lastPhaseEnergyCommunicationTime = "";
+
+        @SerializedName("timeout")
+        public int timeout;
+
+        @SerializedName("instant_total_current")
+        public float instantTotalCurrent;
     }
 
-    public static MeterAggregates parse(String response) {
-        /* parse json string */
-        JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-        MeterAggregates info = new MeterAggregates();
-
-        JsonObject sitejson = jsonObject.get("site").getAsJsonObject();
-        info.gridInstpower = sitejson.get("instant_power").getAsDouble() / 1000;
-        info.gridEnergyexported = sitejson.get("energy_exported").getAsDouble() / 1000;
-        info.gridEnergyimported = sitejson.get("energy_imported").getAsDouble() / 1000;
-
-        JsonObject batteryjson = jsonObject.get("battery").getAsJsonObject();
-        info.batteryInstpower = batteryjson.get("instant_power").getAsDouble() / 1000;
-        info.batteryEnergyexported = batteryjson.get("energy_exported").getAsDouble() / 1000;
-        info.batteryEnergyimported = batteryjson.get("energy_imported").getAsDouble() / 1000;
-
-        JsonObject loadjson = jsonObject.get("load").getAsJsonObject();
-        info.homeInstpower = loadjson.get("instant_power").getAsDouble() / 1000;
-        info.homeEnergyexported = loadjson.get("energy_exported").getAsDouble() / 1000;
-        info.homeEnergyimported = loadjson.get("energy_imported").getAsDouble() / 1000;
-
-        JsonObject solarjson = jsonObject.get("solar").getAsJsonObject();
-        info.solarInstpower = solarjson.get("instant_power").getAsDouble() / 1000;
-        info.solarEnergyexported = solarjson.get("energy_exported").getAsDouble() / 1000;
-        info.solarEnergyimported = solarjson.get("energy_imported").getAsDouble() / 1000;
-
-        return info;
+    private MeterAggregates() {
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/Operations.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/Operations.java
@@ -14,8 +14,7 @@ package org.openhab.binding.teslapowerwall.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Class for holding the set of parameters used to read the battery mode/reserver.
@@ -25,19 +24,15 @@ import com.google.gson.JsonParser;
  */
 @NonNullByDefault
 public class Operations {
+    @SerializedName("real_mode")
+    public String realMode = "";
 
-    public String mode = "";
-    public double reserve;
+    @SerializedName("reactive_mode")
+    public String reactiveMode = "";
+
+    @SerializedName("backup_reserve_percent")
+    public float backupReservePercent;
 
     private Operations() {
-    }
-
-    public static Operations parse(String response) {
-        /* parse json string */
-        JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-        Operations info = new Operations();
-        info.mode = jsonObject.get("real_mode").getAsString();
-        info.reserve = jsonObject.get("backup_reserve_percent").getAsDouble();
-        return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/SystemStatus.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/SystemStatus.java
@@ -14,8 +14,7 @@ package org.openhab.binding.teslapowerwall.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Class for holding the set of parameters used to read the battery soe.
@@ -25,16 +24,212 @@ import com.google.gson.JsonParser;
  */
 @NonNullByDefault
 public class SystemStatus {
-    public double fullPackEnergy;
+    @SerializedName("command_source")
+    public String commandSource = "";
 
-    private SystemStatus() {
+    @SerializedName("battery_target_power")
+    public float batteryTargetPower;
+
+    @SerializedName("battery_target_reactive_power")
+    public int batteryTargetReactivePower;
+
+    @SerializedName("nominal_full_pack_energy")
+    public int nominalFullPackEnergy;
+
+    @SerializedName("nominal_energy_remaining")
+    public int nominalEnergyRemaining;
+
+    @SerializedName("max_power_energy_remaining")
+    public int maxPowerEnergyRemaining;
+
+    @SerializedName("max_power_energy_to_be_charged")
+    public int maxPowerEnergyToBeCharged;
+
+    @SerializedName("max_charge_power")
+    public int maxChargePower;
+
+    @SerializedName("max_discharge_power")
+    public int maxDischargePower;
+
+    @SerializedName("max_apparent_power")
+    public int maxApparentPower;
+
+    @SerializedName("instantaneous_max_discharge_power")
+    public int instantaneousMaxDischargePower;
+
+    @SerializedName("instantaneous_max_charge_power")
+    public int instantaneousMaxChargePower;
+
+    @SerializedName("instantaneous_max_apparent_power")
+    public int instantaneousMaxApparentPower;
+
+    @SerializedName("hardware_capability_charge_power")
+    public int hardwareCapabilityChargePower;
+
+    @SerializedName("hardware_capability_discharge_power")
+    public int hardwareCapabilityDischargePower;
+
+    @SerializedName("hardware_capability_adjusted_charge_power")
+    public int hardwareCapabilityAdjustedChargePower;
+
+    @SerializedName("grid_services_power")
+    public int gridServicesPower;
+
+    @SerializedName("system_island_state")
+    public String systemIslandState = "";
+
+    @SerializedName("available_blocks")
+    public int availableBlocks;
+
+    @SerializedName("available_charger_blocks")
+    public int availableChargerBlocks;
+
+    @SerializedName("battery_blocks")
+    public @NonNullByDefault({}) BatteryBlocks[] batteryBlocks;
+
+    @SerializedName("ffr_power_availability_high")
+    public int ffrPowerAvailabilityHigh;
+
+    @SerializedName("ffr_power_availability_low")
+    public int ffrPowerAvailabilityLow;
+
+    @SerializedName("load_charge_constraint")
+    public int loadChargeConstraint;
+
+    @SerializedName("max_sustained_ramp_rate")
+    public int maxSustainedRampRate;
+
+    @SerializedName("can_reboot")
+    public String canReboot = "";
+
+    @SerializedName("smart_inv_delta_p")
+    public int smartInvDeltaP;
+
+    @SerializedName("smart_inv_delta_q")
+    public int smartInvDeltaQ;
+
+    @SerializedName("last_toggle_timestamp")
+    public String lastToggleTimestamp = "";
+
+    @SerializedName("solar_real_power_limit")
+    public float solarRealPowerLimit;
+
+    @SerializedName("score")
+    public int score;
+
+    @SerializedName("blocks_controlled")
+    public int blocksControlled;
+
+    @SerializedName("primary")
+    public boolean primary;
+
+    @SerializedName("auxiliary_load")
+    public int auxiliaryLoad;
+
+    @SerializedName("all_enable_lines_high")
+    public boolean allEnableLinesHigh;
+
+    @SerializedName("inverter_nominal_usable_power")
+    public int inverterNominalUsablePower;
+
+    @SerializedName("system_available_charge_power_design_pf")
+    public int systemAvailableChargePowerDesignPf;
+
+    @SerializedName("system_available_discharge_power_design_pf")
+    public int systemAvailableDischargePowerDesignPf;
+
+    @SerializedName("system_available_charge_power_unity_pf")
+    public int systemAvailableChargePowerUnityPf;
+
+    @SerializedName("system_available_discharge_power_unity_pf")
+    public int systemAvailableDischargePowerUnityPf;
+
+    @SerializedName("system_charge_power_capability_design_pf")
+    public int systemChargePowerCapabilityDesignPf;
+
+    @SerializedName("system_discharge_power_capability_design_pf")
+    public int systemDischargePowerCapabilityDesignPf;
+
+    @SerializedName("system_charge_power_capability_unity_pf")
+    public int systemChargePowerCapabilityUnityPf;
+
+    @SerializedName("system_discharge_power_capability_unity_pf")
+    public int systemDischargePowerCapabilityUnityPf;
+
+    @SerializedName("system_adjusted_charge_power_capability_design_pf")
+    public int systemAdjustedChargePowerCapabilityDesignPf;
+
+    @SerializedName("system_adjusted_charge_power_capability_unity_pf")
+    public int systemAdjustedChargePowerCapabilityUnityPf;
+
+    @SerializedName("expected_energy_remaining")
+    public int expectedEnergyRemaining;
+
+    public class BatteryBlocks {
+        @SerializedName("Type")
+        public String type = "";
+
+        @SerializedName("PackagePartNumber")
+        public String packagePartNumber = "";
+
+        @SerializedName("PackageSerialNumber")
+        public String packageSerialNumber = "";
+
+        @SerializedName("pinv_state")
+        public String pinvState = "";
+
+        @SerializedName("pinv_grid_state")
+        public String pinvGridState = "";
+
+        @SerializedName("nominal_energy_remaining")
+        public float nominalEnergyRemaining;
+
+        @SerializedName("nominal_full_pack_energy")
+        public float nominalFullPackEnergy;
+
+        @SerializedName("p_out")
+        public int pOut;
+
+        @SerializedName("q_out")
+        public int qOut;
+
+        @SerializedName("v_out")
+        public float vOut;
+
+        @SerializedName("f_out")
+        public float fOut;
+
+        @SerializedName("i_out")
+        public float iOut;
+
+        @SerializedName("energy_charged")
+        public int energyCharged;
+
+        @SerializedName("energy_discharged")
+        public int energyDischarged;
+
+        @SerializedName("off_grid")
+        public boolean offGrid;
+
+        @SerializedName("vf_mode")
+        public boolean vfMode;
+
+        @SerializedName("Type")
+        public boolean wobbleDetected;
+
+        @SerializedName("charge_power_clamped")
+        public boolean chargePowerClamped;
+
+        @SerializedName("backup_ready")
+        public boolean backupReady;
+
+        @SerializedName("OpSeqState")
+        public String opSeqState = "";
+
+        @SerializedName("version")
+        public String version = "";
     }
 
-    public static SystemStatus parse(String response) {
-        /* parse json string */
-        JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-        SystemStatus info = new SystemStatus();
-        info.fullPackEnergy = jsonObject.get("nominal_full_pack_energy").getAsDouble();
-        return info;
+    private SystemStatus() {
     }
 }


### PR DESCRIPTION
Primarily code cleanups to make better use of Java classes for GSON parsing.

Whilst doing this, found the right json that identifies the number of batteries installed, so fixed the calculation of battery degradation which was previously based on a single PW2.