### PR TITLE
[frenchgovtenergydata] This PR add support for tempo tariff to exisiting frenchgovtenergydata binding

### DIFF
--- a/bundles/org.openhab.binding.frenchgovtenergydata/README.md
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/README.md
@@ -10,10 +10,18 @@ The binding offers things for the two usual tariff classes (proposed by example 
 
 - `base`: This is the basic subscription with a fixed kWh price.
 - `hphc`: Alternative subscription offering variable price in a given hour set (low hours/high hours).
+- `tempo`: Alternative suscription with different price in regards of day colors and day or night.
+    Day colors can be Red, White or Blue. 
+    Red day are the one where there is most energy demands in France, and are the most higher price.
+    White day are intermediate pricing, for day where energy demands is not almost important as red day.
+    Blue day are the one with the lower price.
+
+    Blue day, and in some proportion White day get very interesting discount in regards of base tariff.
+    But Red day, in counter part, have very high rate during the daylight.
 
 ## Thing Configuration
 
-Things (both `base` and `hphc`) only offers the configuration of the power output of the electrical delivery point (Linky terminal).
+Things (both `base`, `hphc` and `tempo`) only offers the configuration of the power output of the electrical delivery point (Linky terminal).
 
 | Name                  | Type    | Description                                 | Default       | Required |
 |-----------------------|---------|---------------------------------------------|---------------|----------|
@@ -47,12 +55,34 @@ All channels are read-only.
 | hc-ht        | Number:EnergyPrice | Low hours energy price in €/kWh excluding taxes    | Yes      |
 | hp-ht        | Number:EnergyPrice | High hours energy price in €/kWh excluding taxes   | Yes      |
 
+### `tempo` Tariff Thing
+
+  | Channel      | Type               | Description                                                 | Advanced |
+  |--------------|--------------------|-------------------------------------------------------------|----------|
+  | fixed-ttc    | Number:Currency    | Yearly fixed price including taxes                          | No       |
+  | blue-hc-ttc  | Number:EnergyPrice | Low hours blue day energy price in €/kWh including taxes    | No       |
+  | blue-hp-ttc  | Number:EnergyPrice | High hours blue day energy price in €/kWh including taxes   | No       |
+  | white-hc-ttc | Number:EnergyPrice | Low hours white day energy price in €/kWh including taxes   | No       |
+  | white-hp-ttc | Number:EnergyPrice | High hours white day energy price in €/kWh including taxes  | No       |
+  | red-hc-ttc   | Number:EnergyPrice | Low hours red day energy price in €/kWh including taxes     | No       |
+  | red-hp-ttc   | Number:EnergyPrice | High hours red day energy price in €/kWh including taxes    | No       |
+  | tariff-start | DateTime           | Beginning date for this tariff                              | Yes      |
+  | fixed-ht     | Number:Currency    | Yearly fixed price excluding taxes                          | Yes      |
+  | blue-hc-ht   | Number:EnergyPrice | Low hours blue day energy price in €/kWh excluding taxes    | Yes      |
+  | blue-hp-ht   | Number:EnergyPrice | High hours blue day energy price in €/kWh excluding taxes   | Yes      |
+  | white-hc-ht  | Number:EnergyPrice | Low hours white day energy price in €/kWh excluding taxes   | Yes      |
+  | white-hp-ht  | Number:EnergyPrice | High hours white day energy price in €/kWh excluding taxes  | Yes      |
+  | red-hc-ht    | Number:EnergyPrice | Low hours red day energy price in €/kWh excluding taxes     | Yes      |
+  | red-hp-ht    | Number:EnergyPrice | High hours red day energy price in €/kWh excluding taxes    | Yes      |
+
 ## Full Example
 
 ### Thing Configuration
 
 ```java
+Thing frenchgovtenergydata:base:local "Tarification Actuelle Base" [puissance=9]
 Thing frenchgovtenergydata:hphc:local "Tarification Actuelle HP/HC" [puissance=9]
+Thing frenchgovtenergydata:tempo:local "Tarification Actuelle Tempo" [puissance=9]
 ```
 
 ### Item Configuration

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/FrenchGovtEnergyDataBindingConstants.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/FrenchGovtEnergyDataBindingConstants.java
@@ -31,6 +31,7 @@ public class FrenchGovtEnergyDataBindingConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_BASE = new ThingTypeUID(BINDING_ID, "base");
     public static final ThingTypeUID THING_TYPE_HPHC = new ThingTypeUID(BINDING_ID, "hphc");
+    public static final ThingTypeUID THING_TYPE_TEMPO = new ThingTypeUID(BINDING_ID, "tempo");
 
     // List of all Channel ids
     public static final String CHANNEL_TARIFF_START = "tariff-start";
@@ -42,6 +43,21 @@ public class FrenchGovtEnergyDataBindingConstants {
     public static final String CHANNEL_HC_TTC = "hc-ttc";
     public static final String CHANNEL_HP_HT = "hp-ht";
     public static final String CHANNEL_HP_TTC = "hp-ttc";
+
+    public static final String CHANNEL_RED_HC_HT = "red-hc-ht";
+    public static final String CHANNEL_RED_HC_TTC = "red-hc-ttc";
+    public static final String CHANNEL_RED_HP_HT = "red-hp-ht";
+    public static final String CHANNEL_RED_HP_TTC = "red-hp-ttc";
+
+    public static final String CHANNEL_WHITE_HC_HT = "white-hc-ht";
+    public static final String CHANNEL_WHITE_HC_TTC = "white-hc-ttc";
+    public static final String CHANNEL_WHITE_HP_HT = "white-hp-ht";
+    public static final String CHANNEL_WHITE_HP_TTC = "white-hp-ttc";
+
+    public static final String CHANNEL_BLUE_HC_HT = "blue-hc-ht";
+    public static final String CHANNEL_BLUE_HC_TTC = "blue-hc-ttc";
+    public static final String CHANNEL_BLUE_HP_HT = "blue-hp-ht";
+    public static final String CHANNEL_BLUE_HP_TTC = "blue-hp-ttc";
 
     public static final Currency CURRENCY_EUR = Currency.getInstance("EUR");
 }

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/FrenchGovtEnergyDataHandlerFactory.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/FrenchGovtEnergyDataHandlerFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.frenchgovtenergydata.internal.handler.BaseTariffHandler;
 import org.openhab.binding.frenchgovtenergydata.internal.handler.HpHcTariffHandler;
+import org.openhab.binding.frenchgovtenergydata.internal.handler.TempoTariffHandler;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
@@ -36,7 +37,8 @@ import org.osgi.service.component.annotations.Component;
 @Component(configurationPid = "binding.frenchgovtenergydata", service = ThingHandlerFactory.class)
 public class FrenchGovtEnergyDataHandlerFactory extends BaseThingHandlerFactory {
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_BASE, THING_TYPE_HPHC);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_BASE, THING_TYPE_HPHC,
+            THING_TYPE_TEMPO);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -47,7 +49,14 @@ public class FrenchGovtEnergyDataHandlerFactory extends BaseThingHandlerFactory 
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        return THING_TYPE_BASE.equals(thingTypeUID) ? new BaseTariffHandler(thing)
-                : THING_TYPE_HPHC.equals(thingTypeUID) ? new HpHcTariffHandler(thing) : null;
+        if (THING_TYPE_BASE.equals(thingTypeUID)) {
+            return new BaseTariffHandler(thing);
+        } else if (THING_TYPE_HPHC.equals(thingTypeUID)) {
+            return new HpHcTariffHandler(thing);
+        } else if (THING_TYPE_TEMPO.equals(thingTypeUID)) {
+            return new TempoTariffHandler(thing);
+        }
+
+        return null;
     }
 }

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/Tariff.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/Tariff.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -30,7 +31,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class Tariff {
     protected static final DateTimeFormatter TARIFF_DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
-    protected final String[] values;
+    protected final @NonNull String[] values;
     public final ZonedDateTime dateDebut;
     public final @Nullable ZonedDateTime dateFin;
     public final int puissance;
@@ -52,7 +53,13 @@ public class Tariff {
                 throw new IllegalArgumentException("Incorrect data in '%s'".formatted(line), e);
             }
         } else {
-            throw new IllegalArgumentException("Unexpected number of data, %d expected".formatted(lenControl));
+            this.dateDebut = LocalDate.parse(values[0], TARIFF_DATE_FORMAT).atStartOfDay(ZoneOffset.UTC);
+            this.dateFin = !values[1].isEmpty()
+                    ? LocalDate.parse(values[1], TARIFF_DATE_FORMAT).atStartOfDay(ZoneOffset.UTC)
+                    : null;
+            this.puissance = Integer.parseInt(values[2]);
+            this.fixeHT = 0;
+            this.fixeTTC = 0;
         }
     }
 

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/TempoTariff.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/dto/TempoTariff.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.frenchgovtenergydata.internal.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link TariffHpHc} holds HP-HC price informations
+ *
+ * @author Laurent Arnal - Initial contribution
+ */
+@NonNullByDefault
+public class TempoTariff extends Tariff {
+    public final double blueHcHT;
+    public final double blueHcTTC;
+    public final double blueHpHT;
+    public final double blueHpTTC;
+
+    public final double whiteHcHT;
+    public final double whiteHcTTC;
+    public final double whiteHpHT;
+    public final double whiteHpTTC;
+
+    public final double redHcHT;
+    public final double redHcTTC;
+    public final double redHpHT;
+    public final double redHpTTC;
+
+    public TempoTariff(String line) {
+        super(line, 17);
+        try {
+            if (values.length == 3) {
+                this.blueHcHT = 0;
+                this.blueHcTTC = 0;
+                this.blueHpHT = 0;
+                this.blueHpTTC = 0;
+
+                this.whiteHcHT = 0;
+                this.whiteHcTTC = 0;
+                this.whiteHpHT = 0;
+                this.whiteHpTTC = 0;
+
+                this.redHcHT = 0;
+                this.redHcTTC = 0;
+                this.redHpHT = 0;
+                this.redHpTTC = 0;
+            } else {
+                this.blueHcHT = Double.parseDouble(values[5]);
+                this.blueHcTTC = Double.parseDouble(values[6]);
+                this.blueHpHT = Double.parseDouble(values[7]);
+                this.blueHpTTC = Double.parseDouble(values[8]);
+
+                this.whiteHcHT = Double.parseDouble(values[9]);
+                this.whiteHcTTC = Double.parseDouble(values[10]);
+                this.whiteHpHT = Double.parseDouble(values[11]);
+                this.whiteHpTTC = Double.parseDouble(values[12]);
+
+                this.redHcHT = Double.parseDouble(values[13]);
+                this.redHcTTC = Double.parseDouble(values[14]);
+                this.redHpHT = Double.parseDouble(values[15]);
+                this.redHpTTC = Double.parseDouble(values[16]);
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Incorrect data in '%s'".formatted(line), e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/TempoTariffHandler.java
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/java/org/openhab/binding/frenchgovtenergydata/internal/handler/TempoTariffHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.frenchgovtenergydata.internal.handler;
+
+import static org.openhab.binding.frenchgovtenergydata.internal.FrenchGovtEnergyDataBindingConstants.*;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.frenchgovtenergydata.internal.dto.TempoTariff;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.CurrencyUnits;
+import org.openhab.core.thing.Thing;
+
+/**
+ * The {@link ThingTariffTempoHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Laurent Arnal - Initial contribution
+ */
+@NonNullByDefault
+public class TempoTariffHandler extends TariffHandler<TempoTariff> {
+    private static final String EMPTY_LINE = ";;;;;;;;";
+    private static final String DATASET_ID = "0c3d1d36-c412-4620-8566-e5cbb4fa2b5a";
+
+    public TempoTariffHandler(Thing thing) {
+        super(thing, DATASET_ID);
+    }
+
+    @Override
+    protected Stream<TempoTariff> interpretLines(List<String> lines) {
+        return lines.stream().filter(line -> !line.equals(EMPTY_LINE)).map(TempoTariff::new);
+    }
+
+    @Override
+    protected void updateChannels(TempoTariff tariff) {
+        super.updateChannels(tariff);
+        updateState(CHANNEL_RED_HP_HT, new QuantityType<>(tariff.redHpHT, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_RED_HP_TTC, new QuantityType<>(tariff.redHpTTC, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_RED_HC_HT, new QuantityType<>(tariff.redHcHT, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_RED_HC_TTC, new QuantityType<>(tariff.redHcTTC, CurrencyUnits.BASE_ENERGY_PRICE));
+
+        updateState(CHANNEL_WHITE_HP_HT, new QuantityType<>(tariff.whiteHpHT, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_WHITE_HP_TTC, new QuantityType<>(tariff.whiteHpTTC, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_WHITE_HC_HT, new QuantityType<>(tariff.whiteHcHT, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_WHITE_HC_TTC, new QuantityType<>(tariff.whiteHcTTC, CurrencyUnits.BASE_ENERGY_PRICE));
+
+        updateState(CHANNEL_BLUE_HP_HT, new QuantityType<>(tariff.blueHpHT, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_BLUE_HP_TTC, new QuantityType<>(tariff.blueHpTTC, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_BLUE_HC_HT, new QuantityType<>(tariff.blueHcHT, CurrencyUnits.BASE_ENERGY_PRICE));
+        updateState(CHANNEL_BLUE_HC_TTC, new QuantityType<>(tariff.blueHcTTC, CurrencyUnits.BASE_ENERGY_PRICE));
+    }
+}

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-tarif-base.xml
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-tarif-base.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="frenchgovtenergydata"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="base">
+		<label>Base Tariff</label>
+		<description>Default Tariff Subscription</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
+
+		<channels>
+			<channel id="tariff-start" typeId="timestamp"/>
+			<channel id="fixed-ht" typeId="price-ht">
+				<label>Fixed Price HT</label>
+				<description>Yearly fixed price excluding taxes.</description>
+			</channel>
+			<channel id="fixed-ttc" typeId="price-ttc">
+				<label>Fixed Price TTC</label>
+				<description>Yearly fixed price including taxes.</description>
+			</channel>
+			<channel id="variable-ht" typeId="energy-price-ht">
+				<label>Variable Price HT</label>
+				<description>Energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="variable-ttc" typeId="energy-price-ttc">
+				<label>Variable Price TTC</label>
+				<description>Energy price in €/kWh including taxes.</description>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="puissance" type="integer" min="3" max="36">
+				<default>6</default>
+				<label>Power output</label>
+				<description>PDL power output (in kVA)</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-tarif-hphc.xml
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-tarif-hphc.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="frenchgovtenergydata"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="hphc">
+		<label>HP-HC Tariff</label>
+		<description>High / Low usage Tariff Subscription</description>
+		<semantic-equipment-tag>WebService</semantic-equipment-tag>
+
+		<channels>
+			<channel id="tariff-start" typeId="timestamp"/>
+			<channel id="fixed-ht" typeId="price-ht">
+				<label>Fixed Price HT</label>
+				<description>Yearly fixed price excluding taxes.</description>
+			</channel>
+			<channel id="fixed-ttc" typeId="price-ttc">
+				<label>Fixed Price TTC</label>
+				<description>Yearly fixed price including taxes.</description>
+			</channel>
+			<channel id="hc-ht" typeId="energy-price-ht">
+				<label>Low Hours Price HT</label>
+				<description>Low hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="hc-ttc" typeId="energy-price-ttc">
+				<label>Low Hours Price TTC</label>
+				<description>Low hours energy price in €/kWh including taxes.</description>
+			</channel>
+			<channel id="hp-ht" typeId="energy-price-ht">
+				<label>High Hours Price HT</label>
+				<description>High hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="hp-ttc" typeId="energy-price-ttc">
+				<label>High Hours Price TTC</label>
+				<description>High hours energy price in €/kWh including taxes.</description>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="puissance" type="integer" min="3" max="36">
+				<default>6</default>
+				<label>Power Output</label>
+				<description>PDL power output (in kVA)</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-tarif-tempo.xml
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-tarif-tempo.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="frenchgovtenergydata"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="tempo">
+		<label>Tempo Tariff</label>
+		<description>Temmpo usage Tariff Subscription</description>
+
+		<channels>
+			<channel id="tariff-start" typeId="timestamp"/>
+
+			<channel id="fixed-ht" typeId="price-ht">
+				<label>Fixed Price HT</label>
+				<description>Yearly fixed price excluding taxes.</description>
+			</channel>
+			<channel id="fixed-ttc" typeId="price-ttc">
+				<label>Fixed Price TTC</label>
+				<description>Yearly fixed price including taxes.</description>
+			</channel>
+
+			<channel id="blue-hc-ht" typeId="energy-price-ht">
+				<label>Blue Day Low HT</label>
+				<description>Blue day Low hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="blue-hc-ttc" typeId="energy-price-ttc">
+				<label>Blue Day Low TTC</label>
+				<description>Blue day Low hours energy price in €/kWh including taxes.</description>
+			</channel>
+			<channel id="blue-hp-ht" typeId="energy-price-ht">
+				<label>Blue Day High HT</label>
+				<description>Blue day High hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="blue-hp-ttc" typeId="energy-price-ttc">
+				<label>Blue Day High TTC</label>
+				<description>Blue day High hours energy price in €/kWh including taxes.</description>
+			</channel>
+
+			<channel id="white-hc-ht" typeId="energy-price-ht">
+				<label>White Day Low HT</label>
+				<description>White day Low hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="white-hc-ttc" typeId="energy-price-ttc">
+				<label>White Day Low TTC</label>
+				<description>White day Low hours energy price in €/kWh including taxes.</description>
+			</channel>
+			<channel id="white-hp-ht" typeId="energy-price-ht">
+				<label>White Day High HT</label>
+				<description>White day High hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="white-hp-ttc" typeId="energy-price-ttc">
+				<label>White Day High TTC</label>
+				<description>White day High hours energy price in €/kWh including taxes.</description>
+			</channel>
+
+			<channel id="red-hc-ht" typeId="energy-price-ht">
+				<label>Red Day Low HT</label>
+				<description>Red day Low hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+
+			<channel id="red-hc-ttc" typeId="energy-price-ttc">
+				<label>Red Day Low TTC</label>
+				<description>Red day Low hours energy price in €/kWh including taxes.</description>
+			</channel>
+			<channel id="red-hp-ht" typeId="energy-price-ht">
+				<label>Red Day High HT</label>
+				<description>Red day High hours energy price in €/kWh excluding taxes.</description>
+			</channel>
+			<channel id="red-hp-ttc" typeId="energy-price-ttc">
+				<label>Red Day High TTC</label>
+				<description>Red day High hours energy price in €/kWh including taxes.</description>
+			</channel>
+		</channels>
+
+		<config-description>
+			<parameter name="power" type="integer" min="3" max="36">
+				<default>6</default>
+				<label>Power Output</label>
+				<description>PDL power output (in kVA)</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.frenchgovtenergydata/src/main/resources/OH-INF/thing/thing-types.xml
@@ -4,81 +4,8 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="base">
-		<label>Base Tariff</label>
-		<description>Default Tariff Subscription</description>
-		<semantic-equipment-tag>WebService</semantic-equipment-tag>
 
-		<channels>
-			<channel id="tariff-start" typeId="timestamp"/>
-			<channel id="fixed-ht" typeId="price-ht">
-				<label>Fixed Price HT</label>
-				<description>Yearly fixed price excluding taxes.</description>
-			</channel>
-			<channel id="fixed-ttc" typeId="price-ttc">
-				<label>Fixed Price TTC</label>
-				<description>Yearly fixed price including taxes.</description>
-			</channel>
-			<channel id="variable-ht" typeId="energy-price-ht">
-				<label>Variable Price HT</label>
-				<description>Energy price in €/kWh excluding taxes.</description>
-			</channel>
-			<channel id="variable-ttc" typeId="energy-price-ttc">
-				<label>Variable Price TTC</label>
-				<description>Energy price in €/kWh including taxes.</description>
-			</channel>
-		</channels>
 
-		<config-description>
-			<parameter name="puissance" type="integer" min="3" max="36">
-				<default>6</default>
-				<label>Power output</label>
-				<description>PDL power output (in kVA)</description>
-			</parameter>
-		</config-description>
-	</thing-type>
-
-	<thing-type id="hphc">
-		<label>HP-HC Tariff</label>
-		<description>High / Low usage Tariff Subscription</description>
-		<semantic-equipment-tag>WebService</semantic-equipment-tag>
-
-		<channels>
-			<channel id="tariff-start" typeId="timestamp"/>
-			<channel id="fixed-ht" typeId="price-ht">
-				<label>Fixed Price HT</label>
-				<description>Yearly fixed price excluding taxes.</description>
-			</channel>
-			<channel id="fixed-ttc" typeId="price-ttc">
-				<label>Fixed Price TTC</label>
-				<description>Yearly fixed price including taxes.</description>
-			</channel>
-			<channel id="hc-ht" typeId="energy-price-ht">
-				<label>Low Hours Price HT</label>
-				<description>Low hours energy price in €/kWh excluding taxes.</description>
-			</channel>
-			<channel id="hc-ttc" typeId="energy-price-ttc">
-				<label>Low Hours Price TTC</label>
-				<description>Low hours energy price in €/kWh including taxes.</description>
-			</channel>
-			<channel id="hp-ht" typeId="energy-price-ht">
-				<label>High Hours Price HT</label>
-				<description>High hours energy price in €/kWh excluding taxes.</description>
-			</channel>
-			<channel id="hp-ttc" typeId="energy-price-ttc">
-				<label>High Hours Price TTC</label>
-				<description>High hours energy price in €/kWh including taxes.</description>
-			</channel>
-		</channels>
-
-		<config-description>
-			<parameter name="puissance" type="integer" min="3" max="36">
-				<default>6</default>
-				<label>Power Output</label>
-				<description>PDL power output (in kVA)</description>
-			</parameter>
-		</config-description>
-	</thing-type>
 
 	<channel-type id="price-ht" advanced="true">
 		<item-type>Number:Currency</item-type>


### PR DESCRIPTION
# Add support for tempo tariff to exisiting frenchgovtenergydata binding

This PR just add support for a new tariff dataset for tempo pricing.

# Description

Tempo pricing is based on three day colors.
Day colors can be Red, White or Blue. 
  Red day are the one where there is most energy demands in France, and are the most higher price.
  White day are intermediate pricing, for day where energy demands is not almost important as red day.
  Blue day are the one with the lower price.

