### PR TITLE
[transform.vat] Update rates

### DIFF
--- a/bundles/org.openhab.transform.vat/src/main/resources/vat_rates.yaml
+++ b/bundles/org.openhab.transform.vat/src/main/resources/vat_rates.yaml
@@ -34,7 +34,12 @@
 # Finland
 - country: "FI"
   vatPeriod:
-    - percentage: 24
+    - start: null
+      end: 2024-08-31T22:00:00Z
+      percentage: 24
+    - start: 2024-08-31T22:00:00Z
+      end: null
+      percentage: 25.5
 # France
 - country: "FR"
   vatPeriod:
@@ -94,7 +99,12 @@
 # Slovakia
 - country: "SK"
   vatPeriod:
-    - percentage: 20
+    - start: null
+      end: 2024-12-31T22:00:00Z
+      percentage: 20
+    - start: 2024-12-31T22:00:00Z
+      end: null
+      percentage: 23
 # Slovenia
 - country: "SI"
   vatPeriod:


### PR DESCRIPTION
Update rates for:
- Finland: 25.5% since September 1st 2024.
- Slovakia: 23% since January 1st 2025.