### PR TITLE
[matter] fixes min/max init of color temp values, adds a few tests as well

### DIFF
--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/devices/converter/ColorControlConverter.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/devices/converter/ColorControlConverter.java
@@ -65,23 +65,22 @@ public class ColorControlConverter extends GenericConverter<ColorControlCluster>
     private static final int UPDATE_DELAY = 500;
     // These are the default values, as well as the min and max limits for the color temperature mireds defined in the
     // Matter spec
-    private static final int MAX_MIREDS = 65279;
-    private static final int MIN_MIREDS = 1; // this was 0 until matter 1.4
+    protected static final int MAX_MIREDS = 65279;
+    protected static final int MIN_MIREDS = 1; // this was 0 until matter 1.4
     // These are sane defaults that should be used if the device does not provide a valid range (aka if using default
     // MIN / MAX)
-    private static final int MAX_DEFAULT_MIREDS = 667; // 1500K
-    private static final int MIN_DEFAULT_MIREDS = 154;
+    protected static final int MAX_DEFAULT_MIREDS = 667; // 1500K
+    protected static final int MIN_DEFAULT_MIREDS = 153;
     protected boolean supportsHue = false;
     protected boolean supportsColorTemperature = false;
+    protected int colorTempPhysicalMinMireds = 0;
+    protected int colorTempPhysicalMaxMireds = 0;
     private LevelControlCluster.OptionsBitmap levelControlOptionsBitmap = new LevelControlCluster.OptionsBitmap(true,
             true);
     private boolean lastOnOff = true;
     private HSBType lastHSB = new HSBType("0,0,0");
     private @Nullable ScheduledFuture<?> colorUpdateTimer = null;
     private ScheduledExecutorService colorUpdateScheduler = Executors.newSingleThreadScheduledExecutor();
-    // Color attributes from the device
-    private int colorTempPhysicalMinMireds = 0;
-    private int colorTempPhysicalMaxMireds = 0;
     private EnhancedColorModeEnum lastColorMode = EnhancedColorModeEnum.CURRENT_X_AND_CURRENT_Y;
     private int lastHue = 0;
     private int lastSaturation = 0;
@@ -101,13 +100,11 @@ public class ColorControlConverter extends GenericConverter<ColorControlCluster>
         // The inovelli device for example sends a max mireds of 65279 (matter spec max value), which means they did not
         // actually set the max mireds, but this should never really exceed 667 (1500K)
         Integer maxMireds = initializingCluster.colorTempPhysicalMaxMireds;
-        colorTempPhysicalMaxMireds = (maxMireds == null || maxMireds >= MAX_MIREDS) ? MAX_DEFAULT_MIREDS
-                : Math.min(maxMireds, MAX_DEFAULT_MIREDS);
+        colorTempPhysicalMaxMireds = (maxMireds == null || maxMireds >= MAX_MIREDS) ? MAX_DEFAULT_MIREDS : maxMireds;
         // the inovelli device for example sends a min mireds of 0 (matter 1.3 default) which means they did not
-        // actually set the min mireds, but this should never really be less than 154 (6500K)in real life
+        // actually set the min mireds, but this should never really be less than 153 (6500K) in real life
         Integer minMireds = initializingCluster.colorTempPhysicalMinMireds;
-        colorTempPhysicalMinMireds = (minMireds == null || minMireds <= MIN_MIREDS) ? MIN_DEFAULT_MIREDS
-                : Math.max(minMireds, MIN_DEFAULT_MIREDS);
+        colorTempPhysicalMinMireds = (minMireds == null || minMireds <= MIN_MIREDS) ? MIN_DEFAULT_MIREDS : minMireds;
     }
 
     @Override

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/ColorControlConverterTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/ColorControlConverterTest.java
@@ -214,4 +214,40 @@ class ColorControlConverterTest extends BaseMatterConverterTest {
         // Verify brightness remains 0 since device is off (2 updates, one for onOff, one for level)
         verify(mockHandler, times(2)).updateState(eq(1), eq("colorcontrol-color"), eq(new HSBType("180,100,0")));
     }
+
+    @Test
+    void testConstructorWithDefaultMaxMireds() {
+        // Test when maxMireds is null
+        mockColorCluster.colorTempPhysicalMaxMireds = null;
+        ColorControlConverter converter = new ColorControlConverter(mockColorCluster, mockHandler, 1, "TestLabel");
+        assertEquals(667, converter.colorTempPhysicalMaxMireds);
+
+        // Test when maxMireds is >= MAX_MIREDS
+        mockColorCluster.colorTempPhysicalMaxMireds = ColorControlConverter.MAX_MIREDS;
+        converter = new ColorControlConverter(mockColorCluster, mockHandler, 1, "TestLabel");
+        assertEquals(ColorControlConverter.MAX_DEFAULT_MIREDS, converter.colorTempPhysicalMaxMireds);
+    }
+
+    @Test
+    void testConstructorWithDefaultMinMireds() {
+        // Test when minMireds is null
+        mockColorCluster.colorTempPhysicalMinMireds = null;
+        ColorControlConverter converter = new ColorControlConverter(mockColorCluster, mockHandler, 1, "TestLabel");
+        assertEquals(154, converter.colorTempPhysicalMinMireds);
+
+        // Test when minMireds is <= MIN_MIREDS
+        mockColorCluster.colorTempPhysicalMinMireds = ColorControlConverter.MIN_MIREDS;
+        converter = new ColorControlConverter(mockColorCluster, mockHandler, 1, "TestLabel");
+        assertEquals(ColorControlConverter.MIN_DEFAULT_MIREDS, converter.colorTempPhysicalMinMireds);
+    }
+
+    @Test
+    void testConstructorWithValidMireds() {
+        // Test with valid values
+        mockColorCluster.colorTempPhysicalMinMireds = 200;
+        mockColorCluster.colorTempPhysicalMaxMireds = 400;
+        ColorControlConverter converter = new ColorControlConverter(mockColorCluster, mockHandler, 1, "TestLabel");
+        assertEquals(200, converter.colorTempPhysicalMinMireds);
+        assertEquals(400, converter.colorTempPhysicalMaxMireds);
+    }
 }

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/ColorControlConverterTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/ColorControlConverterTest.java
@@ -233,7 +233,7 @@ class ColorControlConverterTest extends BaseMatterConverterTest {
         // Test when minMireds is null
         mockColorCluster.colorTempPhysicalMinMireds = null;
         ColorControlConverter converter = new ColorControlConverter(mockColorCluster, mockHandler, 1, "TestLabel");
-        assertEquals(154, converter.colorTempPhysicalMinMireds);
+        assertEquals(ColorControlConverter.MIN_DEFAULT_MIREDS, converter.colorTempPhysicalMinMireds);
 
         // Test when minMireds is <= MIN_MIREDS
         mockColorCluster.colorTempPhysicalMinMireds = ColorControlConverter.MIN_MIREDS;


### PR DESCRIPTION
Also defaults to min = 153, since i think i misread that most devices were "between" 153-MAX, but its 153 to MAX.  Only relevant if a devices sets its min to 0 or 1 (which means it probably did not set it)   