### PR TITLE
[spotify] add uom to time-related channels, add i18n

### DIFF
--- a/bundles/org.openhab.binding.spotify/README.md
+++ b/bundles/org.openhab.binding.spotify/README.md
@@ -89,26 +89,26 @@ The channels on the bridge are the ones used to both control the active device a
 
 **Common Channels:**
 
-| Channel Type ID | Item Type | Read/Write | Description                                                                                       |
-| --------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------- |
-| deviceName      | String    | Read-write | Name of the currently active Connect Device,                                                      |
-| devices         | Selection | Read-write | List of currently active Connect Devices, Set the device ID to transfer play to that device.      |
-| deviceVolume    | Dimmer    | Read-write | Get or set the active Connect Device volume.                                                      |
-| deviceShuffle   | Switch    | Read-write | Turn on/off shuffle play on the active device.                                                    |
-| trackPlay       | String    | Read-write | Set which music  to play on the active device. This channel accepts Spotify URIs and URLs.        |
-| trackPlayer     | Player    | Read-write | The Player Control of the active device. Accepts PLAY/PAUSE/NEXT/PREVIOUS commands.               |
-| trackRepeat     | String    | Read-only  | `track` repeats the current track. `context` repeats the current context. `off` turns repeat off. |
-| trackName       | String    | Read-only  | The name of the currently playing track.                                                          |
-| trackDuration   | String    | Read-only  | The duration (m:ss) of the currently playing track. This is updated every second.                 |
-| trackDurationMs | Number    | Read-only  | The duration of the currently playing track in milliseconds.                                      |
-| trackProgress   | String    | Read-only  | The progress (m:ss) of the currently playing track. This is updated every second.                 |
-| trackProgressMs | Number    | Read-only  | The progress of the currently playing track in milliseconds.                                      |
-| playlists       | Selection | Read-write | This channel will be populated with the users playlists. Set the playlist ID to start.            |
-| playlistName    | String    | Read-write | The currently playing playlist. Or empty if no playing list is playing.                           |
-| albumName       | String    | Read-only  | Album Name of the currently playing track.                                                        |
-| albumImage      | RawType   | Read-only  | Album Image of the currently playing track.                                                       |
-| albumImageUrl   | String    | Read-only  | Url to the album Image of the currently playing track.                                            |
-| artistName      | String    | Read-only  | Artist Name of the currently playing track.                                                       |
+| Channel Type ID | Item Type   | Read/Write | Description                                                                                       |
+| --------------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| deviceName      | String      | Read-write | Name of the currently active Connect Device,                                                      |
+| devices         | Selection   | Read-write | List of currently active Connect Devices, Set the device ID to transfer play to that device.      |
+| deviceVolume    | Dimmer      | Read-write | Get or set the active Connect Device volume.                                                      |
+| deviceShuffle   | Switch      | Read-write | Turn on/off shuffle play on the active device.                                                    |
+| trackPlay       | String      | Read-write | Set which music  to play on the active device. This channel accepts Spotify URIs and URLs.        |
+| trackPlayer     | Player      | Read-write | The Player Control of the active device. Accepts PLAY/PAUSE/NEXT/PREVIOUS commands.               |
+| trackRepeat     | String      | Read-only  | `track` repeats the current track. `context` repeats the current context. `off` turns repeat off. |
+| trackName       | String      | Read-only  | The name of the currently playing track.                                                          |
+| trackDuration   | String      | Read-only  | The duration (m:ss) of the currently playing track. This is updated every second.                 |
+| trackDurationMs | Number:Time | Read-only  | The duration of the currently playing track.                                                      |
+| trackProgress   | String      | Read-only  | The progress (m:ss) of the currently playing track. This is updated every second.                 |
+| trackProgressMs | Number:Time | Read-only  | The progress of the currently playing track.                                                      |
+| playlists       | Selection   | Read-write | This channel will be populated with the users playlists. Set the playlist ID to start.            |
+| playlistName    | String      | Read-write | The currently playing playlist. Or empty if no playing list is playing.                           |
+| albumName       | String      | Read-only  | Album Name of the currently playing track.                                                        |
+| albumImage      | RawType     | Read-only  | Album Image of the currently playing track.                                                       |
+| albumImageUrl   | String      | Read-only  | Url to the album Image of the currently playing track.                                            |
+| artistName      | String      | Read-only  | Artist Name of the currently playing track.                                                       |
 
 The `playlists` channel has 2 parameters:
 

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.spotify.internal.handler;
 
 import static org.openhab.binding.spotify.internal.SpotifyBindingConstants.*;
+import static org.openhab.core.library.unit.MetricPrefix.MILLI;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -58,8 +59,10 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.PlayPauseType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -487,7 +490,8 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
                 playerInfo.getProgressMs());
         if (!lastTrackId.equals(trackId)) {
             lastTrackId = trackId;
-            updateChannelState(CHANNEL_PLAYED_TRACKDURATION_MS, new DecimalType(item.getDurationMs()));
+            updateChannelState(CHANNEL_PLAYED_TRACKDURATION_MS,
+                    new QuantityType<>(item.getDurationMs(), MILLI(Units.SECOND)));
             final String formattedProgress;
             synchronized (MUSIC_TIME_FORMAT) {
                 // synchronize because SimpleDateFormat is not thread safe

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/handler/SpotifyBridgeHandler.java
@@ -657,7 +657,7 @@ public class SpotifyBridgeHandler extends BaseBridgeHandler
             synchronized (MUSIC_TIME_FORMAT) {
                 formattedProgress = MUSIC_TIME_FORMAT.format(new Date(progress));
             }
-            updateChannelState(CHANNEL_PLAYED_TRACKPROGRESS_MS, new DecimalType(progress));
+            updateChannelState(CHANNEL_PLAYED_TRACKPROGRESS_MS, new QuantityType<>(progress, MILLI(Units.SECOND)));
             updateChannelState(CHANNEL_PLAYED_TRACKPROGRESS_FMT, formattedProgress);
         }
 

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/i18n/spotify.properties
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/i18n/spotify.properties
@@ -1,10 +1,127 @@
-actions.play.label=Play
-actions.play.description=Play the given Spotify uri
-actions.play.context_uri.label=Context URI
-actions.play.context_uri.description=The context uri or a comma separated list of uris
-actions.play.device_id.label=Device Id
-actions.play.device_id.description=Id of the device to play. If omitted will play on the current active device (Optional)
-actions.play.offset.label=offset
-actions.play.offset.description=Offset to start (Optional).
-actions.play.positions_ms.label=Position ms
-actions.play.positions_ms.description=Position in milliseconds to start (Optional)
+# add-on
+
+addon.spotify.name = Spotify Binding
+addon.spotify.description = This is the openHAB binding for Spotify used to manage Connect devices. Using the Spotify WebAPI.
+
+# thing types
+
+thing-type.spotify.device.label = Spotify Connect Device
+thing-type.spotify.device.description = Thing representing a Spotify Connect device. The device exists in the context of the bridge and the Spotify account associated with the bride. This means the same device can be present as a thing under each Spotify bridge you have configured.
+thing-type.spotify.player.label = Spotify Player Bridge
+thing-type.spotify.player.description = Bridge representing the Spotify Player in the context of a user account. The bridge is associated with one specific Spotify account. If you want to control your devices in the context of different accounts you have to register a bridge for each account. Go to http://your openHAB address::8080/connectspotify to authorize.
+
+# thing types config
+
+thing-type.config.spotify.device.deviceName.label = Spotify Device Name
+thing-type.config.spotify.device.deviceName.description = This is the device name provided by Spotify.
+thing-type.config.spotify.player.clientId.label = Application Client ID
+thing-type.config.spotify.player.clientId.description = This is the Client ID provided by Spotify when you add a new Application for openHAB to your Spotify Account. Go to https://developer.spotify.com/
+thing-type.config.spotify.player.clientSecret.label = Application Client Secret
+thing-type.config.spotify.player.clientSecret.description = This is the Client Secret provided by Spotify when you add a new Application for openHAB to your Spotify Account.
+thing-type.config.spotify.player.refreshPeriod.label = Connect Refresh Period (seconds)
+thing-type.config.spotify.player.refreshPeriod.description = This is the frequency of the polling requests to the Spotify Connect Web API. There are limits to the number of requests that can be sent to the Web API. The more often you poll, the better status updates - at the risk of running out of your request quota.
+
+# channel types
+
+channel-type.spotify.accessToken.label = Access Token
+channel-type.spotify.accessToken.description = The access token used to authorize calls to the Spotify Web API. It can be used from rules or client-side scripting make call to Web API.
+channel-type.spotify.activeDeviceId.label = Active Device Id
+channel-type.spotify.activeDeviceId.description = The Spotify ID of active device
+channel-type.spotify.activeDeviceName.label = Active Device Name
+channel-type.spotify.activeDeviceName.description = The name of the currently active device
+channel-type.spotify.activeDeviceShuffle.label = Active Device Shuffle
+channel-type.spotify.activeDeviceShuffle.description = If shuffle is on or off on the active device
+channel-type.spotify.activeDeviceType.label = Active Device Type
+channel-type.spotify.activeDeviceType.description = Currently active device type, such as "Computer", "Smartphone" or "Speaker".
+channel-type.spotify.activeDevices.label = Active Devices
+channel-type.spotify.activeDevices.description = List of active devices.
+channel-type.spotify.currentlyPlayedAlbumHref.label = Album URL
+channel-type.spotify.currentlyPlayedAlbumHref.description = A link to the Web API endpoint providing full details of the album
+channel-type.spotify.currentlyPlayedAlbumId.label = Album Id
+channel-type.spotify.currentlyPlayedAlbumId.description = The Spotify ID of the album
+channel-type.spotify.currentlyPlayedAlbumImage.label = Album Image
+channel-type.spotify.currentlyPlayedAlbumImage.description = The cover art for the album in widest size
+channel-type.spotify.currentlyPlayedAlbumImageUrl.label = Album Image URL
+channel-type.spotify.currentlyPlayedAlbumImageUrl.description = The URL to the cover art for the album in widest size
+channel-type.spotify.currentlyPlayedAlbumName.label = Album Name
+channel-type.spotify.currentlyPlayedAlbumName.description = The name of the album
+channel-type.spotify.currentlyPlayedAlbumType.label = Album Type
+channel-type.spotify.currentlyPlayedAlbumType.description = The object type: "album"
+channel-type.spotify.currentlyPlayedAlbumUri.label = Album URI
+channel-type.spotify.currentlyPlayedAlbumUri.description = The Spotify URI for the album
+channel-type.spotify.currentlyPlayedArtistHref.label = Artist URL
+channel-type.spotify.currentlyPlayedArtistHref.description = Channel reports currently played artist href
+channel-type.spotify.currentlyPlayedArtistId.label = Artist Id
+channel-type.spotify.currentlyPlayedArtistId.description = The Spotify ID for the artist
+channel-type.spotify.currentlyPlayedArtistType.label = Artist Type
+channel-type.spotify.currentlyPlayedArtistType.description = The object type: "artist"
+channel-type.spotify.currentlyPlayedArtistUri.label = Artist URI
+channel-type.spotify.currentlyPlayedArtistUri.description = A link to the Web API endpoint providing full details of the artist
+channel-type.spotify.currentlyPlayedTrackDiscNumber.label = Track Disc Number
+channel-type.spotify.currentlyPlayedTrackDiscNumber.description = The disk number of currently played track
+channel-type.spotify.currentlyPlayedTrackDuration.label = Track Duration (m:ss)
+channel-type.spotify.currentlyPlayedTrackDuration.description = The duration currently played track formatted (m:ss)
+channel-type.spotify.currentlyPlayedTrackDurationMs.label = Track Duration
+channel-type.spotify.currentlyPlayedTrackDurationMs.description = The duration of the currently played track
+channel-type.spotify.currentlyPlayedTrackDurationMs.state.pattern = %1$tM:%1$tS
+channel-type.spotify.currentlyPlayedTrackExplicit.label = Track Explicit
+channel-type.spotify.currentlyPlayedTrackExplicit.description = Whether or not the track has explicit lyrics (On it does; Off it does not OR unknown)
+channel-type.spotify.currentlyPlayedTrackHref.label = Track URL
+channel-type.spotify.currentlyPlayedTrackId.label = Track Id
+channel-type.spotify.currentlyPlayedTrackId.description = Channel reports track id currently being played.
+channel-type.spotify.currentlyPlayedTrackNumber.label = Track Number
+channel-type.spotify.currentlyPlayedTrackNumber.description = The track number of currently played track
+channel-type.spotify.currentlyPlayedTrackPopularity.label = Track Popularity
+channel-type.spotify.currentlyPlayedTrackPopularity.description = The popularity of the currently played track
+channel-type.spotify.currentlyPlayedTrackProgress.label = Track Progress (m:ss)
+channel-type.spotify.currentlyPlayedTrackProgress.description = The progress of the currently played track formatted (m:ss)
+channel-type.spotify.currentlyPlayedTrackProgressMs.label = Track Progress
+channel-type.spotify.currentlyPlayedTrackProgressMs.description = The progress of the currently played track
+channel-type.spotify.currentlyPlayedTrackProgressMs.state.pattern = %1$tM:%1$tS
+channel-type.spotify.currentlyPlayedTrackType.label = Track Type
+channel-type.spotify.currentlyPlayedTrackType.description = The type of the track currently played track type
+channel-type.spotify.currentlyPlayedTrackUri.label = Track URI
+channel-type.spotify.currentlyPlayedTrackUri.description = The Spotify URI for the track currently played
+channel-type.spotify.deviceActive.label = Device Active
+channel-type.spotify.deviceActive.description = If this device is the currently active device
+channel-type.spotify.deviceId.label = Device Id
+channel-type.spotify.deviceId.description = The Spotify ID of the device
+channel-type.spotify.deviceName.label = Device Name
+channel-type.spotify.deviceName.description = The name of the device
+channel-type.spotify.deviceRestricted.label = Device Restricted
+channel-type.spotify.deviceRestricted.description = Whether controlling this device is restricted. At present if this is "true" then no Web API commands will be accepted by this device
+channel-type.spotify.deviceShuffle.label = Device Shuffle
+channel-type.spotify.deviceShuffle.description = If shuffle is on or off
+channel-type.spotify.deviceType.label = Device Type
+channel-type.spotify.deviceType.description = Device type, such as "Computer", "Smartphone" or "Speaker".
+channel-type.spotify.playlistName.label = Playlist Name
+channel-type.spotify.playlistName.description = Name of the active playlist
+channel-type.spotify.playlists.label = Playlists
+channel-type.spotify.playlists.description = List of the users playlists
+channel-type.spotify.trackPlay.label = Track to Play
+channel-type.spotify.trackPlay.description = Assign track, album, or playlist to play. Accepts Spotify Uri's and links.
+channel-type.spotify.trackRepeat.label = Repeat Mode
+channel-type.spotify.trackRepeat.description = 'track' will repeat the current track. 'context' will repeat the current context. 'off' will turn repeat off.
+channel-type.spotify.trackRepeat.state.option.track = Track
+channel-type.spotify.trackRepeat.state.option.context = Context
+channel-type.spotify.trackRepeat.state.option.off = Off
+
+# channel types config
+
+spotify.config.config.album-image.imageIndex.label = Image Index
+spotify.config.config.album-image.imageIndex.description = Index in list of to select image to show
+spotify.config.config.playlists.limit.label = Limit
+spotify.config.config.playlists.limit.description = The maximum number of playlists to return
+spotify.config.config.playlists.offset.label = Offset
+spotify.config.config.playlists.offset.description = The index of the first playlist to return
+
+actions.play.label = Play
+actions.play.description = Play the given Spotify uri
+actions.play.context_uri.label = Context URI
+actions.play.context_uri.description = The context uri or a comma separated list of uris
+actions.play.device_id.label = Device Id
+actions.play.device_id.description = Id of the device to play. If omitted will play on the current active device (Optional)
+actions.play.offset.label = offset
+actions.play.offset.description = Offset to start (Optional).
+actions.play.positions_ms.label = Position ms
+actions.play.positions_ms.description = Position in milliseconds to start (Optional)

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/thing/thing-types.xml
@@ -209,16 +209,16 @@
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="currentlyPlayedTrackDurationMs" advanced="true">
-		<item-type>Number</item-type>
-		<label>Track Duration (ms)</label>
-		<description>The duration of the currently played track (ms)</description>
-		<state readOnly="true"/>
+		<item-type>Number:Time</item-type>
+		<label>Track Duration</label>
+		<description>The duration of the currently played track</description>
+		<state readOnly="true" pattern="%1$tM:%1$tS"/>
 	</channel-type>
 	<channel-type id="currentlyPlayedTrackProgressMs" advanced="true">
-		<item-type>Number</item-type>
-		<label>Track Progress (ms)</label>
-		<description>The progress of the currently played track (ms)</description>
-		<state readOnly="true"/>
+		<item-type>Number:Time</item-type>
+		<label>Track Progress</label>
+		<description>The progress of the currently played track</description>
+		<state readOnly="true" pattern="%1$tM:%1$tS"/>
 	</channel-type>
 	<channel-type id="currentlyPlayedTrackDuration">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/thing/thing-types.xml
@@ -208,25 +208,25 @@
 		<description>The type of the track currently played track type</description>
 		<state readOnly="true"/>
 	</channel-type>
-	<channel-type id="currentlyPlayedTrackDurationMs" advanced="true">
+	<channel-type id="currentlyPlayedTrackDurationMs">
 		<item-type>Number:Time</item-type>
 		<label>Track Duration</label>
 		<description>The duration of the currently played track</description>
 		<state readOnly="true" pattern="%1$tM:%1$tS"/>
 	</channel-type>
-	<channel-type id="currentlyPlayedTrackProgressMs" advanced="true">
+	<channel-type id="currentlyPlayedTrackProgressMs">
 		<item-type>Number:Time</item-type>
 		<label>Track Progress</label>
 		<description>The progress of the currently played track</description>
 		<state readOnly="true" pattern="%1$tM:%1$tS"/>
 	</channel-type>
-	<channel-type id="currentlyPlayedTrackDuration">
+	<channel-type id="currentlyPlayedTrackDuration" advanced="true">
 		<item-type>String</item-type>
 		<label>Track Duration (m:ss)</label>
 		<description>The duration currently played track formatted (m:ss)</description>
 		<state readOnly="true"/>
 	</channel-type>
-	<channel-type id="currentlyPlayedTrackProgress">
+	<channel-type id="currentlyPlayedTrackProgress" advanced="true">
 		<item-type>String</item-type>
 		<label>Track Progress (m:ss)</label>
 		<description>The progress of the currently played track formatted (m:ss)</description>

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/update/instructions.xml
@@ -12,6 +12,14 @@
 			<update-channel id="trackProgressMs">
 				<type>spotify:currentlyPlayedTrackProgressMs</type>
 			</update-channel>
+
+			<update-channel id="trackDuration">
+				<type>spotify:currentlyPlayedTrackDuration</type>
+			</update-channel>
+
+			<update-channel id="trackProgress">
+				<type>spotify:currentlyPlayedTrackProgress</type>
+			</update-channel>
 		</instruction-set>
 	</thing-type>
 </update:update-descriptions>

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/update/instructions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<update:update-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:update="https://openhab.org/schemas/update-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/update-description/v1.0.0 https://openhab.org/schemas/update-description-1.0.0.xsd">
+
+	<thing-type uid="spotify:player">
+		<instruction-set targetVersion="1">
+			<update-channel id="trackDurationMs">
+				<type>player:currentlyPlayedTrackDurationMs</type>
+			</update-channel>
+
+			<update-channel id="trackProgressMs">
+				<type>player:currentlyPlayedTrackProgressMs</type>
+			</update-channel>
+		</instruction-set>
+	</thing-type>
+</update:update-descriptions>

--- a/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/update/instructions.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/resources/OH-INF/update/instructions.xml
@@ -6,11 +6,11 @@
 	<thing-type uid="spotify:player">
 		<instruction-set targetVersion="1">
 			<update-channel id="trackDurationMs">
-				<type>player:currentlyPlayedTrackDurationMs</type>
+				<type>spotify:currentlyPlayedTrackDurationMs</type>
 			</update-channel>
 
 			<update-channel id="trackProgressMs">
-				<type>player:currentlyPlayedTrackProgressMs</type>
+				<type>spotify:currentlyPlayedTrackProgressMs</type>
 			</update-channel>
 		</instruction-set>
 	</thing-type>


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->

Along with UoM and proper state description, duration/progress can be derived both in absolute time and as `mm:ss` from a single channel. Thus, also advanced definition was switched from uom to old *human-readable* channel.
Consequently, the `String` channels `trackDuration` and `trackProgress` are actually redundant and could be removed, but I kept them for backward compatibility (for now).

In the course of updating i18n, I also noticed that most parts were not yet in the `.properties` file, thus also greater changes there.