### PR TITLE
[victoriametrics] Initial contribution of VictoriaMetrics Persistence Binding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -458,6 +458,7 @@
 /bundles/org.openhab.persistence.mapdb/ @openhab/add-ons-maintainers
 /bundles/org.openhab.persistence.mongodb/ @openhab/add-ons-maintainers
 /bundles/org.openhab.persistence.rrd4j/ @openhab/add-ons-maintainers
+/bundles/org.openhab.persistence.victoriametrics/ @johnuopini
 /bundles/org.openhab.transform.basicprofiles/ @J-N-K
 /bundles/org.openhab.transform.bin2json/ @paulianttila
 /bundles/org.openhab.transform.exec/ @openhab/add-ons-maintainers

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -2268,6 +2268,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.persistence.victoriametrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.transform.basicprofiles</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.persistence.victoriametrics/NOTICE
+++ b/bundles/org.openhab.persistence.victoriametrics/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.persistence.victoriametrics/README.md
+++ b/bundles/org.openhab.persistence.victoriametrics/README.md
@@ -1,0 +1,90 @@
+# VictoriaMetrics Persistence
+
+This service allows you to persist and query states using the [VictoriaMetrics](https://victoriametrics.com/) time series database. Persisted values can be queried directly within openHAB. Victoria Metrics allows pushing data in Prometheus format.
+
+VictoriaMetrics integrates seamlessly with powerful visualization tools such as [Grafana](https://grafana.com/).
+
+## Database Structure
+
+* Item states are persisted in *measurement* points with names equal to the item's name, alias, or defined via metadata. Each measurement includes a mandatory tag named "item" containing the item name.
+* All values are stored in a field called "value" using the following types:
+
+  * **float** for DecimalType and QuantityType
+  * **integer** for `OnOffType`, `OpenClosedType` (stored as 0 or 1), and `DateTimeType` (milliseconds since epoch)
+  * **string** for all other types
+* Optional additional tags (category, label, or type) can be added to each data point.
+
+Example entries for an item named "speedtest":
+
+```
+speedtest{item=speedtest,value=123289369.0,source="openhab"} 1558302027124000000
+speedtest{item=speedtest,value=80423789.0,source="openhab"} 1558332852716000000
+```
+
+## Prerequisites
+
+First, set up and run a [VictoriaMetrics](https://victoriametrics.com/) server. Documentation can be found on the [official VictoriaMetrics site](https://victoriametrics.com/docs/).
+
+## Configuration
+
+Configure this service via the openHAB UI under `Settings` → `Other Services` → `VictoriaMetrics Persistence Service` or in the file `services/victoriametrics.cfg`. File-based configuration takes precedence over UI configuration.
+
+| Property          | Default                                        | Required | Description                                                                                   |
+| ----------------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| url               | [http://127.0.0.1:8428](http://127.0.0.1:8428) | Yes      | VictoriaMetrics server URL (default port: 8428)                                               |
+| user              |                                                | No       | Username for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
+| password          |                                                | No       | Password for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
+| token             |                                                | No       | Authentication token (Bearer token, typically for Enterprise version or reverse proxy setups) |
+| source            | openhab                                        | Yes      | Source tag value to identify data from different openHAB instances                            |
+| replaceUnderscore | false                                          | Yes      | Replace underscores in item names with dots ("\_") → (".") in measurement names               |
+| addCategoryTag    | false                                          | Yes      | Include item's category as "category" tag                                                     |
+| addTypeTag        | false                                          | Yes      | Include item's type as "type" tag                                                             |
+| addLabelTag       | false                                          | Yes      | Include item's label as "label" tag (default to "n/a" if unset)                               |
+
+## Customized Storage Options
+
+By default, each item's data is stored in a measurement matching the item name. Customize the measurement names and add extra tags through item metadata.
+
+### Measurement Name via Item Metadata
+
+Set the `victoriametrics` metadata key on items to change measurement names or add additional tags for organizing data:
+
+```java
+Group:Number:AVG gTempSensors
+
+Number:Temperature tempLivingRoom (gTempSensors) { victoriametrics="temperature" [floor="groundfloor"] }
+Number:Temperature tempKitchen (gTempSensors) { victoriametrics="temperature" [floor="groundfloor"] }
+
+Number:Temperature tempBedRoom (gTempSensors) { victoriametrics="temperature" [floor="firstfloor"] }
+Number:Temperature tempBath (gTempSensors) { victoriametrics="temperature" [floor="firstfloor"] }
+```
+
+Metadata can also be configured in the UI:
+
+* Navigate to the item's configuration → `Metadata` → `Add Metadata`
+* Enter `victoriametrics` as namespace
+* Provide measurement name in value field, e.g., "temperature"
+
+Resulting measurement:
+
+```
+temperature,item=tempLivingRoom,floor=groundfloor
+temperature,item=tempKitchen,floor=groundfloor
+temperature,item=tempBedRoom,floor=firstfloor
+temperature,item=tempBath,floor=firstfloor
+```
+
+*Note:* Do **not** override the "item" tag in metadata. This tag is essential for openHAB's internal operations.
+
+## Connect via TLS
+
+Victoria Metrics uses http protocol, if you wish to use a self signed certificate then:
+
+1. Locate JVM's keystore (`lib/security` directory).
+2. Import certificate:
+
+```shell
+sudo keytool -importcert -file <path-to-certfile> -cacerts -keypass changeit -storepass changeit -alias <alias>
+```
+
+This configuration ensures secure, encrypted communication with your VictoriaMetrics instance.

--- a/bundles/org.openhab.persistence.victoriametrics/README.md
+++ b/bundles/org.openhab.persistence.victoriametrics/README.md
@@ -4,7 +4,7 @@ This service allows you to persist and query states using the [VictoriaMetrics](
 
 VictoriaMetrics integrates seamlessly with powerful visualization tools such as [Grafana](https://grafana.com/).
 
-The binding has been tested with VictoriaMetrics free 1.90.0+, enterprise version has not been tested yet.
+The binding has been tested with VictoriaMetrics free and standalone 1.90.0+, enterprise version or different setups have not been tested yet but should work as well. The service supports both the open source and enterprise versions of VictoriaMetrics.
 
 ## Database Structure
 
@@ -14,7 +14,7 @@ The binding has been tested with VictoriaMetrics free 1.90.0+, enterprise versio
   * **float** for DecimalType and QuantityType
   * **integer** for `OnOffType`, `OpenClosedType` (stored as 0 or 1), and `DateTimeType` (milliseconds since epoch)
   * **string** for all other types
-* Optional additional tags (category, label, or type) can be added to each data point.
+* Optional additional tags (category, label, unit or type) can be added to each data point.
 
 Example entries for an item named "speedtest":
 
@@ -32,7 +32,7 @@ First, set up and run a [VictoriaMetrics](https://victoriametrics.com/) server. 
 Configure this service via the openHAB UI under `Settings` → `Other Services` → `VictoriaMetrics Persistence Service` or in the file `services/victoriametrics.cfg`. File-based configuration takes precedence over UI configuration.
 
 | Property          | Default                                        | Required | Description                                                                                   |
-| ----------------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| ----------------- | ---------------------------------------------- | -------- |-----------------------------------------------------------------------------------------------|
 | url               | [http://127.0.0.1:8428](http://127.0.0.1:8428) | Yes      | VictoriaMetrics server URL (default port: 8428)                                               |
 | user              |                                                | No       | Username for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
 | password          |                                                | No       | Password for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
@@ -42,6 +42,7 @@ Configure this service via the openHAB UI under `Settings` → `Other Services` 
 | addCategoryTag    | false                                          | Yes      | Include item's category as "category" tag                                                     |
 | addTypeTag        | false                                          | Yes      | Include item's type as "type" tag                                                             |
 | addLabelTag       | false                                          | Yes      | Include item's label as "label" tag (default to "n/a" if unset)                               |
+| addUnitTag        | false                                          | Yes      | Include item's unit as "unit" tag for QuantityType items when available                       |
 
 ## Customized Storage Options
 

--- a/bundles/org.openhab.persistence.victoriametrics/README.md
+++ b/bundles/org.openhab.persistence.victoriametrics/README.md
@@ -4,6 +4,8 @@ This service allows you to persist and query states using the [VictoriaMetrics](
 
 VictoriaMetrics integrates seamlessly with powerful visualization tools such as [Grafana](https://grafana.com/).
 
+The binding has been tested with VictoriaMetrics free 1.90.0+, enterprise version has not been tested yet.
+
 ## Database Structure
 
 * Item states are persisted in *measurement* points with names equal to the item's name, alias, or defined via metadata. Each measurement includes a mandatory tag named "item" containing the item name.

--- a/bundles/org.openhab.persistence.victoriametrics/README.md
+++ b/bundles/org.openhab.persistence.victoriametrics/README.md
@@ -37,13 +37,12 @@ Configure this service via the openHAB UI under `Settings` → `Other Services` 
 | user              |                                                | No       | Username for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
 | password          |                                                | No       | Password for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
 | token             |                                                | No       | Authentication token (Bearer token, typically for Enterprise version or reverse proxy setups) |
-| source            | openhab                                        | Yes      | Source tag value to identify data from different openHAB instances                            |
-| replaceUnderscore | false                                          | Yes      | Replace underscores in item names with dots ("\_") → (".") in measurement names               |
+| measurementPrefix | openhab_                                       | Yes      | Prefix for measurement names. If set, the prefix will be added to all measurements            |
+| camelToSnakeCase  | false                                          | Yes      | Convert item names from camelCase to snake_case for measurement names                         |
 | addCategoryTag    | false                                          | Yes      | Include item's category as "category" tag                                                     |
 | addTypeTag        | false                                          | Yes      | Include item's type as "type" tag                                                             |
 | addLabelTag       | false                                          | Yes      | Include item's label as "label" tag (default to "n/a" if unset)                               |
 | addUnitTag        | false                                          | Yes      | Include item's unit as "unit" tag for QuantityType items when available                       |
-| camelToSnakeCase  | false                                          | Yes      | Convert item names from camelCase to snake_case for measurement names                         |
 
 ## Customized Storage Options
 

--- a/bundles/org.openhab.persistence.victoriametrics/README.md
+++ b/bundles/org.openhab.persistence.victoriametrics/README.md
@@ -32,7 +32,7 @@ First, set up and run a [VictoriaMetrics](https://victoriametrics.com/) server. 
 Configure this service via the openHAB UI under `Settings` → `Other Services` → `VictoriaMetrics Persistence Service` or in the file `services/victoriametrics.cfg`. File-based configuration takes precedence over UI configuration.
 
 | Property          | Default                                        | Required | Description                                                                                   |
-| ----------------- | ---------------------------------------------- | -------- |-----------------------------------------------------------------------------------------------|
+|-------------------|------------------------------------------------|----------|-----------------------------------------------------------------------------------------------|
 | url               | [http://127.0.0.1:8428](http://127.0.0.1:8428) | Yes      | VictoriaMetrics server URL (default port: 8428)                                               |
 | user              |                                                | No       | Username for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
 | password          |                                                | No       | Password for HTTP Basic Auth (optional, only if enabled on VictoriaMetrics)                   |
@@ -43,6 +43,7 @@ Configure this service via the openHAB UI under `Settings` → `Other Services` 
 | addTypeTag        | false                                          | Yes      | Include item's type as "type" tag                                                             |
 | addLabelTag       | false                                          | Yes      | Include item's label as "label" tag (default to "n/a" if unset)                               |
 | addUnitTag        | false                                          | Yes      | Include item's unit as "unit" tag for QuantityType items when available                       |
+| camelToSnakeCase  | false                                          | Yes      | Convert item names from camelCase to snake_case for measurement names                         |
 
 ## Customized Storage Options
 

--- a/bundles/org.openhab.persistence.victoriametrics/pom.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/pom.xml
@@ -16,9 +16,6 @@
 
   <properties>
     <bnd.importpackage>!javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*</bnd.importpackage>
-    <okhttp3.version>4.12.0</okhttp3.version>
-    <okio.version>3.6.0</okio.version>
-    <gson.version>2.10.1</gson.version>
   </properties>
 
   <dependencies>
@@ -27,22 +24,39 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>${okhttp3.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
       <version>${okhttp3.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
       <version>${okio.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>${okio.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <!-- This is required by okhttp3 -->
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
     </dependency>
     <!-- JSON support -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
+      <scope>compile</scope>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/bundles/org.openhab.persistence.victoriametrics/pom.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.persistence.victoriametrics</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Persistence Service :: VictoriaMetrics</name>
+
+  <properties>
+    <bnd.importpackage>!javax.annotation.*;!android.*,!com.android.*,!com.google.appengine.*,!dalvik.system,!kotlin.*,!kotlinx.*,!org.conscrypt,!sun.security.ssl,!org.apache.harmony.*,!org.apache.http.*,!rx.*,!org.msgpack.*,!org.bouncycastle.*,!org.openjsse.*</bnd.importpackage>
+    <okhttp3.version>4.12.0</okhttp3.version>
+    <okio.version>3.6.0</okio.version>
+    <gson.version>2.10.1</gson.version>
+  </properties>
+
+  <dependencies>
+    <!-- HTTP client -->
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${okhttp3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>${okio.version}</version>
+    </dependency>
+    <!-- JSON support -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp3.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/feature/feature.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.persistence.victoriametrics-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-persistence-victoriametrics" description="VictoriaMetrics Persistence" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.victoriametrics/${project.version}</bundle>
+		<configfile finalname="${openhab.conf}/services/victoriametrics.cfg" override="false">
+			mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/victoriametrics
+		</configfile>
+	</feature>
+</features>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
@@ -277,21 +277,18 @@ public class VictoriaMetricsPersistenceService implements ModifiablePersistenceS
             String alias = (storeAlias != null && !storeAlias.isBlank()) ? storeAlias : itemName;
             String measurementName = victoriaMetadataService.getMeasurementNameOrDefault(alias);
 
-            if (configuration.isReplaceUnderscore()) {
-                measurementName = measurementName.replace('_', '.');
-            }
-
             if (configuration.isCamelToSnakeCase()) {
                 measurementName = VictoriaMetricsCaseConvertUtils.camelToSnake(measurementName);
             }
+
+            measurementName = configuration.getMeasurementPrefix() + measurementName;
 
             State storeState = Objects
                     .requireNonNullElse(state.as(desiredClasses.get(ItemUtil.getMainItemType(itemType))), state);
             Object value = VictoriaMetricsStateConvertUtils.stateToObject(storeState);
 
-            VictoriaMetricsPoint.Builder pointBuilder = VictoriaMetricsPoint
-                    .newBuilder(measurementName, configuration.getSourceName()).withTime(timeStamp).withValue(value)
-                    .withTag(TAG_ITEM_NAME, alias);
+            VictoriaMetricsPoint.Builder pointBuilder = VictoriaMetricsPoint.newBuilder(measurementName)
+                    .withTime(timeStamp).withValue(value).withTag(TAG_ITEM_NAME, alias);
 
             if (configuration.isAddCategoryTag()) {
                 String categoryName = Objects.requireNonNullElse(category, "n/a");

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.persistence.victoriametrics;
 
-import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_CATEGORY_NAME;
-import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_ITEM_NAME;
-import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_LABEL_NAME;
-import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_TYPE_NAME;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.*;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -42,6 +39,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemFactory;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.ItemUtil;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.ModifiablePersistenceService;
@@ -307,6 +305,12 @@ public class VictoriaMetricsPersistenceService implements ModifiablePersistenceS
             if (configuration.isAddLabelTag()) {
                 String labelName = Objects.requireNonNullElse(itemLabel, "n/a");
                 pointBuilder.withTag(TAG_LABEL_NAME, labelName);
+            }
+            if (configuration.isAddCategoryTag() && state instanceof QuantityType<?> q) {
+                String unit = q.getUnit().getSymbol();
+                if (!unit.isBlank()) {
+                    pointBuilder.withTag(TAG_UNIT_NAME, unit);
+                }
             }
 
             victoriaMetadataService.getMetaData(alias)

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
@@ -49,13 +49,7 @@ import org.openhab.core.persistence.QueryablePersistenceService;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConfiguration;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsHistoricItem;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsMetadataService;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsPersistentItemInfo;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsPoint;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsRepository;
-import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsStateConvertUtils;
+import org.openhab.persistence.victoriametrics.internal.*;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -287,6 +281,10 @@ public class VictoriaMetricsPersistenceService implements ModifiablePersistenceS
                 measurementName = measurementName.replace('_', '.');
             }
 
+            if (configuration.isCamelToSnakeCase()) {
+                measurementName = VictoriaMetricsCaseConvertUtils.camelToSnake(measurementName);
+            }
+
             State storeState = Objects
                     .requireNonNullElse(state.as(desiredClasses.get(ItemUtil.getMainItemType(itemType))), state);
             Object value = VictoriaMetricsStateConvertUtils.stateToObject(storeState);
@@ -306,7 +304,7 @@ public class VictoriaMetricsPersistenceService implements ModifiablePersistenceS
                 String labelName = Objects.requireNonNullElse(itemLabel, "n/a");
                 pointBuilder.withTag(TAG_LABEL_NAME, labelName);
             }
-            if (configuration.isAddCategoryTag() && state instanceof QuantityType<?> q) {
+            if (configuration.isAddUnitTag() && state instanceof QuantityType<?> q) {
                 String unit = q.getUnit().getSymbol();
                 if (!unit.isBlank()) {
                     pointBuilder.withTag(TAG_UNIT_NAME, unit);

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceService.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics;
+
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_CATEGORY_NAME;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_ITEM_NAME;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_LABEL_NAME;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.TAG_TYPE_NAME;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.config.core.ConfigurableService;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemFactory;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.ItemUtil;
+import org.openhab.core.persistence.FilterCriteria;
+import org.openhab.core.persistence.HistoricItem;
+import org.openhab.core.persistence.ModifiablePersistenceService;
+import org.openhab.core.persistence.PersistenceItemInfo;
+import org.openhab.core.persistence.PersistenceService;
+import org.openhab.core.persistence.QueryablePersistenceService;
+import org.openhab.core.persistence.strategy.PersistenceStrategy;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConfiguration;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsHistoricItem;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsMetadataService;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsPersistentItemInfo;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsPoint;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsRepository;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsStateConvertUtils;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the VictoriaMetrics {@link PersistenceService}.
+ * Persists item values using the <a href="http://victoriametrics.org">VictoriaMetrics</a> time series database.
+ *
+ * @author Franz - Initial contribution
+ * @author Joan Pujol Espinar - Original InfluxDB implementation
+ */
+@NonNullByDefault
+@Component(service = { PersistenceService.class,
+        QueryablePersistenceService.class }, configurationPid = "org.openhab.victoriametrics", property = Constants.SERVICE_PID
+                + "=org.openhab.victoriametrics")
+@ConfigurableService(category = "persistence", label = "VictoriaMetrics Persistence Service", description_uri = VictoriaMetricsPersistenceService.CONFIG_URI)
+public class VictoriaMetricsPersistenceService implements ModifiablePersistenceService {
+    public static final String SERVICE_NAME = "victoriametrics";
+
+    private final Logger logger = LoggerFactory.getLogger(VictoriaMetricsPersistenceService.class);
+
+    private static final int COMMIT_INTERVAL = 3; // in s
+    protected static final String CONFIG_URI = "persistence:victoriametrics";
+
+    // External dependencies
+    private final ItemRegistry itemRegistry;
+    private final VictoriaMetricsMetadataService victoriaMetadataService;
+
+    private final VictoriaMetricsConfiguration configuration;
+    private final VictoriaMetricsRepository victoriaRepository;
+    private boolean serviceActivated;
+
+    // Storage
+    private final ScheduledFuture<?> storeJob;
+    private final BlockingQueue<VictoriaMetricsPoint> pointsQueue = new LinkedBlockingQueue<>();
+
+    // Conversion
+    private final Set<ItemFactory> itemFactories = new HashSet<>();
+    private Map<String, Class<? extends State>> desiredClasses = new HashMap<>();
+
+    @Activate
+    public VictoriaMetricsPersistenceService(final @Reference ItemRegistry itemRegistry,
+            final @Reference VictoriaMetricsMetadataService victoriaMetadataService, Map<String, Object> config) {
+        this.itemRegistry = itemRegistry;
+        this.victoriaMetadataService = victoriaMetadataService;
+        this.configuration = new VictoriaMetricsConfiguration(config);
+        if (configuration.isValid()) {
+            this.victoriaRepository = createVictoriaMetricsRepository();
+            this.victoriaRepository.connect();
+            this.storeJob = ThreadPoolManager.getScheduledPool("org.openhab.victoriametrics")
+                    .scheduleWithFixedDelay(this::commit, COMMIT_INTERVAL, COMMIT_INTERVAL, TimeUnit.SECONDS);
+            serviceActivated = true;
+        } else {
+            throw new IllegalArgumentException("Configuration invalid.");
+        }
+        logger.info("VictoriaMetrics persistence service started.");
+    }
+
+    protected VictoriaMetricsRepository createVictoriaMetricsRepository() {
+        return new VictoriaMetricsRepository(configuration, victoriaMetadataService);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        serviceActivated = false;
+        storeJob.cancel(false);
+        commit(); // Ensure we at least tried to store the data
+        if (!pointsQueue.isEmpty()) {
+            logger.warn("VictoriaMetrics failed to finally store {} points.", pointsQueue.size());
+        }
+        victoriaRepository.disconnect();
+        logger.info("VictoriaMetrics persistence service stopped.");
+    }
+
+    @Override
+    public String getId() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public String getLabel(@Nullable Locale locale) {
+        return "VictoriaMetrics";
+    }
+
+    @Override
+    public Set<PersistenceItemInfo> getItemInfo() {
+        if (checkConnection()) {
+            return victoriaRepository.getStoredItemsCount().entrySet().stream()
+                    .map(VictoriaMetricsPersistentItemInfo::new).collect(Collectors.toUnmodifiableSet());
+        } else {
+            logger.info("getItemInfo ignored, VictoriaMetrics is not connected");
+            return Set.of();
+        }
+    }
+
+    @Override
+    public void store(Item item) {
+        store(item, null);
+    }
+
+    @Override
+    public void store(Item item, @Nullable String alias) {
+        store(item, ZonedDateTime.now(), item.getState(), alias);
+    }
+
+    @Override
+    public void store(Item item, ZonedDateTime date, State state) {
+        store(item, date, state, null);
+    }
+
+    @Override
+    public void store(Item item, ZonedDateTime date, State state, @Nullable String alias) {
+        if (!serviceActivated) {
+            logger.warn("VictoriaMetrics service not ready. Storing {} rejected.", item);
+            return;
+        }
+        convert(item, state, date.toInstant(), alias).thenAccept(point -> {
+            if (point == null) {
+                logger.trace("Ignoring item {}, conversion to a VictoriaMetrics point failed.", item.getName());
+                return;
+            }
+            if (pointsQueue.offer(point)) {
+                logger.trace("Queued {} for item {}", point, item);
+            } else {
+                logger.warn("Failed to queue {} for item {}", point, item);
+            }
+        });
+    }
+
+    @Override
+    public boolean remove(FilterCriteria filter) throws IllegalArgumentException {
+        if (serviceActivated && checkConnection()) {
+            if (filter.getItemName() == null) {
+                logger.warn("Item name is missing in filter {} when trying to remove data.", filter);
+                return false;
+            }
+            return victoriaRepository.remove(filter);
+        } else {
+            logger.debug("Remove query {} ignored, VictoriaMetrics is not connected.", filter);
+            return false;
+        }
+    }
+
+    @Override
+    public Iterable<HistoricItem> query(FilterCriteria filter) {
+        return query(filter, null);
+    }
+
+    @Override
+    public Iterable<HistoricItem> query(FilterCriteria filter, @Nullable String alias) {
+        String itemName = filter.getItemName();
+        if (itemName == null) {
+            logger.warn("Item name is missing in filter {} when querying data.", filter);
+            return List.of();
+        }
+        if (serviceActivated && checkConnection()) {
+            logger.trace(
+                    "Query-Filter: itemname: {}, ordering: {}, state: {},  operator: {}, getBeginDate: {}, getEndDate: {}, getPageSize: {}, getPageNumber: {}",
+                    itemName, filter.getOrdering(), filter.getState(), filter.getOperator(), filter.getBeginDate(),
+                    filter.getEndDate(), filter.getPageSize(), filter.getPageNumber());
+            List<VictoriaMetricsRepository.VictoriaRow> results = victoriaRepository.query(filter);
+            return results.stream().map(r -> mapRowToHistoricItem(r, itemName)).collect(Collectors.toList());
+        } else {
+            logger.debug("Query for persisted data ignored, VictoriaMetrics is not connected");
+            return List.of();
+        }
+    }
+
+    private HistoricItem mapRowToHistoricItem(VictoriaMetricsRepository.VictoriaRow row, String itemName) {
+        State state = VictoriaMetricsStateConvertUtils.objectToState(row.value(), itemName, itemRegistry);
+        return new VictoriaMetricsHistoricItem(row.itemName(), state, row.time());
+    }
+
+    @Override
+    public List<PersistenceStrategy> getDefaultStrategies() {
+        return List.of(PersistenceStrategy.Globals.RESTORE, PersistenceStrategy.Globals.CHANGE);
+    }
+
+    private boolean checkConnection() {
+        if (victoriaRepository.isConnected()) {
+            return true;
+        } else if (serviceActivated) {
+            logger.debug("Connection lost, trying re-connection");
+            return victoriaRepository.connect();
+        }
+        return false;
+    }
+
+    private void commit() {
+        if (!pointsQueue.isEmpty() && checkConnection()) {
+            List<VictoriaMetricsPoint> points = new ArrayList<>();
+            pointsQueue.drainTo(points);
+            if (!victoriaRepository.write(points)) {
+                logger.warn("Re-queuing {} elements, failed to write batch.", points.size());
+                pointsQueue.addAll(points);
+                victoriaRepository.disconnect();
+            } else {
+                logger.trace("Wrote {} elements to database", points.size());
+            }
+        }
+    }
+
+    /**
+     * Convert incoming data to a VictoriaMetricsPoint for further processing. Storage is asynchronous, so item data may
+     * have changed.
+     */
+    CompletableFuture<@Nullable VictoriaMetricsPoint> convert(Item item, State state, Instant timeStamp,
+            @Nullable String storeAlias) {
+        String itemName = item.getName();
+        String itemLabel = item.getLabel();
+        String category = item.getCategory();
+        String itemType = item.getType();
+
+        if (state instanceof UnDefType) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            String alias = (storeAlias != null && !storeAlias.isBlank()) ? storeAlias : itemName;
+            String measurementName = victoriaMetadataService.getMeasurementNameOrDefault(alias);
+
+            if (configuration.isReplaceUnderscore()) {
+                measurementName = measurementName.replace('_', '.');
+            }
+
+            State storeState = Objects
+                    .requireNonNullElse(state.as(desiredClasses.get(ItemUtil.getMainItemType(itemType))), state);
+            Object value = VictoriaMetricsStateConvertUtils.stateToObject(storeState);
+
+            VictoriaMetricsPoint.Builder pointBuilder = VictoriaMetricsPoint
+                    .newBuilder(measurementName, configuration.getSourceName()).withTime(timeStamp).withValue(value)
+                    .withTag(TAG_ITEM_NAME, alias);
+
+            if (configuration.isAddCategoryTag()) {
+                String categoryName = Objects.requireNonNullElse(category, "n/a");
+                pointBuilder.withTag(TAG_CATEGORY_NAME, categoryName);
+            }
+            if (configuration.isAddTypeTag()) {
+                pointBuilder.withTag(TAG_TYPE_NAME, itemType);
+            }
+            if (configuration.isAddLabelTag()) {
+                String labelName = Objects.requireNonNullElse(itemLabel, "n/a");
+                pointBuilder.withTag(TAG_LABEL_NAME, labelName);
+            }
+
+            victoriaMetadataService.getMetaData(alias)
+                    .ifPresent(metadata -> metadata.getConfiguration().forEach(pointBuilder::withTag));
+
+            return pointBuilder.build();
+        });
+    }
+
+    @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)
+    public void setItemFactory(ItemFactory itemFactory) {
+        itemFactories.add(itemFactory);
+        calculateItemTypeClasses();
+    }
+
+    public void unsetItemFactory(ItemFactory itemFactory) {
+        itemFactories.remove(itemFactory);
+        calculateItemTypeClasses();
+    }
+
+    private synchronized void calculateItemTypeClasses() {
+        Map<String, Class<? extends State>> desiredClasses = new HashMap<>();
+        itemFactories.forEach(factory -> {
+            for (String itemType : factory.getSupportedItemTypes()) {
+                Item item = factory.createItem(itemType, "victoriaItem");
+                if (item != null) {
+                    item.getAcceptedCommandTypes().stream()
+                            .filter(commandType -> commandType.isAssignableFrom(State.class)).findFirst()
+                            .map(commandType -> (Class<? extends State>) commandType.asSubclass(State.class))
+                            .ifPresent(desiredClass -> desiredClasses.put(itemType, desiredClass));
+                }
+            }
+        });
+        this.desiredClasses = desiredClasses;
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/UnexpectedConditionException.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/UnexpectedConditionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Throw to indicate an unexpected condition that should not have happened (a bug)
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ */
+@NonNullByDefault
+public class UnexpectedConditionException extends Exception {
+    private static final long serialVersionUID = 1128380327167959556L;
+
+    public UnexpectedConditionException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsCaseConvertUtils.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsCaseConvertUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+/**
+ * Utility class for converting camelCase strings to snake_case.
+ * This is useful for formatting item names or metadata keys in a way that is compatible with VictoriaMetrics.
+ *
+ * @author Franz - Initial contribution
+ */
+public class VictoriaMetricsCaseConvertUtils {
+
+    /**
+     * Converts a camelCase string to snake_case.
+     *
+     * @param str the camelCase string to convert
+     * @return the converted snake_case string
+     */
+    public static String camelToSnake(String str) {
+        StringBuilder result = new StringBuilder();
+        char c = str.charAt(0);
+        result.append(Character.toLowerCase(c));
+        for (int i = 1; i < str.length(); i++) {
+            char ch = str.charAt(i);
+            if (Character.isUpperCase(ch)) {
+                result.append('_');
+                result.append(Character.toLowerCase(ch));
+            } else
+                result.append(ch);
+        }
+        return result.toString();
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsCaseConvertUtils.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsCaseConvertUtils.java
@@ -21,22 +21,29 @@ package org.openhab.persistence.victoriametrics.internal;
 public class VictoriaMetricsCaseConvertUtils {
 
     /**
-     * Converts a camelCase string to snake_case.
+     * Converts a camelCase or PascalCase string to snake_case,
+     * preserving acronyms like OpenHAB → open_hab, not open_h_a_b.
      *
      * @param str the camelCase string to convert
      * @return the converted snake_case string
      */
     public static String camelToSnake(String str) {
         StringBuilder result = new StringBuilder();
-        char c = str.charAt(0);
-        result.append(Character.toLowerCase(c));
-        for (int i = 1; i < str.length(); i++) {
-            char ch = str.charAt(i);
-            if (Character.isUpperCase(ch)) {
-                result.append('_');
-                result.append(Character.toLowerCase(ch));
-            } else
-                result.append(ch);
+        char[] chars = str.toCharArray();
+        result.append(Character.toLowerCase(chars[0]));
+        for (int i = 1; i < chars.length; i++) {
+            char current = chars[i];
+            char prev = chars[i - 1];
+            if (Character.isUpperCase(current)) {
+                boolean nextIsLower = i + 1 < chars.length && Character.isLowerCase(chars[i + 1]);
+                boolean prevIsLower = Character.isLowerCase(prev);
+                if (prevIsLower || nextIsLower) {
+                    result.append('_');
+                }
+                result.append(Character.toLowerCase(current));
+            } else {
+                result.append(current);
+            }
         }
         return result.toString();
     }

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
@@ -32,20 +32,18 @@ public class VictoriaMetricsConfiguration {
     public static final String TOKEN_PARAM = "token";
     public static final String USER_PARAM = "user";
     public static final String PASSWORD_PARAM = "password";
-    public static final String SOURCE_PARAM = "source";
-    public static final String REPLACE_UNDERSCORE_PARAM = "replaceUnderscore";
     public static final String ADD_CATEGORY_TAG_PARAM = "addCategoryTag";
     public static final String ADD_LABEL_TAG_PARAM = "addLabelTag";
     public static final String ADD_TYPE_TAG_PARAM = "addTypeTag";
     public static final String ADD_UNIT_TAG_PARAM = "addUnitTag";
     public static final String CAMEL_TO_SNAKE_CASE_PARAM = "camelToSnakeCase";
+    public static final String MEASUREMENT_PREFIX = "measurementPrefix";
     private final Logger logger = LoggerFactory.getLogger(VictoriaMetricsConfiguration.class);
     private final String url;
     private final String user;
     private final String password;
     private final String token;
-    private final String sourceName;
-    private final boolean replaceUnderscore;
+    private final String measurementPrefix;
     private final boolean addCategoryTag;
     private final boolean addTypeTag;
     private final boolean addLabelTag;
@@ -58,13 +56,12 @@ public class VictoriaMetricsConfiguration {
         user = ConfigParser.valueAsOrElse(config.get(USER_PARAM), String.class, "openhab");
         password = ConfigParser.valueAsOrElse(config.get(PASSWORD_PARAM), String.class, "");
         token = ConfigParser.valueAsOrElse(config.get(TOKEN_PARAM), String.class, "");
-        sourceName = ConfigParser.valueAsOrElse(config.get(SOURCE_PARAM), String.class, "openhab");
-        replaceUnderscore = ConfigParser.valueAsOrElse(config.get(REPLACE_UNDERSCORE_PARAM), Boolean.class, false);
         addCategoryTag = ConfigParser.valueAsOrElse(config.get(ADD_CATEGORY_TAG_PARAM), Boolean.class, false);
         addLabelTag = ConfigParser.valueAsOrElse(config.get(ADD_LABEL_TAG_PARAM), Boolean.class, false);
         addTypeTag = ConfigParser.valueAsOrElse(config.get(ADD_TYPE_TAG_PARAM), Boolean.class, false);
         addUnitTag = ConfigParser.valueAsOrElse(config.get(ADD_UNIT_TAG_PARAM), Boolean.class, false);
-        camelToSnakeCase = ConfigParser.valueAsOrElse(config.get(CAMEL_TO_SNAKE_CASE_PARAM), Boolean.class, false);
+        camelToSnakeCase = ConfigParser.valueAsOrElse(config.get(CAMEL_TO_SNAKE_CASE_PARAM), Boolean.class, true);
+        measurementPrefix = ConfigParser.valueAsOrElse(config.get(MEASUREMENT_PREFIX), String.class, "openhab_");
     }
 
     public boolean isValid() {
@@ -73,19 +70,13 @@ public class VictoriaMetricsConfiguration {
         boolean hasPassword = !password.isBlank();
         boolean hasToken = !token.isBlank();
         boolean hasValidCredentials = (!hasBasicCredentials || hasPassword) || hasToken;
-        boolean hasDatabase = !sourceName.isBlank();
-        boolean valid = hasValidCredentials && hasDatabase;
-        if (valid) {
+        if (hasValidCredentials) {
             return true;
         } else {
             String msg = "VictoriaMetrics configuration isn't valid. Addon won't work: ";
             StringJoiner reason = new StringJoiner(",");
-            if (hasBasicCredentials && !hasPassword) {
-                reason.add("User defined but no password");
-            }
-            if (!hasDatabase) {
-                reason.add("No database name / tenant defined");
-            }
+            // We have only this reason right now
+            reason.add("User defined but no password");
             logger.warn("{} {}", msg, reason);
             return false;
         }
@@ -107,12 +98,8 @@ public class VictoriaMetricsConfiguration {
         return token;
     }
 
-    public String getSourceName() {
-        return sourceName;
-    }
-
-    public boolean isReplaceUnderscore() {
-        return replaceUnderscore;
+    public String getMeasurementPrefix() {
+        return measurementPrefix;
     }
 
     public boolean isAddCategoryTag() {
@@ -138,9 +125,9 @@ public class VictoriaMetricsConfiguration {
     @Override
     public String toString() {
         return "VictoriaMetricsConfiguration{" + "url='" + url + "', " + "user='" + user + "', " + "password='"
-                + password.length() + " chars'" + " , " + "token='" + token.length() + " chars'" + ", " + "sourceName='"
-                + sourceName + ", " + "replaceUnderscore=" + replaceUnderscore + ", " + "addCategoryTag="
-                + addCategoryTag + ", " + "addTypeTag=" + addTypeTag + ", " + "addLabelTag=" + addLabelTag + ", "
-                + "camelToSnakeCase=" + camelToSnakeCase + ", " + "addUnitTag=" + addUnitTag + '}';
+                + password.length() + " chars'" + " , " + "token='" + token.length() + " chars'" + ", "
+                + "measurementPrefix='" + measurementPrefix + ", " + "addCategoryTag=" + addCategoryTag + ", "
+                + "addTypeTag=" + addTypeTag + ", " + "addLabelTag=" + addLabelTag + ", " + "camelToSnakeCase="
+                + camelToSnakeCase + ", " + "addUnitTag=" + addUnitTag + '}';
     }
 }

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
@@ -38,6 +38,7 @@ public class VictoriaMetricsConfiguration {
     public static final String ADD_LABEL_TAG_PARAM = "addLabelTag";
     public static final String ADD_TYPE_TAG_PARAM = "addTypeTag";
     public static final String ADD_UNIT_TAG_PARAM = "addUnitTag";
+    public static final String CAMEL_TO_SNAKE_CASE_PARAM = "camelToSnakeCase";
     private final Logger logger = LoggerFactory.getLogger(VictoriaMetricsConfiguration.class);
     private final String url;
     private final String user;
@@ -49,6 +50,7 @@ public class VictoriaMetricsConfiguration {
     private final boolean addTypeTag;
     private final boolean addLabelTag;
     private final boolean addUnitTag;
+    private final boolean camelToSnakeCase;
 
     public VictoriaMetricsConfiguration(Map<String, Object> config) {
         // Set VictoriaMetrics default port
@@ -62,6 +64,7 @@ public class VictoriaMetricsConfiguration {
         addLabelTag = ConfigParser.valueAsOrElse(config.get(ADD_LABEL_TAG_PARAM), Boolean.class, false);
         addTypeTag = ConfigParser.valueAsOrElse(config.get(ADD_TYPE_TAG_PARAM), Boolean.class, false);
         addUnitTag = ConfigParser.valueAsOrElse(config.get(ADD_UNIT_TAG_PARAM), Boolean.class, false);
+        camelToSnakeCase = ConfigParser.valueAsOrElse(config.get(CAMEL_TO_SNAKE_CASE_PARAM), Boolean.class, false);
     }
 
     public boolean isValid() {
@@ -128,12 +131,16 @@ public class VictoriaMetricsConfiguration {
         return addUnitTag;
     }
 
+    public boolean isCamelToSnakeCase() {
+        return camelToSnakeCase;
+    }
+
     @Override
     public String toString() {
         return "VictoriaMetricsConfiguration{" + "url='" + url + "', " + "user='" + user + "', " + "password='"
                 + password.length() + " chars'" + " , " + "token='" + token.length() + " chars'" + ", " + "sourceName='"
                 + sourceName + ", " + "replaceUnderscore=" + replaceUnderscore + ", " + "addCategoryTag="
                 + addCategoryTag + ", " + "addTypeTag=" + addTypeTag + ", " + "addLabelTag=" + addLabelTag + ", "
-                + "addUnitTag=" + addUnitTag + '}';
+                + "camelToSnakeCase=" + camelToSnakeCase + ", " + "addUnitTag=" + addUnitTag + '}';
     }
 }

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import java.util.Map;
+import java.util.StringJoiner;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.config.core.ConfigParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Contains this addon configurable parameters
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault
+public class VictoriaMetricsConfiguration {
+    public static final String URL_PARAM = "url";
+    public static final String TOKEN_PARAM = "token";
+    public static final String USER_PARAM = "user";
+    public static final String PASSWORD_PARAM = "password";
+    public static final String SOURCE_PARAM = "source";
+    public static final String REPLACE_UNDERSCORE_PARAM = "replaceUnderscore";
+    public static final String ADD_CATEGORY_TAG_PARAM = "addCategoryTag";
+    public static final String ADD_LABEL_TAG_PARAM = "addLabelTag";
+    public static final String ADD_TYPE_TAG_PARAM = "addTypeTag";
+    private final Logger logger = LoggerFactory.getLogger(VictoriaMetricsConfiguration.class);
+    private final String url;
+    private final String user;
+    private final String password;
+    private final String token;
+    private final String sourceName;
+    private final boolean replaceUnderscore;
+    private final boolean addCategoryTag;
+    private final boolean addTypeTag;
+    private final boolean addLabelTag;
+
+    public VictoriaMetricsConfiguration(Map<String, Object> config) {
+        // Set VictoriaMetrics default port
+        url = ConfigParser.valueAsOrElse(config.get(URL_PARAM), String.class, "http://127.0.0.1:8428");
+        user = ConfigParser.valueAsOrElse(config.get(USER_PARAM), String.class, "openhab");
+        password = ConfigParser.valueAsOrElse(config.get(PASSWORD_PARAM), String.class, "");
+        token = ConfigParser.valueAsOrElse(config.get(TOKEN_PARAM), String.class, "");
+        sourceName = ConfigParser.valueAsOrElse(config.get(SOURCE_PARAM), String.class, "openhab");
+        replaceUnderscore = ConfigParser.valueAsOrElse(config.get(REPLACE_UNDERSCORE_PARAM), Boolean.class, false);
+        addCategoryTag = ConfigParser.valueAsOrElse(config.get(ADD_CATEGORY_TAG_PARAM), Boolean.class, false);
+        addLabelTag = ConfigParser.valueAsOrElse(config.get(ADD_LABEL_TAG_PARAM), Boolean.class, false);
+        addTypeTag = ConfigParser.valueAsOrElse(config.get(ADD_TYPE_TAG_PARAM), Boolean.class, false);
+    }
+
+    public boolean isValid() {
+        // VM OSS: allow blank credentials
+        boolean hasBasicCredentials = !user.isBlank();
+        boolean hasPassword = !password.isBlank();
+        boolean hasToken = !token.isBlank();
+        boolean hasValidCredentials = (!hasBasicCredentials || hasPassword) || hasToken;
+        boolean hasDatabase = !sourceName.isBlank();
+        boolean valid = hasValidCredentials && hasDatabase;
+        if (valid) {
+            return true;
+        } else {
+            String msg = "VictoriaMetrics configuration isn't valid. Addon won't work: ";
+            StringJoiner reason = new StringJoiner(",");
+            if (hasBasicCredentials && !hasPassword) {
+                reason.add("User defined but no password");
+            }
+            if (!hasDatabase) {
+                reason.add("No database name / tenant defined");
+            }
+            logger.warn("{} {}", msg, reason);
+            return false;
+        }
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public boolean isReplaceUnderscore() {
+        return replaceUnderscore;
+    }
+
+    public boolean isAddCategoryTag() {
+        return addCategoryTag;
+    }
+
+    public boolean isAddTypeTag() {
+        return addTypeTag;
+    }
+
+    public boolean isAddLabelTag() {
+        return addLabelTag;
+    }
+
+    @Override
+    public String toString() {
+        return "VictoriaMetricsConfiguration{url='" + url + "', user='" + user + "', password='" + password.length()
+                + " chars'" + " , token='" + token.length() + " chars'" + ", sourceName='" + sourceName
+                + ", replaceUnderscore=" + replaceUnderscore + ", addCategoryTag=" + addCategoryTag + ", addTypeTag="
+                + addTypeTag + ", addLabelTag=" + addLabelTag + '}';
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConfiguration.java
@@ -37,6 +37,7 @@ public class VictoriaMetricsConfiguration {
     public static final String ADD_CATEGORY_TAG_PARAM = "addCategoryTag";
     public static final String ADD_LABEL_TAG_PARAM = "addLabelTag";
     public static final String ADD_TYPE_TAG_PARAM = "addTypeTag";
+    public static final String ADD_UNIT_TAG_PARAM = "addUnitTag";
     private final Logger logger = LoggerFactory.getLogger(VictoriaMetricsConfiguration.class);
     private final String url;
     private final String user;
@@ -47,6 +48,7 @@ public class VictoriaMetricsConfiguration {
     private final boolean addCategoryTag;
     private final boolean addTypeTag;
     private final boolean addLabelTag;
+    private final boolean addUnitTag;
 
     public VictoriaMetricsConfiguration(Map<String, Object> config) {
         // Set VictoriaMetrics default port
@@ -59,6 +61,7 @@ public class VictoriaMetricsConfiguration {
         addCategoryTag = ConfigParser.valueAsOrElse(config.get(ADD_CATEGORY_TAG_PARAM), Boolean.class, false);
         addLabelTag = ConfigParser.valueAsOrElse(config.get(ADD_LABEL_TAG_PARAM), Boolean.class, false);
         addTypeTag = ConfigParser.valueAsOrElse(config.get(ADD_TYPE_TAG_PARAM), Boolean.class, false);
+        addUnitTag = ConfigParser.valueAsOrElse(config.get(ADD_UNIT_TAG_PARAM), Boolean.class, false);
     }
 
     public boolean isValid() {
@@ -121,11 +124,16 @@ public class VictoriaMetricsConfiguration {
         return addLabelTag;
     }
 
+    public boolean isAddUnitTag() {
+        return addUnitTag;
+    }
+
     @Override
     public String toString() {
-        return "VictoriaMetricsConfiguration{url='" + url + "', user='" + user + "', password='" + password.length()
-                + " chars'" + " , token='" + token.length() + " chars'" + ", sourceName='" + sourceName
-                + ", replaceUnderscore=" + replaceUnderscore + ", addCategoryTag=" + addCategoryTag + ", addTypeTag="
-                + addTypeTag + ", addLabelTag=" + addLabelTag + '}';
+        return "VictoriaMetricsConfiguration{" + "url='" + url + "', " + "user='" + user + "', " + "password='"
+                + password.length() + " chars'" + " , " + "token='" + token.length() + " chars'" + ", " + "sourceName='"
+                + sourceName + ", " + "replaceUnderscore=" + replaceUnderscore + ", " + "addCategoryTag="
+                + addCategoryTag + ", " + "addTypeTag=" + addTypeTag + ", " + "addLabelTag=" + addLabelTag + ", "
+                + "addUnitTag=" + addUnitTag + '}';
     }
 }

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
@@ -27,7 +27,6 @@ public class VictoriaMetricsConstants {
     public static final String TAG_TYPE_NAME = "type";
     public static final String TAG_LABEL_NAME = "label";
     public static final String TAG_UNIT_NAME = "unit";
-    public static final String FIELD_SOURCE_NAME = "source";
     public static final int QUERY_MAX_POINTS = 1000;
     public static final int QUERY_DEFAULT_STEP = 60; // seconds
     public static final long CONNECTION_HEARTBEAT_INTERVAL = 60 * 1000; // 1 minute

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Constants used by this addon
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault
+public class VictoriaMetricsConstants {
+    public static final String TAG_ITEM_NAME = "item";
+    public static final String TAG_CATEGORY_NAME = "category";
+    public static final String TAG_TYPE_NAME = "type";
+    public static final String TAG_LABEL_NAME = "label";
+    public static final String FIELD_SOURCE_NAME = "source";
+    public static final int QUERY_MAX_POINTS = 1000;
+    public static final int QUERY_DEFAULT_STEP = 60; // seconds
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
@@ -26,6 +26,7 @@ public class VictoriaMetricsConstants {
     public static final String TAG_CATEGORY_NAME = "category";
     public static final String TAG_TYPE_NAME = "type";
     public static final String TAG_LABEL_NAME = "label";
+    public static final String TAG_UNIT_NAME = "unit";
     public static final String FIELD_SOURCE_NAME = "source";
     public static final int QUERY_MAX_POINTS = 1000;
     public static final int QUERY_DEFAULT_STEP = 60; // seconds

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsConstants.java
@@ -30,4 +30,5 @@ public class VictoriaMetricsConstants {
     public static final String FIELD_SOURCE_NAME = "source";
     public static final int QUERY_MAX_POINTS = 1000;
     public static final int QUERY_DEFAULT_STEP = 60; // seconds
+    public static final long CONNECTION_HEARTBEAT_INTERVAL = 60 * 1000; // 1 minute
 }

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsHistoricItem.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsHistoricItem.java
@@ -24,8 +24,7 @@ import org.openhab.core.types.State;
 /**
  * Java bean used to return items queries results from VictoriaMetrics.
  *
- * @author Joan Pujol Espinar and Theo Weiss - InfluxDB persistence used as reference
- * @author Franz - Initial VictoriaMetrics adaptation
+ * @author Franz - Initial contribution
  */
 @NonNullByDefault
 public class VictoriaMetricsHistoricItem implements HistoricItem {

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsHistoricItem.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsHistoricItem.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import java.text.DateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.persistence.HistoricItem;
+import org.openhab.core.types.State;
+
+/**
+ * Java bean used to return items queries results from VictoriaMetrics.
+ *
+ * @author Joan Pujol Espinar and Theo Weiss - InfluxDB persistence used as reference
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault
+public class VictoriaMetricsHistoricItem implements HistoricItem {
+
+    private String name = "";
+    private final State state;
+    private final Instant instant;
+
+    public VictoriaMetricsHistoricItem(String name, State state, Instant instant) {
+        this.name = name;
+        this.state = state;
+        this.instant = instant;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public State getState() {
+        return state;
+    }
+
+    @Override
+    public ZonedDateTime getTimestamp() {
+        return instant.atZone(ZoneId.systemDefault());
+    }
+
+    @Override
+    public Instant getInstant() {
+        return instant;
+    }
+
+    @Override
+    public String toString() {
+        return DateFormat.getDateTimeInstance().format(getTimestamp()) + ": " + name + " -> " + state.toString();
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsMetadataService.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsMetadataService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.persistence.victoriametrics.VictoriaMetricsPersistenceService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Utility service for using item metadata in VictoriaMetrics
+ *
+ * @author Franz - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = VictoriaMetricsMetadataService.class)
+public class VictoriaMetricsMetadataService {
+    private final MetadataRegistry metadataRegistry;
+
+    @Activate
+    public VictoriaMetricsMetadataService(@Reference MetadataRegistry metadataRegistry) {
+        this.metadataRegistry = metadataRegistry;
+    }
+
+    /**
+     * Get the measurement name from the item metadata or return the provided default
+     *
+     * @param itemName the item name
+     * @return the metadata measurement name if present, defaultName otherwise
+     */
+    public String getMeasurementNameOrDefault(String itemName) {
+        Optional<Metadata> metadata = getMetaData(itemName);
+        if (metadata.isPresent()) {
+            String metaName = metadata.get().getValue();
+            if (!metaName.isBlank()) {
+                return metaName;
+            }
+        }
+        return itemName;
+    }
+
+    /**
+     * Get an Optional of the metadata for an item
+     *
+     * @param itemName the item name
+     * @return Optional with the metadata (may be empty)
+     */
+    public Optional<Metadata> getMetaData(String itemName) {
+        MetadataKey key = new MetadataKey(VictoriaMetricsPersistenceService.SERVICE_NAME, itemName);
+        return Optional.ofNullable(metadataRegistry.get(key));
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsPersistentItemInfo.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsPersistentItemInfo.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.persistence.PersistenceItemInfo;
+
+/**
+ * Java bean used to return information about stored items
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault
+public class VictoriaMetricsPersistentItemInfo implements PersistenceItemInfo {
+    private final String name;
+    private final Integer count;
+
+    public VictoriaMetricsPersistentItemInfo(Map.Entry<String, Integer> itemInfo) {
+        this.name = itemInfo.getKey();
+        this.count = itemInfo.getValue();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @Nullable
+    public Integer getCount() {
+        return count;
+    }
+
+    @Override
+    @Nullable
+    public Date getEarliest() {
+        return null; // TODO: Implement when available in VictoriaMetrics binding
+    }
+
+    @Override
+    @Nullable
+    public Date getLatest() {
+        return null; // TODO: Implement when available in VictoriaMetrics binding
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsPoint.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsPoint.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.persistence.victoriametrics.internal;
 
-import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.FIELD_SOURCE_NAME;
-
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,16 +40,12 @@ public class VictoriaMetricsPoint {
         tags = builder.tags;
     }
 
-    public static Builder newBuilder(String metricName, String sourceName) {
-        return new Builder(metricName, sourceName);
+    public static Builder newBuilder(String metricName) {
+        return new Builder(metricName);
     }
 
     public String getMetricName() {
         return metricName;
-    }
-
-    public Instant getTime() {
-        return time;
     }
 
     public Object getValue() {
@@ -68,10 +62,8 @@ public class VictoriaMetricsPoint {
         private Object value;
         private final Map<String, String> tags = new HashMap<>();
 
-        private Builder(String metricName, String sourceName) {
+        private Builder(String metricName) {
             this.metricName = metricName;
-            // Default tag to identify the source of the metric, this is a bit like the "bucket" in InfluxDB
-            this.tags.put(FIELD_SOURCE_NAME, sourceName);
         }
 
         public Builder withTime(Instant val) {

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsPoint.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsPoint.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.FIELD_SOURCE_NAME;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.DefaultLocation;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Point data to be stored in VictoriaMetrics.
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault({ DefaultLocation.PARAMETER })
+public class VictoriaMetricsPoint {
+    private final String metricName;
+    private final Instant time;
+    private final Object value;
+    private final Map<String, String> tags;
+
+    private VictoriaMetricsPoint(Builder builder) {
+        metricName = builder.metricName;
+        time = builder.time;
+        value = builder.value;
+        tags = builder.tags;
+    }
+
+    public static Builder newBuilder(String metricName, String sourceName) {
+        return new Builder(metricName, sourceName);
+    }
+
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public Instant getTime() {
+        return time;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(tags);
+    }
+
+    public static final class Builder {
+        private final String metricName;
+        private Instant time;
+        private Object value;
+        private final Map<String, String> tags = new HashMap<>();
+
+        private Builder(String metricName, String sourceName) {
+            this.metricName = metricName;
+            // Default tag to identify the source of the metric, this is a bit like the "bucket" in InfluxDB
+            this.tags.put(FIELD_SOURCE_NAME, sourceName);
+        }
+
+        public Builder withTime(Instant val) {
+            time = val;
+            return this;
+        }
+
+        public Builder withValue(Object val) {
+            value = val;
+            return this;
+        }
+
+        public Builder withTag(String name, Object value) {
+            tags.put(name, value.toString());
+            return this;
+        }
+
+        public VictoriaMetricsPoint build() {
+            return new VictoriaMetricsPoint(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "VictoriaMetricsPoint{" + "metricName='" + metricName + "'" + ", time=" + time + ", value=" + value
+                + ", tags=" + tags + '}';
+    }
+
+    public String toPrometheusFormat() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(metricName);
+        // Add tags if present
+        if (!tags.isEmpty()) {
+            sb.append('{');
+            boolean first = true;
+            for (Map.Entry<String, String> entry : tags.entrySet()) {
+                if (!first) {
+                    sb.append(',');
+                }
+                first = false;
+                sb.append(entry.getKey()).append("=\"").append(escapeLabelValue(entry.getValue())).append("\"");
+            }
+            sb.append('}');
+        }
+        sb.append(' ');
+        sb.append(formatPrometheusValue(value)); // see below
+        // Prometheus expects timestamp in **seconds** (as an integer)
+        sb.append(' ');
+        sb.append(time.getEpochSecond());
+        return sb.toString();
+    }
+
+    private String escapeLabelValue(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+    }
+
+    private String formatPrometheusValue(Object val) {
+        if (val instanceof Number) {
+            return val.toString();
+        } else if (val instanceof Boolean) {
+            // Prometheus doesn't support bool natively, but treat as 1/0
+            return ((Boolean) val) ? "1" : "0";
+        } else {
+            // Strings are discouraged, but you could map them to 0 or NaN
+            return "NaN";
+        }
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsRepository.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsRepository.java
@@ -49,12 +49,24 @@ public class VictoriaMetricsRepository {
     private final VictoriaMetricsMetadataService metadataService;
     private final Gson gson = new Gson();
 
+    /**
+     * Creates a new instance of VictoriaMetricsRepository.
+     *
+     * @param configuration the configuration for connecting to VictoriaMetrics
+     * @param metadataService the service for managing metadata
+     */
     public VictoriaMetricsRepository(VictoriaMetricsConfiguration configuration,
             VictoriaMetricsMetadataService metadataService) {
         this.configuration = configuration;
         this.metadataService = metadataService;
     }
 
+    /**
+     * Checks if the repository is connected to the VictoriaMetrics server.
+     * This could be improved as its called on every write operation and its not really needed.
+     *
+     * @return true if connected, false otherwise
+     */
     public boolean isConnected() {
         try {
             HttpURLConnection conn = getConnection("/api/v1/status/tsdb", "GET");

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsRepository.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsRepository.java
@@ -32,6 +32,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import okhttp3.Protocol;
 import okhttp3.ResponseBody;
 
 /**
@@ -61,6 +62,7 @@ public class VictoriaMetricsRepository {
      * Default http client (we use okhttp3 for better performance)
      */
     private static final okhttp3.OkHttpClient httpClient = new okhttp3.OkHttpClient.Builder()
+            .protocols(List.of(Protocol.HTTP_1_1)) // VictoriaMetrics supports HTTP/1.1
             .retryOnConnectionFailure(true).connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
             .readTimeout(10, java.util.concurrent.TimeUnit.SECONDS).build();
 

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsRepository.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsRepository.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import static java.net.URLEncoder.*;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.persistence.FilterCriteria;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Manages VictoriaMetrics server interaction maintaining client connection.
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault
+public class VictoriaMetricsRepository {
+    private final Logger logger = LoggerFactory.getLogger(VictoriaMetricsRepository.class);
+    private final VictoriaMetricsConfiguration configuration;
+    private final VictoriaMetricsMetadataService metadataService;
+    private final Gson gson = new Gson();
+
+    public VictoriaMetricsRepository(VictoriaMetricsConfiguration configuration,
+            VictoriaMetricsMetadataService metadataService) {
+        this.configuration = configuration;
+        this.metadataService = metadataService;
+    }
+
+    public boolean isConnected() {
+        try {
+            HttpURLConnection conn = getConnection("/api/v1/status/tsdb", "GET");
+            int responseCode = conn.getResponseCode();
+            conn.disconnect();
+            if (responseCode == 200) {
+                logger.trace("Connected to VictoriaMetrics at {}", configuration.getUrl());
+                return true;
+            } else {
+                logger.warn("Failed to connect to VictoriaMetrics, response code: {}", responseCode);
+                return false;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public boolean connect() {
+        return isConnected();
+    }
+
+    public void disconnect() {
+    }
+
+    public boolean write(List<VictoriaMetricsPoint> points) {
+        if (points.isEmpty()) {
+            return true;
+        }
+        try {
+            HttpURLConnection conn = getConnection("/api/v1/import/prometheus", "POST");
+            conn.setDoOutput(true);
+            try (OutputStream os = conn.getOutputStream()) {
+                for (VictoriaMetricsPoint point : points) {
+                    os.write(point.toPrometheusFormat().getBytes());
+                    os.write('\n');
+                }
+            }
+            int code = conn.getResponseCode();
+            conn.disconnect();
+            if (code == 204)
+                logger.trace("Wrote {} points to VictoriaMetrics", points.size());
+            else
+                logger.warn("Failed to write points to VictoriaMetrics, response code: {}", code);
+            return code == 204;
+        } catch (IOException e) {
+            logger.error("Failed to write points to VictoriaMetrics", e);
+            return false;
+        }
+    }
+
+    public List<VictoriaRow> query(FilterCriteria filter) {
+        try {
+            // Build PromQL query for item, filtered by openhab tag and optional time range
+            String itemName = filter.getItemName();
+            if (itemName == null) {
+                logger.warn("No item name specified for query");
+                return List.of();
+            }
+            String name = metadataService.getMeasurementNameOrDefault(itemName);
+            String measurementName = configuration.isReplaceUnderscore() ? name.replace('_', '.') : name;
+            String metricSelector = measurementName + "{" + FIELD_SOURCE_NAME + "=\"" + configuration.getSourceName()
+                    + "\"}";
+            String promql;
+            String endpoint;
+            String urlString;
+            if (filter.getBeginDate() != null && filter.getEndDate() != null) {
+                // Use range query
+                endpoint = "/api/v1/query_range";
+                promql = metricSelector;
+                ZonedDateTime startDate = filter.getBeginDate();
+                ZonedDateTime endDate = filter.getEndDate();
+                ZonedDateTime now = ZonedDateTime.now();
+                // Default to last 24 hours if no dates provided
+                long start = startDate != null ? startDate.toEpochSecond() : now.minusDays(1).toEpochSecond();
+                long end = endDate != null ? endDate.toEpochSecond() : now.toEpochSecond();
+                // We cannot exceed "maxPointsPerTimeseries", which defaults to 3000
+                int step = Math.max(QUERY_DEFAULT_STEP, (int) ((end - start) / QUERY_MAX_POINTS));
+                urlString = String.format("%s?query=%s&start=%d&end=%d&step=%d", endpoint,
+                        encode(promql, StandardCharsets.UTF_8), start, end, step);
+            } else {
+                // Instant query
+                endpoint = "/api/v1/query";
+                promql = metricSelector;
+                urlString = String.format("%s?query=%s", endpoint, encode(promql, StandardCharsets.UTF_8));
+            }
+            // Prepare HTTP request
+            HttpURLConnection conn = getConnection(urlString, "GET");
+            int code = conn.getResponseCode();
+            if (code != 200) {
+                String responseJson;
+                try (java.io.InputStream is = conn.getInputStream()) {
+                    responseJson = new String(is.readAllBytes());
+                }
+                conn.disconnect();
+                JsonObject json = gson.fromJson(responseJson, JsonObject.class);
+                String errorMessage = json != null ? json.get("error").getAsString() : "Unknown error";
+                throw new IOException("Query failed, code: " + code + ", URL: " + urlString + ", r: " + errorMessage);
+            }
+            String responseJson;
+            try (java.io.InputStream is = conn.getInputStream()) {
+                responseJson = new String(is.readAllBytes());
+            }
+            conn.disconnect();
+            // Parse JSON response with Gson
+            JsonObject json = gson.fromJson(responseJson, JsonObject.class);
+            if (json == null || !"success".equals(json.get("status").getAsString())) {
+                logger.warn("VictoriaMetrics query failed: {}", responseJson);
+                return List.of();
+            }
+            JsonArray data = json.getAsJsonObject("data").getAsJsonArray("result");
+            List<VictoriaRow> rows = new java.util.ArrayList<>();
+            for (JsonElement el : data) {
+                JsonObject obj = el.getAsJsonObject();
+                String entryName = obj.getAsJsonObject("metric").get("__name__").getAsString();
+                JsonArray values = obj.has("values") ? obj.getAsJsonArray("values") : null; // For range query
+                JsonArray value = obj.has("value") ? obj.getAsJsonArray("value") : null; // For instant query
+                if (values != null) {
+                    // Range query: each "values" entry is [timestamp, value]
+                    for (JsonElement vEl : values) {
+                        JsonArray vArr = vEl.getAsJsonArray();
+                        long ts = vArr.get(0).getAsLong();
+                        String valStr = vArr.get(1).getAsString();
+                        rows.add(new VictoriaRow(entryName, valStr, Instant.ofEpochSecond(ts)));
+                    }
+                } else if (value != null) {
+                    // Instant query
+                    long ts = value.get(0).getAsLong();
+                    String valStr = value.get(1).getAsString();
+                    rows.add(new VictoriaRow(entryName, valStr, Instant.ofEpochSecond(ts)));
+                }
+            }
+            // Invert if specified
+            if (filter.getOrdering() == FilterCriteria.Ordering.DESCENDING) {
+                rows.sort((r1, r2) -> r2.time.compareTo(r1.time));
+            }
+            // Apply pagination if specified
+            int pageSize = filter.getPageSize();
+            int pageNumber = filter.getPageNumber();
+            int fromIndex = pageNumber * pageSize;
+            int toIndex = Math.min(fromIndex + pageSize, rows.size());
+            if (fromIndex < rows.size()) {
+                return rows.subList(fromIndex, toIndex);
+            } else {
+                return List.of(); // or whatever empty result
+            }
+        } catch (Exception e) {
+            logger.error("Failed to query VictoriaMetrics", e);
+            return List.of();
+        }
+    }
+
+    public boolean remove(FilterCriteria filter) {
+        try {
+            String itemName = filter.getItemName();
+            if (itemName == null) {
+                logger.warn("No item name specified for remove");
+                return false;
+            }
+            String name = metadataService.getMeasurementNameOrDefault(itemName);
+            String match = name + "{" + FIELD_SOURCE_NAME + "=\"" + configuration.getSourceName() + "\"}";
+            String urlString = "/api/v1/admin/tsdb/delete_series?match[]=" + encode(match, StandardCharsets.UTF_8);
+            ZonedDateTime start = filter.getBeginDate();
+            if (start != null)
+                urlString += "&start=" + (start.toEpochSecond());
+            ZonedDateTime end = filter.getEndDate();
+            if (end != null)
+                urlString += "&end=" + (end.toEpochSecond());
+            HttpURLConnection conn = getConnection(urlString, "POST");
+            int code = conn.getResponseCode();
+            conn.disconnect();
+            if (code != 204) {
+                logger.warn("VictoriaMetrics remove failed, response code: {}", code);
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            logger.error("Failed to remove data from VictoriaMetrics", e);
+            return false;
+        }
+    }
+
+    /**
+     * Returns a map of all stored item names with their count of stored points.
+     *
+     * @return Map with {@code <ItemName, ItemCount>} entries
+     */
+    public Map<String, Integer> getStoredItemsCount() {
+        try {
+            String promql = "count({source=\"openhab\"}) by (__name__)";
+            String responseJson = promQLQuery(promql);
+            Map<String, Integer> result = new java.util.LinkedHashMap<>();
+            Gson gson = new Gson();
+            JsonObject json = gson.fromJson(responseJson, JsonObject.class);
+            // Check if query succeeded
+            if (json == null || !"success".equals(json.get("status").getAsString())) {
+                logger.warn("VictoriaMetrics query for stored items failed: {}", responseJson);
+                return result;
+            }
+            JsonArray data = json.getAsJsonObject("data").getAsJsonArray("result");
+            for (JsonElement el : data) {
+                JsonObject obj = el.getAsJsonObject();
+                String name = obj.getAsJsonObject("metric").get("__name__").getAsString();
+                // Value array: [ <timestamp>, "<count as string>" ]
+                int count = Integer.parseInt(obj.getAsJsonArray("value").get(1).getAsString());
+                result.put(name, count);
+            }
+            return result;
+        } catch (Exception e) {
+            logger.error("Failed to get stored items count from VictoriaMetrics", e);
+            return java.util.Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Executes a PromQL query against the VictoriaMetrics server.
+     *
+     * @param promql the PromQL query string
+     * @return the response from the server as a JSON string
+     * @throws IOException if an error occurs during the request
+     */
+    private String promQLQuery(String promql) throws IOException {
+        String url = "/api/v1/query?query=" + encode(promql, StandardCharsets.UTF_8);
+        HttpURLConnection conn = getConnection(url, "GET");
+        int code = conn.getResponseCode();
+        if (code != 200) {
+            throw new IOException("VictoriaMetrics query failed, response code: " + code);
+        }
+        try (java.io.InputStream is = conn.getInputStream()) {
+            return new String(is.readAllBytes());
+        }
+    }
+
+    /**
+     * Creates a connection to the VictoriaMetrics server with the specified URL and method.
+     *
+     * @param path the path to the API endpoint
+     * @param method the HTTP method to use (GET, POST, etc.)
+     * @return the HttpURLConnection object
+     * @throws IOException if an error occurs while opening the connection
+     */
+    private HttpURLConnection getConnection(String path, String method) throws IOException {
+        if (path.startsWith("/"))
+            path = path.substring(1);
+        URL url = URI.create(configuration.getUrl() + path).toURL();
+        logger.trace("Connecting at {}", url);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoOutput(true);
+        conn.setRequestMethod(method);
+        // Check if the config has an user
+        String username = configuration.getUser();
+        if (!username.isEmpty()) {
+            String auth = username + ":" + configuration.getPassword();
+            String encoded = java.util.Base64.getEncoder().encodeToString(auth.getBytes());
+            conn.setRequestProperty("Authorization", "Basic " + encoded);
+        }
+        // Check if config has a token (enterprise only)
+        String token = configuration.getToken();
+        if (!token.isEmpty()) {
+            conn.setRequestProperty("Authorization", "Bearer " + token);
+        }
+        return conn;
+    }
+
+    // Row object for result mapping
+    public record VictoriaRow(String itemName, Object value, Instant time) {
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsStateConvertUtils.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsStateConvertUtils.java
@@ -111,6 +111,14 @@ public class VictoriaMetricsStateConvertUtils {
         return new StringType(String.valueOf(value));
     }
 
+    /**
+     * Converts a value to a {@link State} which is suitable for the given {@link Item}.
+     * This is needed for querying a {@link VictoriaMetricsHistoricItem}.
+     *
+     * @param value to be converted to a {@link State}
+     * @param itemToSetState the {@link Item} to get the {@link State} for
+     * @return the state of the item represented by the itemToSetState parameter, else the string value of
+     */
     public static State objectToState(@Nullable Object value, Item itemToSetState) {
         String valueStr = String.valueOf(value);
 

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsStateConvertUtils.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/java/org/openhab/persistence/victoriametrics/internal/VictoriaMetricsStateConvertUtils.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.items.GroupItem;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.items.ColorItem;
+import org.openhab.core.library.items.ContactItem;
+import org.openhab.core.library.items.DateTimeItem;
+import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.ImageItem;
+import org.openhab.core.library.items.LocationItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.PlayerItem;
+import org.openhab.core.library.items.RollershutterItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.PlayPauseType;
+import org.openhab.core.library.types.PointType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.RawType;
+import org.openhab.core.library.types.RewindFastforwardType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Conversion logic between openHAB {@link State} types and VictoriaMetrics storage types.
+ *
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@NonNullByDefault
+public class VictoriaMetricsStateConvertUtils {
+    static final Number DIGITAL_VALUE_OFF = 0; // Visible for testing
+    static final Number DIGITAL_VALUE_ON = 1; // Visible for testing
+    private static final Logger LOGGER = LoggerFactory.getLogger(VictoriaMetricsStateConvertUtils.class);
+
+    /**
+     * Converts {@link State} to objects suitable for VictoriaMetrics values.
+     *
+     * @param state to be converted
+     * @return integer or double value for DecimalType, 0 or 1 for OnOffType and OpenClosedType,
+     *         integer for DateTimeType, String for all others
+     */
+    public static Object stateToObject(State state) {
+        Object value;
+        if (state instanceof HSBType) {
+            value = state.toString();
+        } else if (state instanceof PointType) {
+            value = state.toString();
+        } else if (state instanceof DecimalType type) {
+            value = type.toBigDecimal();
+        } else if (state instanceof QuantityType<?> type) {
+            value = type.toBigDecimal();
+        } else if (state instanceof OnOffType) {
+            value = state == OnOffType.ON ? DIGITAL_VALUE_ON : DIGITAL_VALUE_OFF;
+        } else if (state instanceof OpenClosedType) {
+            value = state == OpenClosedType.OPEN ? DIGITAL_VALUE_ON : DIGITAL_VALUE_OFF;
+        } else if (state instanceof DateTimeType type) {
+            value = type.getInstant().toEpochMilli();
+        } else {
+            value = state.toFullString();
+        }
+        return value;
+    }
+
+    /**
+     * Converts a value to a {@link State} which is suitable for the given {@link Item}. This is
+     * needed for querying a {@link VictoriaMetricsHistoricItem}.
+     *
+     * @param value to be converted to a {@link State}
+     * @param itemName name of the {@link Item} to get the {@link State} for
+     * @return the state of the item represented by the itemName parameter, else the string value of
+     *         the Object parameter
+     */
+    public static State objectToState(Object value, String itemName, ItemRegistry itemRegistry) {
+        try {
+            Item item = itemRegistry.getItem(itemName);
+            return objectToState(value, item);
+        } catch (ItemNotFoundException e) {
+            LOGGER.info("Could not find item '{}' in registry", itemName);
+        }
+
+        return new StringType(String.valueOf(value));
+    }
+
+    public static State objectToState(@Nullable Object value, Item itemToSetState) {
+        String valueStr = String.valueOf(value);
+
+        @Nullable
+        Item item = itemToSetState;
+        if (item instanceof GroupItem groupItem) {
+            item = groupItem.getBaseItem();
+        }
+        if (item instanceof ColorItem) {
+            return new HSBType(valueStr);
+        } else if (item instanceof LocationItem) {
+            return new PointType(valueStr);
+        } else if (item instanceof NumberItem numberItem) {
+            Unit<?> unit = numberItem.getUnit();
+            if (unit == null) {
+                return new DecimalType(valueStr);
+            } else {
+                return new QuantityType<>(new BigDecimal(valueStr), unit);
+            }
+        } else if (item instanceof DimmerItem) {
+            return new PercentType(valueStr);
+        } else if (item instanceof SwitchItem) {
+            return OnOffType.from(toBoolean(valueStr));
+        } else if (item instanceof ContactItem) {
+            return toBoolean(valueStr) ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
+        } else if (item instanceof RollershutterItem) {
+            return new PercentType(valueStr);
+        } else if (item instanceof DateTimeItem) {
+            return new DateTimeType(Instant.ofEpochMilli(new BigDecimal(valueStr).longValue()));
+        } else if (item instanceof PlayerItem) {
+            try {
+                return PlayPauseType.valueOf(valueStr);
+            } catch (IllegalArgumentException ignored) {
+            }
+            try {
+                return RewindFastforwardType.valueOf(valueStr);
+            } catch (IllegalArgumentException ignored) {
+            }
+        } else if (item instanceof ImageItem) {
+            return RawType.valueOf(valueStr);
+        } else {
+            return new StringType(valueStr);
+        }
+        return UnDefType.UNDEF;
+    }
+
+    private static boolean toBoolean(@Nullable Object object) {
+        if (object instanceof Boolean boolean1) {
+            return boolean1;
+        } else if (object != null) {
+            if ("1".equals(object) || "1.0".equals(object)) {
+                return true;
+            } else {
+                return Boolean.parseBoolean(String.valueOf(object));
+            }
+        } else {
+            return false;
+        }
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/addon/addon.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon:addon id="victoriametrics" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
+
+	<type>persistence</type>
+	<name>VictoriaMetrics Persistence</name>
+	<description>This is the persistence add-on for VictoriaMetrics.</description>
+	<connection>local</connection>
+
+	<service-id>org.openhab.victoriametrics</service-id>
+
+	<config-description-ref uri="persistence:victoriametrics"/>
+
+	<!-- Discovery is optional. Only add if you can detect the service! -->
+	<discovery-methods>
+		<discovery-method>
+			<service-type>process</service-type>
+			<match-properties>
+				<match-property>
+					<name>command</name>
+					<regex>(?i).*[/\\](victoria-metrics)(-prod)?(\.exe)?$</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+</addon:addon>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
@@ -92,5 +92,12 @@
 			<default>false</default>
 		</parameter>
 
+		<parameter name="camelToSnakeCase" type="boolean" required="true" groupName="misc">
+			<label>Camel to Snake Case</label>
+			<description>Whether item names should be converted from CamelCase to snake_case ("TestItem" -> "test_item"). Only
+				for measurement name, not for tags. Also applies to alias names.</description>
+			<default>false</default>
+		</parameter>
+
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
@@ -85,5 +85,11 @@
 			<default>false</default>
 		</parameter>
 
+		<parameter name="addUnitTag" type="boolean" required="true" groupName="tags">
+			<label>Add Unit Tag</label>
+			<description>Should the item measurement unit symbol be included as tag "unit" on QuantityType items? If no unit is set tag will not be added.</description>
+			<default>false</default>
+		</parameter>
+
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
@@ -87,7 +87,8 @@
 
 		<parameter name="addUnitTag" type="boolean" required="true" groupName="tags">
 			<label>Add Unit Tag</label>
-			<description>Should the item measurement unit symbol be included as tag "unit" on QuantityType items? If no unit is set tag will not be added.</description>
+			<description>Should the item measurement unit symbol be included as tag "unit" on QuantityType items? If no unit is
+				set tag will not be added.</description>
 			<default>false</default>
 		</parameter>
 

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
@@ -52,19 +52,18 @@
 				requires it).</description>
 		</parameter>
 
-		<parameter name="source" type="text" required="true" groupName="connection">
-			<label>Source Tag Value</label>
-			<!-- VM supports multi-tenancy via "db" query param; not always needed -->
-			<description>The name of the source tag (change this if you need to manage multiple openhab instances on the same
-				endpoint)</description>
-			<default>openhab</default>
+		<parameter name="measurementPrefix" type="text" required="true" groupName="misc">
+			<label>Name prefix</label>
+			<description>Prefix for measurement names. If set, the prefix will be added to all measurements (e.g., "myPrefix_").
+				If not set, no prefix is added. This is applied after the item name is converted to snake_case (if enabled).</description>
+			<default>openhab_</default>
 		</parameter>
 
-		<parameter name="replaceUnderscore" type="boolean" required="true" groupName="misc">
-			<label>Replace Underscore</label>
-			<description>Whether underscores "_" in item names should be replaced by a dot "." ("test_item" -> "test.item"). Only
+		<parameter name="camelToSnakeCase" type="boolean" required="true" groupName="misc">
+			<label>Camel to Snake Case</label>
+			<description>Whether item names should be converted from CamelCase to snake_case ("TestItem" -> "test_item"). Only
 				for measurement name, not for tags. Also applies to alias names.</description>
-			<default>false</default>
+			<default>true</default>
 		</parameter>
 
 		<parameter name="addCategoryTag" type="boolean" required="true" groupName="tags">
@@ -91,13 +90,5 @@
 				set tag will not be added.</description>
 			<default>false</default>
 		</parameter>
-
-		<parameter name="camelToSnakeCase" type="boolean" required="true" groupName="misc">
-			<label>Camel to Snake Case</label>
-			<description>Whether item names should be converted from CamelCase to snake_case ("TestItem" -> "test_item"). Only
-				for measurement name, not for tags. Also applies to alias names.</description>
-			<default>false</default>
-		</parameter>
-
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+	<config-description uri="persistence:victoriametrics">
+
+		<parameter-group name="connection">
+			<label>Connection</label>
+			<description>This group defines connection parameters.</description>
+			<advanced>false</advanced>
+		</parameter-group>
+
+		<parameter-group name="tags">
+			<label>Additional Tags</label>
+			<description>This group defines additional tags which can be added to your measurements.</description>
+			<advanced>false</advanced>
+		</parameter-group>
+
+		<parameter-group name="misc">
+			<label>Miscellaneous</label>
+			<description>This group defines miscellaneous parameters.</description>
+			<advanced>false</advanced>
+		</parameter-group>
+
+		<parameter name="url" type="text" required="true" groupName="connection">
+			<context>url</context>
+			<label>Victoria Metrics URL</label>
+			<!-- VictoriaMetrics default is port 8428, not 8086 -->
+			<description>The VictoriaMetrics base URL (e.g., http://127.0.0.1:8428)</description>
+			<default>http://127.0.0.1:8428</default>
+		</parameter>
+
+		<parameter name="user" type="text" required="false" groupName="connection">
+			<label>Username</label>
+			<!-- Only relevant if using HTTP basic auth (not default in VM OSS) -->
+			<description>Basic auth username (only needed if HTTP Basic Auth is enabled in VictoriaMetrics).</description>
+		</parameter>
+
+		<parameter name="password" type="text" required="false" groupName="connection">
+			<context>password</context>
+			<label>Password</label>
+			<!-- Only relevant if using HTTP basic auth (not default in VM OSS) -->
+			<description>Basic auth password (only needed if HTTP Basic Auth is enabled in VictoriaMetrics).</description>
+		</parameter>
+
+		<parameter name="token" type="text" required="false" groupName="connection">
+			<label>Authentication Token</label>
+			<!-- VM supports Bearer token only on some enterprise setups -->
+			<description>The token to authenticate (Bearer token, typically used in VictoriaMetrics Enterprise or if
+				reverse proxy
+				requires it).</description>
+		</parameter>
+
+		<parameter name="source" type="text" required="true" groupName="connection">
+			<label>Source Tag Value</label>
+			<!-- VM supports multi-tenancy via "db" query param; not always needed -->
+			<description>The name of the source tag (change this if you need to manage multiple openhab instances on the same
+				endpoint)</description>
+			<default>openhab</default>
+		</parameter>
+
+		<parameter name="replaceUnderscore" type="boolean" required="true" groupName="misc">
+			<label>Replace Underscore</label>
+			<description>Whether underscores "_" in item names should be replaced by a dot "." ("test_item" -> "test.item"). Only
+				for measurement name, not for tags. Also applies to alias names.</description>
+			<default>false</default>
+		</parameter>
+
+		<parameter name="addCategoryTag" type="boolean" required="true" groupName="tags">
+			<label>Add Category Tag</label>
+			<description>Should the category of the item be included as tag "category"? If no category is set, "n/a" is used.</description>
+			<default>false</default>
+		</parameter>
+
+		<parameter name="addTypeTag" type="boolean" required="true" groupName="tags">
+			<label>Add Type Tag</label>
+			<description>Should the item type be included as tag "type"?</description>
+			<default>false</default>
+		</parameter>
+
+		<parameter name="addLabelTag" type="boolean" required="true" groupName="tags">
+			<label>Add Label Tag</label>
+			<description>Should the item label be included as tag "label"? If no label is set, "n/a" is used.</description>
+			<default>false</default>
+		</parameter>
+
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
@@ -1,0 +1,37 @@
+# add-on
+
+addon.victoriametrics.name = VictoriaMetrics Persistence
+addon.victoriametrics.description = This is the persistence add-on for VictoriaMetrics.
+
+# add-on
+
+persistence.config.victoriametrics.addCategoryTag.label = Add Category Tag
+persistence.config.victoriametrics.addCategoryTag.description = Should the category of the item be included as tag "category"? If no category is set, "n/a" is used.
+persistence.config.victoriametrics.addLabelTag.label = Add Label Tag
+persistence.config.victoriametrics.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
+persistence.config.victoriametrics.addTypeTag.label = Add Type Tag
+persistence.config.victoriametrics.addTypeTag.description = Should the item type be included as tag "type"?
+persistence.config.victoriametrics.db.label = Database/Tenant
+persistence.config.victoriametrics.db.description = The name of the database/tenant (used in multi-tenant VictoriaMetrics setups; optional for most installations)
+persistence.config.victoriametrics.group.connection.label = Connection
+persistence.config.victoriametrics.group.connection.description = This group defines connection parameters.
+persistence.config.victoriametrics.group.misc.label = Miscellaneous
+persistence.config.victoriametrics.group.misc.description = This group defines miscellaneous parameters.
+persistence.config.victoriametrics.group.tags.label = Additional Tags
+persistence.config.victoriametrics.group.tags.description = This group defines additional tags which can be added to your measurements.
+persistence.config.victoriametrics.password.label = Database Password
+persistence.config.victoriametrics.password.description = Database password
+persistence.config.victoriametrics.replaceUnderscore.label = Replace Underscore
+persistence.config.victoriametrics.replaceUnderscore.description = Whether underscores "_" in item names should be replaced by a dot "." ("test_item" -> "test.item"). Only for measurement name, not for tags. Also applies to alias names.
+persistence.config.victoriametrics.retentionPolicy.label = Retention Policy / Bucket
+persistence.config.victoriametrics.retentionPolicy.description = Logical field for compatibility. Retention is a global server setting in VictoriaMetrics.
+persistence.config.victoriametrics.token.label = Authentication Token
+persistence.config.victoriametrics.token.description = The token to authenticate to database (alternative to username/password for VictoriaMetrics 2.0)
+persistence.config.victoriametrics.url.label = Database URL
+persistence.config.victoriametrics.url.description = The database URL, e.g. http://127.0.0.1:8428
+persistence.config.victoriametrics.user.label = Username
+persistence.config.victoriametrics.user.description = Database username
+persistence.config.victoriametrics.version.label = Database Version
+persistence.config.victoriametrics.version.description = VictoriaMetrics version
+persistence.config.victoriametrics.version.option.V1 = VictoriaMetrics 1
+persistence.config.victoriametrics.version.option.V2 = VictoriaMetrics 2

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
@@ -3,35 +3,38 @@
 addon.victoriametrics.name = VictoriaMetrics Persistence
 addon.victoriametrics.description = This is the persistence add-on for VictoriaMetrics.
 
-# add-on
+# add-on parameter groups
+
+persistence.config.victoriametrics.group.connection.label = Connection
+persistence.config.victoriametrics.group.connection.description = This group defines connection parameters.
+persistence.config.victoriametrics.group.tags.label = Additional Tags
+persistence.config.victoriametrics.group.tags.description = This group defines additional tags which can be added to your measurements.
+persistence.config.victoriametrics.group.misc.label = Miscellaneous
+persistence.config.victoriametrics.group.misc.description = This group defines miscellaneous parameters.
+
+# connection parameters
+
+persistence.config.victoriametrics.url.label = Victoria Metrics URL
+persistence.config.victoriametrics.url.description = The VictoriaMetrics base URL (e.g., http://127.0.0.1:8428)
+persistence.config.victoriametrics.user.label = Username
+persistence.config.victoriametrics.user.description = Basic auth username (only needed if HTTP Basic Auth is enabled in VictoriaMetrics).
+persistence.config.victoriametrics.password.label = Password
+persistence.config.victoriametrics.password.description = Basic auth password (only needed if HTTP Basic Auth is enabled in VictoriaMetrics).
+persistence.config.victoriametrics.token.label = Authentication Token
+persistence.config.victoriametrics.token.description = The token to authenticate (Bearer token, typically used in VictoriaMetrics Enterprise or if reverse proxy requires it).
+persistence.config.victoriametrics.source.label = Source Tag Value
+persistence.config.victoriametrics.source.description = The name of the source tag (change this if you need to manage multiple openhab instances on the same endpoint)
+
+# tag parameters
 
 persistence.config.victoriametrics.addCategoryTag.label = Add Category Tag
 persistence.config.victoriametrics.addCategoryTag.description = Should the category of the item be included as tag "category"? If no category is set, "n/a" is used.
-persistence.config.victoriametrics.addLabelTag.label = Add Label Tag
-persistence.config.victoriametrics.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
 persistence.config.victoriametrics.addTypeTag.label = Add Type Tag
 persistence.config.victoriametrics.addTypeTag.description = Should the item type be included as tag "type"?
-persistence.config.victoriametrics.db.label = Database/Tenant
-persistence.config.victoriametrics.db.description = The name of the database/tenant (used in multi-tenant VictoriaMetrics setups; optional for most installations)
-persistence.config.victoriametrics.group.connection.label = Connection
-persistence.config.victoriametrics.group.connection.description = This group defines connection parameters.
-persistence.config.victoriametrics.group.misc.label = Miscellaneous
-persistence.config.victoriametrics.group.misc.description = This group defines miscellaneous parameters.
-persistence.config.victoriametrics.group.tags.label = Additional Tags
-persistence.config.victoriametrics.group.tags.description = This group defines additional tags which can be added to your measurements.
-persistence.config.victoriametrics.password.label = Database Password
-persistence.config.victoriametrics.password.description = Database password
+persistence.config.victoriametrics.addLabelTag.label = Add Label Tag
+persistence.config.victoriametrics.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
+
+# misc parameters
+
 persistence.config.victoriametrics.replaceUnderscore.label = Replace Underscore
 persistence.config.victoriametrics.replaceUnderscore.description = Whether underscores "_" in item names should be replaced by a dot "." ("test_item" -> "test.item"). Only for measurement name, not for tags. Also applies to alias names.
-persistence.config.victoriametrics.retentionPolicy.label = Retention Policy / Bucket
-persistence.config.victoriametrics.retentionPolicy.description = Logical field for compatibility. Retention is a global server setting in VictoriaMetrics.
-persistence.config.victoriametrics.token.label = Authentication Token
-persistence.config.victoriametrics.token.description = The token to authenticate to database (alternative to username/password for VictoriaMetrics 2.0)
-persistence.config.victoriametrics.url.label = Database URL
-persistence.config.victoriametrics.url.description = The database URL, e.g. http://127.0.0.1:8428
-persistence.config.victoriametrics.user.label = Username
-persistence.config.victoriametrics.user.description = Database username
-persistence.config.victoriametrics.version.label = Database Version
-persistence.config.victoriametrics.version.description = VictoriaMetrics version
-persistence.config.victoriametrics.version.option.V1 = VictoriaMetrics 1
-persistence.config.victoriametrics.version.option.V2 = VictoriaMetrics 2

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
@@ -22,8 +22,6 @@ persistence.config.victoriametrics.password.label = Password
 persistence.config.victoriametrics.password.description = Basic auth password (only needed if HTTP Basic Auth is enabled in VictoriaMetrics).
 persistence.config.victoriametrics.token.label = Authentication Token
 persistence.config.victoriametrics.token.description = The token to authenticate (Bearer token, typically used in VictoriaMetrics Enterprise or if reverse proxy requires it).
-persistence.config.victoriametrics.source.label = Source Tag Value
-persistence.config.victoriametrics.source.description = The name of the source tag (change this if you need to manage multiple openhab instances on the same endpoint)
 
 # tag parameters
 
@@ -35,10 +33,10 @@ persistence.config.victoriametrics.addLabelTag.label = Add Label Tag
 persistence.config.victoriametrics.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
 persistence.config.victoriametrics.addUnitTag.label = Add Unit Tag
 persistence.config.victoriametrics.addUnitTag.description = Should the item measurement unit symbol be included as tag "unit" on QuantityType items? If no unit is set tag will not be added.
-persistence.config.victoriametrics.camelToSnakeCase.label = Camel to Snake Case
-persistence.config.victoriametrics.camelToSnakeCase.description = Whether item names should be converted from CamelCase to snake_case ("TestItem" -> "test_item"). Only for measurement name, not for tags. Also applies to alias names.
 
 # misc parameters
 
-persistence.config.victoriametrics.replaceUnderscore.label = Replace Underscore
-persistence.config.victoriametrics.replaceUnderscore.description = Whether underscores "_" in item names should be replaced by a dot "." ("test_item" -> "test.item"). Only for measurement name, not for tags. Also applies to alias names.
+persistence.config.victoriametrics.measurementPrefix.label = Prefix for Measurements
+persistence.config.victoriametrics.measurementPrefix.description = Prefix for measurement names. If set, the prefix will be added to all measurements (e.g., "myPrefix_"). If not set, no prefix is added. This is applied after the item name is converted to snake_case (if enabled).
+persistence.config.victoriametrics.camelToSnakeCase.label = Camel to Snake Case
+persistence.config.victoriametrics.camelToSnakeCase.description = Whether item names should be converted from CamelCase to snake_case ("TestItem" -> "test_item"). Only for measurement name, not for tags. Also applies to alias names.

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
@@ -33,6 +33,8 @@ persistence.config.victoriametrics.addTypeTag.label = Add Type Tag
 persistence.config.victoriametrics.addTypeTag.description = Should the item type be included as tag "type"?
 persistence.config.victoriametrics.addLabelTag.label = Add Label Tag
 persistence.config.victoriametrics.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
+persistence.config.victoriametrics.addUnitTag.label = Add Unit Tag
+persistence.config.victoriametrics.addUnitTag.description = Should the item measurement unit symbol be included as tag "unit" on QuantityType items? If no unit is set tag will not be added.
 
 # misc parameters
 

--- a/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
+++ b/bundles/org.openhab.persistence.victoriametrics/src/main/resources/OH-INF/i18n/victoriametrics.properties
@@ -35,6 +35,8 @@ persistence.config.victoriametrics.addLabelTag.label = Add Label Tag
 persistence.config.victoriametrics.addLabelTag.description = Should the item label be included as tag "label"? If no label is set, "n/a" is used.
 persistence.config.victoriametrics.addUnitTag.label = Add Unit Tag
 persistence.config.victoriametrics.addUnitTag.description = Should the item measurement unit symbol be included as tag "unit" on QuantityType items? If no unit is set tag will not be added.
+persistence.config.victoriametrics.camelToSnakeCase.label = Camel to Snake Case
+persistence.config.victoriametrics.camelToSnakeCase.description = Whether item names should be converted from CamelCase to snake_case ("TestItem" -> "test_item"). Only for measurement name, not for tags. Also applies to alias names.
 
 # misc parameters
 

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/ItemToStorePointCreatorTest.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/ItemToStorePointCreatorTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConfiguration.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.DefaultLocation;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.i18n.UnitProvider;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.persistence.victoriametrics.internal.ItemTestHelper;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConstants;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsMetadataService;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsPoint;
+
+/**
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault(value = { DefaultLocation.PARAMETER, DefaultLocation.RETURN_TYPE })
+public class ItemToStorePointCreatorTest {
+
+    private static final Map<String, Object> BASE_CONFIGURATION = Map.of(URL_PARAM, "http://localhost:8428", USER_PARAM,
+            "user", PASSWORD_PARAM, "password", SOURCE_PARAM, "openhab");
+
+    private @Mock UnitProvider unitProviderMock;
+    private @Mock ItemRegistry itemRegistryMock;
+    private @Mock MetadataRegistry metadataRegistry;
+    private VictoriaMetricsPersistenceService instance;
+
+    @BeforeEach
+    public void setup() {
+        instance = getService(false, false, false, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void convertBasicItem(Number number) throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", number);
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getMetricName(), equalTo(item.getName()));
+        assertThat("Must Store item name", point.getTags(), hasEntry("item", item.getName()));
+        assertThat(point.getValue(), equalTo(new BigDecimal(number.toString())));
+    }
+
+    @SuppressWarnings("unused")
+    private static Stream<Number> convertBasicItem() {
+        return Stream.of(5, 5.5, 5L);
+    }
+
+    @Test
+    public void shouldUseAliasAsMeasurementNameIfProvided() throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), "aliasName").get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getMetricName(), is("aliasName"));
+    }
+
+    @Test
+    public void shouldStoreCategoryTagIfProvidedAndConfigured() throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+        item.setCategory("categoryValue");
+
+        instance = getService(false, true, false, false);
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), hasEntry(VictoriaMetricsConstants.TAG_CATEGORY_NAME, "categoryValue"));
+
+        instance = getService(false, false, false, false);
+        point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), not(hasKey(VictoriaMetricsConstants.TAG_CATEGORY_NAME)));
+    }
+
+    @Test
+    public void shouldStoreTypeTagIfProvidedAndConfigured() throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+
+        instance = getService(false, false, false, true);
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), hasEntry(VictoriaMetricsConstants.TAG_TYPE_NAME, "Number"));
+
+        instance = getService(false, false, false, false);
+        point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), not(hasKey(VictoriaMetricsConstants.TAG_TYPE_NAME)));
+    }
+
+    @Test
+    public void shouldStoreTypeLabelIfProvidedAndConfigured() throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+        item.setLabel("ItemLabel");
+
+        instance = getService(false, false, true, false);
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), hasEntry(VictoriaMetricsConstants.TAG_LABEL_NAME, "ItemLabel"));
+
+        instance = getService(false, false, false, false);
+        point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), not(hasKey(VictoriaMetricsConstants.TAG_LABEL_NAME)));
+    }
+
+    @Test
+    public void shouldStoreMetadataAsTagsIfProvided() throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+        MetadataKey metadataKey = new MetadataKey(VictoriaMetricsPersistenceService.SERVICE_NAME, item.getName());
+
+        when(metadataRegistry.get(metadataKey))
+                .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
+
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), null).get();
+
+        if (point == null) {
+            Assertions.fail("'point' is null");
+            return;
+        }
+
+        assertThat(point.getTags(), hasEntry("key1", "val1"));
+        assertThat(point.getTags(), hasEntry("key2", "val2"));
+    }
+
+    @Test
+    public void shouldUseMeasurementNameFromMetadataIfProvided() throws ExecutionException, InterruptedException {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+        MetadataKey metadataKey = new MetadataKey(VictoriaMetricsPersistenceService.SERVICE_NAME, item.getName());
+
+        VictoriaMetricsPoint point = instance.convert(item, item.getState(), Instant.now(), null).get();
+        if (point == null) {
+            Assertions.fail();
+            return;
+        }
+        assertThat(point.getMetricName(), equalTo(item.getName()));
+
+        point = instance.convert(item, item.getState(), Instant.now(), null).get();
+        if (point == null) {
+            Assertions.fail();
+            return;
+        }
+        assertThat(point.getMetricName(), equalTo(item.getName()));
+        assertThat(point.getTags(), hasEntry("item", item.getName()));
+
+        when(metadataRegistry.get(metadataKey))
+                .thenReturn(new Metadata(metadataKey, "measurementName", Map.of("key1", "val1", "key2", "val2")));
+
+        point = instance.convert(item, item.getState(), Instant.now(), null).get();
+        if (point == null) {
+            Assertions.fail();
+            return;
+        }
+        assertThat(point.getMetricName(), equalTo("measurementName"));
+        assertThat(point.getTags(), hasEntry("item", item.getName()));
+
+        when(metadataRegistry.get(metadataKey))
+                .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
+
+        point = instance.convert(item, item.getState(), Instant.now(), null).get();
+        if (point == null) {
+            Assertions.fail();
+            return;
+        }
+        assertThat(point.getMetricName(), equalTo(item.getName()));
+        assertThat(point.getTags(), hasEntry("item", item.getName()));
+    }
+
+    private VictoriaMetricsPersistenceService getService(boolean replaceUnderscore, boolean category, boolean label,
+            boolean typeTag) {
+        VictoriaMetricsMetadataService metadataService = new VictoriaMetricsMetadataService(metadataRegistry);
+
+        Map<String, Object> configuration = new HashMap<>();
+        configuration.putAll(BASE_CONFIGURATION);
+        configuration.put(REPLACE_UNDERSCORE_PARAM, replaceUnderscore);
+        configuration.put(ADD_CATEGORY_TAG_PARAM, category);
+        configuration.put(ADD_LABEL_TAG_PARAM, label);
+        configuration.put(ADD_TYPE_TAG_PARAM, typeTag);
+
+        VictoriaMetricsPersistenceService instance = new VictoriaMetricsPersistenceService(itemRegistryMock,
+                metadataService, configuration);
+        instance.setItemFactory(new CoreItemFactory(unitProviderMock));
+        return instance;
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsCaseConvertUtilsTest.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsCaseConvertUtilsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsCaseConvertUtils;
+
+/**
+ * Unit tests for {@link VictoriaMetricsCaseConvertUtils}.
+ *
+ * @author Franz
+ */
+public class VictoriaMetricsCaseConvertUtilsTest {
+
+    @Test
+    public void testCamelToSnake() {
+        assertEquals("open_hab", VictoriaMetricsCaseConvertUtils.camelToSnake("OpenHAB"));
+        assertEquals("my_variable_name", VictoriaMetricsCaseConvertUtils.camelToSnake("myVariableName"));
+        assertEquals("simple", VictoriaMetricsCaseConvertUtils.camelToSnake("simple"));
+        assertEquals("ip_address", VictoriaMetricsCaseConvertUtils.camelToSnake("IPAddress"));
+        assertEquals("log_id", VictoriaMetricsCaseConvertUtils.camelToSnake("LogID"));
+        assertEquals("mqtt_topic_id", VictoriaMetricsCaseConvertUtils.camelToSnake("MQTTTopicID"));
+        assertEquals("abc", VictoriaMetricsCaseConvertUtils.camelToSnake("ABC"));
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConfiguration.*;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.persistence.victoriametrics.internal.ItemTestHelper;
+import org.openhab.persistence.victoriametrics.internal.UnexpectedConditionException;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsMetadataService;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsRepository;
+
+/**
+ * @author Joan Pujol Espinar - Initial contribution
+ * @author Franz - Initial VictoriaMetrics adaptation
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
+public class VictoriaMetricsPersistenceServiceTest {
+    private static final Map<String, Object> VALID_CONFIGURATION = Map.of(URL_PARAM, "http://localhost:8428",
+            USER_PARAM, "user", PASSWORD_PARAM, "password", SOURCE_PARAM, "openhab");
+
+    private static final Map<String, Object> INVALID_CONFIGURATION = Map.of(URL_PARAM, "http://localhost:8428",
+            USER_PARAM, "user", SOURCE_PARAM, "openhab");
+
+    private @Mock @NonNullByDefault({}) VictoriaMetricsRepository repositoryMock;
+
+    private final VictoriaMetricsMetadataService metadataService = new VictoriaMetricsMetadataService(
+            mock(MetadataRegistry.class));
+
+    @Test
+    public void activateWithValidConfigShouldConnectRepository() {
+        getService(VALID_CONFIGURATION);
+        verify(repositoryMock).connect();
+    }
+
+    @Test
+    public void activateWithInvalidConfigShouldFail() {
+        assertThrows(IllegalArgumentException.class, () -> getService(INVALID_CONFIGURATION));
+    }
+
+    @Test
+    public void storeItemWithConnectedRepository() throws UnexpectedConditionException {
+        VictoriaMetricsPersistenceService instance = getService(VALID_CONFIGURATION);
+        when(repositoryMock.isConnected()).thenReturn(true);
+        instance.store(ItemTestHelper.createNumberItem("number", 5));
+        verify(repositoryMock, timeout(5000)).write(any());
+    }
+
+    @Test
+    public void storeItemWithDisconnectedRepositoryIsIgnored() throws UnexpectedConditionException {
+        VictoriaMetricsPersistenceService instance = getService(VALID_CONFIGURATION);
+        when(repositoryMock.isConnected()).thenReturn(false);
+        instance.store(ItemTestHelper.createNumberItem("number", 5));
+        verify(repositoryMock, never()).write(any());
+    }
+
+    private VictoriaMetricsPersistenceService getService(Map<String, Object> config) {
+        return new VictoriaMetricsPersistenceService(mock(ItemRegistry.class), metadataService, config) {
+            @Override
+            protected VictoriaMetricsRepository createVictoriaMetricsRepository() {
+                return repositoryMock;
+            }
+        };
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsPersistenceServiceTest.java
@@ -42,10 +42,10 @@ import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsRepositor
 @NonNullByDefault
 public class VictoriaMetricsPersistenceServiceTest {
     private static final Map<String, Object> VALID_CONFIGURATION = Map.of(URL_PARAM, "http://localhost:8428",
-            USER_PARAM, "user", PASSWORD_PARAM, "password", SOURCE_PARAM, "openhab");
+            USER_PARAM, "user", PASSWORD_PARAM, "password", MEASUREMENT_PREFIX, "openhab_");
 
     private static final Map<String, Object> INVALID_CONFIGURATION = Map.of(URL_PARAM, "http://localhost:8428",
-            USER_PARAM, "user", SOURCE_PARAM, "openhab");
+            USER_PARAM, "user", MEASUREMENT_PREFIX, "openhab_");
 
     private @Mock @NonNullByDefault({}) VictoriaMetricsRepository repositoryMock;
 

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsRepositoryHttpTest.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsRepositoryHttpTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openhab.core.persistence.FilterCriteria;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsConfiguration;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsMetadataService;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsPoint;
+import org.openhab.persistence.victoriametrics.internal.VictoriaMetricsRepository;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+/**
+ * @author Franz - Initial contribution
+ */
+public class VictoriaMetricsRepositoryHttpTest {
+    private MockWebServer mockWebServer;
+    private VictoriaMetricsRepository repository;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        // Mock the metadata service
+        VictoriaMetricsMetadataService metadataService = Mockito.mock(VictoriaMetricsMetadataService.class);
+        Mockito.when(metadataService.getMeasurementNameOrDefault(Mockito.anyString())).thenReturn("test.metric");
+        // Create the configuration for VictoriaMetricsRepository
+        VictoriaMetricsConfiguration config = new VictoriaMetricsConfiguration(
+                Map.of("url", mockWebServer.url("/").toString()));
+        repository = new VictoriaMetricsRepository(config, metadataService);
+        // No need to connect here, as we are testing HTTP interactions
+    }
+
+    @AfterEach
+    public void teardown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testWritePoint() throws Exception {
+        // Arrange: VM expects HTTP 200 on write
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+        VictoriaMetricsPoint point = VictoriaMetricsPoint.newBuilder("test.metric", "openhab").withTime(Instant.now())
+                .withValue(123.3).withTag("location", "livingroom").build();
+        // Act
+        repository.write(List.of(point));
+        // Assert: Check the request format sent to VictoriaMetrics
+        var request = mockWebServer.takeRequest();
+        Assertions.assertEquals("/api/v1/import/prometheus", request.getPath()); // adapt as needed
+        Assertions.assertEquals("POST", request.getMethod());
+        String body = request.getBody().readUtf8();
+        assertTrue(body.contains("test.metric"));
+        assertTrue(body.contains("location=\"livingroom\""));
+    }
+
+    @Test
+    public void testQueryResponse() throws Exception {
+        String jsonResponse = "{\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[{\"metric\":{\"__name__\":\"test.metric\",\"location\":\"livingroom\"},\"value\":[1655304672,\"123.4\"]}]}}";
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(jsonResponse));
+        // Build real FilterCriteria object
+        ZonedDateTime begin = ZonedDateTime.ofInstant(Instant.now().minusSeconds(3600), ZoneId.systemDefault());
+        ZonedDateTime end = ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
+        FilterCriteria filter = new FilterCriteria().setItemName("test.metric").setBeginDate(begin).setEndDate(end);
+        var result = repository.query(filter);
+        assertNotNull(result);
+        // add more specific assertions depending on what repository.query(filter) returns
+    }
+}

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsRepositoryHttpTest.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/VictoriaMetricsRepositoryHttpTest.java
@@ -66,7 +66,7 @@ public class VictoriaMetricsRepositoryHttpTest {
     public void testWritePoint() throws Exception {
         // Arrange: VM expects HTTP 200 on write
         mockWebServer.enqueue(new MockResponse().setResponseCode(200));
-        VictoriaMetricsPoint point = VictoriaMetricsPoint.newBuilder("test.metric", "openhab").withTime(Instant.now())
+        VictoriaMetricsPoint point = VictoriaMetricsPoint.newBuilder("test.metric").withTime(Instant.now())
                 .withValue(123.3).withTag("location", "livingroom").build();
         // Act
         repository.write(List.of(point));

--- a/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/internal/ItemTestHelper.java
+++ b/bundles/org.openhab.persistence.victoriametrics/src/test/java/org/openhab/persistence/victoriametrics/internal/ItemTestHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.victoriametrics.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.types.DecimalType;
+
+/**
+ * @author Joan Pujol Espinar - Initial contribution
+ */
+@NonNullByDefault
+public class ItemTestHelper {
+
+    public static NumberItem createNumberItem(String name, Number value) {
+        NumberItem numberItem = new NumberItem(name);
+        if (value instanceof Integer || value instanceof Long) {
+            numberItem.setState(new DecimalType(value.longValue()));
+        } else {
+            numberItem.setState(new DecimalType(value.doubleValue()));
+        }
+        return numberItem;
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -487,6 +487,7 @@
     <module>org.openhab.persistence.mapdb</module>
     <module>org.openhab.persistence.mongodb</module>
     <module>org.openhab.persistence.rrd4j</module>
+    <module>org.openhab.persistence.victoriametrics</module>
     <!-- voice -->
     <module>org.openhab.voice.googlestt</module>
     <module>org.openhab.voice.googletts</module>


### PR DESCRIPTION
This PR introduces a new persistence binding for openHAB, enabling integration with VictoriaMetrics, a high-performance, scalable time-series database optimized for efficient storage and fast retrieval of metrics.

### Classification

This is a Novel Addition providing enhanced performance and ease of use for users looking for an alternative to InfluxDB, especially considering limitations and changes in InfluxDB 3.x support.

### Motivation and Goals

VictoriaMetrics offers significant performance improvements and simplicity in handling time-series data compared to other solutions such as InfluxDB. Given the community discussions around limitations and future uncertainty with InfluxDB (see [this thread](https://community.openhab.org/t/what-database-to-use-instead-of-influxdb/149874/21)), this new binding addresses the need for a robust alternative.

Additionally, aligning with [this proposal](https://community.openhab.org/t/proposal-micrometer-persistence-service/147306), efficient metrics management is becoming increasingly essential.

### Features for End Users

* Native support for reading and writing data using VictoriaMetrics (using prometheus protocol)
* Improved query performance and resource utilization.
* Seamless integration with openHAB's graphing and historical data visualization capabilities.
* Straightforward configuration similar to existing persistence bindings.

### Limitations

As of now FilterCriteria support is limited, i only support "EQ" and sorting DESCENDING/ASCENDING, currently the other operators are ignored (LT/GT...)

### Documentation

The binding includes detailed documentation explaining configuration options, setup procedures, and examples to help users integrate VictoriaMetrics easily into their openHAB installations.

### Guidelines and Checks

* This contribution follows the openHAB coding guidelines.
* Static code analysis checks have been performed and addressed where necessary.
* I have signed off my work as per the contributing guidelines.

# Testing

The binding has been tested in local environments. Further community testing is encouraged.

A built JAR is available at:
[https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/](https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/)

Additionally, discussions and feedback can be found and contributed to via the openHAB community forum:
[official thread](https://community.openhab.org/t/victoria-metrics-persistence-service/164343)