### PR TITLE
[jsscripting] Use Node.js 22.13.1 for webpack build

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -97,8 +97,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.15.1</version>
         <configuration>
-          <nodeVersion>v16.17.1</nodeVersion>
-          <!-- DO NOT DOWNGRADE: NodeJS < 16 doesn't support Apple Silicon -->
+          <nodeVersion>v22.13.1</nodeVersion>
           <workingDirectory>target/js</workingDirectory>
         </configuration>
         <executions>


### PR DESCRIPTION
This aligns with the Node.js version openhab-js is developed on.