### PR TITLE
[jsscripting] Infer Import-Package declaration during build

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/bnd.bnd
+++ b/bundles/org.openhab.automation.jsscripting/bnd.bnd
@@ -1,19 +1,19 @@
 Bundle-SymbolicName: ${project.artifactId}
 DynamicImport-Package: *
-Import-Package: org.openhab.core.automation.module.script,org.openhab.core.items,org.openhab.core.library.types,javax.management,javax.script,javax.xml.datatype,javax.xml.stream;version="[1.0,2)",org.osgi.framework;version="[1.8,2)",org.slf4j;version="[1.7,2)"
+Import-Package: !com.oracle.truffle.*,!org.graalvm.*,*
 Require-Capability:
-    osgi.extender:=
-      filter:="(osgi.extender=osgi.serviceloader.processor)",
-    osgi.serviceloader:=
-      filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)";
-      cardinality:=multiple
+  osgi.extender:=
+    filter:="(osgi.extender=osgi.serviceloader.processor)",
+  osgi.serviceloader:=
+    filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)";
+    cardinality:=multiple
 Require-Bundle: org.graalvm.sdk.collections;bundle-version="24.2.0",\
- org.graalvm.sdk.jniutils;bundle-version="24.2.0",\
- org.graalvm.sdk.nativeimage;bundle-version="24.2.0",\
- org.graalvm.sdk.word;bundle-version="24.2.0",\
- org.graalvm.shadowed.icu4j;bundle-version="24.2.0",\
- org.graalvm.truffle.truffle-compiler;bundle-version="24.2.0",\
- org.graalvm.truffle.truffle-runtime;bundle-version="24.2.0"
+  org.graalvm.sdk.jniutils;bundle-version="24.2.0",\
+  org.graalvm.sdk.nativeimage;bundle-version="24.2.0",\
+  org.graalvm.sdk.word;bundle-version="24.2.0",\
+  org.graalvm.shadowed.icu4j;bundle-version="24.2.0",\
+  org.graalvm.truffle.truffle-compiler;bundle-version="24.2.0",\
+  org.graalvm.truffle.truffle-runtime;bundle-version="24.2.0"
 
 SPI-Provider: *
 SPI-Consumer: *

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -15,11 +15,6 @@
   <name>openHAB Add-ons :: Bundles :: Automation :: JavaScript Scripting</name>
 
   <properties>
-    <bnd.importpackage>!sun.misc.*,
-      !sun.reflect.*,
-      !com.sun.management.*,
-      !jdk.internal.reflect.*,
-      !jdk.vm.ci.services</bnd.importpackage>
     <!-- Remember to check if the fix https://github.com/openhab/openhab-core/pull/4437 still works when upgrading GraalJS -->
     <graaljs.version>24.2.0</graaljs.version>
     <ohjs.version>openhab@5.11.1</ohjs.version>


### PR DESCRIPTION
Instead of manually declaring Import-Package (which was incomplete), let the Karaf Maven plugin infer those during build time and filter our what's provided by Require-Bundle.