### PR TITLE
[ring] Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -329,7 +329,7 @@
 /bundles/org.openhab.binding.resol/ @ramack
 /bundles/org.openhab.binding.revogi/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.rfxcom/ @martinvw @paulianttila
-/bundles/org.openhab.binding.ring/ @morph166955
+/bundles/org.openhab.binding.ring/ @psmedley
 /bundles/org.openhab.binding.rme/ @kgoderis
 /bundles/org.openhab.binding.robonect/ @reyem
 /bundles/org.openhab.binding.roku/ @mlobstein


### PR DESCRIPTION
In PR 18668, the ring binding was merged. I picked up on a previous PR from @morph166955 and got it to the point it can be merged. In doing so, I neglected to updated CODEOWNERS. This PR makes this change.