### PR TITLE
[rrd4j] Bugfix descending order

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -510,12 +510,13 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
             FetchData result = request.fetchData();
 
             List<HistoricItem> items = new ArrayList<>();
-            long ts = result.getFirstTimestamp();
             long step = result.getRowCount() > 1 ? result.getStep() : 0;
 
             double prevValue = Double.NaN;
             State prevState = null;
             double[] values = result.getValues(DATASOURCE_STATE);
+            // Descending order shall start with the last timestamp and go backward
+            long ts = (ordering == Ordering.DESCENDING) ? result.getLastTimestamp() : result.getFirstTimestamp();
             step = (ordering == Ordering.DESCENDING) ? -1 * step : step;
             int startIndex = (ordering == Ordering.DESCENDING) ? values.length - 1 : 0;
             int endIndex = (ordering == Ordering.DESCENDING) ? -1 : values.length;


### PR DESCRIPTION
Descending order started with `getFirstTimestamp`. Time steps are negative which shifts the iteration variable `ts`  _before_ start so all values are rejected.
Iteration starts now with `getFirstTimestamp` for ascending order and `getLastTimestamp` for descending order.