### PR TITLE
[jrubyscripting] Update version to 9.4.13.0

### DIFF
--- a/bundles/org.openhab.automation.jrubyscripting/pom.xml
+++ b/bundles/org.openhab.automation.jrubyscripting/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <bnd.importpackage>com.sun.nio.*;resolution:=optional,com.sun.security.*;resolution:=optional,org.apache.tools.ant.*;resolution:=optional,org.bouncycastle.*;resolution:=optional,org.joda.*;resolution:=optional,sun.management.*;resolution:=optional,sun.nio.*;resolution:=optional,jakarta.annotation;resolution:=optional,jdk.crac.management;resolution:=optional</bnd.importpackage>
-    <jruby.version>9.4.9.0</jruby.version>
+    <jruby.version>9.4.13.0</jruby.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is an update for openHAB 4.3.x branch for jrubyscripting.

OH5 uses jruby 10.x so this doesn't apply to it.

Release Notes: https://www.jruby.org/2025/06/10/jruby-9-4-13-0.html

It contains many security fixes, but primarily:

- Fixed a slow memory leak in subclass management.

