### PR TITLE
[groovyscripting] Update Groovy to 4.0.27

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/README.md
+++ b/bundles/org.openhab.automation.groovyscripting/README.md
@@ -1,6 +1,6 @@
 # Groovy Scripting
 
-This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.26 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
+This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.27 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
 
 ## Creating Groovy Scripts
 

--- a/bundles/org.openhab.automation.groovyscripting/pom.xml
+++ b/bundles/org.openhab.automation.groovyscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <bnd.importpackage>com.ibm.icu.*;resolution:=optional,groovy.runtime.metaclass;resolution:=optional,groovyjarjarantlr4.stringtemplate;resolution:=optional,org.abego.treelayout.*;resolution:=optional,org.apache.ivy.*;resolution:=optional,org.fusesource.jansi.*;resolution:=optional,org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
-    <groovy.version>4.0.26</groovy.version>
+    <groovy.version>4.0.27</groovy.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Updates Groovy from 4.0.26 to 4.0.27.

For release notes, see https://groovy-lang.org/changelogs/changelog-4.0.27.html.

