### PR TITLE
[roku] Prevent progress bar calculation greater than 100%

### DIFF
--- a/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
+++ b/bundles/org.openhab.binding.roku/src/main/java/org/openhab/binding/roku/internal/handler/RokuHandler.java
@@ -217,7 +217,7 @@ public class RokuHandler extends BaseThingHandler {
                         updateState(TIME_TOTAL, UnDefType.UNDEF);
                     }
 
-                    if (position >= 0 && duration > 0) {
+                    if (duration > 0 && position >= 0 && position <= duration) {
                         updateState(END_TIME, new DateTimeType(Instant.now().plusSeconds(duration - position)));
                         updateState(PROGRESS,
                                 new PercentType(BigDecimal.valueOf(Math.round(position / (double) duration * 100.0))));


### PR DESCRIPTION
Regression of #18059. Check to ensure that `position` is less than or equal to `duration` to avoid percent calculations greater than 100%. This will prevent the IllegalArgumentException that can occur when updating the state value that uses PercentType. I have only noticed this once in my logs as seen below:
![image](https://github.com/user-attachments/assets/7db6ba2b-dbfe-487b-b85b-010c66a58f0d)
