### PR TITLE
[Flume] Fixed usage alert not firing

### DIFF
--- a/bundles/org.openhab.binding.flume/src/main/java/org/openhab/binding/flume/internal/api/FlumeApi.java
+++ b/bundles/org.openhab.binding.flume/src/main/java/org/openhab/binding/flume/internal/api/FlumeApi.java
@@ -385,7 +385,7 @@ public class FlumeApi {
      * @throws ExecutionException
      * @throws IOException
      */
-    private JsonObject sendAndValidate(Request request, boolean verifyToken)
+    private synchronized JsonObject sendAndValidate(Request request, boolean verifyToken)
             throws FlumeApiException, InterruptedException, TimeoutException, ExecutionException, IOException {
         ContentResponse response;
 


### PR DESCRIPTION
# Description

This fix address an issue where the usage-alert were not being queried correctly. This was brought up in the following thread on the forum: [thread](https://community.openhab.org/t/flume-water-monitoring/119526/22?u=jsjames)

This addresses several issues:
- the expiry time was not reseting in the proper location, and hence the call to query the usage-alerts was occurring every 1 minute (vs. 5)
- The logic condition was incorrect and hence the query was very sporadic (only occurring when forceUpdate was true)

# Testing

This is now working as expected in my home environment for the last several days.
