### PR TITLE
[mercedesme] Message dumps

### DIFF
--- a/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
+++ b/bundles/org.openhab.binding.mercedesme/src/main/java/org/openhab/binding/mercedesme/internal/server/MBWebsocket.java
@@ -13,8 +13,6 @@
 package org.openhab.binding.mercedesme.internal.server;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -70,7 +68,6 @@ public class MBWebsocket {
     private Instant runTill = Instant.now();
     private @Nullable Session session;
     private List<ClientMessage> commandQueue = new ArrayList<>();
-    private List<File> fileDumps = new ArrayList<>();
 
     private boolean keepAlive = false;
 
@@ -182,10 +179,6 @@ public class MBWebsocket {
      */
     public void dispose() {
         interrupt();
-        fileDumps.forEach(file -> {
-            file.delete();
-        });
-        fileDumps.clear();
     }
 
     public void keepAlive(boolean b) {
@@ -234,23 +227,6 @@ public class MBWebsocket {
              */
         } catch (IOException e) {
             logger.warn("IOException decoding message {}", e.getMessage());
-            try {
-                // write max 10 file dumps
-                if (fileDumps.size() >= 10) {
-                    logger.warn("MercedesMe Max File dump exceeded - please report files from {}",
-                            fileDumps.get(0).getCanonicalPath());
-                } else {
-                    String sizeInfo = blob.length + "-" + length + "-" + offset + "-";
-                    File outputFile = File.createTempFile("mercedesme-" + sizeInfo, null);
-                    FileOutputStream outputStream = new FileOutputStream(outputFile);
-                    outputStream.write(blob);
-                    outputStream.close();
-                    fileDumps.add(outputFile);
-                    logger.warn("MercedesMe File dump {}", outputFile.getCanonicalPath());
-                }
-            } catch (IOException e1) {
-                logger.warn("MercedesMe File dump error {}", e1.getMessage());
-            }
         } catch (Error err) {
             logger.warn("Error decoding message {}", err.getMessage());
         }

--- a/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/internal/handler/AccountHandlerMock.java
+++ b/bundles/org.openhab.binding.mercedesme/src/test/java/org/openhab/binding/mercedesme/internal/handler/AccountHandlerMock.java
@@ -90,7 +90,7 @@ public class AccountHandlerMock extends AccountHandler {
     }
 
     public void connect() {
-        super.ws.onConnect(mock(Session.class));
+        super.mbWebsocket.onConnect(mock(Session.class));
     }
 
     @Override


### PR DESCRIPTION
There are sporadic issues raised in community that proto messages cannot be decoded. This is shown in the logs with an `IOException`.
See
https://community.openhab.org/t/mercedes-me/136866/119
https://community.openhab.org/t/mercedes-me/136866/113

**Problem**
Binary response cannot be logged so I'm _blind_ about the root cause.

**My proposal**
If message decoding exception occurs I'm writing a file into `temp` directory. Implementation ensures
- max 10 files are written
- for info: file size is approx 7KB
- files are deleted in `dispose` so openhab restart or stopping thing will deleted them in order to keep temp dir clean

