### PR TITLE
[asuswrt] Additional fix to address recovery when offline

### DIFF
--- a/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/constants/AsuswrtBindingSettings.java
+++ b/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/constants/AsuswrtBindingSettings.java
@@ -37,9 +37,10 @@ public class AsuswrtBindingSettings {
     public static final Boolean HTTP_SSL_TRUST_ALL = true; // trust all ssl-certs
 
     public static final Integer COOKIE_LIFETIME_S = 3600; // lifetime of login-cookie
-    public static final Integer POLLING_INTERVAL_S_MIN = 5; // minimum polling interval
-    public static final Integer POLLING_INTERVAL_S_DEFAULT = 20; // default polling interval
-    public static final Integer RECONNECT_INTERVAL_S = 30; // interval trying try to reconnect to router
+    public static final Integer POLLING_INTERVAL_MIN_S = 5; // minimum polling interval
+    public static final Integer POLLING_INTERVAL_DEFAULT_S = 20; // default polling interval
+    public static final Integer RECONNECT_BACKOFF_START_S = 30;
+    public static final Integer RECONNECT_BACKOFF_MAX_S = 3000;
     public static final Integer DISCOVERY_TIMEOUT_S = 10; // discovery service timeout in s
     public static final Integer DISCOVERY_AUTOREMOVE_S = 1800; // discovery service remove things after x seconds
 

--- a/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/structures/AsuswrtConfiguration.java
+++ b/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/structures/AsuswrtConfiguration.java
@@ -36,7 +36,6 @@ public class AsuswrtConfiguration {
     public String username = "";
     public String password = "";
     public int pollingInterval = 20;
-    public int reconnectInterval = 60;
     public int discoveryInterval = 3600;
     public int httpPort = 80;
     public int httpsPort = 443;


### PR DESCRIPTION
This is an additional fix/enhancement so that the binding can recover on an interrupted connection (#18456).

Current implementation:

when the router goes offline, the binding starts a reconnectJobScheduler job which will call reconnectJobAction at the appropriate time. This reconnectJobAction attempts to connect(). However, if the connect is unsuccessful, no further action is taken and hence no additional reconnect will be attempted in the future.

New implementation (fix);

when reconnectJobAction calls connect(), connect() now returns whether it was successful or not.  If unsuccessful, reconnectJobScheduler is rescheduled for sometime in the future - using a exponential backoff delay.

# Testing

This fix has been successfully running in my setup for over 1 month without issues and able to recover in the case of a connection disruption.
