### PR TITLE
[shelly] Add support for Shelly Plug S Gen3, Outdoor Plug S Gen3, AZ Plug

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -86,7 +86,8 @@ See section [Discovery](#discovery) for details.
 | shellyplus1pm        | Shelly Plus 1PM with 1x relay + power meter              | SNSW-001P16EU, S3SW-001P16EU, S4SW-001P16EU |
 | shellyplus2pm-relay  | Shelly Plus 2PM with 2x relay + power meter, relay mode  | SNSW-002P16EU, SNSW-102P16EU                |
 | shellyplus2pm-roller | Shelly Plus 2PM with 2x relay + power meter, roller mode | SNSW-002P16EU, SNSW-102P16EU                |
-| shellyplusplug       | Shelly Plug-S                                            | SNPL-00112EU                                |
+| shellyplusplug       | Shelly Plug-S Gen 3, Shelly AZ Plug                      | SNPL-00112EU                                |
+| shellyplusplug       | Shelly Outdoor Plug-S                                    | S3PL-20112EU                                |
 | shellyplusplug       | Shelly Plug-IT                                           | SNPL-00110IT                                |
 | shellyplusplug       | Shelly Plug-UK                                           | SNPL-00112UK                                |
 | shellyplusplugus     | Shelly Plug-US                                           | SNPL-00116US                                |
@@ -99,7 +100,7 @@ See section [Discovery](#discovery) for details.
 | shellypluswdus       | Shelly Plus Wall Dimmer US                               | SNDM-0013US                                 |
 | shellyplusrgbwpm     | Shelly Plus RGBW PM                                      | SNDC-0D4P10WW                               |
 | shellywalldisplay    | Shelly Plus Wall Display                                 | SAWD-0A1XX10EU1                             |
-| shellyblugw          | SHelly BLU Gateway                                       | SNGW-BT01                                   |
+| shellyblugw          | Shelly BLU Gateway                                       | SNGW-BT01                                   |
 
 ### Shelly Plus Mini series (Generation 2+3+4)
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -81,10 +81,12 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_PLUS2PMUL_ROLLER = "SNSW-002P15UL-roller";
     public static final String SHELLYDT_PLUSPLUGS = "SNPL-00112EU";
     public static final String SHELLYDT_PLUSPLUGS_2 = "SNPL-10112EU";
+    public static final String SHELLYDT_PLUSPLUGSG3 = "S3PL-00112EU"; // Shelly Plug-S G3, Shelly AZ Plug
+    public static final String SHELLYDT_PLUSPLUGOUTDOORSG3 = "S3PL-20112EU";
+
     public static final String SHELLYDT_PLUSPLUGIT = "SNPL-00110IT";
     public static final String SHELLYDT_PLUSPLUGUK = "SNPL-00112UK";
     public static final String SHELLYDT_PLUSPLUGUS = "SNPL-00116US";
-    public static final String SHELLYDT_PLUSPLUGSG3 = "S3PL-00112EU";
     public static final String SHELLYDT_PLUSI4 = "SNSN-0024X";
     public static final String SHELLYDT_PLUSI4G3 = "S3SN-0024X";
     public static final String SHELLYDT_PLUSI4DC = "SNSN-0D24X";
@@ -158,7 +160,7 @@ public class ShellyThingCreator {
     public static final String THING_TYPE_SHELLY4PRO_STR = "shelly4pro";
     public static final String THING_TYPE_SHELLYPLUG_STR = "shellyplug";
     public static final String THING_TYPE_SHELLYPLUGS_STR = "shellyplugs";
-    public static final String THING_TYPE_SHELLYPLUGU1_STR = "shellyplugu1"; // Shely Plug US
+    public static final String THING_TYPE_SHELLYPLUGU1_STR = "shellyplugu1"; // Shelly Plug US
     public static final String THING_TYPE_SHELLYDIMMER_STR = "shellydimmer";
     public static final String THING_TYPE_SHELLYDIMMER2_STR = "shellydimmer2";
     public static final String THING_TYPE_SHELLYIX3_STR = "shellyix3";
@@ -184,7 +186,7 @@ public class ShellyThingCreator {
     public static final String THING_TYPE_SHELLYBUTTON2_STR = "shellybutton2";
     public static final String THING_TYPE_SHELLYUNI_STR = "shellyuni";
 
-    // Shelly Plus Seriens
+    // Shelly Plus Series
     public static final String THING_TYPE_SHELLYPLUS1_STR = "shellyplus1";
     public static final String THING_TYPE_SHELLYPLUS1G3_STR = "shelly1g3";
     public static final String THING_TYPE_SHELLYPLUS1G4_STR = "shelly1g4";
@@ -419,10 +421,11 @@ public class ShellyThingCreator {
             Map.entry(SHELLYDT_PLUS2PMG3_ROLLER, THING_TYPE_SHELLYPLUS2PM_ROLLER_STR),
             Map.entry(SHELLYDT_PLUSPLUGS, THING_TYPE_SHELLYPLUSPLUGS_STR),
             Map.entry(SHELLYDT_PLUSPLUGS_2, THING_TYPE_SHELLYPLUSPLUGS_STR),
+            Map.entry(SHELLYDT_PLUSPLUGSG3, THING_TYPE_SHELLYPLUSPLUGS_STR),
             Map.entry(SHELLYDT_PLUSPLUGIT, THING_TYPE_SHELLYPLUSPLUGS_STR),
+            Map.entry(SHELLYDT_PLUSPLUGOUTDOORSG3, THING_TYPE_SHELLYPLUSPLUGS_STR),
             Map.entry(SHELLYDT_PLUSPLUGUK, THING_TYPE_SHELLYPLUSPLUGS_STR),
             Map.entry(SHELLYDT_PLUSPLUGUS, THING_TYPE_SHELLYPLUSPLUGUS_STR),
-            Map.entry(SHELLYDT_PLUSPLUGSG3, THING_TYPE_SHELLYPLUSPLUGS_STR),
             Map.entry(SHELLYDT_PLUSI4, THING_TYPE_SHELLYPLUSI4_STR),
             Map.entry(SHELLYDT_PLUSI4G3, THING_TYPE_SHELLYPLUSI4_STR),
             Map.entry(SHELLYDT_PLUSI4DC, THING_TYPE_SHELLYPLUSI4DC_STR),
@@ -606,7 +609,8 @@ public class ShellyThingCreator {
         if (serviceNameLowerCase.startsWith(THING_TYPE_SHELLY2_PREFIX)) { // Shelly v2
             return getRelayOrRollerType(THING_TYPE_SHELLY2_RELAY_STR, THING_TYPE_SHELLY2_ROLLER_STR, mode);
         }
-        if (serviceNameLowerCase.startsWith(THING_TYPE_SHELLYPLUG_STR) && !serviceNameLowerCase.contains("plugus")) {
+        if (serviceNameLowerCase.startsWith(THING_TYPE_SHELLYPLUG_STR) && !serviceNameLowerCase.contains("plugus")
+                && !serviceNameLowerCase.contains("plugsg3")) {
             // shellyplug-s needs to be mapped to shellyplugs to follow the schema
             // for the thing types: <thing type>-<mode>
             if (serviceNameLowerCase.startsWith(THING_TYPE_SHELLYPLUGS_STR) || serviceNameLowerCase.contains("-s")) {

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -151,7 +151,9 @@ public class ShellyThingCreatorTest {
                 Arguments.of("SNSW-102P16EU", "relay", THING_TYPE_SHELLYPLUS2PM_RELAY_STR), //
                 Arguments.of("SNSW-102P16EU", "roller", THING_TYPE_SHELLYPLUS2PM_ROLLER_STR), //
                 Arguments.of(SHELLYDT_PLUSPLUGS, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
+                Arguments.of(SHELLYDT_PLUSPLUGSG3, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
                 Arguments.of(SHELLYDT_PLUSPLUGIT, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
+                Arguments.of(SHELLYDT_PLUSPLUGOUTDOORSG3, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
                 Arguments.of(SHELLYDT_PLUSPLUGUK, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
                 Arguments.of(SHELLYDT_PLUSPLUGUS, "", THING_TYPE_SHELLYPLUSPLUGUS_STR), //
                 Arguments.of(SHELLYDT_PLUSI4DC, "", THING_TYPE_SHELLYPLUSI4DC_STR), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -75,6 +75,9 @@ public class ShellyThingCreatorTest {
     private static Stream<Arguments> provideTestCasesForGetThingUIDReturnsThingUidAccordingToRuleset() {
         return Stream.of( //
                 Arguments.of("johndoe-" + DEVICE_ID, "", "", "shellyunknown"), //
+                Arguments.of("shellyazplug-" + DEVICE_ID, SHELLYDT_PLUSPLUGSG3, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
+                Arguments.of("shellyoutdoorsg3-" + DEVICE_ID, SHELLYDT_PLUSPLUGOUTDOORSG3, "",
+                        THING_TYPE_SHELLYPLUSPLUGS_STR), //
                 Arguments.of("shellyswitch25-" + DEVICE_ID, "", "relay", THING_TYPE_SHELLY25_RELAY_STR), //
                 Arguments.of("shellyswitch25xx-" + DEVICE_ID, "", "relay", THING_TYPE_SHELLY25_RELAY_STR), //
                 Arguments.of("shellyswitch25xx-" + DEVICE_ID, "", "", THING_TYPE_SHELLY25_ROLLER_STR), //
@@ -85,6 +88,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of("shellyplug-" + DEVICE_ID, "", "", THING_TYPE_SHELLYPLUG_STR), //
                 Arguments.of("shellyplug-u1-" + DEVICE_ID, "", "", THING_TYPE_SHELLYPLUG_STR), //
                 Arguments.of("shellyplugs-" + DEVICE_ID, "", "", THING_TYPE_SHELLYPLUGS_STR), //
+                Arguments.of("shellyplugsg3-" + DEVICE_ID, SHELLYDT_PLUSPLUGSG3, "", THING_TYPE_SHELLYPLUSPLUGS_STR), //
                 Arguments.of("shellyplug-s-" + DEVICE_ID, "", "", THING_TYPE_SHELLYPLUGS_STR), //
                 Arguments.of("shellyplug-su1-" + DEVICE_ID, "", "", THING_TYPE_SHELLYPLUGS_STR), //
                 Arguments.of("shellyplugu1-" + DEVICE_ID, "", "", THING_TYPE_SHELLYPLUGU1_STR), //


### PR DESCRIPTION
The changes in #17869 do not seem to work because this is a gen3 device.
Also adds support for Shelly Outdoor Plug S Gen3 and Shelly AZ Plug.