### PR TITLE
[teslapowerwall] Fix error with JSON parsing

### DIFF
--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
@@ -65,13 +65,13 @@ public class MeterAggregates {
         public float instantAverageCurrent;
 
         @SerializedName("i_a_current")
-        public int iaCurrent;
+        public float iaCurrent;
 
         @SerializedName("i_b_current")
-        public int ibCurrent;
+        public float ibCurrent;
 
         @SerializedName("i_c_current")
-        public int icCurrent;
+        public float icCurrent;
 
         @SerializedName("last_phase_voltage_communication_time")
         public String lastPhaseVoltageCommunicationTime = "";
@@ -83,7 +83,7 @@ public class MeterAggregates {
         public String lastPhaseEnergyCommunicationTime = "";
 
         @SerializedName("timeout")
-        public int timeout;
+        public float timeout;
 
         @SerializedName("instant_total_current")
         public float instantTotalCurrent;


### PR DESCRIPTION
One of my powerwalls starting reporting a gson parsing error today:
`Expected an int but was 60000000000 at line 1 column 570 path $.site.timeout`

I updated the class to a float for timeout and a few others to be safe.