### PR TITLE
[froniuswattpilot] Improve dispose behaviour & Upgrade wattpilot4j

### DIFF
--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.florianhotze.sdk</groupId>
       <artifactId>wattpilot4j</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.2.0</bundle>
+		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.3.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
This upgrades wattpilot4j to 1.3.0, allowing to:
- Remove the Thing handler from the listeners on dispose.
- Handle the wait-for-disconnect internally in wattpilot4j.