### PR TITLE
[jdbc] Downgrade dbutils to 1.6

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -21,7 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <hikari.version>5.1.0</hikari.version>
-    <dbutils.version>1.8.1</dbutils.version>
+    <dbutils.version>1.6</dbutils.version>
     <yank.version>3.5.0</yank.version>
 
     <!-- JDBC database driver versions -->


### PR DESCRIPTION
This reverts to the version prior to #18472, which seems to fix:
> java.util.ServiceConfigurationError: org.apache.commons.dbutils.ColumnHandler: org.apache.commons.dbutils.handlers.columns.StringColumnHandler not a subtype

Unfortunately that brings us back to the 2014 version of this dependency. Version 1.7 (from 2017) also causes the issue.

It seems that Yank 3.5 doesn't depend on anything new in 1.7+.

Regression of #18472
Resolves #18662