### PR TITLE
Fix unresolved property values in feature.xml files.

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -5,19 +5,19 @@
 
 	<feature name="openhab-automation-jsscripting" description="JavaScript Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.js.js-language/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.js.js-scriptengine/${graaljs.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/${graaljs.version}</bundle>
-		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/${graaljs.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/${graaljs.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.js.js-language/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.js.js-scriptengine/24.2.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/24.2.1</bundle>
+		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.2.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
@@ -4,23 +4,23 @@
 
 	<feature name="openhab-automation-pythonscripting" description="Python Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.llvm.llvm-api/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/${graalpy.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-language/${graalpy.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-resources/${graalpy.version}</bundle>
-		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/${graalpy.version}</bundle>
-		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/${graalpy.version}</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/${graalpy.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.llvm.llvm-api/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/24.2.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-language/24.2.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-resources/24.2.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/24.2.1</bundle>
+		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/24.2.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.2.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.pythonscripting/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
These properties do not exist outside the Maven projects causing the distro build to fail.

See: https://ci.openhab.org/job/openHAB-Distribution/4691/console

`[ERROR] Failed to execute goal org.apache.karaf.tooling:karaf-maven-plugin:4.4.7:kar (default-kar) on project openhab-addons: Cannot find version for: org.openhab.osgiify/org.graalvm.js.js-language/ -> [Help 1]`