### PR TITLE
[tuya] Allow refresh commands for offline Things

### DIFF
--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -259,16 +259,16 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (getThing().getStatus() != ThingStatus.ONLINE) {
-            logger.warn("Channel '{}' received a command but device is not ONLINE. Discarding command.", channelUID);
-            return;
-        }
-
         if (command instanceof RefreshType) {
             State state = channelStateCache.get(channelUID.getId());
             if (state != null) {
                 updateState(channelUID, state);
             }
+            return;
+        }
+
+        if (getThing().getStatus() != ThingStatus.ONLINE) {
+            logger.warn("Channel '{}' received a command but device is not ONLINE. Discarding command.", channelUID);
             return;
         }
 


### PR DESCRIPTION
There's nothing wrong with a newly linked Item showing the last state known if the Thing is offline. That's what already linked Items do.