### PR TITLE
[exec] Fix 'run' channel state not writable

### DIFF
--- a/bundles/org.openhab.binding.exec/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.exec/src/main/resources/OH-INF/thing/thing-types.xml
@@ -69,7 +69,7 @@
 		<item-type>Switch</item-type>
 		<label>Running</label>
 		<description>Send ON to execute the command and the current state tells whether it is running or not</description>
-		<state readOnly="true"></state>
+		<state readOnly="false"></state>
 	</channel-type>
 	<channel-type id="lastexecution">
 		<item-type>DateTime</item-type>


### PR DESCRIPTION
Seemed like a bug. Adding an item linked to the 'run' channel to android device controls and then pressing it - opened up the openhab app instead of invoking the channel. With this change it works correctly and invokes the channel immediately.
