### PR TITLE
Refactor timestamps to `Instant` in discovery methods

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -14,6 +14,7 @@ package org.openhab.binding.amazonechocontrol.internal.discovery;
 
 import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.*;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -53,7 +54,7 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
     private final Set<List<EnabledFeedTO>> discoveredFlashBriefings = new HashSet<>();
 
     private @Nullable ScheduledFuture<?> startScanStateJob;
-    private @Nullable Long activateTimeStamp;
+    private @Nullable Instant activateTimeStamp;
 
     public AmazonEchoDiscovery() {
         super(AccountHandler.class, SUPPORTED_ECHO_THING_TYPES_UIDS, 5);
@@ -62,7 +63,7 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
     @Override
     protected void startScan() {
         stopScanJob();
-        final Long activateTimeStamp = this.activateTimeStamp;
+        final Instant activateTimeStamp = this.activateTimeStamp;
         if (activateTimeStamp != null) {
             removeOlderResults(activateTimeStamp);
         }
@@ -111,7 +112,7 @@ public class AmazonEchoDiscovery extends AbstractThingHandlerDiscoveryService<Ac
     @Override
     public void initialize() {
         if (activateTimeStamp == null) {
-            activateTimeStamp = new Date().getTime();
+            activateTimeStamp = Instant.now();
         }
         super.initialize();
     }

--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/philipstv/PhilipsTVConnectionManager.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/philipstv/PhilipsTVConnectionManager.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -676,8 +677,14 @@ public class PhilipsTVConnectionManager implements DiscoveryListener {
     }
 
     @Override
-    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService discoveryService, long l,
-            @Nullable Collection<ThingTypeUID> collection, @Nullable ThingUID thingUID) {
+    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
         return Collections.emptyList();
     }
 

--- a/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/AsuswrtDiscoveryService.java
+++ b/bundles/org.openhab.binding.asuswrt/src/main/java/org/openhab/binding/asuswrt/internal/AsuswrtDiscoveryService.java
@@ -95,7 +95,7 @@ public class AsuswrtDiscoveryService extends AbstractThingHandlerDiscoveryServic
      * Removes all scan results.
      */
     private void removeAllResults() {
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     /**

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/discovery/IndegoDiscoveryService.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/discovery/IndegoDiscoveryService.java
@@ -84,6 +84,6 @@ public class IndegoDiscoveryService extends AbstractThingHandlerDiscoveryService
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 }

--- a/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.boschshc/src/main/java/org/openhab/binding/boschshc/internal/discovery/ThingDiscoveryService.java
@@ -128,7 +128,7 @@ public class ThingDiscoveryService extends AbstractThingHandlerDiscoveryService<
     public void dispose() {
         super.dispose();
         logger.trace("dispose");
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
         thingHandler.unregisterDiscoveryListener();
 
         super.deactivate();

--- a/bundles/org.openhab.binding.broadlinkthermostat/src/main/java/org/openhab/binding/broadlinkthermostat/internal/discovery/BroadlinkDiscoveryService.java
+++ b/bundles/org.openhab.binding.broadlinkthermostat/src/main/java/org/openhab/binding/broadlinkthermostat/internal/discovery/BroadlinkDiscoveryService.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.broadlinkthermostat.internal.BroadlinkBindingC
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -68,7 +69,7 @@ public class BroadlinkDiscoveryService extends AbstractDiscoveryService {
     }
 
     private void createScanner() {
-        var timestampOfLastScan = getTimestampOfLastScan();
+        Instant timestampOfLastScan = getTimestampOfLastScan();
         BLDevice[] blDevices = new BLDevice[0];
         try {
             @Nullable

--- a/bundles/org.openhab.binding.bticinosmarther/src/main/java/org/openhab/binding/bticinosmarther/internal/discovery/SmartherModuleDiscoveryService.java
+++ b/bundles/org.openhab.binding.bticinosmarther/src/main/java/org/openhab/binding/bticinosmarther/internal/discovery/SmartherModuleDiscoveryService.java
@@ -86,7 +86,7 @@ public class SmartherModuleDiscoveryService extends AbstractThingHandlerDiscover
     public void dispose() {
         super.dispose();
         logger.debug("Bridge[{}] Deactivating chronothermostat discovery service", this.bridgeUID);
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/discovery/DaikinACUnitDiscoveryService.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/discovery/DaikinACUnitDiscoveryService.java
@@ -17,6 +17,7 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class DaikinACUnitDiscoveryService extends AbstractDiscoveryService {
     }
 
     private void scanner() {
-        var timestampOfLastScan = getTimestampOfLastScan();
+        Instant timestampOfLastScan = getTimestampOfLastScan();
         for (InetAddress broadcastAddress : getBroadcastAddresses()) {
             logger.trace("Starting broadcast for {}", broadcastAddress.toString());
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
@@ -298,6 +298,6 @@ public class ThingDiscoveryService extends AbstractThingHandlerDiscoveryService<
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 }

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
@@ -76,7 +76,7 @@ public class DeviceDiscoveryService extends AbstractDiscoveryService {
     public void deactivate() {
         logger.debug("deactivate discovery service for device type {} thing types are: {}", deviceType,
                 super.getSupportedThingTypes().toString());
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/SceneDiscoveryService.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/SceneDiscoveryService.java
@@ -73,7 +73,7 @@ public class SceneDiscoveryService extends AbstractDiscoveryService {
     public void deactivate() {
         logger.debug("deactivate discovery service for scene type {} remove thing tyspes {}", sceneType,
                 super.getSupportedThingTypes());
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/ZoneTemperatureControlDiscoveryService.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/ZoneTemperatureControlDiscoveryService.java
@@ -77,7 +77,7 @@ public class ZoneTemperatureControlDiscoveryService extends AbstractDiscoverySer
     public void deactivate() {
         logger.debug("Deactivate discovery service for zone teperature control type remove thing types {}",
                 super.getSupportedThingTypes());
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     /**

--- a/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/discovery/EcoflowDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/discovery/EcoflowDeviceDiscoveryService.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.ecoflow.internal.EcoflowBindingConstants.THING
 import static org.openhab.binding.ecoflow.internal.EcoflowBindingConstants.THING_TYPE_DELTA2MAX;
 import static org.openhab.binding.ecoflow.internal.EcoflowBindingConstants.THING_TYPE_POWERSTREAM;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -97,7 +98,7 @@ public class EcoflowDeviceDiscoveryService extends AbstractThingHandlerDiscovery
 
     private void scanForDevices() {
         this.api.ifPresent(api -> {
-            var timestampOfLastScan = getTimestampOfLastScan();
+            Instant timestampOfLastScan = getTimestampOfLastScan();
             try {
                 List<DeviceListResponseEntry> devices = api.getDeviceList();
                 logger.debug("Ecoflow discovery found {} devices", devices.size());

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java
@@ -14,6 +14,7 @@ package org.openhab.binding.ecovacs.internal.discovery;
 
 import static org.openhab.binding.ecovacs.internal.EcovacsBindingConstants.*;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -94,7 +95,7 @@ public class EcovacsDeviceDiscoveryService extends AbstractThingHandlerDiscovery
 
     private void scanForDevices() {
         this.api.ifPresent(api -> {
-            var timestampOfLastScan = getTimestampOfLastScan();
+            Instant timestampOfLastScan = getTimestampOfLastScan();
             try {
                 List<EcovacsDevice> devices = api.getDevices();
                 logger.debug("Ecovacs discovery found {} devices", devices.size());

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/discovery/ElroConnectsBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/discovery/ElroConnectsBridgeDiscoveryService.java
@@ -132,7 +132,7 @@ public class ElroConnectsBridgeDiscoveryService
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/discovery/ElroConnectsDiscoveryService.java
+++ b/bundles/org.openhab.binding.elroconnects/src/main/java/org/openhab/binding/elroconnects/internal/discovery/ElroConnectsDiscoveryService.java
@@ -111,7 +111,7 @@ public class ElroConnectsDiscoveryService extends AbstractThingHandlerDiscoveryS
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/FreeAtHomeDiscoveryService.java
+++ b/bundles/org.openhab.binding.freeathome/src/main/java/org/openhab/binding/freeathome/internal/FreeAtHomeDiscoveryService.java
@@ -103,7 +103,7 @@ public class FreeAtHomeDiscoveryService extends AbstractThingHandlerDiscoverySer
     @Override
     protected void startScan() {
         if (backgroundDiscoveryJob == null) {
-            this.removeOlderResults(Instant.now().toEpochMilli());
+            this.removeOlderResults(Instant.now());
 
             isScanTerminated = false;
             backgroundDiscoveryJob = scheduler.schedule(runnable, BACKGROUND_DISCOVERY_DELAY, TimeUnit.SECONDS);
@@ -124,11 +124,11 @@ public class FreeAtHomeDiscoveryService extends AbstractThingHandlerDiscoverySer
 
         backgroundDiscoveryJob = null;
 
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override
     public void deactivate() {
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 }

--- a/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/discovery/TrackerDiscoveryService.java
+++ b/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/discovery/TrackerDiscoveryService.java
@@ -117,7 +117,7 @@ public class TrackerDiscoveryService extends AbstractDiscoveryService {
     @Override
     @Deactivate
     protected void deactivate() {
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
         super.deactivate();
     }
 

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/discovery/HomeConnectDiscoveryService.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/discovery/HomeConnectDiscoveryService.java
@@ -14,6 +14,7 @@ package org.openhab.binding.homeconnect.internal.discovery;
 
 import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.*;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +98,7 @@ public class HomeConnectDiscoveryService extends AbstractThingHandlerDiscoverySe
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(System.currentTimeMillis(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
     }
 
     @Override

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/SimpleDiscoveryListener.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/SimpleDiscoveryListener.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.homematic.test.util;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -42,6 +43,12 @@ public class SimpleDiscoveryListener implements DiscoveryListener {
     @Override
     public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
         discoveredResults.add(result);
+    }
+
+    @Override
+    public @Nullable Collection<@NonNull ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+            @Nullable Collection<@NonNull ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return null;
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/Clip2ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/Clip2ThingDiscoveryService.java
@@ -83,7 +83,7 @@ public class Clip2ThingDiscoveryService extends AbstractThingHandlerDiscoverySer
     public void dispose() {
         super.dispose();
         thingHandler.unregisterDiscoveryService();
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getBridgeUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getBridgeUID());
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueDeviceDiscoveryService.java
@@ -127,7 +127,7 @@ public class HueDeviceDiscoveryService extends AbstractThingHandlerDiscoveryServ
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli(), bridgeUID);
+        removeOlderResults(Instant.now(), bridgeUID);
         thingHandler.unregisterDiscoveryListener();
     }
 

--- a/bundles/org.openhab.binding.hydrawise/src/main/java/org/openhab/binding/hydrawise/internal/discovery/HydrawiseCloudControllerDiscoveryService.java
+++ b/bundles/org.openhab.binding.hydrawise/src/main/java/org/openhab/binding/hydrawise/internal/discovery/HydrawiseCloudControllerDiscoveryService.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.hydrawise.internal.discovery;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -64,7 +64,7 @@ public class HydrawiseCloudControllerDiscoveryService extends AbstractDiscoveryS
     public void deactivate() {
         HydrawiseAccountHandler localHandler = this.handler;
         if (localHandler != null) {
-            removeOlderResults(new Date().getTime(), localHandler.getThing().getUID());
+            removeOlderResults(Instant.now(), localHandler.getThing().getUID());
         }
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/discovery/InsteonDiscoveryService.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/discovery/InsteonDiscoveryService.java
@@ -85,7 +85,7 @@ public class InsteonDiscoveryService extends AbstractDiscoveryService {
         } else if (!modem.getDB().isComplete()) {
             logger.debug("modem database not complete, scanning aborted.");
         } else {
-            long startTime = Instant.now().toEpochMilli();
+            Instant startTime = Instant.now();
 
             if (handler.isDeviceDiscoveryEnabled()) {
                 modem.getDB().getDevices().stream().filter(address -> !modem.hasDevice(address)).forEach(address -> {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/discovery/InsteonLegacyDiscoveryService.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/discovery/InsteonLegacyDiscoveryService.java
@@ -74,6 +74,6 @@ public class InsteonLegacyDiscoveryService extends AbstractDiscoveryService {
     }
 
     public void removeAllResults() {
-        removeOlderResults(Instant.now().toEpochMilli(), handler.getThing().getUID());
+        removeOlderResults(Instant.now(), handler.getThing().getUID());
     }
 }

--- a/bundles/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/internal/handler/IppPrinterHandler.java
+++ b/bundles/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/internal/handler/IppPrinterHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.ipp.internal.IppBindingConstants.*;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
@@ -174,6 +175,12 @@ public class IppPrinterHandler extends BaseThingHandler implements DiscoveryList
         if (thingUID.equals(getThing().getUID())) {
             updateStatus(ThingStatus.OFFLINE);
         }
+    }
+
+    @Override
+    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return Set.of();
     }
 
     @Override

--- a/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/discovery/IRobotDiscoveryService.java
+++ b/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/discovery/IRobotDiscoveryService.java
@@ -23,6 +23,7 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -102,7 +103,7 @@ public class IRobotDiscoveryService extends AbstractDiscoveryService {
     private Runnable createScanner() {
         return () -> {
             Set<String> robots = new HashSet<>();
-            var timestampOfLastScan = getTimestampOfLastScan();
+            Instant timestampOfLastScan = getTimestampOfLastScan();
             for (InetAddress broadcastAddress : getBroadcastAddresses()) {
                 logger.debug("Starting broadcast for {}", broadcastAddress.toString());
 

--- a/bundles/org.openhab.binding.leapmotion/src/main/java/org/openhab/binding/leapmotion/internal/discovery/LeapMotionDiscoveryService.java
+++ b/bundles/org.openhab.binding.leapmotion/src/main/java/org/openhab/binding/leapmotion/internal/discovery/LeapMotionDiscoveryService.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.leapmotion.internal.discovery;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 
@@ -92,6 +93,6 @@ public class LeapMotionDiscoveryService extends AbstractDiscoveryService {
     }
 
     private void removeDiscoveryResult() {
-        removeOlderResults(System.currentTimeMillis());
+        removeOlderResults(Instant.now());
     }
 }

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/discovery/LGThinqDiscoveryService.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/discovery/LGThinqDiscoveryService.java
@@ -153,7 +153,7 @@ public class LGThinqDiscoveryService extends AbstractThingHandlerDiscoveryServic
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli(), bridgeHandlerUID);
+        removeOlderResults(Instant.now(), bridgeHandlerUID);
         thingHandler.unregisterDiscoveryListener();
     }
 }

--- a/bundles/org.openhab.binding.livisismarthome/src/main/java/org/openhab/binding/livisismarthome/internal/discovery/LivisiDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.livisismarthome/src/main/java/org/openhab/binding/livisismarthome/internal/discovery/LivisiDeviceDiscoveryService.java
@@ -65,7 +65,7 @@ public class LivisiDeviceDiscoveryService extends AbstractThingHandlerDiscoveryS
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxDeviceDiscoveryService.java
@@ -60,7 +60,7 @@ public class MaxDeviceDiscoveryService extends AbstractThingHandlerDiscoveryServ
     public void dispose() {
         super.dispose();
         thingHandler.unregisterDeviceStatusListener(this);
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -81,7 +81,7 @@ public class MieleApplianceDiscoveryService extends AbstractThingHandlerDiscover
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
         thingHandler.unregisterDiscoveryListener(this);
     }
 

--- a/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.mielecloud/src/main/java/org/openhab/binding/mielecloud/internal/discovery/ThingDiscoveryService.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mielecloud.internal.discovery;
 import static org.openhab.binding.mielecloud.internal.MieleCloudBindingConstants.*;
 import static org.openhab.binding.mielecloud.internal.handler.MieleHandlerFactory.SUPPORTED_THING_TYPES;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,7 +81,7 @@ public class ThingDiscoveryService extends AbstractThingHandlerDiscoveryService<
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(System.currentTimeMillis(), getBridgeUid());
+        removeOlderResults(Instant.now(), getBridgeUid());
     }
 
     /**
@@ -167,7 +168,7 @@ public class ThingDiscoveryService extends AbstractThingHandlerDiscoveryService<
     protected void startBackgroundDiscovery() {
         logger.debug("Starting background discovery");
 
-        removeOlderResults(System.currentTimeMillis(), getBridgeUid());
+        removeOlderResults(Instant.now(), getBridgeUid());
         discoveringDevices = true;
     }
 
@@ -181,7 +182,7 @@ public class ThingDiscoveryService extends AbstractThingHandlerDiscoveryService<
      * Invoked when a device is removed from the Miele cloud.
      */
     public void onDeviceRemoved(String deviceIdentifier) {
-        removeOlderResults(System.currentTimeMillis(), getBridgeUid());
+        removeOlderResults(Instant.now(), getBridgeUid());
     }
 
     private String getLabel(DeviceState deviceState) {

--- a/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/discovery/XiaomiItemDiscoveryService.java
+++ b/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/discovery/XiaomiItemDiscoveryService.java
@@ -86,7 +86,7 @@ public class XiaomiItemDiscoveryService extends AbstractDiscoveryService impleme
     }
 
     public void onHandlerRemoved() {
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscoveryTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscoveryTests.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal.discovery;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -202,6 +203,12 @@ public class HomeAssistantDiscoveryTests extends AbstractHomeAssistantTests {
 
         @Override
         public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
+        }
+
+        @Override
+        public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+            return Collections.emptyList();
         }
 
         @Override

--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/src/test/java/org/openhab/binding/mqtt/ruuvigateway/internal/discovery/RuuviGatewayDiscoveryTests.java
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/src/test/java/org/openhab/binding/mqtt/ruuvigateway/internal/discovery/RuuviGatewayDiscoveryTests.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -142,6 +143,12 @@ public class RuuviGatewayDiscoveryTests {
 
         @Override
         public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
+        }
+
+        @Override
+        public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+            return Collections.emptyList();
         }
 
         @Override

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
@@ -139,7 +139,7 @@ public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService imp
     @Override
     protected void startBackgroundDiscovery() {
         // Remove results that are restored after a restart
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
         subscribe();
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
@@ -65,7 +65,7 @@ public class NikoHomeControlDiscoveryService
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     /**

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboHubDiscoveryService.java
@@ -72,7 +72,7 @@ public class NoboHubDiscoveryService extends AbstractThingHandlerDiscoveryServic
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     private final Runnable scanner = new Runnable() {

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
@@ -71,7 +71,7 @@ public class NoboThingDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     public void deactivate() {
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     public void detectZones(Collection<Zone> zones) {

--- a/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/discovery/OwDiscoveryService.java
+++ b/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/discovery/OwDiscoveryService.java
@@ -134,6 +134,6 @@ public class OwDiscoveryService extends AbstractThingHandlerDiscoveryService<Ows
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 }

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/discovery/OpenWeatherMapDiscoveryService.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/discovery/OpenWeatherMapDiscoveryService.java
@@ -72,7 +72,7 @@ public class OpenWeatherMapDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     public void deactivate() {
-        removeOlderResults(Instant.now().toEpochMilli(), bridgeHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), bridgeHandler.getThing().getUID());
         super.deactivate();
     }
 

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/discovery/PilightDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/discovery/PilightDeviceDiscoveryService.java
@@ -149,7 +149,7 @@ public class PilightDeviceDiscoveryService extends AbstractThingHandlerDiscovery
 
     @Override
     public void initialize() {
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
         thingHandler.registerDiscoveryListener(this);
 
         super.initialize();
@@ -160,7 +160,7 @@ public class PilightDeviceDiscoveryService extends AbstractThingHandlerDiscovery
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
         thingHandler.unregisterDiscoveryListener();
     }
 

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/discovery/PowermaxDiscoveryService.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/discovery/PowermaxDiscoveryService.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.powermax.internal.discovery;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -100,7 +100,7 @@ public class PowermaxDiscoveryService extends AbstractThingHandlerDiscoveryServi
 
     private void updateFromSettings(@Nullable PowermaxPanelSettings settings) {
         if (settings != null) {
-            long beforeUpdate = new Date().getTime();
+            Instant beforeUpdate = Instant.now();
 
             for (int i = 1; i <= settings.getNbZones(); i++) {
                 PowermaxZoneSettings zoneSettings = settings.getZoneSettings(i);

--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/discovery/RingDiscoveryService.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/discovery/RingDiscoveryService.java
@@ -95,7 +95,7 @@ public class RingDiscoveryService extends AbstractThingHandlerDiscoveryService<A
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.touchwand/src/main/java/org/openhab/binding/touchwand/internal/discovery/TouchWandUnitDiscoveryService.java
+++ b/bundles/org.openhab.binding.touchwand/src/main/java/org/openhab/binding/touchwand/internal/discovery/TouchWandUnitDiscoveryService.java
@@ -137,14 +137,14 @@ public class TouchWandUnitDiscoveryService extends AbstractThingHandlerDiscovery
 
     @Override
     public void initialize() {
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
         super.initialize();
     }
 
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
     }
 
     @Override

--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/Tr064DiscoveryService.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/Tr064DiscoveryService.java
@@ -52,7 +52,7 @@ public class Tr064DiscoveryService extends AbstractThingHandlerDiscoveryService<
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli(), thingHandler.getThing().getUID());
+        removeOlderResults(Instant.now(), thingHandler.getThing().getUID());
     }
 
     @Override

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -91,7 +91,7 @@ public class TradfriDiscoveryService extends AbstractThingHandlerDiscoveryServic
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
         thingHandler.unregisterDeviceUpdateListener(this);
     }
 

--- a/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
 import static org.openhab.binding.tradfri.internal.config.TradfriDeviceConfig.CONFIG_ID;
 
+import java.time.Instant;
 import java.util.Collection;
 
 import org.junit.jupiter.api.AfterEach;
@@ -64,6 +65,12 @@ public class TradfriDiscoveryServiceTest {
         @Override
         public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
             discoveryResult = result;
+        }
+
+        @Override
+        public Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                Collection<ThingTypeUID> thingTypeUIDs, ThingUID bridgeUID) {
+            return null;
         }
 
         @Override

--- a/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
+++ b/bundles/org.openhab.binding.tuya/src/main/java/org/openhab/binding/tuya/internal/TuyaDiscoveryService.java
@@ -18,8 +18,8 @@ import static org.openhab.binding.tuya.internal.TuyaBindingConstants.CONFIG_PROD
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.PROPERTY_CATEGORY;
 import static org.openhab.binding.tuya.internal.TuyaBindingConstants.THING_TYPE_TUYA_DEVICE;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +158,7 @@ public class TuyaDiscoveryService extends AbstractThingHandlerDiscoveryService<P
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(new Date().getTime());
+        removeOlderResults(Instant.now());
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/discovery/VelbusThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/discovery/VelbusThingDiscoveryService.java
@@ -62,7 +62,7 @@ public class VelbusThingDiscoveryService extends AbstractThingHandlerDiscoverySe
     @Override
     public void dispose() {
         super.dispose();
-        removeOlderResults(Instant.now().toEpochMilli());
+        removeOlderResults(Instant.now());
         thingHandler.clearDefaultPacketListener();
     }
 

--- a/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/discovery/WebthingDiscoveryService.java
+++ b/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/discovery/WebthingDiscoveryService.java
@@ -141,7 +141,7 @@ public class WebthingDiscoveryService extends AbstractDiscoveryService implement
 
     @Override
     protected synchronized void stopScan() {
-        removeOlderResults(Instant.now().minus(Duration.ofMinutes(10)).toEpochMilli());
+        removeOlderResults(Instant.now().minus(Duration.ofMinutes(10)));
 
         // stop running discovery tasks
         for (var future : runningDiscoveryTasks) {

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
@@ -18,6 +18,7 @@ import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 import static org.openhab.core.thing.Thing.*;
 
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 
@@ -69,6 +70,12 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         @Override
         public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
             discoveryResult = result;
+        }
+
+        @Override
+        public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+            return List.of();
         }
 
         @Override

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueDeviceDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueDeviceDiscoveryServiceOSGiTest.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -139,6 +140,12 @@ public class HueDeviceDiscoveryServiceOSGiTest extends AbstractHueOSGiTestParent
 
             @Override
             public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
+            }
+
+            @Override
+            public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                    @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+                return null;
             }
 
             @Override

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 import static org.openhab.core.config.discovery.inbox.InboxPredicates.forThingTypeUID;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -160,6 +161,12 @@ public class HueBridgeNupnpDiscoveryOSGITest extends JavaOSGiTest {
             }
 
             @Override
+            public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                    @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+                return null;
+            }
+
+            @Override
             public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
                     @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
                 return null;
@@ -209,6 +216,12 @@ public class HueBridgeNupnpDiscoveryOSGITest extends JavaOSGiTest {
 
             @Override
             public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
+            }
+
+            @Override
+            public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+                    @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
- Refactor to use `removeOlderResults(Instant)`. This removes all usages of deprecated method `removeOlderResults(long)` and prepares for the removal of this method.
- Add `removeOlderResults` overload to `DiscoveryListener` implementations. This prepares for the removal of `long` overloads from the interface.
- Declare `Instant` for timestampOfLastScan. Previous temporary changes for breaking API change compatibility were #18845 and #18890.

Related to openhab/openhab-core#4866