### PR TITLE
[WIP] [shelly] Add Shelly Blu Wall Switch 4 and Shelly BLU RC Button 4

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -126,14 +126,15 @@ See section [Discovery](#discovery) for details.
 
 ### Shelly BLU
 
-| thing-type        | Model                                                  | Vendor ID               |
-| ----------------- | ------------------------------------------------------ | ----------------------- |
-| shellyblubutton   | Shelly BLU Button 1                                    | SBBT                    |
-| shellybludw       | Shelly BLU Door/Windows                                | SBDW                    |
-| shellyblumotion   | Shelly BLU Motion                                      | SBMO                    |
-| shellybluht       | Shelly BLU H&T                                         | SBMO                    |
-| shellyblugw       | Shelly BLU Gateway                                     | SNGW-BT01               |
-| shellyblugw3      | Shelly BLU Gateway 3                                   | S3GW-1DBT001            |
+| thing-type           | Model                                    | Vendor ID               |
+| -------------------- | ---------------------------------------- | ----------------------- |
+| shellyblubutton      | Shelly BLU Button 1                      | SBBT-002C               |
+| shellybluwallswitch4 | Shelly BLU Wall Switch 4                 | SBBT-004CEU             |
+| shellybludw          | Shelly BLU Door/Windows                  | SBDW                    |
+| shellyblumotion      | Shelly BLU Motion                        | SBMO                    |
+| shellybluht          | Shelly BLU H&T                           | SBMO                    |
+| shellyblugw          | Shelly BLU Gateway                       | SNGW-BT01               |
+| shellyblugw3         | Shelly BLU Gateway 3                     | S3GW-1DBT001            |
 
 ### Special Thing Types
 
@@ -436,6 +437,7 @@ The following trigger types are sent:
 | LONG_PRESSED       | The button was pressed for a longer time (lastEvent=L)              |
 | SHORT_LONG_PRESSED | A short followed by a long button push (lastEvent=SL)               |
 | LONG_SHORT_PRESSED | A long followed by a short button push (lastEvent=LS)               |
+| HOLDING            | A button continuously pressed (holded) (lastEvent=H)                |
 
 Check the channel definitions for the various devices to see if the device supports those events.
 You could use the Shelly App to set the timing for those events.
@@ -1572,6 +1574,20 @@ See notes on discovery of Shelly BLU devices above.
 | Group   | Channel       | Type     | read-only | Description                                                                         |
 | ------- | ------------- | -------- | --------- | ----------------------------------------------------------------------------------- |
 | status  | lastEvent     | String   | yes       | Last event type (S/SS/SSS/L)                                                        |
+|         | eventCount    | Number   | yes       | Counter gets incremented every time the device issues a button event.               |
+|         | button        | Trigger  | yes       | Event trigger with payload, see SHORT_PRESSED or LONG_PRESSED                       |
+|         | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                   |
+| battery | batteryLevel  | Number   | yes       | Battery Level in %                                                                  |
+|         | lowBattery    | Switch   | yes       | Low battery alert (< 20%)                                                           |
+| device  | gatewayDevice | String   | yes       | Shelly forwarded last status update (BLU gateway), could vary from packet to packet |
+
+### Shelly BLU Wall Switch 4 (thing-type: shellybluwallswitch4)
+
+See notes on discovery of Shelly BLU devices above.
+
+| Group   | Channel       | Type     | read-only | Description                                                                         |
+| ------- | ------------- | -------- | --------- | ----------------------------------------------------------------------------------- |
+| status  | lastEvent     | String   | yes       | Last event type (S/SS/SSS/L)                 ??????????????                                       |
 |         | eventCount    | Number   | yes       | Counter gets incremented every time the device issues a button event.               |
 |         | button        | Trigger  | yes       | Event trigger with payload, see SHORT_PRESSED or LONG_PRESSED                       |
 |         | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                   |

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -108,6 +108,7 @@ public class ShellyBindingConstants {
             // Shelly BLU
             THING_TYPE_SHELLYBLUBUTTON, //
             THING_TYPE_SHELLYBLUWALLSWITCH4, //
+            THING_TYPE_SHELLYBLURCBUTTON4, //
             THING_TYPE_SHELLYBLUDW, //
             THING_TYPE_SHELLYBLUMOTION, //
             THING_TYPE_SHELLYBLUHT, //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -107,6 +107,7 @@ public class ShellyBindingConstants {
 
             // Shelly BLU
             THING_TYPE_SHELLYBLUBUTTON, //
+            THING_TYPE_SHELLYBLUWALLSWITCH4, //
             THING_TYPE_SHELLYBLUDW, //
             THING_TYPE_SHELLYBLUMOTION, //
             THING_TYPE_SHELLYBLUHT, //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -98,7 +98,7 @@ public class ShellyDeviceProfile {
     public boolean isHT = false; // true for H&T
     public boolean isDW = false; // true for Door Window sensor
     public boolean isButton = false; // true for a Shelly Button 1
-    public boolean isMultiButton = false; // true for a Shelly BLU Wall Switch 4
+    public boolean isMultiButton = false; // true for a Shelly BLU Wall Switch 4 or RC Button 4
     public boolean isIX = false; // true for a Shelly IX
     public boolean isTRV = false; // true for a Shelly TRV
     public boolean isSmoke = false; // true for Shelly Smoke
@@ -232,14 +232,15 @@ public class ShellyDeviceProfile {
                 || thingType.equals(THING_TYPE_SHELLYPLUSI4DC_STR);
         isButton = thingType.equals(THING_TYPE_SHELLYBUTTON1_STR) || thingType.equals(THING_TYPE_SHELLYBUTTON2_STR)
                 || thingType.equals(THING_TYPE_SHELLYBLUBUTTON_STR);
-        isMultiButton = thingType.equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
+        isMultiButton = thingType.equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR)
+                || thingType.equals(THING_TYPE_SHELLYBLURCBUTTON4_STR);
         isTRV = thingType.equals(THING_TYPE_SHELLYTRV_STR);
         isWall = thingType.equals(THING_TYPE_SHELLYPLUSWALLDISPLAY_STR);
         is3EM = thingType.equals(THING_TYPE_SHELLY3EM_STR) || thingType.startsWith(THING_TYPE_SHELLYPRO3EM_STR);
         isEM50 = thingType.startsWith(THING_TYPE_SHELLYPROEM50_STR);
 
         isSensor = isHT || isFlood || isDW || isSmoke || isGas || isButton || isUNI || isMotion || isSense || isTRV
-                || isWall;
+                || isWall || isMultiButton;
         hasBattery = isHT || isFlood || isDW || isSmoke || isButton || isMotion || isTRV || isBlu;
         alwaysOn = !hasBattery || (isMotion && !isBlu) || isSense; // true means: device is reachable all the time (no
                                                                    // sleep mode)
@@ -436,10 +437,16 @@ public class ShellyDeviceProfile {
     public static String buildBluServiceName(String name, String mac) throws IllegalArgumentException {
         String model = name.contains("-") ? substringBefore(name, "-") : name; // e.g. SBBT-02C or just SBDW
         switch (model) {
-            case SHELLYDT_BLUBUTTON:
-                return (THING_TYPE_SHELLYBLUBUTTON_STR + "-" + mac).toLowerCase();
-            case SHELLYDT_BLUWALLSWITCH4:
-                return (THING_TYPE_SHELLYBLUWALLSWITCH4_STR + "-" + mac).toLowerCase();
+            case "SBBT":
+                switch (getString(name)) {
+                    default:
+                    case SHELLYDT_BLUBUTTON:
+                        return (THING_TYPE_SHELLYBLUBUTTON_STR + "-" + mac).toLowerCase();
+                    case SHELLYDT_BLUWALLSWITCH4:
+                        return (THING_TYPE_SHELLYBLUWALLSWITCH4_STR + "-" + mac).toLowerCase();
+                    case SHELLYDT_BLURCBUTTON4:
+                        return (THING_TYPE_SHELLYBLURCBUTTON4_STR + "-" + mac).toLowerCase();
+                }
             case SHELLYDT_BLUDW:
                 return (THING_TYPE_SHELLYBLUDW_STR + "-" + mac).toLowerCase();
             case SHELLYDT_BLUMOTION:

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -98,6 +98,7 @@ public class ShellyDeviceProfile {
     public boolean isHT = false; // true for H&T
     public boolean isDW = false; // true for Door Window sensor
     public boolean isButton = false; // true for a Shelly Button 1
+    public boolean isMultiButton = false; // true for a Shelly BLU Wall Switch 4
     public boolean isIX = false; // true for a Shelly IX
     public boolean isTRV = false; // true for a Shelly TRV
     public boolean isSmoke = false; // true for Shelly Smoke
@@ -231,6 +232,7 @@ public class ShellyDeviceProfile {
                 || thingType.equals(THING_TYPE_SHELLYPLUSI4DC_STR);
         isButton = thingType.equals(THING_TYPE_SHELLYBUTTON1_STR) || thingType.equals(THING_TYPE_SHELLYBUTTON2_STR)
                 || thingType.equals(THING_TYPE_SHELLYBLUBUTTON_STR);
+        isMultiButton = thingType.equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
         isTRV = thingType.equals(THING_TYPE_SHELLYTRV_STR);
         isWall = thingType.equals(THING_TYPE_SHELLYPLUSWALLDISPLAY_STR);
         is3EM = thingType.equals(THING_TYPE_SHELLY3EM_STR) || thingType.startsWith(THING_TYPE_SHELLYPRO3EM_STR);
@@ -277,6 +279,8 @@ public class ShellyDeviceProfile {
             return CHANNEL_GROUP_LIGHT_CONTROL;
         } else if (isButton) {
             return CHANNEL_GROUP_STATUS;
+        } else if (isMultiButton) {
+            return CHANNEL_GROUP_STATUS + idx;
         } else if (isSensor) {
             return CHANNEL_GROUP_SENSOR;
         }
@@ -293,7 +297,7 @@ public class ShellyDeviceProfile {
         int idx = i + 1; // group names are 1-based
         if (isRGBW2) {
             return CHANNEL_GROUP_LIGHT_CONTROL;
-        } else if (isIX) {
+        } else if (isIX || isMultiButton) {
             return CHANNEL_GROUP_STATUS + idx;
         } else if (isButton) {
             return CHANNEL_GROUP_STATUS;
@@ -307,7 +311,7 @@ public class ShellyDeviceProfile {
 
     public String getInputSuffix(int i) {
         int idx = i + 1; // channel names are 1-based
-        if (isRGBW2 || isIX) {
+        if (isRGBW2 || isIX || isMultiButton) {
             return ""; // RGBW2 has only 1 channel
         } else if (isRoller || isDimmer) {
             // Roller has 2 relays, but it will be mapped to 1 roller with 2 inputs
@@ -330,7 +334,7 @@ public class ShellyDeviceProfile {
         List<ShellySettingsRgbwLight> lights = settings.lights;
         if (isButton) {
             return true;
-        } else if (isIX && inputs != null && idx < inputs.size()) {
+        } else if ((isMultiButton || isIX) && inputs != null && idx < inputs.size()) {
             ShellySettingsInput input = inputs.get(idx);
             btnType = getString(input.btnType);
         } else if (isDimmer) {
@@ -434,6 +438,8 @@ public class ShellyDeviceProfile {
         switch (model) {
             case SHELLYDT_BLUBUTTON:
                 return (THING_TYPE_SHELLYBLUBUTTON_STR + "-" + mac).toLowerCase();
+            case SHELLYDT_BLUWALLSWITCH4:
+                return (THING_TYPE_SHELLYBLUWALLSWITCH4_STR + "-" + mac).toLowerCase();
             case SHELLYDT_BLUDW:
                 return (THING_TYPE_SHELLYBLUDW_STR + "-" + mac).toLowerCase();
             case SHELLYDT_BLUMOTION:

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
@@ -82,6 +82,7 @@ public class Shelly1ApiJsonDTO {
     public static final String SHELLY_EVENT_TRIPLE_SHORTPUSH = "triple_shortpush";
     public static final String SHELLY_EVENT_SHORT_LONGTPUSH = "shortpush_longpush";
     public static final String SHELLY_EVENT_LONG_SHORTPUSH = "longpush_shortpush";
+    public static final String SHELLY_EVENT_HOLD = "hold";
 
     // Dimmer
     public static final String SHELLY_EVENT_BTN1_ON = "btn1_on";
@@ -241,6 +242,7 @@ public class Shelly1ApiJsonDTO {
     public static final String SHELLY_BTNEVENT_2SHORTPUSH = "SS";
     public static final String SHELLY_BTNEVENT_3SHORTPUSH = "SSS";
     public static final String SHELLY_BTNEVENT_LONGPUSH = "L";
+    public static final String SHELLY_BTNEVENT_HOLD = "H";
     public static final String SHELLY_BTNEVENT_SHORTLONGPUSH = "SL";
     public static final String SHELLY_BTNEVENT_LONGSHORTPUSH = "LS";
 
@@ -1329,6 +1331,8 @@ public class Shelly1ApiJsonDTO {
             case SHELLY_BTNEVENT_LONGSHORTPUSH:
             case SHELLY_EVENT_LONG_SHORTPUSH:
                 return "LONG_SHORT_PRESSED";
+            case SHELLY_EVENT_HOLD:
+                return "HOLDING";
             default:
                 return "";
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1CoIoTProtocol.java
@@ -206,9 +206,9 @@ public class Shelly1CoIoTProtocol {
             // event count
             updateChannel(updates, group, CHANNEL_STATUS_EVENTCOUNT + profile.getInputSuffix(idx), getDecimal(count));
             logger.trace(
-                    "{}: Check button[{}] for event trigger (inButtonMode={}, isButton={}, hasBattery={}, serial={}, count={}, lastEventCount[{}]={}",
-                    thingName, idx, profile.inButtonMode(idx), profile.isButton, profile.hasBattery, serial, count, idx,
-                    lastEventCount[idx]);
+                    "{}: Check button[{}] for event trigger (inButtonMode={}, isButton={}, isMultiButton={}, hasBattery={}, serial={}, count={}, lastEventCount[{}]={}",
+                    thingName, idx, profile.inButtonMode(idx), profile.isButton, profile.isMultiButton,
+                    profile.hasBattery, serial, count, idx, lastEventCount[idx]);
             if (profile.inButtonMode(idx) && ((profile.hasBattery && count == 1) || lastEventCount[idx] == -1
                     || count != lastEventCount[idx])) {
                 if (!profile.isButton || (profile.isButton && (serial != 0x200))) { // skip duplicate on wake-up

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -1211,8 +1211,8 @@ public class Shelly2ApiJsonDTO {
         public Integer pid;
         @SerializedName("Battery")
         public Integer battery;
-        @SerializedName("Button")
-        public Integer buttonEvent;
+        @SerializedName("Buttons")
+        public Integer[] buttonEvents;
         @SerializedName("Illuminance")
         public Integer illuminance;
         @SerializedName("Window")

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -15,6 +15,7 @@ package org.openhab.binding.shelly.internal.api2;
 import static org.openhab.binding.shelly.internal.ShellyBindingConstants.*;
 import static org.openhab.binding.shelly.internal.api1.Shelly1ApiJsonDTO.*;
 import static org.openhab.binding.shelly.internal.api2.Shelly2ApiJsonDTO.*;
+import static org.openhab.binding.shelly.internal.discovery.ShellyThingCreator.*;
 import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
 
 import java.util.ArrayList;
@@ -60,33 +61,45 @@ public class ShellyBluApi extends Shelly2ApiRpc {
     private int lastPid = -1;
     private final int pidCycleThreshold = 50;
 
-    private static final Map<String, String> MAP_INPUT_EVENT_TYPE = Map.of( //
-            SHELLY2_EVENT_1PUSH, SHELLY_BTNEVENT_1SHORTPUSH, //
-            SHELLY2_EVENT_2PUSH, SHELLY_BTNEVENT_2SHORTPUSH, //
-            SHELLY2_EVENT_3PUSH, SHELLY_BTNEVENT_3SHORTPUSH, //
-            SHELLY2_EVENT_LPUSH, SHELLY_BTNEVENT_LONGPUSH, //
-            SHELLY2_EVENT_LSPUSH, SHELLY_BTNEVENT_LONGSHORTPUSH, //
-            SHELLY2_EVENT_SLPUSH, SHELLY_BTNEVENT_SHORTLONGPUSH, //
-            "1", SHELLY_BTNEVENT_1SHORTPUSH, //
-            "2", SHELLY_BTNEVENT_2SHORTPUSH, //
-            "3", SHELLY_BTNEVENT_3SHORTPUSH, //
-            "4", SHELLY_BTNEVENT_LONGPUSH);
+    private static final Map<String, String> MAP_INPUT_EVENT_TYPE = Map.ofEntries( //
+            Map.entry(SHELLY2_EVENT_1PUSH, SHELLY_BTNEVENT_1SHORTPUSH), //
+            Map.entry(SHELLY2_EVENT_2PUSH, SHELLY_BTNEVENT_2SHORTPUSH), //
+            Map.entry(SHELLY2_EVENT_3PUSH, SHELLY_BTNEVENT_3SHORTPUSH), //
+            Map.entry(SHELLY2_EVENT_LPUSH, SHELLY_BTNEVENT_LONGPUSH), //
+            Map.entry(SHELLY2_EVENT_LSPUSH, SHELLY_BTNEVENT_LONGSHORTPUSH), //
+            Map.entry(SHELLY2_EVENT_SLPUSH, SHELLY_BTNEVENT_SHORTLONGPUSH), //
+            Map.entry("1", SHELLY_BTNEVENT_1SHORTPUSH), //
+            Map.entry("2", SHELLY_BTNEVENT_2SHORTPUSH), //
+            Map.entry("3", SHELLY_BTNEVENT_3SHORTPUSH), //
+            Map.entry("4", SHELLY_BTNEVENT_LONGPUSH), //
+            Map.entry("254", SHELLY_BTNEVENT_HOLD));
+
+    private ShellyInputState createShellyInputState() {
+        ShellyInputState input = new ShellyInputState();
+        input.input = 0;
+        input.event = "";
+        input.eventCount = 0;
+        return input;
+    }
 
     /**
      * Regular constructor - called by Thing handler
      *
-     * @param thingName Symbolic thing name
+     * @param thingLabel Symbolic thing name
      * @param thing Thing Handler (ThingHandlerInterface)
      */
-    public ShellyBluApi(String thingName, ShellyThingTable thingTable, ShellyThingInterface thing) {
-        super(thingName, thingTable, thing);
-
-        ShellyInputState input = new ShellyInputState();
+    public ShellyBluApi(String thingLabel, ShellyThingTable thingTable, ShellyThingInterface thing) {
+        super(thingLabel, thingTable, thing);
         deviceStatus.inputs = new ArrayList<>();
-        input.input = 0;
-        input.event = "";
-        input.eventCount = 0;
-        deviceStatus.inputs.add(input);
+        ShellyDeviceProfile profile = thing.getProfile();
+
+        // TODO clarify: get number of XML entries of type "button" resp "buttonState" from somewhere in the thing stuff
+        // ?
+        int numInputs = thing.getThingType().equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR) ? 4 : 1;
+        for (int i = 0; i < numInputs; i++) {
+            deviceStatus.inputs.add(createShellyInputState());
+        }
+        logger.trace("{} ShellyBluApi constructor number of inputs: {}", thingLabel, profile.numInputs);
     }
 
     @Override
@@ -162,6 +175,27 @@ public class ShellyBluApi extends Shelly2ApiRpc {
             } else {
                 inputs = profile.settings.inputs = new ArrayList<>();
                 inputs.add(settings);
+            }
+            profile.status = deviceStatus;
+        }
+
+        if (profile.isMultiButton) {
+            logger.trace("{}: Create inputs profile BLUWS4: ", thingName);
+            profile.numInputs = 4;
+            boolean add = false;
+
+            if (profile.settings.inputs == null) {
+                profile.settings.inputs = new ArrayList<>(profile.numInputs);
+                add = true;
+            }
+
+            for (int i = 0; i < profile.numInputs; i++) {
+                ShellySettingsInput settings = new ShellySettingsInput();
+                settings.btnType = SHELLY_BTNT_MOMENTARY;
+                if (add)
+                    profile.settings.inputs.add(i, settings);
+                else
+                    profile.settings.inputs.set(i, settings);
             }
             profile.status = deviceStatus;
         }
@@ -297,19 +331,27 @@ public class ShellyBluApi extends Shelly2ApiRpc {
                             sensorData.motion = e.data.motionState == 1;
                         }
 
-                        if (e.data.buttonEvent != null) {
-                            ShellyInputState input = deviceStatus.inputs != null ? deviceStatus.inputs.get(0)
-                                    : new ShellyInputState();
-                            input.event = mapValue(MAP_INPUT_EVENT_TYPE, e.data.buttonEvent + "");
-                            input.eventCount++;
-                            deviceStatus.inputs.set(0, input);
-                            // sensorData.inputs.set(0, input);
+                        if (e.data.buttonEvents != null) {
+                            logger.trace("{}: Shelly BLU button events received: {}", thingName,
+                                    gson.toJson(e.data.buttonEvents));
+                            for (int bttnIdx = 0; bttnIdx < e.data.buttonEvents.length; bttnIdx++) {
+                                if (e.data.buttonEvents[bttnIdx] != 0) {
+                                    ShellyInputState input = deviceStatus.inputs != null
+                                            ? deviceStatus.inputs.get(bttnIdx)
+                                            : new ShellyInputState();
+                                    input.event = mapValue(MAP_INPUT_EVENT_TYPE, e.data.buttonEvents[bttnIdx] + "");
+                                    input.eventCount++;
+                                    deviceStatus.inputs.set(bttnIdx, input);
 
-                            String group = getProfile().getInputGroup(0);
-                            String suffix = profile.getInputSuffix(0);
-                            t.updateChannel(group, CHANNEL_STATUS_EVENTTYPE + suffix, getStringType(input.event));
-                            t.updateChannel(group, CHANNEL_STATUS_EVENTCOUNT + suffix, getDecimal(input.eventCount));
-                            t.triggerButton(profile.getInputGroup(0), 0, input.event);
+                                    String group = getProfile().getInputGroup(bttnIdx);
+                                    String suffix = profile.getInputSuffix(bttnIdx);
+                                    t.updateChannel(group, CHANNEL_STATUS_EVENTTYPE + suffix,
+                                            getStringType(input.event));
+                                    t.updateChannel(group, CHANNEL_STATUS_EVENTCOUNT + suffix,
+                                            getDecimal(input.eventCount));
+                                    t.triggerButton(profile.getInputGroup(bttnIdx), bttnIdx, input.event);
+                                }
+                            }
                         }
                         updated |= ShellyComponents.updateDeviceStatus(t, deviceStatus);
                         updated |= ShellyComponents.updateSensors(getThing(), deviceStatus);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java
@@ -95,7 +95,8 @@ public class ShellyBluApi extends Shelly2ApiRpc {
 
         // TODO clarify: get number of XML entries of type "button" resp "buttonState" from somewhere in the thing stuff
         // ?
-        int numInputs = thing.getThingType().equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR) ? 4 : 1;
+        int numInputs = thing.getThingType().equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR)
+                || thing.getThingType().equals(THING_TYPE_SHELLYBLURCBUTTON4_STR) ? 4 : 1;
         for (int i = 0; i < numInputs; i++) {
             deviceStatus.inputs.add(createShellyInputState());
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -138,6 +138,7 @@ public class ShellyThingCreator {
     // Shelly BLU Series
     public static final String SHELLYDT_BLUBUTTON = "SBBT-002C";
     public static final String SHELLYDT_BLUWALLSWITCH4 = "SBBT-EU3870";
+    public static final String SHELLYDT_BLURCBUTTON4 = "SBBT-004CUS";
     public static final String SHELLYDT_BLUDW = "SBDW";
     public static final String SHELLYDT_BLUMOTION = "SBMO";
     public static final String SHELLYDT_BLUHT = "SBHT";
@@ -238,6 +239,7 @@ public class ShellyThingCreator {
     public static final String THING_TYPE_SHELLYBLU_PREFIX = "shellyblu";
     public static final String THING_TYPE_SHELLYBLUBUTTON_STR = THING_TYPE_SHELLYBLU_PREFIX + "button";
     public static final String THING_TYPE_SHELLYBLUWALLSWITCH4_STR = THING_TYPE_SHELLYBLU_PREFIX + "wallswitch4";
+    public static final String THING_TYPE_SHELLYBLURCBUTTON4_STR = THING_TYPE_SHELLYBLU_PREFIX + "rcbutton4";
     public static final String THING_TYPE_SHELLYBLUDW_STR = THING_TYPE_SHELLYBLU_PREFIX + "dw";
     public static final String THING_TYPE_SHELLYBLUMOTION_STR = THING_TYPE_SHELLYBLU_PREFIX + "motion";
     public static final String THING_TYPE_SHELLYBLUHT_STR = THING_TYPE_SHELLYBLU_PREFIX + "ht";
@@ -371,6 +373,8 @@ public class ShellyThingCreator {
             THING_TYPE_SHELLYBLUBUTTON_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUWALLSWITCH4 = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
+    public static final ThingTypeUID THING_TYPE_SHELLYBLURCBUTTON4 = new ThingTypeUID(BINDING_ID,
+            THING_TYPE_SHELLYBLURCBUTTON4_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUDW = new ThingTypeUID(BINDING_ID, THING_TYPE_SHELLYBLUDW_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUMOTION = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUMOTION_STR);
@@ -476,6 +480,7 @@ public class ShellyThingCreator {
             // BLU Series
             Map.entry(SHELLYDT_BLUBUTTON, THING_TYPE_SHELLYBLUBUTTON_STR),
             Map.entry(SHELLYDT_BLUWALLSWITCH4, THING_TYPE_SHELLYBLUWALLSWITCH4_STR),
+            Map.entry(SHELLYDT_BLURCBUTTON4, THING_TYPE_SHELLYBLURCBUTTON4_STR),
             Map.entry(SHELLYDT_BLUDW, THING_TYPE_SHELLYBLUDW_STR),
             Map.entry(SHELLYDT_BLUMOTION, THING_TYPE_SHELLYBLUMOTION_STR),
             Map.entry(SHELLYDT_BLUHT, THING_TYPE_SHELLYBLUHT_STR),
@@ -560,6 +565,7 @@ public class ShellyThingCreator {
 
             Map.entry(THING_TYPE_SHELLYBLUBUTTON_STR, THING_TYPE_SHELLYBLUBUTTON_STR),
             Map.entry(THING_TYPE_SHELLYBLUWALLSWITCH4_STR, THING_TYPE_SHELLYBLUWALLSWITCH4_STR),
+            Map.entry(THING_TYPE_SHELLYBLURCBUTTON4_STR, THING_TYPE_SHELLYBLURCBUTTON4_STR),
             Map.entry(THING_TYPE_SHELLYBLUDW_STR, THING_TYPE_SHELLYBLUDW_STR),
             Map.entry(THING_TYPE_SHELLYBLUMOTION_STR, THING_TYPE_SHELLYBLUMOTION_STR),
             Map.entry(THING_TYPE_SHELLYBLUHT_STR, THING_TYPE_SHELLYBLUHT_STR),

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -136,7 +136,8 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_MINIG4_1PM = "S4SW-001P8EU";
 
     // Shelly BLU Series
-    public static final String SHELLYDT_BLUBUTTON = "SBBT";
+    public static final String SHELLYDT_BLUBUTTON = "SBBT-002C";
+    public static final String SHELLYDT_BLUWALLSWITCH4 = "SBBT-EU3870";
     public static final String SHELLYDT_BLUDW = "SBDW";
     public static final String SHELLYDT_BLUMOTION = "SBMO";
     public static final String SHELLYDT_BLUHT = "SBHT";
@@ -236,6 +237,7 @@ public class ShellyThingCreator {
     // Shelly BLU Series
     public static final String THING_TYPE_SHELLYBLU_PREFIX = "shellyblu";
     public static final String THING_TYPE_SHELLYBLUBUTTON_STR = THING_TYPE_SHELLYBLU_PREFIX + "button";
+    public static final String THING_TYPE_SHELLYBLUWALLSWITCH4_STR = THING_TYPE_SHELLYBLU_PREFIX + "wallswitch4";
     public static final String THING_TYPE_SHELLYBLUDW_STR = THING_TYPE_SHELLYBLU_PREFIX + "dw";
     public static final String THING_TYPE_SHELLYBLUMOTION_STR = THING_TYPE_SHELLYBLU_PREFIX + "motion";
     public static final String THING_TYPE_SHELLYBLUHT_STR = THING_TYPE_SHELLYBLU_PREFIX + "ht";
@@ -367,6 +369,8 @@ public class ShellyThingCreator {
     // Shelly Blu series
     public static final ThingTypeUID THING_TYPE_SHELLYBLUBUTTON = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUBUTTON_STR);
+    public static final ThingTypeUID THING_TYPE_SHELLYBLUWALLSWITCH4 = new ThingTypeUID(BINDING_ID,
+            THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUDW = new ThingTypeUID(BINDING_ID, THING_TYPE_SHELLYBLUDW_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUMOTION = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUMOTION_STR);
@@ -471,6 +475,7 @@ public class ShellyThingCreator {
 
             // BLU Series
             Map.entry(SHELLYDT_BLUBUTTON, THING_TYPE_SHELLYBLUBUTTON_STR),
+            Map.entry(SHELLYDT_BLUWALLSWITCH4, THING_TYPE_SHELLYBLUWALLSWITCH4_STR),
             Map.entry(SHELLYDT_BLUDW, THING_TYPE_SHELLYBLUDW_STR),
             Map.entry(SHELLYDT_BLUMOTION, THING_TYPE_SHELLYBLUMOTION_STR),
             Map.entry(SHELLYDT_BLUHT, THING_TYPE_SHELLYBLUHT_STR),
@@ -554,6 +559,7 @@ public class ShellyThingCreator {
             Map.entry(THING_TYPE_SHELLYPRO4PM_STR, THING_TYPE_SHELLYPRO4PM_STR),
 
             Map.entry(THING_TYPE_SHELLYBLUBUTTON_STR, THING_TYPE_SHELLYBLUBUTTON_STR),
+            Map.entry(THING_TYPE_SHELLYBLUWALLSWITCH4_STR, THING_TYPE_SHELLYBLUWALLSWITCH4_STR),
             Map.entry(THING_TYPE_SHELLYBLUDW_STR, THING_TYPE_SHELLYBLUDW_STR),
             Map.entry(THING_TYPE_SHELLYBLUMOTION_STR, THING_TYPE_SHELLYBLUMOTION_STR),
             Map.entry(THING_TYPE_SHELLYBLUHT_STR, THING_TYPE_SHELLYBLUHT_STR),

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
@@ -61,13 +61,22 @@ public class ShellyBluSensorHandler extends ShellyBaseHandler {
         LOGGER.debug("{}: Create thing for new BLU device {}: {} / {}", gateway, e.data.name, model, mac);
         ThingTypeUID tuid;
         switch (model) {
-            case SHELLYDT_BLUBUTTON:
-                ttype = THING_TYPE_SHELLYBLUBUTTON_STR;
-                tuid = THING_TYPE_SHELLYBLUBUTTON;
-                break;
-            case SHELLYDT_BLUWALLSWITCH4:
-                ttype = THING_TYPE_SHELLYBLUWALLSWITCH4_STR;
-                tuid = THING_TYPE_SHELLYBLUWALLSWITCH4;
+            case "SBBT":
+                switch (getString(e.data.name)) {
+                    default:
+                    case SHELLYDT_BLUBUTTON:
+                        ttype = THING_TYPE_SHELLYBLUBUTTON_STR;
+                        tuid = THING_TYPE_SHELLYBLUBUTTON;
+                        break;
+                    case SHELLYDT_BLUWALLSWITCH4:
+                        ttype = THING_TYPE_SHELLYBLUWALLSWITCH4_STR;
+                        tuid = THING_TYPE_SHELLYBLUWALLSWITCH4;
+                        break;
+                    case SHELLYDT_BLURCBUTTON4:
+                        ttype = THING_TYPE_SHELLYBLURCBUTTON4_STR;
+                        tuid = THING_TYPE_SHELLYBLURCBUTTON4;
+                        break;
+                }
                 break;
             case SHELLYDT_BLUDW:
                 ttype = THING_TYPE_SHELLYBLUDW_STR;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
@@ -65,6 +65,10 @@ public class ShellyBluSensorHandler extends ShellyBaseHandler {
                 ttype = THING_TYPE_SHELLYBLUBUTTON_STR;
                 tuid = THING_TYPE_SHELLYBLUBUTTON;
                 break;
+            case SHELLYDT_BLUWALLSWITCH4:
+                ttype = THING_TYPE_SHELLYBLUWALLSWITCH4_STR;
+                tuid = THING_TYPE_SHELLYBLUWALLSWITCH4;
+                break;
             case SHELLYDT_BLUDW:
                 ttype = THING_TYPE_SHELLYBLUDW_STR;
                 tuid = THING_TYPE_SHELLYBLUDW;

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -125,6 +125,7 @@ thing-type.shelly.shellypro4pm.description = Shelly Pro 4PM - 4xRelay Switch wit
 
 # BLU devices
 thing-type.shelly.shellyblubutton.description = Shelly BLU Button 1 / Button Tough 1
+thing-type.shelly.shellybluwallswitch4.description = Shelly BLU Wall Switch 4 / Shelly BLU RC Button 4
 thing-type.shelly.shellybludw.description = Shelly BLU Door/Window Sensor
 thing-type.shelly.shellyblumotion.description = Shelly BLU Motion Sensor
 thing-type.shelly.shellybluht.description = Shelly BLU Shelly H&amp;T (Humidity &amp; Temperature Sensor)
@@ -490,13 +491,14 @@ channel-type.shelly.supplyVoltage.description = External voltage supplied to the
 channel-type.shelly.lastUpdate.label = Last Update
 channel-type.shelly.lastUpdate.description = Timestamp of last status update
 channel-type.shelly.lastEvent.label = Last Event
-channel-type.shelly.lastEvent.description = Event Type (S=Short push, SS=Double-Short push, SSS=Triple-Short push, L=Long push, SL=Short-Long push, LS=Long-Short push)
+channel-type.shelly.lastEvent.description = Event Type (S=Short push, SS=Double-Short push, SSS=Triple-Short push, L=Long push, SL=Short-Long push, LS=Long-Short push, H=Hold)
 channel-type.shelly.lastEvent.state.option.S = Short push
 channel-type.shelly.lastEvent.state.option.SS = Double-Short push
 channel-type.shelly.lastEvent.state.option.SSS = Triple-Short push
 channel-type.shelly.lastEvent.state.option.L = Long push
 channel-type.shelly.lastEvent.state.option.SL = Short-Long push
 channel-type.shelly.lastEvent.state.option.LS = Long-Short push
+channel-type.shelly.lastEvent.state.option.H = Hold
 channel-type.shelly.eventCount.label = Event Count
 channel-type.shelly.eventCount.description = Number of input events received from device
 channel-type.shelly.eventTrigger.label = Event

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -125,7 +125,8 @@ thing-type.shelly.shellypro4pm.description = Shelly Pro 4PM - 4xRelay Switch wit
 
 # BLU devices
 thing-type.shelly.shellyblubutton.description = Shelly BLU Button 1 / Button Tough 1
-thing-type.shelly.shellybluwallswitch4.description = Shelly BLU Wall Switch 4 / Shelly BLU RC Button 4
+thing-type.shelly.shellybluwallswitch4.description = Shelly BLU Wall Switch 4
+thing-type.shelly.shellyblurcbutton4.description = Shelly BLU RC Button 4
 thing-type.shelly.shellybludw.description = Shelly BLU Door/Window Sensor
 thing-type.shelly.shellyblumotion.description = Shelly BLU Motion Sensor
 thing-type.shelly.shellybluht.description = Shelly BLU Shelly H&amp;T (Humidity &amp; Temperature Sensor)

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
@@ -37,6 +37,24 @@
 		<config-description-ref uri="thing-type:shelly:blubattery"/>
 	</thing-type>
 
+	<thing-type id="shellyblurcbutton4">
+		<label>Shelly BLU Wall Switch 4</label>
+		<description>@text/thing-type.shelly.shellyblurcbutton4.description</description>
+		<category>WallSwitch</category>
+		<semantic-equipment-tag>Button</semantic-equipment-tag>
+		<channel-groups>
+			<channel-group id="status1" typeId="buttonState"/>
+			<channel-group id="status2" typeId="buttonState"/>
+			<channel-group id="status3" typeId="buttonState"/>
+			<channel-group id="status4" typeId="buttonState"/>
+			<channel-group id="battery" typeId="batteryStatus"/>
+			<channel-group id="device" typeId="deviceStatus"/>
+		</channel-groups>
+
+		<representation-property>serviceName</representation-property>
+		<config-description-ref uri="thing-type:shelly:blubattery"/>
+	</thing-type>
+
 	<thing-type id="shellybludw">
 		<label>Shelly BLU Door/Window</label>
 		<description>@text/thing-type.shelly.shellybludw.description</description>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
@@ -19,6 +19,24 @@
 		<config-description-ref uri="thing-type:shelly:blubattery"/>
 	</thing-type>
 
+	<thing-type id="shellybluwallswitch4">
+		<label>Shelly BLU Wall Switch 4</label>
+		<description>@text/thing-type.shelly.shellybluwallswitch4.description</description>
+		<category>WallSwitch</category>
+		<semantic-equipment-tag>Button</semantic-equipment-tag>
+		<channel-groups>
+			<channel-group id="status1" typeId="buttonState"/>
+			<channel-group id="status2" typeId="buttonState"/>
+			<channel-group id="status3" typeId="buttonState"/>
+			<channel-group id="status4" typeId="buttonState"/>
+			<channel-group id="battery" typeId="batteryStatus"/>
+			<channel-group id="device" typeId="deviceStatus"/>
+		</channel-groups>
+
+		<representation-property>serviceName</representation-property>
+		<config-description-ref uri="thing-type:shelly:blubattery"/>
+	</thing-type>
+
 	<thing-type id="shellybludw">
 		<label>Shelly BLU Door/Window</label>
 		<description>@text/thing-type.shelly.shellybludw.description</description>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_sensor.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_sensor.xml
@@ -295,6 +295,7 @@
 				<option value="L">@text/channel-type.shelly.lastEvent.state.option.L</option>
 				<option value="SL">@text/channel-type.shelly.lastEvent.state.option.SL</option>
 				<option value="LS">@text/channel-type.shelly.lastEvent.state.option.LS</option>
+				<option value="H">@text/channel-type.shelly.lastEvent.state.option.H</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -46,6 +46,7 @@ public class ShellyDeviceProfileTest {
                 // Shelly BLU
                 Arguments.of(THING_TYPE_SHELLYBLUBUTTON_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUWALLSWITCH4_STR, true, true), //
+                Arguments.of(THING_TYPE_SHELLYBLURCBUTTON4_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUDW_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUMOTION_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUHT_STR, true, true), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -45,6 +45,7 @@ public class ShellyDeviceProfileTest {
         return Stream.of( //
                 // Shelly BLU
                 Arguments.of(THING_TYPE_SHELLYBLUBUTTON_STR, true, true), //
+                Arguments.of(THING_TYPE_SHELLYBLUWALLSWITCH4_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUDW_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUMOTION_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUHT_STR, true, true), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -193,6 +193,7 @@ public class ShellyThingCreatorTest {
                 // BLU Series
                 Arguments.of(SHELLYDT_BLUBUTTON, "", THING_TYPE_SHELLYBLUBUTTON_STR), //
                 Arguments.of(SHELLYDT_BLUWALLSWITCH4, "", THING_TYPE_SHELLYBLUWALLSWITCH4_STR), //
+                Arguments.of(SHELLYDT_BLURCBUTTON4, "", THING_TYPE_SHELLYBLURCBUTTON4_STR), //
                 Arguments.of(SHELLYDT_BLUDW, "", THING_TYPE_SHELLYBLUDW_STR), //
                 Arguments.of(SHELLYDT_BLUMOTION, "", THING_TYPE_SHELLYBLUMOTION_STR), //
                 Arguments.of(SHELLYDT_BLUHT, "", THING_TYPE_SHELLYBLUHT_STR), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -192,6 +192,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_PRO4PM_2, "", THING_TYPE_SHELLYPRO4PM_STR), //
                 // BLU Series
                 Arguments.of(SHELLYDT_BLUBUTTON, "", THING_TYPE_SHELLYBLUBUTTON_STR), //
+                Arguments.of(SHELLYDT_BLUWALLSWITCH4, "", THING_TYPE_SHELLYBLUWALLSWITCH4_STR), //
                 Arguments.of(SHELLYDT_BLUDW, "", THING_TYPE_SHELLYBLUDW_STR), //
                 Arguments.of(SHELLYDT_BLUMOTION, "", THING_TYPE_SHELLYBLUMOTION_STR), //
                 Arguments.of(SHELLYDT_BLUHT, "", THING_TYPE_SHELLYBLUHT_STR), //


### PR DESCRIPTION
This PR implements support for the Shelly devices based on BLU Button 4, known as Shelly Blu Wall Switch 4 and Shelly BLU RC Button 4.

Mainly the transportation scheme from a device used as BLU gateway to OH shelly binding is adapted:
- JSON serialization class Shelly2NotifyEventMessage
  - member Button changed to Buttons, instead of a single byte now a byte array is transported where the index ([0..3]) within the array represents the button ID [1..4]
  - the BLU gateway script oh-blu-scanner.js is extended so that it first collects all 0x3A events in an array befor adding to the JSON serializer
  - BLU Button1 is now simply a subset of BLU Button 4
- BLU Button 4 supports a new state `HOLD`, an according event type is added, which may be used for interessting use cases like continuous dimming (light) or sliding (roller shutter)

Regarding the device profile:
- I kindly ask the reviewers to check, if their might be an approach to cover these new devices mapping to existing code, that channel discovery took me a while to figure out and might be coverable with existing means.

For testing find here a [pre-build](https://github.com/UdoKrie/openhab-dev/blob/main/shelly/OH5.0.x/org.openhab.binding.shelly-5.0.0-SNAPSHOT.jar) jar