### PR TITLE
[shelly] Remove trailing blanks from properties files

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -8,7 +8,7 @@ addon.shelly.config.defaultPassword.description = Default password for device ac
 addon.shelly.config.localIP.label = Host Interface IP
 addon.shelly.config.localIP.description = This interface will be used to setup CoIoT listen and build Action URLs. openHAB's network configuration will be used if this is not set (recommended)
 addon.shelly.config.autoCoIoT.label = Auto-CoIoT
-addon.shelly.config.autoCoIoT.description = If enabled CoIoT will be automatically used when the devices runs a firmware version 1.6 or newer; false: Use thing configuration to enabled/disable CoIoT events.  
+addon.shelly.config.autoCoIoT.description = If enabled CoIoT will be automatically used when the devices runs a firmware version 1.6 or newer; false: Use thing configuration to enabled/disable CoIoT events.
 
 # Config status messages
 message.config-status.error.network-config = Invalid system or openHAB network configuration was detected (local IP {0}).
@@ -122,17 +122,17 @@ thing-type.shelly.shellypro3.description = Shelly Pro 3 - 3xRelay Switch
 thing-type.shelly.shellypro3em.description = Shelly Pro 3EM - 3xPower Meter
 thing-type.shelly.shellyproem50.description = Shelly Pro EM-50 - 2xPower Meter + 1xOutput
 thing-type.shelly.shellypro4pm.description = Shelly Pro 4PM - 4xRelay Switch with Power Meter
- 
+
 # BLU devices
 thing-type.shelly.shellyblubutton.description = Shelly BLU Button 1 / Button Tough 1
 thing-type.shelly.shellybludw.description = Shelly BLU Door/Window Sensor
 thing-type.shelly.shellyblumotion.description = Shelly BLU Motion Sensor
-thing-type.shelly.shellybluht.description = Shelly BLU Shelly H&amp;T (Humidity &amp; Temperature Sensor) 
+thing-type.shelly.shellybluht.description = Shelly BLU Shelly H&amp;T (Humidity &amp; Temperature Sensor)
 thing-type.shelly.shellyblugw.description = Shelly BLU Gateway
- 
+
 # Wall Displays
 thing-type.shelly.shellywalldisplay.description = Shelly Wall Display with sensors and input/output
- 
+
 # thing config - shellydevice
 thing-type.config.shelly.deviceIp.label = IP Address
 thing-type.config.shelly.deviceIp.description = IP Address of the Shelly device
@@ -173,7 +173,7 @@ thing-type.config.shelly.light.brightnessAutoOn.description = ON: Light is switc
 
 # thing config - battery
 thing-type.config.shelly.battery.lowBattery.label = Low Battery Treshold (%)
-thing-type.config.shelly.battery.lowBattery.description = An alarm is triggered when the device reports a battery charge lower than this threshold. Default: 20% 
+thing-type.config.shelly.battery.lowBattery.description = An alarm is triggered when the device reports a battery charge lower than this threshold. Default: 20%
 
 # channel groups
 channel-group-type.shelly.sensorData.label = Sensor Data
@@ -417,7 +417,7 @@ channel-type.shelly.sensorExtDigitalInput.description = State of digital input c
 channel-type.shelly.sensorExtAnalogInput.label = Analog Input
 channel-type.shelly.sensorExtAnalogInput.description = Percentage of analog input from external sensor
 channel-type.shelly.motionActive.label = Motion Active
-channel-type.shelly.motionActive.description = Indicates if motion sensor is active or within sleep time 
+channel-type.shelly.motionActive.description = Indicates if motion sensor is active or within sleep time
 channel-type.shelly.motionTimestamp.label = Last Motion
 channel-type.shelly.motionTimestamp.description = Timestamp when last motion was detected
 channel-type.shelly.sensorValve.label = Valve
@@ -520,7 +520,7 @@ channel-type.shelly.alarmTrigger.option.EXT_POWER = External power supply was co
 channel-type.shelly.alarmTrigger.option.BUTTON = Button was pressed
 channel-type.shelly.alarmTrigger.option.SENSOR = Sensor data updated
 channel-type.shelly.alarmState.label = Alarm State
-channel-type.shelly.alarmState.description = Alarm State (Unknown/None/Mild/Heavy/Test)   
+channel-type.shelly.alarmState.description = Alarm State (Unknown/None/Mild/Heavy/Test)
 channel-type.shelly.alarmState.state.option.unknown = Unknown
 channel-type.shelly.alarmState.state.option.none = None
 channel-type.shelly.alarmState.state.option.mild = Mild
@@ -547,7 +547,7 @@ message.manager.invalid-url = Invalid URL or syntax
 message.manager.buttons.ok = OK
 message.manager.buttons.abort = Abort
 
-message.manager.action.unknown = Action {0} is unknown 
+message.manager.action.unknown = Action {0} is unknown
 message.manager.action.reset-stats = Reset Statistics
 message.manager.action.restart = Reboot Device
 message.manager.action.restart.info = The device is restarting and reconnects to WiFi. It will take a moment until device status is refreshed in openHAB.
@@ -571,30 +571,30 @@ message.manager.action.checkupd.new = Firmware update available: {0}
 message.manager.action.checkupd.ok = Firmware check completed, check device overview for new version.
 message.manager.action.checkupd.runnuing = Firmware check was initiated.
 message.manager.action.checkupd.failed = Unable to check for firmware update: {0}
-message.manager.action.setwifirec-enable = The device performs an auto-restart if WiFi Recovery Mode is enabled and device is facing WiFi connectivity issues. 
-message.manager.action.setwifirec-disable = WiFi Recovery Mode will be disabled. 
+message.manager.action.setwifirec-enable = The device performs an auto-restart if WiFi Recovery Mode is enabled and device is facing WiFi connectivity issues.
+message.manager.action.setwifirec-disable = WiFi Recovery Mode will be disabled.
 message.manager.action.setwifirec-confirm = WiFi Recovery Mode has been {0}.
 message.manager.action.setwifirec-failed = Unable to update setting for WiFi Recovery Mode: {0}
 message.manager.action.setwifirangeext-enable = WiFi Range Extender will be enabled.
-message.manager.action.setwifirangeext-disable = WiFi Range Extender will be disabled. 
+message.manager.action.setwifirangeext-disable = WiFi Range Extender will be disabled.
 message.manager.action.setwifirangeext-confirm = WiFiRange Extender has been set, restart required: {0}
 message.manager.action.setwifirangeext-failed = Unable to update setting for WiFi Range Extender: {0}
-message.manager.action.setethernet-enable = Ethernet interface will be enabled, this requires a device reboot. 
-message.manager.action.setethernet-disable = Ethernet interface will be disabled, this may require a device reboot. 
+message.manager.action.setethernet-enable = Ethernet interface will be enabled, this requires a device reboot.
+message.manager.action.setethernet-disable = Ethernet interface will be disabled, this may require a device reboot.
 message.manager.action.setethernet-confirm = Ethernet interface has been {0}.
 message.manager.action.setethernet-failed = Unable to update setting for Ethernet interface: {0}
-message.manager.action.setbluetooth-enable = Bluetooth interface will be enabled, this requires a device reboot. 
-message.manager.action.setbluetooth-disable = Bluetooth interface will be disabled, this may require a device reboot. 
+message.manager.action.setbluetooth-enable = Bluetooth interface will be enabled, this requires a device reboot.
+message.manager.action.setbluetooth-disable = Bluetooth interface will be disabled, this may require a device reboot.
 message.manager.action.setbluetooth-confirm = Bluetooth interface has been {0}.
 message.manager.action.setbluetooth-failed = Unable to update setting for Bluetooth interface: {0}
-message.manager.action.aproaming-enable = WiFi Access Point Roaming will be enabled. Check product documentation for details. 
-message.manager.action.aproaming-disable = WiFi Access Point Roaming will be disabled. 
+message.manager.action.aproaming-enable = WiFi Access Point Roaming will be enabled. Check product documentation for details.
+message.manager.action.aproaming-disable = WiFi Access Point Roaming will be disabled.
 message.manager.action.aproaming-confirm = Unable to update setting WiFi Access Point Roaming: {0}
 message.manager.action.aproaming-failed = Unable to update setting for WiFi Recovery Mode: {0}
 message.manager.action.resetsta-info = The WiFi STA/AP Cache will be cleared and the device reconnects to the strongest Access Point.
 message.manager.action.resetsta-confirm = Device is reconnecting to the strongest WiFi Access Point.
 message.manager.action.resetsta-failed = Unable to clear STA/AP list and reconnect to WiFi: {0}
-message.manager.action.debug-enable = Device Debug will be enabled. Use this feature only if requested by Allterco Support. 
+message.manager.action.debug-enable = Device Debug will be enabled. Use this feature only if requested by Allterco Support.
 message.manager.action.debug-disable = Device Debug will be disabled.
 message.manager.action.debug-confirm = Device Debug was {0}.
 message.manager.action.getdebug-failed = Unable to get Debug Log: {0}


### PR DESCRIPTION
As indicated by Markus here is a commit dedicated to remove trailing white spaces from the shelly_xx.properties files