### PR TITLE
[shelly] Add support for Shelly Blu Wall Switch 4 and Shelly BLU RC B…

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -125,12 +125,13 @@ See section [Discovery](#discovery) for details.
 
 ### Shelly BLU
 
-| thing-type        | Model                                                  | Vendor ID |
-| ----------------- | ------------------------------------------------------ | --------- |
-| shellyblubutton   | Shelly BLU Button 1                                    | SBBT      |
-| shellybludw       | Shelly BLU Door/Windows                                | SBDW      |
-| shellyblumotion   | Shelly BLU Motion                                      | SBMO      |
-| shellybluht       | Shelly BLU H&T                                         | SBMO      |
+| thing-type           | Model                                    | Vendor ID               |
+| -------------------- | ---------------------------------------- | ----------------------- |
+| shellyblubutton      | Shelly BLU Button 1                      | SBBT-002C               |
+| shellybluwallswitch4 | Shelly BLU Wall Switch 4                 | SBBT-004CEU             |
+| shellybludw          | Shelly BLU Door/Windows                  | SBDW                    |
+| shellyblumotion      | Shelly BLU Motion                        | SBMO                    |
+| shellybluht          | Shelly BLU H&T                           | SBMO                    |
 
 ### Special Thing Types
 
@@ -433,6 +434,7 @@ The following trigger types are sent:
 | LONG_PRESSED       | The button was pressed for a longer time (lastEvent=L)              |
 | SHORT_LONG_PRESSED | A short followed by a long button push (lastEvent=SL)               |
 | LONG_SHORT_PRESSED | A long followed by a short button push (lastEvent=LS)               |
+| HOLDING            | A button continuously pressed (holded) (lastEvent=H)                |
 
 Check the channel definitions for the various devices to see if the device supports those events.
 You could use the Shelly App to set the timing for those events.
@@ -1530,6 +1532,20 @@ See notes on discovery of Shelly BLU devices above.
 | Group   | Channel       | Type     | read-only | Description                                                                         |
 | ------- | ------------- | -------- | --------- | ----------------------------------------------------------------------------------- |
 | status  | lastEvent     | String   | yes       | Last event type (S/SS/SSS/L)                                                        |
+|         | eventCount    | Number   | yes       | Counter gets incremented every time the device issues a button event.               |
+|         | button        | Trigger  | yes       | Event trigger with payload, see SHORT_PRESSED or LONG_PRESSED                       |
+|         | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                   |
+| battery | batteryLevel  | Number   | yes       | Battery Level in %                                                                  |
+|         | lowBattery    | Switch   | yes       | Low battery alert (< 20%)                                                           |
+| device  | gatewayDevice | String   | yes       | Shelly forwarded last status update (BLU gateway), could vary from packet to packet |
+
+### Shelly BLU Wall Switch 4 (thing-type: shellybluwallswitch4)
+
+See notes on discovery of Shelly BLU devices above.
+
+| Group   | Channel       | Type     | read-only | Description                                                                         |
+| ------- | ------------- | -------- | --------- | ----------------------------------------------------------------------------------- |
+| status  | lastEvent     | String   | yes       | Last event type (S/SS/SSS/L)                 ??????????????                                       |
 |         | eventCount    | Number   | yes       | Counter gets incremented every time the device issues a button event.               |
 |         | button        | Trigger  | yes       | Event trigger with payload, see SHORT_PRESSED or LONG_PRESSED                       |
 |         | lastUpdate    | DateTime | yes       | Timestamp of the last measurement                                                   |

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -105,6 +105,7 @@ public class ShellyBindingConstants {
 
             // Shelly BLU
             THING_TYPE_SHELLYBLUBUTTON, //
+            THING_TYPE_SHELLYBLUWALLSWITCH4, //
             THING_TYPE_SHELLYBLUDW, //
             THING_TYPE_SHELLYBLUMOTION, //
             THING_TYPE_SHELLYBLUHT, //

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -97,6 +97,7 @@ public class ShellyDeviceProfile {
     public boolean isHT = false; // true for H&T
     public boolean isDW = false; // true for Door Window sensor
     public boolean isButton = false; // true for a Shelly Button 1
+    public boolean isMultiButton = false; // true for a Shelly BLU Wall Switch 4
     public boolean isIX = false; // true for a Shelly IX
     public boolean isTRV = false; // true for a Shelly TRV
     public boolean isSmoke = false; // true for Shelly Smoke
@@ -231,6 +232,7 @@ public class ShellyDeviceProfile {
                 || thingType.equals(THING_TYPE_SHELLYPLUSI4DC_STR);
         isButton = thingType.equals(THING_TYPE_SHELLYBUTTON1_STR) || thingType.equals(THING_TYPE_SHELLYBUTTON2_STR)
                 || thingType.equals(THING_TYPE_SHELLYBLUBUTTON_STR);
+        isMultiButton = thingType.equals(THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
         isTRV = thingType.equals(THING_TYPE_SHELLYTRV_STR);
         isWall = thingType.equals(THING_TYPE_SHELLYPLUSWALLDISPLAY_STR);
         is3EM = thingType.equals(THING_TYPE_SHELLY3EM_STR) || thingType.startsWith(THING_TYPE_SHELLYPRO3EM_STR);
@@ -277,6 +279,8 @@ public class ShellyDeviceProfile {
             return CHANNEL_GROUP_LIGHT_CONTROL;
         } else if (isButton) {
             return CHANNEL_GROUP_STATUS;
+        } else if (isMultiButton) {
+            return CHANNEL_GROUP_STATUS + idx;
         } else if (isSensor) {
             return CHANNEL_GROUP_SENSOR;
         }
@@ -293,7 +297,7 @@ public class ShellyDeviceProfile {
         int idx = i + 1; // group names are 1-based
         if (isRGBW2) {
             return CHANNEL_GROUP_LIGHT_CONTROL;
-        } else if (isIX) {
+        } else if (isIX || isMultiButton) {
             return CHANNEL_GROUP_STATUS + idx;
         } else if (isButton) {
             return CHANNEL_GROUP_STATUS;
@@ -307,7 +311,7 @@ public class ShellyDeviceProfile {
 
     public String getInputSuffix(int i) {
         int idx = i + 1; // channel names are 1-based
-        if (isRGBW2 || isIX) {
+        if (isRGBW2 || isIX || isMultiButton) {
             return ""; // RGBW2 has only 1 channel
         } else if (isRoller || isDimmer) {
             // Roller has 2 relays, but it will be mapped to 1 roller with 2 inputs
@@ -330,7 +334,7 @@ public class ShellyDeviceProfile {
         List<ShellySettingsRgbwLight> lights = settings.lights;
         if (isButton) {
             return true;
-        } else if (isIX && inputs != null && idx < inputs.size()) {
+        } else if ((isMultiButton || isIX) && inputs != null && idx < inputs.size()) {
             ShellySettingsInput input = inputs.get(idx);
             btnType = getString(input.btnType);
         } else if (isDimmer) {
@@ -433,6 +437,8 @@ public class ShellyDeviceProfile {
         switch (model) {
             case SHELLYDT_BLUBUTTON:
                 return (THING_TYPE_SHELLYBLUBUTTON_STR + "-" + mac).toLowerCase();
+            case SHELLYDT_BLUWALLSWITCH4:
+                return (THING_TYPE_SHELLYBLUWALLSWITCH4_STR + "-" + mac).toLowerCase();
             case SHELLYDT_BLUDW:
                 return (THING_TYPE_SHELLYBLUDW_STR + "-" + mac).toLowerCase();
             case SHELLYDT_BLUMOTION:

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1ApiJsonDTO.java
@@ -82,6 +82,7 @@ public class Shelly1ApiJsonDTO {
     public static final String SHELLY_EVENT_TRIPLE_SHORTPUSH = "triple_shortpush";
     public static final String SHELLY_EVENT_SHORT_LONGTPUSH = "shortpush_longpush";
     public static final String SHELLY_EVENT_LONG_SHORTPUSH = "longpush_shortpush";
+    public static final String SHELLY_EVENT_HOLD = "hold";
 
     // Dimmer
     public static final String SHELLY_EVENT_BTN1_ON = "btn1_on";
@@ -241,6 +242,7 @@ public class Shelly1ApiJsonDTO {
     public static final String SHELLY_BTNEVENT_2SHORTPUSH = "SS";
     public static final String SHELLY_BTNEVENT_3SHORTPUSH = "SSS";
     public static final String SHELLY_BTNEVENT_LONGPUSH = "L";
+    public static final String SHELLY_BTNEVENT_HOLD = "H";
     public static final String SHELLY_BTNEVENT_SHORTLONGPUSH = "SL";
     public static final String SHELLY_BTNEVENT_LONGSHORTPUSH = "LS";
 
@@ -1329,6 +1331,8 @@ public class Shelly1ApiJsonDTO {
             case SHELLY_BTNEVENT_LONGSHORTPUSH:
             case SHELLY_EVENT_LONG_SHORTPUSH:
                 return "LONG_SHORT_PRESSED";
+            case SHELLY_EVENT_HOLD:
+                return "HOLDING";
             default:
                 return "";
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiJsonDTO.java
@@ -1159,8 +1159,8 @@ public class Shelly2ApiJsonDTO {
         public Integer pid;
         @SerializedName("Battery")
         public Integer battery;
-        @SerializedName("Button")
-        public Integer buttonEvent;
+        @SerializedName("Buttons")
+        public Integer[] buttonEvents;
         @SerializedName("Illuminance")
         public Integer illuminance;
         @SerializedName("Window")

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -124,7 +124,8 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_MINIG3_1PM = "S3SW-001P8EU";
 
     // Shelly BLU Series
-    public static final String SHELLYDT_BLUBUTTON = "SBBT";
+    public static final String SHELLYDT_BLUBUTTON = "SBBT-002C";
+    public static final String SHELLYDT_BLUWALLSWITCH4 = "SBBT-EU3870";
     public static final String SHELLYDT_BLUDW = "SBDW";
     public static final String SHELLYDT_BLUMOTION = "SBMO";
     public static final String SHELLYDT_BLUHT = "SBHT";
@@ -216,6 +217,7 @@ public class ShellyThingCreator {
     // Shelly BLU Series
     public static final String THING_TYPE_SHELLYBLU_PREFIX = "shellyblu";
     public static final String THING_TYPE_SHELLYBLUBUTTON_STR = THING_TYPE_SHELLYBLU_PREFIX + "button";
+    public static final String THING_TYPE_SHELLYBLUWALLSWITCH4_STR = THING_TYPE_SHELLYBLU_PREFIX + "wallswitch4";
     public static final String THING_TYPE_SHELLYBLUDW_STR = THING_TYPE_SHELLYBLU_PREFIX + "dw";
     public static final String THING_TYPE_SHELLYBLUMOTION_STR = THING_TYPE_SHELLYBLU_PREFIX + "motion";
     public static final String THING_TYPE_SHELLYBLUHT_STR = THING_TYPE_SHELLYBLU_PREFIX + "ht";
@@ -342,6 +344,8 @@ public class ShellyThingCreator {
     // Shelly Blu series
     public static final ThingTypeUID THING_TYPE_SHELLYBLUBUTTON = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUBUTTON_STR);
+    public static final ThingTypeUID THING_TYPE_SHELLYBLUWALLSWITCH4 = new ThingTypeUID(BINDING_ID,
+            THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUDW = new ThingTypeUID(BINDING_ID, THING_TYPE_SHELLYBLUDW_STR);
     public static final ThingTypeUID THING_TYPE_SHELLYBLUMOTION = new ThingTypeUID(BINDING_ID,
             THING_TYPE_SHELLYBLUMOTION_STR);
@@ -436,6 +440,7 @@ public class ShellyThingCreator {
 
         // BLU Series
         THING_TYPE_MAPPING.put(SHELLYDT_BLUBUTTON, THING_TYPE_SHELLYBLUBUTTON_STR);
+        THING_TYPE_MAPPING.put(SHELLYDT_BLUWALLSWITCH4, THING_TYPE_SHELLYBLUWALLSWITCH4_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_BLUDW, THING_TYPE_SHELLYBLUDW_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_BLUMOTION, THING_TYPE_SHELLYBLUMOTION_STR);
         THING_TYPE_MAPPING.put(SHELLYDT_BLUHT, THING_TYPE_SHELLYBLUHT_STR);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
@@ -65,6 +65,10 @@ public class ShellyBluSensorHandler extends ShellyBaseHandler {
                 ttype = THING_TYPE_SHELLYBLUBUTTON_STR;
                 tuid = THING_TYPE_SHELLYBLUBUTTON;
                 break;
+            case SHELLYDT_BLUWALLSWITCH4:
+                ttype = THING_TYPE_SHELLYBLUWALLSWITCH4_STR;
+                tuid = THING_TYPE_SHELLYBLUWALLSWITCH4;
+                break;
             case SHELLYDT_BLUDW:
                 ttype = THING_TYPE_SHELLYBLUDW_STR;
                 tuid = THING_TYPE_SHELLYBLUDW;

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -122,6 +122,7 @@ thing-type.shelly.shellypro4pm.description = Shelly Pro 4PM - 4xRelay Switch wit
  
 # BLU devices
 thing-type.shelly.shellyblubutton.description = Shelly BLU Button 1 / Button Tough 1
+thing-type.shelly.shellybluwallswitch4.description = Shelly BLU Wall Switch 4 / Shelly BLU RC Button 4
 thing-type.shelly.shellybludw.description = Shelly BLU Door/Window Sensor
 thing-type.shelly.shellyblumotion.description = Shelly BLU Motion Sensor
 thing-type.shelly.shellybluht.description = Shelly BLU Shelly H&amp;T (Humidity &amp; Temperature Sensor) 
@@ -487,13 +488,14 @@ channel-type.shelly.supplyVoltage.description = External voltage supplied to the
 channel-type.shelly.lastUpdate.label = Last Update
 channel-type.shelly.lastUpdate.description = Timestamp of last status update
 channel-type.shelly.lastEvent.label = Last Event
-channel-type.shelly.lastEvent.description = Event Type (S=Short push, SS=Double-Short push, SSS=Triple-Short push, L=Long push, SL=Short-Long push, LS=Long-Short push)
+channel-type.shelly.lastEvent.description = Event Type (S=Short push, SS=Double-Short push, SSS=Triple-Short push, L=Long push, SL=Short-Long push, LS=Long-Short push, H=Hold)
 channel-type.shelly.lastEvent.state.option.S = Short push
 channel-type.shelly.lastEvent.state.option.SS = Double-Short push
 channel-type.shelly.lastEvent.state.option.SSS = Triple-Short push
 channel-type.shelly.lastEvent.state.option.L = Long push
 channel-type.shelly.lastEvent.state.option.SL = Short-Long push
 channel-type.shelly.lastEvent.state.option.LS = Long-Short push
+channel-type.shelly.lastEvent.state.option.H = Hold
 channel-type.shelly.eventCount.label = Event Count
 channel-type.shelly.eventCount.description = Number of input events received from device
 channel-type.shelly.eventTrigger.label = Event

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyBlu.xml
@@ -18,6 +18,24 @@
 		<config-description-ref uri="thing-type:shelly:blubattery"/>
 	</thing-type>
 
+	<thing-type id="shellybluwallswitch4">
+		<label>Shelly BLU Wall Switch 4</label>
+		<description>@text/thing-type.shelly.shellybluwallswitch4.description</description>
+		<category>WallSwitch</category>
+		<semantic-equipment-tag>Button</semantic-equipment-tag>
+		<channel-groups>
+			<channel-group id="status1" typeId="buttonState"/>
+			<channel-group id="status2" typeId="buttonState"/>
+			<channel-group id="status3" typeId="buttonState"/>
+			<channel-group id="status4" typeId="buttonState"/>
+			<channel-group id="battery" typeId="batteryStatus"/>
+			<channel-group id="device" typeId="deviceStatus"/>
+		</channel-groups>
+
+		<representation-property>serviceName</representation-property>
+		<config-description-ref uri="thing-type:shelly:blubattery"/>
+	</thing-type>
+
 	<thing-type id="shellybludw">
 		<label>Shelly BLU Door/Window</label>
 		<description>@text/thing-type.shelly.shellybludw.description</description>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_sensor.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen1_sensor.xml
@@ -284,6 +284,7 @@
 				<option value="L">@text/channel-type.shelly.lastEvent.state.option.L</option>
 				<option value="SL">@text/channel-type.shelly.lastEvent.state.option.SL</option>
 				<option value="LS">@text/channel-type.shelly.lastEvent.state.option.LS</option>
+				<option value="H">@text/channel-type.shelly.lastEvent.state.option.H</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -45,6 +45,7 @@ public class ShellyDeviceProfileTest {
         return Stream.of( //
                 // Shelly BLU
                 Arguments.of(THING_TYPE_SHELLYBLUBUTTON_STR, true, true), //
+                Arguments.of(THING_TYPE_SHELLYBLUWALLSWITCH4_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUDW_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUMOTION_STR, true, true), //
                 Arguments.of(THING_TYPE_SHELLYBLUHT_STR, true, true), //

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -190,6 +190,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_PRO4PM_2, "", THING_TYPE_SHELLYPRO4PM_STR), //
                 // BLU Series
                 Arguments.of(SHELLYDT_BLUBUTTON, "", THING_TYPE_SHELLYBLUBUTTON_STR), //
+                Arguments.of(SHELLYDT_BLUWALLSWITCH4, "", THING_TYPE_SHELLYBLUWALLSWITCH4_STR), //
                 Arguments.of(SHELLYDT_BLUDW, "", THING_TYPE_SHELLYBLUDW_STR), //
                 Arguments.of(SHELLYDT_BLUMOTION, "", THING_TYPE_SHELLYBLUMOTION_STR), //
                 Arguments.of(SHELLYDT_BLUHT, "", THING_TYPE_SHELLYBLUHT_STR), //
@@ -201,8 +202,9 @@ public class ShellyThingCreatorTest {
     @Test
     void getThingUIDReturnsThingTypeMatchingServiceName() {
         Set<ThingTypeUID> excludedThingTypeUids = Set.of(THING_TYPE_SHELLYBLUDW, THING_TYPE_SHELLYBLUMOTION,
-                THING_TYPE_SHELLYBLUHT, THING_TYPE_SHELLYBLUGW, THING_TYPE_SHELLYBLUBUTTON, THING_TYPE_SHELLY2_RELAY,
-                THING_TYPE_SHELLY2_ROLLER, THING_TYPE_SHELLY25_ROLLER, THING_TYPE_SHELLY25_RELAY,
+                THING_TYPE_SHELLYBLUHT, THING_TYPE_SHELLYBLUGW, THING_TYPE_SHELLYBLUBUTTON,
+                THING_TYPE_SHELLYBLUWALLSWITCH4, THING_TYPE_SHELLY2_RELAY, THING_TYPE_SHELLY2_ROLLER,
+                THING_TYPE_SHELLY25_ROLLER, THING_TYPE_SHELLY25_RELAY,
                 new ThingTypeUID(ShellyBindingConstants.BINDING_ID, THING_TYPE_SHELLYPLUSHTG3_STR),
                 new ThingTypeUID(ShellyBindingConstants.BINDING_ID, THING_TYPE_SHELLYPLUS2PM_RELAY_STR),
                 new ThingTypeUID(ShellyBindingConstants.BINDING_ID, THING_TYPE_SHELLYPLUS2PM_ROLLER_STR),


### PR DESCRIPTION
This PR implements support for the Shelly devices based on BLU Button 4, known as Shelly Blu Wall Switch 4 and Shelly BLU RC Button 4.

Mainly the transportation scheme from a device used as BLU gateway to OH shelly binding is adapted:

* JSON serialization class Shelly2NotifyEventMessage
   * member Button changed to Buttons, instead of a single byte now a byte array is transported where the index ([0..3]) within the array represents the button ID [1..4]
  * the BLU gateway script oh-blu-scanner.js is extended so that it first collects all 0x3A events in an array befor adding to the JSON serializer
  * BLU Button1 is now simply a subset of BLU Button 4
* BLU Button 4 supports a new state HOLD, an according event type is added, which may be used for interessting use cases like continuous dimming (light) or sliding (roller shutter)

Regarding the device profile:

* I kindly ask the reviewers to check, if their might be an approach to cover these new devices mapping to existing code, that channel discovery took me a while to figure out and might be coverable with existing means.

A pre-build jar fro OH4.3.x can be found [here](https://github.com/UdoKrie/openhab-dev/blob/main/shelly/OH4.3.x/org.openhab.binding.shelly-4.3.6-SNAPSHOT.jar)