### PR TITLE
Use `var` for timestampOfLastScan to support upcoming Instant-based API

### DIFF
--- a/bundles/org.openhab.binding.broadlinkthermostat/src/main/java/org/openhab/binding/broadlinkthermostat/internal/discovery/BroadlinkDiscoveryService.java
+++ b/bundles/org.openhab.binding.broadlinkthermostat/src/main/java/org/openhab/binding/broadlinkthermostat/internal/discovery/BroadlinkDiscoveryService.java
@@ -68,7 +68,7 @@ public class BroadlinkDiscoveryService extends AbstractDiscoveryService {
     }
 
     private void createScanner() {
-        long timestampOfLastScan = getTimestampOfLastScan();
+        var timestampOfLastScan = getTimestampOfLastScan();
         BLDevice[] blDevices = new BLDevice[0];
         try {
             @Nullable

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/discovery/DaikinACUnitDiscoveryService.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/discovery/DaikinACUnitDiscoveryService.java
@@ -94,7 +94,7 @@ public class DaikinACUnitDiscoveryService extends AbstractDiscoveryService {
     }
 
     private void scanner() {
-        long timestampOfLastScan = getTimestampOfLastScan();
+        var timestampOfLastScan = getTimestampOfLastScan();
         for (InetAddress broadcastAddress : getBroadcastAddresses()) {
             logger.trace("Starting broadcast for {}", broadcastAddress.toString());
 

--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java
@@ -94,7 +94,7 @@ public class EcovacsDeviceDiscoveryService extends AbstractThingHandlerDiscovery
 
     private void scanForDevices() {
         this.api.ifPresent(api -> {
-            long timestampOfLastScan = getTimestampOfLastScan();
+            var timestampOfLastScan = getTimestampOfLastScan();
             try {
                 List<EcovacsDevice> devices = api.getDevices();
                 logger.debug("Ecovacs discovery found {} devices", devices.size());

--- a/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/discovery/IRobotDiscoveryService.java
+++ b/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/discovery/IRobotDiscoveryService.java
@@ -102,7 +102,7 @@ public class IRobotDiscoveryService extends AbstractDiscoveryService {
     private Runnable createScanner() {
         return () -> {
             Set<String> robots = new HashSet<>();
-            long timestampOfLastScan = getTimestampOfLastScan();
+            var timestampOfLastScan = getTimestampOfLastScan();
             for (InetAddress broadcastAddress : getBroadcastAddresses()) {
                 logger.debug("Starting broadcast for {}", broadcastAddress.toString());
 


### PR DESCRIPTION
This is a non-breaking change for future-proofing in case openhab/openhab-core#4866 will be accepted. It will make sure that the new overload `removeOlderResults(Instant)` is automatically selected when `getTimestampOfLastScan()` is changed to return an `Instant` rather than `long`.

There are two variants of the `getTimestampOfLastScan()` usages.

This one will already work:
```java
removeOlderResults(getTimestampOfLastScan());
```

whereas this one will currently not:
```java
long lastScan = getTimestampOfLastScan();
removeOlderResults(lastScan);
```

This PR can be merged before any of the other related PR's.

Using `var` when the type is not obvious is somewhat controversial, but it will ease the migration. I will provide another PR for finally changing to `Instant` when core PR is merged. So `long` → `var` → `Instant`.

Based on search:
```bash
$ grep -R "getTimestampOfLastScan()" . | grep -v "removeOlderResults"
./bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java:        // Results newer than `getTimestampOfLastScan()` will also be notified again but do not lead to duplicates.
./bundles/org.openhab.binding.broadlinkthermostat/src/main/java/org/openhab/binding/broadlinkthermostat/internal/discovery/BroadlinkDiscoveryService.java:        long timestampOfLastScan = getTimestampOfLastScan();
./bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/discovery/DaikinACUnitDiscoveryService.java:        long timestampOfLastScan = getTimestampOfLastScan();
./bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/discovery/IRobotDiscoveryService.java:            long timestampOfLastScan = getTimestampOfLastScan();
./bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/discovery/EcovacsDeviceDiscoveryService.java:            long timestampOfLastScan = getTimestampOfLastScan();
```

Related to #18838