### PR TITLE
[rrd4j] Fix rrd4j query boundaries

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -488,7 +488,10 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
                         ConsolFun consolFun = getConsolidationFunction(db);
                         FetchRequest request = db.createFetchRequest(consolFun, end, end, 1);
                         Archive archive = db.findMatchingArchive(request);
-                        start = archive.getStartTime() - archive.getArcStep();
+                        long arcStep = archive.getArcStep();
+                        start = archive.getStartTime() - arcStep;
+                        end = end % arcStep == 0 ? end : (end / arcStep + 1) * arcStep; // Make sure end is aligned with
+                                                                                        // matching archive
                     }
                 } else {
                     throw new UnsupportedOperationException(


### PR DESCRIPTION
A previous fix looks like not being complete, see https://github.com/openhab/openhab-addons/issues/18523#issuecomment-3001574197

This issue pops up again because the alignment of the archives relative to the current time matters in this query. In previous testing, the alignment did not hit the problem of the request date being after the matched archive end date.