### PR TITLE
[pythonscripting] cleanups for the final release

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/feature/feature.xml
@@ -19,7 +19,8 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/24.2.1</bundle>
 		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/24.2.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/24.2.1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/24.2.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/24.2.1</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi-libffi/24.2.1</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/24.2.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.pythonscripting/${project.version}</bundle>
 	</feature>

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngine.java
@@ -76,10 +76,7 @@ public class PythonScriptEngine
 
     private static final String SYSTEM_PROPERTY_ATTACH_LIBRARY_FAILURE_ACTION = "polyglotimpl.AttachLibraryFailureAction";
 
-    private static final String PYTHON_OPTION_EXECUTABLE = "python.Executable";
-    private static final String PYTHON_OPTION_PYTHONHOME = "python.PythonHome";
     private static final String PYTHON_OPTION_PYTHONPATH = "python.PythonPath";
-    private static final String PYTHON_OPTION_INPUTFILEPATH = "python.InputFilePath";
     private static final String PYTHON_OPTION_EMULATEJYTHON = "python.EmulateJython";
     private static final String PYTHON_OPTION_POSIXMODULEBACKEND = "python.PosixModuleBackend";
     private static final String PYTHON_OPTION_DONTWRITEBYTECODEFLAG = "python.DontWriteBytecodeFlag";
@@ -207,23 +204,16 @@ public class PythonScriptEngine
                 .option(PYTHON_OPTION_POSIXMODULEBACKEND, "java") //
                 // Force to automatically import site.py module, to make Python packages available
                 .option(PYTHON_OPTION_FORCEIMPORTSITE, Boolean.toString(true)) //
-                // The sys.executable path, a virtual path that is used by the interpreter
-                // to discover packages
-                .option(PYTHON_OPTION_EXECUTABLE,
-                        PythonScriptEngineFactory.PYTHON_DEFAULT_PATH.resolve("bin").resolve("python").toString())
-                // Set the python home to be read from the embedded resources
-                .option(PYTHON_OPTION_PYTHONHOME, PythonScriptEngineFactory.PYTHON_DEFAULT_PATH.toString()) //
-                // Set python path to point to sources stored in
-                .option(PYTHON_OPTION_PYTHONPATH,
-                        PythonScriptEngineFactory.PYTHON_LIB_PATH.toString() + File.pathSeparator
-                                + PythonScriptEngineFactory.PYTHON_DEFAULT_PATH.toString())
-                // pass the path to be executed
-                .option(PYTHON_OPTION_INPUTFILEPATH, PythonScriptEngineFactory.PYTHON_DEFAULT_PATH.toString()) //
                 // make sure the TopLevelExceptionHandler calls the excepthook to print Python exceptions
                 .option(PYTHON_OPTION_ALWAYSRUNEXCEPTHOOK, Boolean.toString(true)) //
                 // emulate jython behavior (will slowdown the engine)
                 .option(PYTHON_OPTION_EMULATEJYTHON,
-                        String.valueOf(pythonScriptEngineConfiguration.isJythonEmulation()));
+                        String.valueOf(pythonScriptEngineConfiguration.isJythonEmulation()))
+
+                // Set python path to point to sources stored in
+                // pass the path to be executed
+                .option(PYTHON_OPTION_PYTHONPATH, PythonScriptEngineFactory.PYTHON_LIB_PATH.toString()
+                        + File.pathSeparator + PythonScriptEngineFactory.PYTHON_DEFAULT_PATH.toString());
 
         if (pythonScriptEngineConfiguration.isCachingEnabled()) {
             contextConfig.option(PYTHON_OPTION_DONTWRITEBYTECODEFLAG, Boolean.toString(false)) //


### PR DESCRIPTION
this pull request removes unnecessary graalpy options like python.Executable, python.PythonHome and python.InputFilePath. For now we depend only from python.PythonPath. The others are default.

Additonally, I fixed the startlevelbehavior of nfi and added libffi. Both are not used yet. 

As NFI dependencies are included, you can activate NativeModules via ENV Vars like

```
EXTRA_JAVA_OPTS="
  -Dpython.NativeModules=true
  -Dpython.IsolateNativeModules=true
"
```

