### PR TITLE
Use `var` for timestampOfLastScan to support upcoming Instant-based API

### DIFF
--- a/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/discovery/EcoflowDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.ecoflow/src/main/java/org/openhab/binding/ecoflow/internal/discovery/EcoflowDeviceDiscoveryService.java
@@ -97,7 +97,7 @@ public class EcoflowDeviceDiscoveryService extends AbstractThingHandlerDiscovery
 
     private void scanForDevices() {
         this.api.ifPresent(api -> {
-            long timestampOfLastScan = getTimestampOfLastScan();
+            var timestampOfLastScan = getTimestampOfLastScan();
             try {
                 List<DeviceListResponseEntry> devices = api.getDeviceList();
                 logger.debug("Ecoflow discovery found {} devices", devices.size());


### PR DESCRIPTION
Follow-up to #18845, since #18525 got merged in the meantime.