### PR TITLE
[insteon] Refactor static copy factory methods to instance methods

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/config/InsteonChannelConfiguration.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/config/InsteonChannelConfiguration.java
@@ -61,12 +61,18 @@ public class InsteonChannelConfiguration {
         return s;
     }
 
-    public static InsteonChannelConfiguration copyOf(InsteonChannelConfiguration original, int onLevel,
-            RampRate rampRate) {
+    /**
+     * Creates a copy of this configuration
+     *
+     * @param defaultOnLevel default on level value
+     * @param defaultRampRate default ramp rate value
+     * @return a new configuration instance
+     */
+    public InsteonChannelConfiguration copy(int defaultOnLevel, RampRate defaultRampRate) {
         InsteonChannelConfiguration config = new InsteonChannelConfiguration();
-        config.group = original.group;
-        config.onLevel = original.onLevel != -1 ? original.onLevel : onLevel;
-        config.rampRate = original.rampRate != -1 ? original.rampRate : rampRate.getTimeInSeconds();
+        config.group = group;
+        config.onLevel = onLevel != -1 ? onLevel : defaultOnLevel;
+        config.rampRate = rampRate != -1 ? rampRate : defaultRampRate.getTimeInSeconds();
         config.original = false;
         return config;
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
@@ -359,8 +359,8 @@ public class InsteonDevice extends BaseDevice<InsteonAddress, InsteonDeviceHandl
                 .forEach(record -> getResponderFeatures().stream()
                         .filter(feature -> feature.getComponentId() == record.getComponentId()).findFirst()
                         .ifPresent(feature -> {
-                            InsteonChannelConfiguration adjustConfig = InsteonChannelConfiguration.copyOf(config,
-                                    record.getOnLevel(), record.getRampRate());
+                            InsteonChannelConfiguration adjustConfig = config.copy(record.getOnLevel(),
+                                    record.getRampRate());
                             feature.handleCommand(adjustConfig, cmd);
                         }));
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDB.java
@@ -348,7 +348,7 @@ public class LinkDB {
             // move last record if overwritten by a different record
             if (prevRecord != null && prevRecord.isLast() && !prevRecord.equals(record)) {
                 int location = prevRecord.getLocation() - LinkDBRecord.SIZE;
-                records.put(location, LinkDBRecord.withNewLocation(location, prevRecord));
+                records.put(location, prevRecord.withNewLocation(location));
                 if (logger.isTraceEnabled()) {
                     logger.trace("moved last record for {} to location {}", device.getAddress(),
                             HexUtils.getHexString(location));

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBChange.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBChange.java
@@ -33,7 +33,7 @@ public class LinkDBChange extends DatabaseChange<LinkDBRecord> {
 
     @Override
     public LinkDBRecord getRecord() {
-        return type == ChangeType.DELETE ? LinkDBRecord.asInactive(record) : record;
+        return type == ChangeType.DELETE ? record.asInactive() : record;
     }
 
     /**
@@ -59,7 +59,7 @@ public class LinkDBChange extends DatabaseChange<LinkDBRecord> {
      * @return the link db change
      */
     public static LinkDBChange forModify(LinkDBRecord record, byte[] data) {
-        return new LinkDBChange(LinkDBRecord.withNewData(data, record), ChangeType.MODIFY);
+        return new LinkDBChange(record.withNewData(data), ChangeType.MODIFY);
     }
 
     /**

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBRecord.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/LinkDBRecord.java
@@ -47,6 +47,36 @@ public class LinkDBRecord extends DatabaseRecord {
     }
 
     /**
+     * Creates a copy of this record as inactive
+     *
+     * @return the inactive record
+     */
+    public LinkDBRecord asInactive() {
+        RecordType type = RecordType.asInactive(getFlags());
+        return new LinkDBRecord(getLocation(), type, getGroup(), getAddress(), getData());
+    }
+
+    /**
+     * Creates a copy of this record with new data
+     *
+     * @param data the new data to use
+     * @return a new record instance with the new data
+     */
+    public LinkDBRecord withNewData(byte[] data) {
+        return new LinkDBRecord(getLocation(), getType(), getGroup(), getAddress(), data);
+    }
+
+    /**
+     * Creates a copy of this record with new location
+     *
+     * @param location the new location to use
+     * @return a new record instance with the new location
+     */
+    public LinkDBRecord withNewLocation(int location) {
+        return new LinkDBRecord(location, getType(), getGroup(), getAddress(), getData());
+    }
+
+    /**
      * Factory method for creating a new LinkDBRecord from a set of parameters
      *
      * @param location the record location to use
@@ -95,39 +125,5 @@ public class LinkDBRecord extends DatabaseRecord {
         byte[] data = msg.getBytes("userData11", 3);
 
         return new LinkDBRecord(location, type, group, address, data);
-    }
-
-    /**
-     * Factory method for creating a new LinkDBRecord from another instance as inactive
-     *
-     * @param record the link db record to use
-     * @return the inactive link db record
-     */
-    public static LinkDBRecord asInactive(LinkDBRecord record) {
-        RecordType type = RecordType.asInactive(record.getFlags());
-
-        return new LinkDBRecord(record.getLocation(), type, record.getGroup(), record.getAddress(), record.getData());
-    }
-
-    /**
-     * Factory method for creating a new LinkDBRecord from another instance with new data
-     *
-     * @param data the new data to use
-     * @param record the link db record to use
-     * @return the link db record with new data
-     */
-    public static LinkDBRecord withNewData(byte[] data, LinkDBRecord record) {
-        return new LinkDBRecord(record.getLocation(), record.getType(), record.getGroup(), record.getAddress(), data);
-    }
-
-    /**
-     * Factory method for creating a new LinkDBRecord from another instance with new location
-     *
-     * @param location the new location to use
-     * @param record the link db record to use
-     * @return the link db record with new location
-     */
-    public static LinkDBRecord withNewLocation(int location, LinkDBRecord record) {
-        return new LinkDBRecord(location, record.getType(), record.getGroup(), record.getAddress(), record.getData());
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDBChange.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDBChange.java
@@ -48,7 +48,7 @@ public class ModemDBChange extends DatabaseChange<ModemDBRecord> {
      * @return the modem db change
      */
     public static ModemDBChange forModify(ModemDBRecord record, byte[] data) {
-        return new ModemDBChange(ModemDBRecord.withNewData(data, record), ChangeType.MODIFY);
+        return new ModemDBChange(record.withNewData(data), ChangeType.MODIFY);
     }
 
     /**

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDBRecord.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/database/ModemDBRecord.java
@@ -51,6 +51,16 @@ public class ModemDBRecord extends DatabaseRecord {
     }
 
     /**
+     * Creates a copy of this record with new data
+     *
+     * @param data the new data to use
+     * @return a new record instance with the new data
+     */
+    public ModemDBRecord withNewData(byte[] data) {
+        return new ModemDBRecord(getType(), getGroup(), getAddress(), data);
+    }
+
+    /**
      * Factory method for creating a new ModemDBRecord from a set of parameters
      *
      * @param address the record address
@@ -130,16 +140,5 @@ public class ModemDBRecord extends DatabaseRecord {
         }
 
         return records;
-    }
-
-    /**
-     * Factory method for creating a new ModemDBRecord from another instance with new data
-     *
-     * @param data the new record data to use
-     * @param record the modem db record to use
-     * @return the modem db record with new type
-     */
-    public static ModemDBRecord withNewData(byte[] data, ModemDBRecord record) {
-        return new ModemDBRecord(record.getType(), record.getGroup(), record.getAddress(), data);
     }
 }


### PR DESCRIPTION
This change refactors static copy factory methods used in Insteon binding, to instance methods instead.