### PR TITLE
Remove deprecated `DiscoveryListener` method implementations

### DIFF
--- a/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/philipstv/PhilipsTVConnectionManager.java
+++ b/bundles/org.openhab.binding.androidtv/src/main/java/org/openhab/binding/androidtv/internal/protocol/philipstv/PhilipsTVConnectionManager.java
@@ -682,12 +682,6 @@ public class PhilipsTVConnectionManager implements DiscoveryListener {
         return Collections.emptyList();
     }
 
-    @Override
-    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return Collections.emptyList();
-    }
-
     public void dispose() {
         discoveryServiceRegistry.removeDiscoveryListener(this);
         ScheduledFuture<?> refreshScheduler = this.refreshScheduler;

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/SimpleDiscoveryListener.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/test/util/SimpleDiscoveryListener.java
@@ -50,10 +50,4 @@ public class SimpleDiscoveryListener implements DiscoveryListener {
             @Nullable Collection<@NonNull ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
         return null;
     }
-
-    @Override
-    public @Nullable Collection<@NonNull ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<@NonNull ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return null;
-    }
 }

--- a/bundles/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/internal/handler/IppPrinterHandler.java
+++ b/bundles/org.openhab.binding.ipp/src/main/java/org/openhab/binding/ipp/internal/handler/IppPrinterHandler.java
@@ -182,10 +182,4 @@ public class IppPrinterHandler extends BaseThingHandler implements DiscoveryList
             @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
         return Set.of();
     }
-
-    @Override
-    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return Set.of();
-    }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscoveryTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscoveryTests.java
@@ -211,12 +211,6 @@ public class HomeAssistantDiscoveryTests extends AbstractHomeAssistantTests {
             return Collections.emptyList();
         }
 
-        @Override
-        public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-                @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-            return Collections.emptyList();
-        }
-
         public List<DiscoveryResult> getDiscoveryResults() {
             ArrayList<DiscoveryResult> localResults = new ArrayList<>(discoveryResults);
             discoveryResults.clear();

--- a/bundles/org.openhab.binding.mqtt.ruuvigateway/src/test/java/org/openhab/binding/mqtt/ruuvigateway/internal/discovery/RuuviGatewayDiscoveryTests.java
+++ b/bundles/org.openhab.binding.mqtt.ruuvigateway/src/test/java/org/openhab/binding/mqtt/ruuvigateway/internal/discovery/RuuviGatewayDiscoveryTests.java
@@ -151,12 +151,6 @@ public class RuuviGatewayDiscoveryTests {
             return Collections.emptyList();
         }
 
-        @Override
-        public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-                @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-            return Collections.emptyList();
-        }
-
         public CopyOnWriteArrayList<DiscoveryResult> getDiscoveryResults() {
             return discoveryResults;
         }

--- a/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryServiceTest.java
@@ -72,12 +72,6 @@ public class TradfriDiscoveryServiceTest {
                 Collection<ThingTypeUID> thingTypeUIDs, ThingUID bridgeUID) {
             return null;
         }
-
-        @Override
-        public Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-                Collection<ThingTypeUID> thingTypeUIDs, ThingUID bridgeUID) {
-            return null;
-        }
     };
 
     private DiscoveryResult discoveryResult;

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
@@ -77,12 +77,6 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
                 @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
             return List.of();
         }
-
-        @Override
-        public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-                @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-            return List.of();
-        }
     };
 
     @Override

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueDeviceDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueDeviceDiscoveryServiceOSGiTest.java
@@ -147,12 +147,6 @@ public class HueDeviceDiscoveryServiceOSGiTest extends AbstractHueOSGiTestParent
                     @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
                 return null;
             }
-
-            @Override
-            public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-                    @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-                return null;
-            }
         });
 
         discoveryService.addLightDiscovery(light);

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
@@ -165,12 +165,6 @@ public class HueBridgeNupnpDiscoveryOSGITest extends JavaOSGiTest {
                     @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
                 return null;
             }
-
-            @Override
-            public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-                    @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-                return null;
-            }
         });
 
         sut.startScan();


### PR DESCRIPTION
This removes the now deprecated `DiscoveryListener.removeOlderResults(long)` implementations.

#18838 introduced the new `DiscoveryListener.removeOlderResults(Instant)` implementations in a4b5f0faddd7fe15e965901740eaa4c71e8aa875.

This is the last step for the addons repository to complete the plan outlined in https://github.com/openhab/openhab-core/issues/4866

Depends on openhab/openhab-core#4883