### PR TITLE
[shelly] Fix Shelly Pro 4PM discovery, thing init for unknown thing

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -123,7 +123,7 @@ See section [Discovery](#discovery) for details.
 | shellypro3          | Shelly Pro 3 with 3x relay (dry contacts)                | SPSW-003XE16EU                                 |
 | shellypro3em        | Shelly Pro 3 with 3 integrated power meters              | SPEM-003CEBEU                                  |
 | shellyproem50       | Shelly Pro EM-50 with 2 power meters and 1 relay         | SPEM-002CEBEU50                                |
-| shellypro4pm        | Shelly Pro 4 PM with 4x relay + power meter              | SPSW-004PE16EU, SPSW-104PE16EU                 |
+| shellypro4pm        | Shelly Pro 4 PM with 4x relay + power meter              | SHPSW04P, SPSW-004PE16EU, SPSW-104PE16EU       |
 
 ### Shelly BLU
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiInterface.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyApiInterface.java
@@ -136,7 +136,7 @@ public interface ShellyApiInterface {
 
     void setActionURLs() throws ShellyApiException;
 
-    void sendIRKey(String keyCode) throws ShellyApiException, IllegalArgumentException;
+    void sendIRKey(String keyCode) throws ShellyApiException;
 
     void postEvent(String device, String index, String event, Map<String, String> parms) throws ShellyApiException;
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api1/Shelly1HttpApi.java
@@ -493,10 +493,9 @@ public class Shelly1HttpApi extends ShellyHttpClient implements ShellyApiInterfa
      *            plain or hex64 format
      *
      * @throws ShellyApiException
-     * @throws IllegalArgumentException
      */
     @Override
-    public void sendIRKey(String keyCode) throws ShellyApiException, IllegalArgumentException {
+    public void sendIRKey(String keyCode) throws ShellyApiException {
         String type = "";
         if (profile.irCodes.containsKey(keyCode)) {
             type = SHELLY_IR_CODET_STORED;

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -248,6 +248,9 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
                 profile.status.relays.add(new ShellySettingsRelay());
                 relayStatus.relays.add(new ShellyShortStatusRelay());
             }
+            if (getString(profile.device.mode).isEmpty()) {
+                profile.device.mode = SHELLY_MODE_RELAY; // Pro 2 does not return profile
+            }
         }
 
         if (profile.numInputs > 0) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/Shelly2ApiRpc.java
@@ -1246,7 +1246,7 @@ public class Shelly2ApiRpc extends Shelly2ApiClient implements ShellyApiInterfac
     }
 
     @Override
-    public void sendIRKey(String keyCode) throws ShellyApiException, IllegalArgumentException {
+    public void sendIRKey(String keyCode) throws ShellyApiException {
         throw new ShellyApiException("API call not implemented");
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -39,7 +39,6 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_SHELLY2 = "SHSW-21";
     public static final String SHELLYDT_SHELLY25 = "SHSW-25";
     public static final String SHELLYDT_SHPRO = "SHSW-44";
-    public static final String SHELLYDT_4PRO = "SHPSW04P";
     public static final String SHELLYDT_EM = "SHEM";
     public static final String SHELLYDT_3EM = "SHEM-3";
     public static final String SHELLYDT_HT = "SHHT-1";
@@ -115,6 +114,7 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_PROEM50 = "SPEM-002CEBEU50";
     public static final String SHELLYDT_PRO4PM = "SPSW-004PE16EU";
     public static final String SHELLYDT_PRO4PM_2 = "SPSW-104PE16EU";
+    public static final String SHELLYDT_4PRO = "SHPSW04P";
 
     // Shelly Plus Mini Series
     // Mini Generation 2
@@ -374,7 +374,6 @@ public class ShellyThingCreator {
             Map.entry(SHELLYDT_1L, THING_TYPE_SHELLY1L), //
             Map.entry(SHELLYDT_1, THING_TYPE_SHELLY1), //
             Map.entry(SHELLYDT_SHPRO, THING_TYPE_SHELLY4PRO), //
-            Map.entry(SHELLYDT_4PRO, THING_TYPE_SHELLY4PRO), //
             Map.entry(SHELLYDT_3EM, THING_TYPE_SHELLY3EM), //
             Map.entry(SHELLYDT_EM, THING_TYPE_SHELLYEM), //
             Map.entry(SHELLYDT_SHPLG_S, THING_TYPE_SHELLYPLUGS), //
@@ -450,7 +449,8 @@ public class ShellyThingCreator {
             Map.entry(SHELLYDT_PROEM50, THING_TYPE_SHELLYPROEM50), //
             Map.entry(SHELLYDT_PRO3EM, THING_TYPE_SHELLYPRO3EM), //
             Map.entry(SHELLYDT_PRO4PM, THING_TYPE_SHELLYPRO4PM), //
-            Map.entry(SHELLYDT_PRO4PM_2, THING_TYPE_SHELLYPRO4PM),
+            Map.entry(SHELLYDT_PRO4PM_2, THING_TYPE_SHELLYPRO4PM), //
+            Map.entry(SHELLYDT_4PRO, THING_TYPE_SHELLYPRO4PM), //
 
             // BLU Series
             Map.entry(SHELLYDT_BLUBUTTON, THING_TYPE_SHELLYBLUBUTTON),
@@ -486,6 +486,7 @@ public class ShellyThingCreator {
             Map.entry(SHELLYDT_PRO2PM_3, THING_TYPE_SHELLYPRO2PM_ROLLER));
 
     private static final Map<String, ThingTypeUID> THING_TYPE_BY_SERVICE_NAME = Map.ofEntries(
+            // Shelly Gen1
             Map.entry(THING_TYPE_SHELLY1_STR, THING_TYPE_SHELLY1),
             Map.entry(THING_TYPE_SHELLY1PM_STR, THING_TYPE_SHELLY1PM),
             Map.entry(THING_TYPE_SHELLY1L_STR, THING_TYPE_SHELLY1L),
@@ -513,6 +514,7 @@ public class ShellyThingCreator {
             Map.entry(THING_TYPE_SHELLYUNI_STR, THING_TYPE_SHELLYUNI),
             Map.entry(THING_TYPE_SHELLYMOTION2_STR, THING_TYPE_SHELLYMOTION),
 
+            // Shelly Plus
             Map.entry(THING_TYPE_SHELLYPLUS1_STR, THING_TYPE_SHELLYPLUS1),
             Map.entry(THING_TYPE_SHELLYPLUS1G3_STR, THING_TYPE_SHELLYPLUS1),
             Map.entry(THING_TYPE_SHELLYPLUS1G4_STR, THING_TYPE_SHELLYPLUS1),
@@ -534,9 +536,9 @@ public class ShellyThingCreator {
             Map.entry(THING_TYPE_SHELLYPLUSDIMMER10V_STR, THING_TYPE_SHELLYPLUSDIMMER10V),
             Map.entry(THING_TYPE_SHELLYPLUSDIMMER0110VG3_STR, THING_TYPE_SHELLYPLUSDIMMER10V),
             Map.entry(THING_TYPE_SHELLYPLUSRGBWPM_STR, THING_TYPE_SHELLYPLUSRGBWPM),
-
             Map.entry(THING_TYPE_SHELLYPLUSWALLDISPLAY_STR, THING_TYPE_SHELLYPLUSWALLDISPLAY),
 
+            // Shelly Plus Mini
             Map.entry(THING_TYPE_SHELLY1MINI_STR, THING_TYPE_SHELLY1MINI),
             Map.entry(THING_TYPE_SHELLYMINI1G3_STR, THING_TYPE_SHELLY1MINI),
             Map.entry(THING_TYPE_SHELLYMINI1G4_STR, THING_TYPE_SHELLY1MINI),
@@ -544,9 +546,8 @@ public class ShellyThingCreator {
             Map.entry(THING_TYPE_SHELLYPMMINIG3_STR, THING_TYPE_SHELLYPMMINI),
             Map.entry(THING_TYPE_SHELLYPMMINIG4_STR, THING_TYPE_SHELLYPMMINI),
             Map.entry(THING_TYPE_SHELLY1PMMINI_STR, THING_TYPE_SHELLY1PMMINI),
-            // Map.entry(THING_TYPE_SHELLY1PMMINIG3_STR, THING_TYPE_SHELLY1PMMINIG3),
-            // Map.entry(THING_TYPE_SHELLY1PMMINIG4_STR, THING_TYPE_SHELLY1PMMINIG3),
 
+            // Shelly Pro
             Map.entry(THING_TYPE_SHELLYPRO1_STR, THING_TYPE_SHELLYPRO1),
             Map.entry(THING_TYPE_SHELLYPRO1PM_STR, THING_TYPE_SHELLYPRO1PM),
             Map.entry(THING_TYPE_SHELLYPRO1CB_STR, THING_TYPE_SHELLYPRO1CB),
@@ -558,6 +559,7 @@ public class ShellyThingCreator {
             Map.entry(THING_TYPE_SHELLYPRO3_STR, THING_TYPE_SHELLYPRO3),
             Map.entry(THING_TYPE_SHELLYPRO4PM_STR, THING_TYPE_SHELLYPRO4PM),
 
+            // Shelly BLU
             Map.entry(THING_TYPE_SHELLYBLUBUTTON_STR, THING_TYPE_SHELLYBLUBUTTON),
             Map.entry(THING_TYPE_SHELLYBLUDW_STR, THING_TYPE_SHELLYBLUDW),
             Map.entry(THING_TYPE_SHELLYBLUMOTION_STR, THING_TYPE_SHELLYBLUMOTION),
@@ -565,6 +567,7 @@ public class ShellyThingCreator {
             Map.entry(THING_TYPE_SHELLYBLUGW_STR, THING_TYPE_SHELLYBLUGW),
             Map.entry(THING_TYPE_SHELLYBLUGWG3_STR, THING_TYPE_SHELLYBLUGW),
 
+            // Password protected device
             Map.entry(THING_TYPE_SHELLYPROTECTED_STR, THING_TYPE_SHELLYPROTECTED));
 
     public static ThingUID getThingUID(String serviceName) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -194,7 +194,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
             } catch (ShellyApiException e) {
                 start = handleApiException(e);
             } catch (IllegalArgumentException e) {
-                logger.debug("{}: Unable to initialize, retrying later", thingName, e);
+                logger.debug("{}: Unable to initialize", thingName, e);
             } finally {
                 // even this initialization failed we start the status update
                 // the updateJob will then try to auto-initialize the thing

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -193,8 +193,6 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
                 }
             } catch (ShellyApiException e) {
                 start = handleApiException(e);
-            } catch (IllegalArgumentException e) {
-                logger.debug("{}: Unable to initialize", thingName, e);
             } finally {
                 // even this initialization failed we start the status update
                 // the updateJob will then try to auto-initialize the thing
@@ -1007,7 +1005,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      */
     protected boolean initializeThingConfig() {
         thingType = getThing().getThingTypeUID().getId();
-        if (THING_TYPE_SHELLYUNKNOWN_STR.equals(thingType)) {
+        if (THING_TYPE_SHELLYUNKNOWN.equals(getThing().getThingTypeUID())) {
             setThingOfflineAndDisconnect(ThingStatusDetail.COMMUNICATION_ERROR, "offline.device-unsupported");
             return false;
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -185,7 +185,7 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
     public void initialize() {
         // start background initialization:
         initJob = scheduler.schedule(() -> {
-            boolean start = true;
+            boolean start = false;
             try {
                 if (initializeThingConfig()) {
                     logger.debug("{}: Config: {}", thingName, config);
@@ -1007,6 +1007,11 @@ public abstract class ShellyBaseHandler extends BaseThingHandler
      */
     protected boolean initializeThingConfig() {
         thingType = getThing().getThingTypeUID().getId();
+        if (THING_TYPE_SHELLYUNKNOWN_STR.equals(thingType)) {
+            setThingOfflineAndDisconnect(ThingStatusDetail.COMMUNICATION_ERROR, "offline.device-unsupported");
+            return false;
+        }
+
         final Map<String, String> properties = getThing().getProperties();
         thingName = getString(properties.get(PROPERTY_SERVICE_NAME));
         if (thingName.isEmpty()) {

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/i18n/shelly.properties
@@ -16,6 +16,7 @@ message.config-status.error.missing-device-address = IP/MAC Address of the Shell
 message.config-status.error.missing-userid = No user ID in the Thing configuration
 
 # Thing status descriptions
+message.offline.device-unsupported = Device model is currently not supported.
 message.offline.conf-error-no-credentials = Device is password protected, but no credentials have been configured.
 message.offline.conf-error-access-denied = Access denied, check user id and password.
 message.offline.conf-error-wrong-mode = Device is in device mode {0}, thing requires {1}. Delete the thing and re-discover the device.

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen2_relay.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/shellyGen2_relay.xml
@@ -261,14 +261,8 @@
 			<channel-group id="relay1" typeId="relayChannel">
 				<label>@text/channel-group-type.shelly.relayChannel1.label</label>
 			</channel-group>
-			<channel-group id="meter1" typeId="meter">
-				<label>@text/channel-group-type.shelly.meter1.label</label>
-			</channel-group>
 			<channel-group id="relay2" typeId="relayChannel">
 				<label>@text/channel-group-type.shelly.relayChannel2.label</label>
-			</channel-group>
-			<channel-group id="meter2" typeId="meter">
-				<label>@text/channel-group-type.shelly.meter1.label</label>
 			</channel-group>
 			<channel-group id="device" typeId="deviceStatus"/>
 		</channel-groups>

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -86,7 +86,8 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYBUTTON2, false, false), //
                 Arguments.of(THING_TYPE_SHELLYMOTION, false, false), //
                 Arguments.of(THING_TYPE_SHELLYTRV, false, false), //
-                // Generation 2 Plus series
+
+                // Shelly Plus
                 Arguments.of(THING_TYPE_SHELLYPLUS1, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPLUS1PM, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPLUS2PM_RELAY, true, false), //
@@ -98,7 +99,8 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLY1MINI, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPMMINI, true, false), //
                 Arguments.of(THING_TYPE_SHELLY1PMMINI, true, false), //
-                // Generation 2 Pro series
+
+                // Shelly Pro
                 Arguments.of(THING_TYPE_SHELLYPRO1, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPRO1PM, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPRO2_RELAY, true, false), //
@@ -113,7 +115,8 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYPLUSHTG3, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPLUSSMOKE, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPLUSWALLDISPLAY, true, false), //
-                Arguments.of(THING_TYPE_SHELLYPROTECTED, false, false), //
-                Arguments.of(THING_TYPE_SHELLYUNKNOWN, false, false));
+
+                Arguments.of(THING_TYPE_SHELLYPROTECTED, false, false), // password protected device
+                Arguments.of(THING_TYPE_SHELLYUNKNOWN, false, false)); // unknown device
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreatorTest.java
@@ -115,7 +115,6 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_1L, "", THING_TYPE_SHELLY1L), //
                 Arguments.of(SHELLYDT_1, "", THING_TYPE_SHELLY1), //
                 Arguments.of(SHELLYDT_SHPRO, "", THING_TYPE_SHELLY4PRO), //
-                Arguments.of(SHELLYDT_4PRO, "", THING_TYPE_SHELLY4PRO), //
                 Arguments.of(SHELLYDT_3EM, "", THING_TYPE_SHELLY3EM), //
                 Arguments.of(SHELLYDT_EM, "", THING_TYPE_SHELLYEM), //
                 Arguments.of(SHELLYDT_SHPLG_S, "", THING_TYPE_SHELLYPLUGS), //
@@ -171,6 +170,7 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_MINIG3_1, "", THING_TYPE_SHELLY1MINI), //
                 Arguments.of(SHELLYDT_MINIG3_PM, "", THING_TYPE_SHELLYPMMINI), //
                 Arguments.of(SHELLYDT_MINIG3_1PM, "", THING_TYPE_SHELLY1PMMINI), //
+
                 // Pro Series
                 Arguments.of(SHELLYDT_PRO1, "", THING_TYPE_SHELLYPRO1), //
                 Arguments.of(SHELLYDT_PRO1_2, "", THING_TYPE_SHELLYPRO1), //
@@ -193,12 +193,15 @@ public class ShellyThingCreatorTest {
                 Arguments.of(SHELLYDT_PRO3EM, "", THING_TYPE_SHELLYPRO3EM), //
                 Arguments.of(SHELLYDT_PRO4PM, "", THING_TYPE_SHELLYPRO4PM), //
                 Arguments.of(SHELLYDT_PRO4PM_2, "", THING_TYPE_SHELLYPRO4PM), //
+                Arguments.of(SHELLYDT_4PRO, "", THING_TYPE_SHELLYPRO4PM), //
+
                 // BLU Series
                 Arguments.of(SHELLYDT_BLUBUTTON, "", THING_TYPE_SHELLYBLUBUTTON), //
                 Arguments.of(SHELLYDT_BLUDW, "", THING_TYPE_SHELLYBLUDW), //
                 Arguments.of(SHELLYDT_BLUMOTION, "", THING_TYPE_SHELLYBLUMOTION), //
                 Arguments.of(SHELLYDT_BLUHT, "", THING_TYPE_SHELLYBLUHT), //
                 Arguments.of(SHELLYDT_BLUGW, "", THING_TYPE_SHELLYBLUGW), //
+
                 // Wall displays
                 Arguments.of(SHELLYDT_PLUSWALLDISPLAY, "", THING_TYPE_SHELLYPLUSWALLDISPLAY));
     }


### PR DESCRIPTION
This PR fixes some discovery / initialization issues
- Shelly Pro 4PM was no longer discovered
- Shelly Pro 2 was discovered, but initialization failed
- Unknown device types will be added using type shellyunknown. Now the initialization of those things is blocked.