### PR TITLE
[shelly] Do not set connect timeout for shared `HttpClient`

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java
@@ -81,7 +81,6 @@ public class ShellyHttpClient {
         this.thingName = thingName;
         setConfig(thingName, config);
         this.httpClient = httpClient;
-        this.httpClient.setConnectTimeout(SHELLY_API_TIMEOUT_MS);
     }
 
     public void setConfig(String thingName, ShellyThingConfiguration config) {


### PR DESCRIPTION
The connect timeout was set to 10 seconds and was effective for all bindings using the common `HttpClient`:

https://github.com/openhab/openhab-addons/blob/66990cbe9aaf361571b2a4b07b9522b847c4bd9d/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java#L304

The request/response is already set to the same value:

https://github.com/openhab/openhab-addons/blob/66990cbe9aaf361571b2a4b07b9522b847c4bd9d/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpClient.java#L162-L163

https://github.com/openhab/openhab-addons/blob/66990cbe9aaf361571b2a4b07b9522b847c4bd9d/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java#L171-L172

https://github.com/openhab/openhab-addons/blob/66990cbe9aaf361571b2a4b07b9522b847c4bd9d/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerPage.java#L495-L496

The Jetty default connect timeout will now be used. I have not been able to find where it's set, but on my 5.0 system without any `conf/services/runtime.cfg` settings it seems to be 15 seconds.

Resolves #18916