### PR TITLE
[shelly] Decouple BLU device names

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -439,7 +439,7 @@ public class ShellyDeviceProfile {
      */
     public static String buildBluServiceName(String name, String mac) throws IllegalArgumentException {
         String model = name.contains("-") ? substringBefore(name, "-") : name; // e.g. SBBT-02C or just SBDW
-        return "shellyblu" + switch (model) {
+        return THING_TYPE_SHELLYBLU_PREFIX + switch (model) {
             case SHELLYDT_BLUBUTTON -> "button";
             case SHELLYDT_BLUDW -> "dw";
             case SHELLYDT_BLUMOTION -> "motion";

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -429,6 +429,14 @@ public class ShellyDeviceProfile {
         return true;
     }
 
+    /**
+     * Generates a service name based on the provided model name and MAC address.
+     * Delimiters will be stripped from the returned MAC address.
+     *
+     * @param name Model name such as SBBT-02C or just SBDW
+     * @param mac MAC address with or without colon delimiters
+     * @return service name in the form <code>&lt;service name&gt;-&lt;mac&gt;</code>
+     */
     public static String buildBluServiceName(String name, String mac) throws IllegalArgumentException {
         String model = name.contains("-") ? substringBefore(name, "-") : name; // e.g. SBBT-02C or just SBDW
         return "shellyblu" + switch (model) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -437,6 +437,6 @@ public class ShellyDeviceProfile {
             case SHELLYDT_BLUMOTION -> "motion";
             case SHELLYDT_BLUHT -> "ht";
             default -> throw new IllegalArgumentException("Unsupported BLU device model " + model);
-        } + "-" + mac.toLowerCase();
+        } + "-" + mac.replaceAll(":", "").toLowerCase();
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -431,17 +431,12 @@ public class ShellyDeviceProfile {
 
     public static String buildBluServiceName(String name, String mac) throws IllegalArgumentException {
         String model = name.contains("-") ? substringBefore(name, "-") : name; // e.g. SBBT-02C or just SBDW
-        switch (model) {
-            case SHELLYDT_BLUBUTTON:
-                return (THING_TYPE_SHELLYBLUBUTTON_STR + "-" + mac).toLowerCase();
-            case SHELLYDT_BLUDW:
-                return (THING_TYPE_SHELLYBLUDW_STR + "-" + mac).toLowerCase();
-            case SHELLYDT_BLUMOTION:
-                return (THING_TYPE_SHELLYBLUMOTION_STR + "-" + mac).toLowerCase();
-            case SHELLYDT_BLUHT:
-                return (THING_TYPE_SHELLYBLUHT_STR + "-" + mac).toLowerCase();
-            default:
-                throw new IllegalArgumentException("Unsupported BLU device model " + model);
-        }
+        return "shellyblu" + switch (model) {
+            case SHELLYDT_BLUBUTTON -> "button";
+            case SHELLYDT_BLUDW -> "dw";
+            case SHELLYDT_BLUMOTION -> "motion";
+            case SHELLYDT_BLUHT -> "ht";
+            default -> throw new IllegalArgumentException("Unsupported BLU device model " + model);
+        } + "-" + mac.toLowerCase();
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java
@@ -57,25 +57,20 @@ public class ShellyBluSensorHandler extends ShellyBaseHandler {
     public static void addBluThing(String gateway, Shelly2NotifyEvent e, @Nullable ShellyThingTable thingTable) {
         String model = substringBefore(getString(e.data.name), "-").toUpperCase();
         String mac = e.data.addr.replaceAll(":", "");
-        String ttype = "";
         LOGGER.debug("{}: Create thing for new BLU device {}: {} / {}", gateway, e.data.name, model, mac);
-        ThingTypeUID tuid;
+        ThingTypeUID thingTypeUID;
         switch (model) {
             case SHELLYDT_BLUBUTTON:
-                ttype = THING_TYPE_SHELLYBLUBUTTON_STR;
-                tuid = THING_TYPE_SHELLYBLUBUTTON;
+                thingTypeUID = THING_TYPE_SHELLYBLUBUTTON;
                 break;
             case SHELLYDT_BLUDW:
-                ttype = THING_TYPE_SHELLYBLUDW_STR;
-                tuid = THING_TYPE_SHELLYBLUDW;
+                thingTypeUID = THING_TYPE_SHELLYBLUDW;
                 break;
             case SHELLYDT_BLUMOTION:
-                ttype = THING_TYPE_SHELLYBLUMOTION_STR;
-                tuid = THING_TYPE_SHELLYBLUMOTION;
+                thingTypeUID = THING_TYPE_SHELLYBLUMOTION;
                 break;
             case SHELLYDT_BLUHT:
-                ttype = THING_TYPE_SHELLYBLUHT_STR;
-                tuid = THING_TYPE_SHELLYBLUHT;
+                thingTypeUID = THING_TYPE_SHELLYBLUHT;
                 break;
             default:
                 LOGGER.debug("{}: Unsupported BLU device model {}, MAC={}", gateway, model, mac);
@@ -87,13 +82,13 @@ public class ShellyBluSensorHandler extends ShellyBaseHandler {
         addProperty(properties, PROPERTY_MODEL_ID, model);
         addProperty(properties, PROPERTY_SERVICE_NAME, serviceName);
         addProperty(properties, PROPERTY_DEV_NAME, e.data.name);
-        addProperty(properties, PROPERTY_DEV_TYPE, ttype);
+        addProperty(properties, PROPERTY_DEV_TYPE, thingTypeUID.getId());
         addProperty(properties, PROPERTY_DEV_GEN, "BLU");
         addProperty(properties, PROPERTY_GW_DEVICE, gateway);
         addProperty(properties, CONFIG_DEVICEADDRESS, mac);
 
         if (thingTable != null) {
-            thingTable.discoveredResult(tuid, model, serviceName, mac, properties);
+            thingTable.discoveredResult(thingTypeUID, model, serviceName, mac, properties);
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -134,7 +134,7 @@ public class ShellyDeviceProfileTest {
                 Arguments.of("SBDW", "001A2B3C4D5E", "shellybludw-001a2b3c4d5e"), //
                 Arguments.of("SBMO", "001A2B3C4D5E", "shellyblumotion-001a2b3c4d5e"), //
                 Arguments.of("SBHT", "001A2B3C4D5E", "shellybluht-001a2b3c4d5e"), //
-                Arguments.of("SBHT", "00:1A:2B:3C:4D:5E", "shellybluht-00:1a:2b:3c:4d:5e"));
+                Arguments.of("SBHT", "00:1A:2B:3C:4D:5E", "shellybluht-001a2b3c4d5e"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
+++ b/bundles/org.openhab.binding.shelly/src/test/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfileTest.java
@@ -14,11 +14,13 @@ package org.openhab.binding.shelly.internal.api;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openhab.binding.shelly.internal.discovery.ShellyThingCreator.*;
 
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -115,5 +117,30 @@ public class ShellyDeviceProfileTest {
                 Arguments.of(THING_TYPE_SHELLYPLUSWALLDISPLAY, true, false), //
                 Arguments.of(THING_TYPE_SHELLYPROTECTED, false, false), //
                 Arguments.of(THING_TYPE_SHELLYUNKNOWN, false, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForBuildBluServiceName")
+    void buildBluServiceName(String name, String mac, String expectedServiceName) {
+        String actualServiceName = ShellyDeviceProfile.buildBluServiceName(name, mac);
+        assertThat(actualServiceName, is(equalTo(expectedServiceName)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForBuildBluServiceName() {
+        return Stream.of( //
+                Arguments.of("SBBT", "001A2B3C4D5E", "shellyblubutton-001a2b3c4d5e"), //
+                Arguments.of("SBBT-02C", "001A2B3C4D5E", "shellyblubutton-001a2b3c4d5e"), //
+                Arguments.of("SBBT-02C-03D", "001A2B3C4D5E", "shellyblubutton-001a2b3c4d5e"), //
+                Arguments.of("SBDW", "001A2B3C4D5E", "shellybludw-001a2b3c4d5e"), //
+                Arguments.of("SBMO", "001A2B3C4D5E", "shellyblumotion-001a2b3c4d5e"), //
+                Arguments.of("SBHT", "001A2B3C4D5E", "shellybluht-001a2b3c4d5e"), //
+                Arguments.of("SBHT", "00:1A:2B:3C:4D:5E", "shellybluht-00:1a:2b:3c:4d:5e"));
+    }
+
+    @Test
+    void buildBluServiceNameWhenNameUnknownThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            ShellyDeviceProfile.buildBluServiceName("sbbt", "001A2B3C4D5E");
+        });
     }
 }


### PR DESCRIPTION
This cherry-picks two commits from #18923 to reduce the size of that PR. I believe this PR can be processed faster, and I can then rebase the other one.

Refactoring is in the first commit and a small fix is in the second. I'm not sure the MAC address is already normalized in this case, so it's now normalized within the method itself:

https://github.com/openhab/openhab-addons/blob/8f7578e63897736479ddbd720e920b85aeaa2867/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api2/ShellyBluApi.java#L243

The reason for my doubt is that in this other place, `Shelly2NotifyEvent.data.addr` is normalized before calling the method:

https://github.com/openhab/openhab-addons/blob/8f7578e63897736479ddbd720e920b85aeaa2867/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java#L59

https://github.com/openhab/openhab-addons/blob/8f7578e63897736479ddbd720e920b85aeaa2867/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBluSensorHandler.java#L84

So either this issue is now fixed, and in any case there is no harm done and the method is now more robust.

Related to #18802