### PR TITLE
[electroluxappliance] Filter state addition

### DIFF
--- a/bundles/org.openhab.binding.electroluxappliance/README.md
+++ b/bundles/org.openhab.binding.electroluxappliance/README.md
@@ -121,6 +121,7 @@ The following channels are supported:
 | on-timer-active           | Switch             | Whether a timer is active to turn on the appliance.                                                 | Yes - When on applies on-timer-duration  |
 | on-timer-duration         | Number:Time        | Whether a timer is active to turn on the appliance. (Applied when on-timer-active is switched on)   | Yes - to set time for on-timer-active    |
 | on-timer-time             | DateTime           | The time when the auto on timer will be reached.                                                    | No                                       |
+| filter-state              | String             | The air filters state.                                                                              | No                                       |
 
 ## Full Example
 
@@ -178,4 +179,5 @@ DateTime Electrolux_Air_Conditioner_Offtimertime "Auto Off Expiry [%1$tF %1$tR]"
 Switch Electrolux_Air_Conditioner_Timer_On_Activate "Timer On Activate" <Switch> (Electrolux_Air_Conditioner) [Mode, Status] { channel="electroluxappliance:portable-air-conditioner:myAPI:myportable-air-con:on-timer-active" }
 Number:Time Electrolux_Air_Conditioner_Timer_On_Duration "Timer On Duration [%.1f %unit%]" <Settings> (Electrolux_Air_Conditioner) [Point] { channel="electroluxappliance:portable-air-conditioner:myAPI:myportable-air-con:on-timer-duration", unit="s" }
 DateTime Electrolux_Air_Conditioner_Ontimertime "Auto On Expiry [%1$tF %1$tR]" <Time> (Electrolux_Air_Conditioner) [Status, Timestamp] { channel="electroluxappliance:portable-air-conditioner:myAPI:myportable-air-con:on-timer-time" }
+String Electrolux_Air_Conditioner_Filter_State "Filter State" <text> (Electrolux_Air_Conditioner) [Info, Status] { channel="electroluxappliance:portable-air-conditioner:a4f9fc0801:40308110:filter-state" }
 ```

--- a/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/ElectroluxApplianceBindingConstants.java
+++ b/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/ElectroluxApplianceBindingConstants.java
@@ -94,6 +94,7 @@ public class ElectroluxApplianceBindingConstants {
     public static final String CHANNEL_ON_TIMER_ACTIVE = "on-timer-active";
     public static final String CHANNEL_ON_TIMER_DURATION = "on-timer-duration";
     public static final String CHANNEL_ON_TIMER_TIME = "on-timer-time";
+    public static final String CHANNEL_FILTER_STATE = "filter-state";
 
     // List of all Properties ids
     public static final String PROPERTY_BRAND = "brand";

--- a/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/dto/PortableAirConditionerStateDTO.java
+++ b/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/dto/PortableAirConditionerStateDTO.java
@@ -172,7 +172,7 @@ public class PortableAirConditionerStateDTO extends ApplianceStateDTO {
         @SerializedName("fanSpeedSetting")
         private String fanSpeedSetting = NOT_READ_STRING;
 
-        public boolean isReadFanSpeedSetting() {
+        public boolean getIsReadFanSpeedSetting() {
             return !NOT_READ_STRING.equals(fanSpeedSetting);
         }
 
@@ -196,7 +196,15 @@ public class PortableAirConditionerStateDTO extends ApplianceStateDTO {
         }
 
         @SerializedName("filterState")
-        private String filterState = "";
+        private String filterState = NOT_READ_STRING;
+
+        public boolean getIsReadFilterState() {
+            return !NOT_READ_STRING.equals(filterState);
+        }
+
+        public String getFilterState() {
+            return filterState;
+        }
 
         @SerializedName("dataModelVersion")
         private String dataModelVersion = "";

--- a/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/handler/ElectroluxPortableAirConditionerHandler.java
+++ b/bundles/org.openhab.binding.electroluxappliance/src/main/java/org/openhab/binding/electroluxappliance/internal/handler/ElectroluxPortableAirConditionerHandler.java
@@ -227,7 +227,7 @@ public class ElectroluxPortableAirConditionerHandler extends ElectroluxAppliance
                     return reported.getUiLockModeOn() ? OnOffType.ON : OnOffType.OFF;
                 }
             case CHANNEL_FAN_MODE:
-                if (reported.isReadFanSpeedSetting()) {
+                if (reported.getIsReadFanSpeedSetting()) {
                     return new StringType(reported.getFanSpeedSetting().toUpperCase());
                 }
             case CHANNEL_MODE:
@@ -292,6 +292,11 @@ public class ElectroluxPortableAirConditionerHandler extends ElectroluxAppliance
                     return new DateTimeType(
                             dto.getApplianceStateTimestamp().plus(reported.getStopTime(), ChronoUnit.SECONDS));
                 }
+            case CHANNEL_FILTER_STATE:
+                if (reported.getIsReadFilterState()) {
+                    return new StringType(reported.getFilterState().toUpperCase());
+                }
+
         }
         return UnDefType.UNDEF;
     }

--- a/bundles/org.openhab.binding.electroluxappliance/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.electroluxappliance/src/main/resources/OH-INF/thing/thing-types.xml
@@ -144,6 +144,7 @@
 			<channel id="on-timer-active" typeId="on-timer-active"/>
 			<channel id="on-timer-duration" typeId="on-timer-duration"/>
 			<channel id="on-timer-time" typeId="on-timer-time"/>
+			<channel id="filter-state" typeId="filter-state"/>
 		</channels>
 
 		<properties>
@@ -728,6 +729,23 @@
 			<tag>Timestamp</tag>
 		</tags>
 		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="filter-state">
+		<item-type>String</item-type>
+		<label>Filter State</label>
+		<description>The air filters state.</description>
+		<category>text</category>
+		<tags>
+			<tag>Status</tag>
+			<tag>Info</tag>
+		</tags>
+		<state readOnly="true">
+			<options>
+				<option value="GOOD">Good</option>
+				<option value="CLEAN">Dirty</option>
+			</options>
+		</state>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
A minor addition of one channel to the Air Conditioner support. I couldn't see it until it changed last night what the states would be.

This add the representation for the filter's state and whether it need's cleaning.

I think on the backend the a bit got lost in translation, as the states are GOOD means its clean, and CLEAN means cleaning required. For simpler representation this has been mapped to GOOD and DIRTY (which is also what the AEG app translates the states to when displaying that the air filter need's cleaning).

