### PR TITLE
[tibber] Improve Thing Action error handling

### DIFF
--- a/bundles/org.openhab.binding.tibber/README.md
+++ b/bundles/org.openhab.binding.tibber/README.md
@@ -119,6 +119,7 @@ Performing a calcuation a `parameters` object is needed containing e.g. your bou
 Parameter object allow 2 types: Java `Map` or JSON `String`.
 The result is returned as JSON encoded `String`.
 Refer below sections how the result looks like.
+If the action cannot be performed, a warning will be logged and an empty `String` will be returned.
 Some real life scenarios are schown in [Action Examples](#action-examples) section.
 
 ### `priceInfoStart`
@@ -345,7 +346,7 @@ For use cases like battery electric vehicle or heat-pump.
 
 #### Example
 
-```javascript
+```java
 rule "Tibber Schedule Calculation"
 when
     System started // use your trigger
@@ -464,5 +465,4 @@ Number:Energy               Tibber_API_Last_Hour_Consumption    "Last Hour Consu
 Number:Energy               Tibber_API_Total_Production         "Total Production"          {channel="tibber:tibberapi:xyz:statistics#total-production"}
 Number:Energy               Tibber_API_Daily_Production         "Daily Production"          {channel="tibber:tibberapi:xyz:statistics#daily-production"}
 Number:Energy               Tibber_API_Last_Hour_Production     "Last Hour Production"      {channel="tibber:tibberapi:xyz:statistics#last-hour-production"}
-
 ```

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/Utils.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/Utils.java
@@ -107,7 +107,7 @@ public class Utils {
      * @param durationString duration with number and optional unit
      * @return duration in seconds
      */
-    public static long parseDuration(String durationString) {
+    public static long parseDuration(String durationString) throws CalculationParameterException {
         try {
             return Long.parseLong(durationString); // check if String is a number
         } catch (NumberFormatException e) {
@@ -127,7 +127,8 @@ public class Utils {
      * @return true if parameters were given as JSON String
      */
     @SuppressWarnings("unchecked")
-    public static boolean convertParameters(Object parameters, Map<String, Object> targetMap) {
+    public static boolean convertParameters(Object parameters, Map<String, Object> targetMap)
+            throws CalculationParameterException {
         if (parameters instanceof String json) {
             JsonObject parametersJson = (JsonObject) JsonParser.parseString(json);
             Map<String, JsonElement> parameterMap = parametersJson.asMap();
@@ -172,7 +173,7 @@ public class Utils {
      * @param curve JSON array
      * @return List of CurveEntry
      */
-    public static List<CurveEntry> convertCurve(JsonElement curve) {
+    public static List<CurveEntry> convertCurve(JsonElement curve) throws CalculationParameterException {
         List<CurveEntry> curveList = new ArrayList<>();
         JsonArray curveArray = ((JsonArray) curve);
         int previousPower = Integer.MAX_VALUE;

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/calculator/PriceCalculator.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/calculator/PriceCalculator.java
@@ -144,7 +144,7 @@ public class PriceCalculator {
      * @param durationSeconds duration in seconds
      * @return price according to priceMap
      */
-    public double calculatePrice(Instant start, int powerW, long durationSeconds) {
+    public double calculatePrice(Instant start, int powerW, long durationSeconds) throws PriceCalculationException {
         checkBoundaries(start, start.plus(durationSeconds, ChronoUnit.SECONDS));
         Entry<Instant, PriceInfo> startEntry = priceMap.floorEntry(start);
         Entry<Instant, PriceInfo> nextEntry = priceMap.higherEntry(start);
@@ -173,7 +173,8 @@ public class PriceCalculator {
      * @param curve power duration tuples representing a device power curve
      * @return Map with results of cheapest start and price plus most expensive start
      */
-    public Map<String, Object> calculateBestPrice(Instant earliestStart, Instant latestEnd, List<CurveEntry> curve) {
+    public Map<String, Object> calculateBestPrice(Instant earliestStart, Instant latestEnd, List<CurveEntry> curve)
+            throws PriceCalculationException {
         checkBoundaries(earliestStart, latestEnd);
         int totalDuration = 0;
         for (Iterator<CurveEntry> iterator = curve.iterator(); iterator.hasNext();) {
@@ -226,7 +227,8 @@ public class PriceCalculator {
      * @param ascending true for ascending, false for descending order
      * @return list matching exactly between the timestamps with PriceInfo
      */
-    public List<PriceInfo> listPrices(Instant earliestStart, Instant latestEnd, boolean ascending) {
+    public List<PriceInfo> listPrices(Instant earliestStart, Instant latestEnd, boolean ascending)
+            throws PriceCalculationException {
         checkBoundaries(earliestStart, latestEnd);
         TreeMap<Instant, PriceInfo> calculationMap = new TreeMap<>();
         for (Entry<Instant, PriceInfo> entry : priceMap.entrySet()) {
@@ -287,7 +289,7 @@ public class PriceCalculator {
      * @return List of ScheduleEntries
      */
     public List<ScheduleEntry> calculateNonConsecutive(Instant earliestStart, Instant latestEnd, int powerW,
-            int durationS) {
+            int durationS) throws PriceCalculationException {
         checkBoundaries(earliestStart, latestEnd);
         List<PriceInfo> sortedList = listPrices(earliestStart, latestEnd, true);
         List<ScheduleEntry> schedule = new ArrayList<>();
@@ -367,7 +369,7 @@ public class PriceCalculator {
      * @param start
      * @param end
      */
-    private void checkBoundaries(Instant start, Instant end) {
+    private void checkBoundaries(Instant start, Instant end) throws PriceCalculationException {
         if (!start.isBefore(end)) {
             throw new PriceCalculationException("Calculation start " + start + " is after end " + end);
         }

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/exception/CalculationParameterException.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/exception/CalculationParameterException.java
@@ -20,7 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * @author Bernd Weymann - Initial contribution
  */
 @NonNullByDefault
-public class CalculationParameterException extends RuntimeException {
+public class CalculationParameterException extends Exception {
     private static final long serialVersionUID = -1841031906330289887L;
 
     public CalculationParameterException(String reason) {

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/exception/PriceCalculationException.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/exception/PriceCalculationException.java
@@ -21,7 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * @author Bernd Weymann - Initial contribution
  */
 @NonNullByDefault
-public class PriceCalculationException extends RuntimeException {
+public class PriceCalculationException extends Exception {
     private static final long serialVersionUID = 4330974498657720965L;
 
     public PriceCalculationException(String reason) {

--- a/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
+++ b/bundles/org.openhab.binding.tibber/src/main/java/org/openhab/binding/tibber/internal/handler/TibberHandler.java
@@ -351,7 +351,7 @@ public class TibberHandler extends BaseThingHandler {
         }
     }
 
-    public PriceCalculator getPriceCalculator() {
+    public PriceCalculator getPriceCalculator() throws PriceCalculationException {
         synchronized (calculatorLock) {
             if (calculator.isPresent()) {
                 return calculator.get();

--- a/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestActions.java
+++ b/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestActions.java
@@ -70,7 +70,7 @@ public class TestActions {
     }
 
     @Test
-    void testBounadries() {
+    void testBoundaries() {
         TibberActions actions = getActions();
         assertNotNull(actions);
 
@@ -124,7 +124,7 @@ public class TestActions {
     }
 
     @Test
-    void testCurve() {
+    void testCurve() throws CalculationParameterException {
         TibberActions actions = getActions();
         assertNotNull(actions);
 
@@ -176,20 +176,12 @@ public class TestActions {
     }
 
     @Test
-    void testParameterException() {
+    void testParameterError() {
         TibberActions actions = getActions();
         assertNotNull(actions);
 
         // will not work because now() as default parameter earliestStart is out of bounds
-        try {
-            actions.bestPriceSchedule(Map.of());
-            fail("Wrong parameters exception expected");
-        } catch (CalculationParameterException cpe) {
-            String message = cpe.getMessage();
-            assertNotNull(message);
-            assertTrue(message.startsWith("Cannot perform calculation with parameters"));
-            return;
-        }
-        fail("Wrong parameters exception expected");
+        String actual = actions.bestPriceSchedule(Map.of());
+        assertEquals("", actual);
     }
 }

--- a/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestParameterConversions.java
+++ b/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestParameterConversions.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.tibber.internal.dto.CurveEntry;
+import org.openhab.binding.tibber.internal.exception.CalculationParameterException;
 
 /**
  * The {@link TestParameterConversions} tests the conversion of price calculation parameters.
@@ -33,7 +34,7 @@ import org.openhab.binding.tibber.internal.dto.CurveEntry;
 public class TestParameterConversions {
 
     @Test
-    void testParameterConversion() {
+    void testParameterConversion() throws CalculationParameterException {
         Instant now = Instant.now();
         String json = "{\"earliestStart\":\"" + now.toString() + "\"}";
         Map<String, Object> params = new HashMap<>();
@@ -49,7 +50,7 @@ public class TestParameterConversions {
     }
 
     @Test
-    void testMapToMapConversion() {
+    void testMapToMapConversion() throws CalculationParameterException {
         Map<String, Object> params = new HashMap<>();
         params.put(PARAM_CURVE, List.of(new CurveEntry(1000, 60)));
         Map<String, Object> convertedParams = new HashMap<>();

--- a/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestPriceCalculator.java
+++ b/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestPriceCalculator.java
@@ -32,6 +32,7 @@ import org.openhab.binding.tibber.internal.calculator.PriceCalculator;
 import org.openhab.binding.tibber.internal.dto.CurveEntry;
 import org.openhab.binding.tibber.internal.dto.PriceInfo;
 import org.openhab.binding.tibber.internal.dto.ScheduleEntry;
+import org.openhab.binding.tibber.internal.exception.CalculationParameterException;
 import org.openhab.binding.tibber.internal.exception.PriceCalculationException;
 
 import com.google.gson.JsonArray;
@@ -82,7 +83,7 @@ public class TestPriceCalculator {
     }
 
     @Test
-    void testPriceCalculation() {
+    void testPriceCalculation() throws PriceCalculationException {
         // Price of first available hour
         Instant start = priceCalculator.priceInfoStart();
         double price = priceCalculator.calculatePrice(start, 1000, 3600);
@@ -130,7 +131,7 @@ public class TestPriceCalculator {
     }
 
     @Test
-    void testPriceList() {
+    void testPriceList() throws PriceCalculationException {
         // out of bounds
         Instant start = Instant.parse("2025-05-18T05:23:14.000+02:00");
         Instant end = Instant.parse("2025-05-18T14:49:58.000+02:00");
@@ -149,7 +150,7 @@ public class TestPriceCalculator {
     }
 
     @Test
-    void testCurveCalculation() {
+    void testCurveCalculation() throws CalculationParameterException, PriceCalculationException {
         String fileName = "src/test/resources/laundry-curve.json";
         try {
             String content = new String(Files.readAllBytes(Paths.get(fileName)));
@@ -173,7 +174,7 @@ public class TestPriceCalculator {
     }
 
     @Test
-    void testBestPriceCalculation() {
+    void testBestPriceCalculation() throws PriceCalculationException {
         Map<String, Object> result = priceCalculator.calculateBestPrice(priceCalculator.priceInfoStart(),
                 priceCalculator.priceInfoEnd(), List.of(new CurveEntry(1786, 1800)));
         assertEquals("2025-05-18T12:00:00Z", result.get("cheapestStart"), "Cheapest Start");
@@ -190,7 +191,7 @@ public class TestPriceCalculator {
     }
 
     @Test
-    void testBestPriceScheduleCalculation() {
+    void testBestPriceScheduleCalculation() throws PriceCalculationException {
         List<ScheduleEntry> schedule = priceCalculator.calculateNonConsecutive(priceCalculator.priceInfoStart(),
                 priceCalculator.priceInfoEnd(), 11000, 8 * 3600 + 54 * 60);
         assertEquals(2, schedule.size(), "Number of schedules");

--- a/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestPriceCalculator15.java
+++ b/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TestPriceCalculator15.java
@@ -31,6 +31,8 @@ import org.openhab.binding.tibber.internal.calculator.PriceCalculator;
 import org.openhab.binding.tibber.internal.dto.CurveEntry;
 import org.openhab.binding.tibber.internal.dto.PriceInfo;
 import org.openhab.binding.tibber.internal.dto.ScheduleEntry;
+import org.openhab.binding.tibber.internal.exception.CalculationParameterException;
+import org.openhab.binding.tibber.internal.exception.PriceCalculationException;
 
 import com.google.gson.JsonParser;
 
@@ -51,7 +53,7 @@ public class TestPriceCalculator15 {
     }
 
     @Test
-    void testPriceCalculation() {
+    void testPriceCalculation() throws PriceCalculationException {
         // Price of first available hour
         Instant start = priceCalculator.priceInfoStart();
         double price = priceCalculator.calculatePrice(start, 1000, 3600);
@@ -83,7 +85,7 @@ public class TestPriceCalculator15 {
     }
 
     @Test
-    void testPriceList() {
+    void testPriceList() throws PriceCalculationException {
         // out of bounds
         Instant start = Instant.parse("2025-05-18T05:23:14.000+02:00");
         Instant end = Instant.parse("2025-05-18T14:49:58.000+02:00");
@@ -102,7 +104,7 @@ public class TestPriceCalculator15 {
     }
 
     @Test
-    void testCurveCalculation() {
+    void testCurveCalculation() throws CalculationParameterException, PriceCalculationException {
         String fileName = "src/test/resources/laundry-curve.json";
         try {
             String content = new String(Files.readAllBytes(Paths.get(fileName)));
@@ -126,7 +128,7 @@ public class TestPriceCalculator15 {
     }
 
     @Test
-    void testBestPriceCalculation() {
+    void testBestPriceCalculation() throws PriceCalculationException {
         Map<String, Object> result = priceCalculator.calculateBestPrice(priceCalculator.priceInfoStart(),
                 priceCalculator.priceInfoEnd(), List.of(new CurveEntry(1786, 1800)));
         assertEquals("2025-05-18T12:30:00Z", result.get("cheapestStart"), "Cheapest Start");
@@ -143,7 +145,7 @@ public class TestPriceCalculator15 {
     }
 
     @Test
-    void testBestPriceScheduleCalculation() {
+    void testBestPriceScheduleCalculation() throws PriceCalculationException {
         List<ScheduleEntry> schedule = priceCalculator.calculateNonConsecutive(priceCalculator.priceInfoStart(),
                 priceCalculator.priceInfoEnd(), 11000, 8 * 3600 + 54 * 60);
         assertEquals(7, schedule.size(), "Number of schedules");

--- a/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TibberTest.java
+++ b/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TibberTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.openhab.binding.tibber.internal.calculator.PriceCalculator;
 import org.openhab.binding.tibber.internal.dto.CurveEntry;
 import org.openhab.binding.tibber.internal.dto.PriceInfo;
+import org.openhab.binding.tibber.internal.exception.CalculationParameterException;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -123,7 +124,7 @@ public class TibberTest {
         }
     }
 
-    void laundryCurveConversion() {
+    void laundryCurveConversion() throws CalculationParameterException {
         String fileName = "src/test/resources/laundry-curve.json";
         try {
             String content = new String(Files.readAllBytes(Paths.get(fileName)));


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/18726#discussion_r2194727365

I'm not sure there is consistent handling in rule engines when a Java `RuntimeException` is thrown by a Thing Action. Instead, special values are now returned making it possible for rules to handle those in any rule language.

For `priceInfoStart` and `priceInfoEnd` it was already documented that a special value would be returned in case of an error:
> ### `priceInfoStart`
> In case of error `Instant.MAX` is returned.

> ### `priceInfoEnd`
> In case of error `Instant.MIN` is returned.

However, this was only half true: In some cases, a `RuntimeException` would be thrown instead.