### PR TITLE
[bambulab] Add the missing i18n text for action input

### DIFF
--- a/bundles/org.openhab.binding.bambulab/src/main/resources/OH-INF/i18n/bambulab.properties
+++ b/bundles/org.openhab.binding.bambulab/src/main/resources/OH-INF/i18n/bambulab.properties
@@ -29,7 +29,7 @@ thing-type.bambulab.printer.channel.camera-record.description = Turns on/off ope
 thing-type.bambulab.printer.channel.chamber-temperature.label = Chamber Temperature
 thing-type.bambulab.printer.channel.chamber-temperature.description = Current temperature inside the printer chamber.
 thing-type.bambulab.printer.channel.command.label = Command
-thing-type.bambulab.printer.channel.command.description = Send command to run. See <a href="https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.bambulab#sendcommand">Actions > sendCommand</a>
+thing-type.bambulab.printer.channel.command.description = Send command to run. See <a href="https://www.openhab.org/addons/bindings/bambulab/#sendcommand" target="_blank">Actions > sendCommand</a>
 thing-type.bambulab.printer.channel.end-date.label = End Time of the Print
 thing-type.bambulab.printer.channel.end-date.description = Estimated end date of the print.
 thing-type.bambulab.printer.channel.gcode-file.label = G-code File
@@ -957,6 +957,8 @@ thing-type.bambulab.printer.channel.xcam.description = XCam details of the print
 
 action.sendCommand.label = Sends command to 3D printer
 action.sendCommand.description = Transmits a command to the 3D printer for execution, enabling direct control over its operations.
+action.sendCommand.commandLabel = Command
+action.sendCommand.commandDescription = The command to be sent to the printer. It is in the format <code>CommandType:Parameter1:Parameter2:...</code>. For the list of commands, see the <a href="https://www.openhab.org/addons/bindings/bambulab/#sendcommand" target="_blank">documentation</a>.
 action.refreshChannels.label = Reports the complete status of the printer
 action.refreshChannels.description = This is unnecessary for the X1 series since it already transmits the full object each time. However, the P1 series only sends the values that have been updated compared to the previous report. As a rule of thumb, refrain from executing this command at intervals less than 5 minutes on the P1P, as it may cause lag due to its hardware limitations.
 printer.handler.init.noHostname = Please pass hostname!


### PR DESCRIPTION
There's also a related bug in MainUI that prevents the links from working properly:
https://github.com/openhab/openhab-webui/issues/3262
Fixed in https://github.com/openhab/openhab-webui/pull/3265