### PR TITLE
[ondilo] Implement review findings

### DIFF
--- a/bundles/org.openhab.binding.ondilo/README.md
+++ b/bundles/org.openhab.binding.ondilo/README.md
@@ -28,7 +28,7 @@ Each Ondilo ICO will appear as a new Thing in the inbox.
 
 Ondilo ICO takes measures every hour.
 Higher polling will not increase the update interval.
-The binding automatically adjusts the polling schedule to match the expected time of the next measure, which is typically 1 hour (plus 1.5 minutes buffer) after the previous measure.
+The binding automatically adjusts the polling schedule to match the expected time of the next measure, which is typically 1 hour (plus 3 minutes buffer) after the previous measure.
 
 The requests to the Ondilo Customer API are limited to the following per user quotas:
 

--- a/bundles/org.openhab.binding.ondilo/src/main/java/org/openhab/binding/ondilo/internal/OndiloBridge.java
+++ b/bundles/org.openhab.binding.ondilo/src/main/java/org/openhab/binding/ondilo/internal/OndiloBridge.java
@@ -134,11 +134,11 @@ public class OndiloBridge {
 
     private void adaptPollingToValueTime(Instant lastValueTime, int refreshInterval) {
         // Measures are taken every 60 minutes, so we should be able to
-        // retrieve next data directly 60 minutes + buffer of 90 seconds after the last measure.
+        // retrieve next data directly 60 minutes + buffer of 3 minutes after the last measure.
         // This can help to avoid polling too frequently and hitting API rate limits.
-        // If the last measure was taken at 12:00°°, we will poll again at 13:01³°.
+        // If the last measure was taken at 12:00, we will poll again at 13:03.
         // This allows for a buffer in case the measure is not available immediately.
-        Instant nextValueTime = lastValueTime.plusSeconds(3690); // 60 minutes + 1 minute + 30 seconds buffer
+        Instant nextValueTime = lastValueTime.plusSeconds(3780); // 60 minutes + 3 minutes
         Instant now = Instant.now();
         Instant scheduledTime = now.plusSeconds(refreshInterval);
         if (nextValueTime.isBefore(scheduledTime)) {
@@ -148,7 +148,7 @@ public class OndiloBridge {
                 if (ondiloBridgePollingJob != null) {
                     ondiloBridgePollingJob.cancel(true);
                 }
-                ondiloBridgePollingJob = scheduler.scheduleWithFixedDelay(() -> pollOndiloICOs(), delay,
+                this.ondiloBridgePollingJob = scheduler.scheduleWithFixedDelay(() -> pollOndiloICOs(), delay,
                         refreshInterval, TimeUnit.SECONDS);
                 logger.trace("Rescheduled polling to {} (delay {} seconds)", nextValueTime, delay);
             }


### PR DESCRIPTION
The issue from https://github.com/openhab/openhab-addons/pull/18914#discussion_r2203404215 was present in another location, leading so several poll-jobs running in parallel.

this PR fixes this issue and increases the buffer to 3min, as 2min still didn't catch the latest measure.