### PR TITLE
[pythonscripting] change python helper lib version to final release

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/pom.xml
+++ b/bundles/org.openhab.automation.pythonscripting/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <graalpy.version>24.2.1</graalpy.version>
-    <helperlib.version>v1.0.0-rc3</helperlib.version>
+    <helperlib.version>v1.0.0</helperlib.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
this just changes the used helper lib version which includes the following fixes

- improved rule config handling for openhab 5
- fix datetime conversion for null values
- add datetime conversion for getLastStateUpdate and getLastStateChange

