### PR TITLE
[mqtt.homeassistant] correct GPS Accuracy channel type

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/thing/homeassistant-channels.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/resources/OH-INF/thing/homeassistant-channels.xml
@@ -56,7 +56,7 @@
 		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
 	</channel-type>
 
-	<channel-type id="ha-gps-accuracy" advanced="true">
+	<channel-type id="ha-gps-accuracy">
 		<item-type>Number:Length</item-type>
 		<label>GPS Accuracy</label>
 		<description>The accuracy of the GPS fix, in meters.</description>
@@ -111,6 +111,14 @@
 	<channel-type id="ha-dimmer-advanced" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Dimmer</label>
+		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
+	</channel-type>
+
+	<channel-type id="ha-gps-accuracy-advanced" advanced="true">
+		<item-type>Number:Length</item-type>
+		<label>GPS Accuracy</label>
+		<description>The accuracy of the GPS fix, in meters.</description>
+		<autoUpdatePolicy>veto</autoUpdatePolicy>
 		<config-description-ref uri="channel-type:mqtt:ha-channel"/>
 	</channel-type>
 


### PR DESCRIPTION
ComponentChannel.Builder automatically adds -advanced to the type if is an advanced child, so bring the definitions in the XML inline with that for gps-accuracy.

Fixes #18604
