### PR TITLE
[shelly] Fix constant names

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyDeviceProfile.java
@@ -412,8 +412,8 @@ public class ShellyDeviceProfile {
 
     public static boolean isGeneration2(ThingTypeUID thingTypeUID) {
         String thingTypeID = thingTypeUID.getId();
-        return thingTypeID.startsWith(SERVICE_NAME_SHELLYPLUS_PREFIX)
-                || thingTypeID.startsWith(SERVICE_NAME_SHELLYPRO_PREFIX) || thingTypeID.contains("mini")
+        return thingTypeID.startsWith(THING_TYPE_SHELLYPLUS_PREFIX)
+                || thingTypeID.startsWith(THING_TYPE_SHELLYPRO_PREFIX) || thingTypeID.contains("mini")
                 || THING_TYPE_SHELLYPLUSWALLDISPLAY.equals(thingTypeUID)
                 || THING_TYPE_SHELLYPLUSHTG3.equals(thingTypeUID) || isBluSeries(thingTypeUID)
                 || THING_TYPE_SHELLYBLUGW.equals(thingTypeUID);

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/discovery/ShellyThingCreator.java
@@ -145,10 +145,12 @@ public class ShellyThingCreator {
     public static final String SHELLYDT_BLUGW = "SNGW-BT01";
     public static final String SHELLYDT_BLUGWG3 = "S3GW-1DBT001";
 
+    // Thing Type ID prefixes
+    public static final String THING_TYPE_SHELLYPLUS_PREFIX = "shellyplus";
+    public static final String THING_TYPE_SHELLYPRO_PREFIX = "shellypro";
+
     // Service name prefixes
     public static final String SERVICE_NAME_SHELLYBLU_PREFIX = "shellyblu";
-    public static final String SERVICE_NAME_SHELLYPLUS_PREFIX = "shellyplus";
-    public static final String SERVICE_NAME_SHELLYPRO_PREFIX = "shellypro";
 
     private static final String SERVICE_NAME_SHELLY2_PREFIX = "shellyswitch";
     private static final String SERVICE_NAME_SHELLY25_PREFIX = "shellyswitch25";


### PR DESCRIPTION
Rename constants with wrong names, which could lead to confusion and bugs.

They slipped into #18923 with the opposite effect of what was the intention of that PR.