### PR TITLE
[mqtt.homeassistant] add none as an implicit preset for Climate

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/component/Climate.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.mqtt.homeassistant.internal.component;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,8 @@ public class Climate extends AbstractComponent<Climate.Configuration> {
 
     private static final Map<String, String> SWING_MODE_LABELS = Map.of(SWING_MODE_ON,
             "@text/state.climate.swing-mode.on", SWING_MODE_OFF, "@text/state.climate.swing-mode.off");
+
+    private static final String PRESET_MODE_NONE = "none";
 
     public static class Configuration extends EntityConfiguration {
         private final boolean retain, optimistic;
@@ -431,8 +434,12 @@ public class Climate extends AbstractComponent<Climate.Configuration> {
                 config.getModeCommandTemplate(), config.getModeCommandTopic(), config.getModeStateTemplate(),
                 config.getModeStateTopic());
 
+        List<String> presetModes = new ArrayList<>(config.getPresetModes());
+        if (!presetModes.isEmpty()) {
+            presetModes.add(0, PRESET_MODE_NONE);
+        }
         buildOptionalChannel(PRESET_MODE_CH_ID, ComponentChannelType.STRING,
-                new TextValue(config.getPresetModes().toArray(new String[0])), "Preset", updateListener,
+                new TextValue(presetModes.toArray(new String[0])), "Preset", updateListener,
                 config.getPresetModeCommandTemplate(), config.getPresetModeCommandTopic(),
                 config.getPresetModeValueTemplate(), config.getPresetModeStateTopic());
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/ClimateTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/component/ClimateTests.java
@@ -249,6 +249,14 @@ public class ClimateTests extends AbstractComponentTests {
         assertState(component, Climate.MODE_CH_ID, new StringType("heat"));
         assertState(component, Climate.TEMPERATURE_CH_ID, QuantityType.valueOf(24, SIUnits.CELSIUS));
         assertState(component, Climate.PRESET_MODE_CH_ID, new StringType("manual"));
+        TextValue presetModes = (TextValue) component.getChannel(Climate.PRESET_MODE_CH_ID).getState().getCache();
+        Set<String> presets = presetModes.getStates().keySet();
+        assertThat(presets.size(), is(5));
+        assertThat(presets.contains("none"), is(true));
+        assertThat(presets.contains("auto"), is(true));
+        assertThat(presets.contains("manual"), is(true));
+        assertThat(presets.contains("off"), is(true));
+        assertThat(presets.contains("on"), is(true));
         component.getChannel(Climate.PRESET_MODE_CH_ID).getState().publishValue(new StringType("on"));
         assertPublished("zigbee2mqtt/th2/set/preset", "on");
     }


### PR DESCRIPTION
See https://github.com/home-assistant/core/blob/f65fa3842932ece090e62b508945f9e8d4eaf136/homeassistant/components/mqtt/climate.py#L607.

none is not allowed in the configuration, but is always added as an allowed value

Fixes #18598
