### PR TITLE
[zwavejs] Fix configuration as channel 

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -612,8 +612,6 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
         for (Channel channel : thing.getChannels()) {
             if (!result.channels.containsKey(channel.getUID().getId())) {
                 channelsToRemove.add(channel);
-            } else {
-                result.channels.remove(channel.getUID().getId());
             }
         }
         if (!channelsToRemove.isEmpty()) {

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.measure.quantity.Power;
 
@@ -88,6 +89,37 @@ public class ZwaveJSNodeHandlerTest {
             verify(callback).statusUpdated(argThat(arg -> arg.getUID().equals(thing.getUID())),
                     argThat(arg -> arg.getStatus().equals(ThingStatus.ONLINE)));
             verify(callback, times(74)).stateUpdated(any(), any());
+        } finally {
+            handler.dispose();
+        }
+    }
+
+    @Test
+    public void testNode7ConfigCreationFlip() {
+        final Thing thing = ZwaveJSNodeHandlerMock.mockThing(7);
+        final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        final ZwaveJSNodeHandlerMock handler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,
+                "store_4.json", false);
+
+        // Capture initial state
+        Configuration startConfiguration = handler.getThing().getConfiguration();
+        List<Channel> startChannels = handler.getThing().getChannels();
+
+        // Test flipping configAsChannel to true
+        handler.configAsChannel = true;
+        handler.initialize();
+        List<Channel> configAsChannelChannels = handler.getThing().getChannels();
+
+        // Test flipping configAsChannel back to false
+        handler.configAsChannel = false;
+        handler.initialize();
+        List<Channel> endChannels = handler.getThing().getChannels();
+
+        try {
+            assertEquals(63, startConfiguration.getProperties().size());
+            assertEquals(31, startChannels.size());
+            assertEquals(93, configAsChannelChannels.size());
+            assertEquals(31, endChannels.size());
         } finally {
             handler.dispose();
         }

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -17,10 +17,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.measure.quantity.Power;
 
@@ -118,8 +115,6 @@ public class ZwaveJSNodeHandlerTest {
         handler.initialize();
         List<Channel> endChannels = handler.getThing().getChannels();
 
-        compareChannelsAndConfig(startChannels, startConfiguration, configAsChannelChannels);
-
         try {
             assertEquals(63, startConfiguration.getProperties().size());
             assertEquals(31, startChannels.size());
@@ -145,27 +140,6 @@ public class ZwaveJSNodeHandlerTest {
         } finally {
             handler.dispose();
         }
-    }
-
-    private void compareChannelsAndConfig(List<Channel> startChannels, Configuration startConfig,
-            List<Channel> configAsChannels) {
-        Set<String> startChannelIds = startChannels.stream().map(ch -> ch.getUID().getId()).collect(Collectors.toSet());
-
-        Set<String> configAsChannelIds = configAsChannels.stream().map(ch -> ch.getUID().getId())
-                .collect(Collectors.toSet());
-
-        Set<String> configPropertyKeys = startConfig.getProperties().keySet();
-
-        // Find channels that exist in start but not in configAsChannels
-        Set<String> missingChannels = new HashSet<>(startChannelIds);
-        missingChannels.removeAll(configAsChannelIds);
-
-        // Find config properties that don't have corresponding channels
-        Set<String> missingConfigChannels = new HashSet<>(configPropertyKeys);
-        missingConfigChannels.removeAll(configAsChannelIds);
-
-        System.out.println("Missing channels from configAsChannels: " + missingChannels);
-        System.out.println("Config properties without corresponding channels: " + missingConfigChannels);
     }
 
     @Test

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandlerTest.java
@@ -98,7 +98,7 @@ public class ZwaveJSNodeHandlerTest {
     }
 
     @Test
-    public void testNode7ConfigCreationFlip() {
+    public void testNode7ConfigChannelToggle() {
         final Thing thing = ZwaveJSNodeHandlerMock.mockThing(7);
         final ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
         final ZwaveJSNodeHandlerMock handler = ZwaveJSNodeHandlerMock.createAndInitHandler(callback, thing,


### PR DESCRIPTION
Reported in the community forums. Changing the parameter `configurationAsChannel` was inconsistent. Also added a test to prevent regression