### PR TITLE
[airparif] Fix duplicate channel

### DIFF
--- a/bundles/org.openhab.binding.airparif/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.airparif/src/main/resources/OH-INF/thing/channels.xml
@@ -22,15 +22,6 @@
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
 
-
-	<channel-type id="timestamp" advanced="true">
-		<item-type>DateTime</item-type>
-		<label>@text/timestampChannelLabel</label>
-		<description>@text/timestampChannelDescription</description>
-		<category>time</category>
-		<state readOnly="true"/>
-	</channel-type>
-
 	<channel-type id="hazel-level">
 		<item-type>Number</item-type>
 		<label>Hazel Level</label>


### PR DESCRIPTION
Fixes: https://github.com/openhab/openhab-addons/issues/18591

Other version is here:
https://github.com/openhab/openhab-addons/blob/9ec05520b4cbd4897e34a8c7ddfcfee2678ecdf1/bundles/org.openhab.binding.airparif/src/main/resources/OH-INF/thing/channels.xml#L7-L16