### PR TITLE
[xmpp] Upgrade dependency

### DIFF
--- a/bundles/org.openhab.binding.xmppclient/pom.xml
+++ b/bundles/org.openhab.binding.xmppclient/pom.xml
@@ -15,13 +15,13 @@
   <name>openHAB Add-ons :: Bundles :: XMPPClient Binding</name>
 
   <properties>
-    <smack.version>4.3.3</smack.version>
+    <smack.version>4.4.8</smack.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
-      <artifactId>smack-java7</artifactId>
+      <artifactId>smack-java8</artifactId>
       <version>${smack.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.minidns</groupId>
       <artifactId>minidns-core</artifactId>
-      <version>0.3.3</version>
+      <version>1.1.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
@@ -5,21 +5,27 @@
 	<feature name="openhab-binding-xmppclient" description="XMPP Client Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-extensions/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-experimental/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-im/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-tcp/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-core/0.6.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-jid/0.6.3</bundle>
-		<bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/0.6.3</bundle>
-		<bundle dependency="true">mvn:org.minidns/minidns-core/0.3.3</bundle>
-		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.69</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-core/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-sasl-javax/4.3.3</bundle>
-		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_7</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-resolver-javax/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-xmlparser/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-extensions/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-experimental/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-xmlparser-xpp3/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-im/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-tcp/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.jxmpp/jxmpp-core/1.0.3</bundle>
+		<bundle dependency="true">mvn:org.jxmpp/jxmpp-jid/1.0.3</bundle>
+		<bundle dependency="true">mvn:org.jxmpp/jxmpp-util-cache/1.0.3</bundle>
+		<bundle dependency="true">mvn:org.minidns/minidns-core/1.1.1</bundle>
+		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.65</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-core/4.4.8</bundle>
+		<bundle dependency="true">mvn:com.google.guava/guava/28.2-jre</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.10</bundle>
+		<bundle dependency="true">mvn:org.xmlunit/xmlunit-core/2.6.2</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-sasl-javax/4.4.8</bundle>
+		<bundle dependency="true">mvn:org.igniterealtime.smack/smack-xmlparser-stax/4.4.8</bundle>
 		<!-- FIXME: implicit dependencies required at runtime but not automatically installed, this is a workaround -->
-		<bundle start-level="80">mvn:org.igniterealtime.smack/smack-resolver-javax/4.3.3</bundle>
-		<bundle start-level="80">mvn:org.igniterealtime.smack/smack-java7/4.3.3</bundle>
+		<bundle start-level="80">mvn:org.igniterealtime.smack/smack-resolver-javax/4.4.8</bundle>
+		<bundle start-level="80">mvn:org.igniterealtime.smack/smack-java8/4.4.8</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.xmppclient/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
This is an attempt to fix: https://github.com/openhab/openhab-addons/issues/18982

When xmpp is installed, it takes down openhab. The  library is (very) old. 

The dependency's do not yet seem to be resolved. I seem unable to fix:
```
missing requirement [smack-core/4.4.8] osgi.wiring.package; filter:="(osgi.wiring.package=sun.security.pkcs11)"]]]
```

Help would be very much appreciated.  