### PR TITLE
[plex] Improve support for hostname as `server` configuration

### DIFF
--- a/bundles/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/handler/PlexPlayerHandler.java
+++ b/bundles/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/handler/PlexPlayerHandler.java
@@ -70,6 +70,7 @@ public class PlexPlayerHandler extends BaseThingHandler {
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.debug("Received command {} on channel {}", command, channelUID);
         if (command instanceof RefreshType) {
             logger.debug("REFRESH not implemented");
             return;

--- a/bundles/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/handler/PlexServerHandler.java
+++ b/bundles/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/handler/PlexServerHandler.java
@@ -131,11 +131,18 @@ public class PlexServerHandler extends BaseBridgeHandler implements PlexUpdateLi
             }
         }
         logger.debug("Fetch API with config, {}", config.toString());
-        if (!plexAPIConnector.getApi()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Unable to fetch API, token may be wrong?");
+        try {
+            if (!plexAPIConnector.getApi()) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "Unable to find server, make sure `server` matches the Plex network configuration.");
+                return;
+            }
+        } catch (Exception e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Unable to fetch API, make sure `server` and `token` are correct.");
             return;
         }
+
         isRunning = true;
         onUpdate(); // Start the session refresh
         scheduler.execute(() -> { // Start the web socket
@@ -171,13 +178,12 @@ public class PlexServerHandler extends BaseBridgeHandler implements PlexUpdateLi
     public List<String> getAvailablePlayers() {
         List<String> availablePlayers = new ArrayList<>();
         MediaContainer sessionData = plexAPIConnector.getSessionData();
+        logger.debug("Bridge: Scanning for available players");
 
         if (sessionData != null && sessionData.getSize() > 0) {
             for (MediaType tmpMeta : sessionData.getMediaTypes()) {
                 if (tmpMeta != null && playerHandlers.get(tmpMeta.getPlayer().getMachineIdentifier()) == null) {
-                    if ("1".equals(tmpMeta.getPlayer().getLocal())) {
-                        availablePlayers.add(tmpMeta.getPlayer().getMachineIdentifier());
-                    }
+                    availablePlayers.add(tmpMeta.getPlayer().getMachineIdentifier());
                 }
             }
         }


### PR DESCRIPTION
BUGFIX: https://github.com/openhab/openhab-addons/issues/18164
* Better handling of `server` in configuration. Now possible to add hostname which can be matched against plex configuration
* Updated error handling which not supports `CONFIGURATION_ERROR`