### PR TITLE
[knx] Refine default semantic tags

### DIFF
--- a/bundles/org.openhab.binding.knx/src/main/resources/OH-INF/thing/device.xml
+++ b/bundles/org.openhab.binding.knx/src/main/resources/OH-INF/thing/device.xml
@@ -130,7 +130,7 @@
 		<label>Contact</label>
 		<description>A channel to manage a generic Group Addresses with a DPT compatible with Contact Items</description>
 		<tags>
-			<tag>Control</tag>
+			<tag>Status</tag>
 			<tag>OpenState</tag>
 		</tags>
 		<config-description-ref uri="channel-type:knx:single"/>
@@ -152,8 +152,8 @@
 		<label>Number</label>
 		<description>A channel to manage a generic Group Addresses with a DPT compatible with Number Items</description>
 		<tags>
-			<tag>Control</tag>
-			<tag>OpenLevel</tag>
+			<tag>Status</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<config-description-ref uri="channel-type:knx:single"/>
 	</channel-type>
@@ -163,7 +163,7 @@
 		<description>Control a number item (i.e. the status is not owned by KNX)</description>
 		<tags>
 			<tag>Control</tag>
-			<tag>OpenLevel</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<config-description-ref uri="channel-type:knx:single"/>
 	</channel-type>
@@ -174,7 +174,7 @@
 		<label>String</label>
 		<description>A channel to manage a generic Group Addresses with a DPT compatible with String Items</description>
 		<tags>
-			<tag>Control</tag>
+			<tag>Status</tag>
 			<tag>Info</tag>
 		</tags>
 		<config-description-ref uri="channel-type:knx:single"/>
@@ -196,7 +196,7 @@
 		<label>DateTime</label>
 		<description>A channel to manage a generic Group Addresses with a DPT compatible with DateTime Items</description>
 		<tags>
-			<tag>Control</tag>
+			<tag>Status</tag>
 			<tag>Timestamp</tag>
 		</tags>
 		<config-description-ref uri="channel-type:knx:single"/>


### PR DESCRIPTION
Basically set better defaults.
In KNX, DPT 9.001 is default for number, and represents Temperature.
Contact is typically a read-only status, so Status matches better.
Things like DateTime and Info Strings are typically sent from KNX to OH, so changed to Status.

@andrewfg In KNX, you have quite a strict mapping from DPT to Semantic Tag.
Is there a way to adapt the suggestion once the user has entered the group address with DPT?
