### PR TITLE
[tibber] Refactor `Optional` to nullable

### DIFF
--- a/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TibberHandlerMock.java
+++ b/bundles/org.openhab.binding.tibber/src/test/java/org/openhab/binding/tibber/internal/TibberHandlerMock.java
@@ -14,8 +14,6 @@ package org.openhab.binding.tibber.internal;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.Optional;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.tibber.internal.calculator.PriceCalculator;
@@ -39,6 +37,6 @@ public class TibberHandlerMock extends TibberHandler {
     }
 
     public void setPriceCalculator(PriceCalculator calc) {
-        super.calculator = Optional.of(calc);
+        super.calculator = calc;
     }
 }


### PR DESCRIPTION
`Optional` is primarily meant as a return type, not a field type. See for example Brian Goetz, Java’s language architect, [shedding light](https://stackoverflow.com/questions/26327957/should-java-8-getters-return-optional-type/26328555#26328555) on Oracle’s intention with the `Optional` type.

This refactoring aims to make the code clearer, more idiomatic and less error-prone.