### PR TITLE
[bluetooth.grundfosalpha] Fix name

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.grundfosalpha/README.md
+++ b/bundles/org.openhab.binding.bluetooth.grundfosalpha/README.md
@@ -1,4 +1,4 @@
-# GrundfosAlpha Binding
+# Bluetooth Grundfos Alpha Adapter
 
 This binding adds support for reading out the data of Grundfos Alpha pumps with a [Grundfos Alpha Reader](https://product-selection.grundfos.com/products/alpha-reader) or [Alpha3 pump](https://product-selection.grundfos.com/products/alpha/alpha3) with built-in Bluetooth.
 

--- a/bundles/org.openhab.binding.bluetooth.grundfosalpha/pom.xml
+++ b/bundles/org.openhab.binding.bluetooth.grundfosalpha/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>org.openhab.binding.bluetooth.grundfosalpha</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: GrundfosAlpha Binding</name>
+  <name>openHAB Add-ons :: Bundles :: Grundfos Alpha Bluetooth Adapter</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Fix name for consistency with other Bluetooth sub bindings.