### PR TITLE
[froniuswattpilot] Upgrade wattpilot4j to 2.0.0

### DIFF
--- a/bundles/org.openhab.binding.froniuswattpilot/pom.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/pom.xml
@@ -16,9 +16,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.florianhotze.sdk</groupId>
+      <groupId>dev.digiried</groupId>
       <artifactId>wattpilot4j</artifactId>
-      <version>1.3.0</version>
+      <version>2.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-froniuswattpilot" description="Fronius Wattpilot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:com.florianhotze.sdk/wattpilot4j/1.3.0</bundle>
+		<bundle dependency="true">mvn:dev.digiried/wattpilot4j/2.0.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.froniuswattpilot/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
+++ b/bundles/org.openhab.binding.froniuswattpilot/src/main/java/org/openhab/binding/froniuswattpilot/internal/FroniusWattpilotHandler.java
@@ -41,16 +41,16 @@ import org.openhab.core.types.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.florianhotze.wattpilot.WattpilotClient;
-import com.florianhotze.wattpilot.WattpilotClientListener;
-import com.florianhotze.wattpilot.WattpilotInfo;
-import com.florianhotze.wattpilot.WattpilotStatus;
-import com.florianhotze.wattpilot.commands.SetChargingCurrentCommand;
-import com.florianhotze.wattpilot.commands.SetChargingModeCommand;
-import com.florianhotze.wattpilot.commands.SetEnforcedChargingStateCommand;
-import com.florianhotze.wattpilot.commands.SetSurplusPowerThresholdCommand;
-import com.florianhotze.wattpilot.dto.ChargingMode;
-import com.florianhotze.wattpilot.dto.EnforcedChargingState;
+import dev.digiried.wattpilot.WattpilotClient;
+import dev.digiried.wattpilot.WattpilotClientListener;
+import dev.digiried.wattpilot.WattpilotInfo;
+import dev.digiried.wattpilot.WattpilotStatus;
+import dev.digiried.wattpilot.commands.SetChargingCurrentCommand;
+import dev.digiried.wattpilot.commands.SetChargingModeCommand;
+import dev.digiried.wattpilot.commands.SetEnforcedChargingStateCommand;
+import dev.digiried.wattpilot.commands.SetSurplusPowerThresholdCommand;
+import dev.digiried.wattpilot.dto.ChargingMode;
+import dev.digiried.wattpilot.dto.EnforcedChargingState;
 
 /**
  * The {@link FroniusWattpilotHandler} is responsible for handling commands, which are


### PR DESCRIPTION
This new version brings no code changes,
it only moves the library to a new namespace.