### PR TITLE
[ipcamera] Fix Reolink needs changes to JSON formatting to work in newer firmwares

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/ReolinkHandler.java
@@ -58,6 +58,14 @@ public class ReolinkHandler extends ChannelDuplexHandler {
         requestUrl = url;
     }
 
+    private String enableAlarmBuilder(String command, String alarmType, String enable) {
+        return "[\r\n" + "    {\r\n" + "        \"cmd\": \"" + command + "\",\r\n" + "        \"param\": {\r\n"
+                + "            \"" + alarmType + "\": {\r\n" + "                \"enable\": " + enable + ",\r\n"
+                + "                \"schedule\": {\r\n" + "                    \"channel\": "
+                + ipCameraHandler.cameraConfig.getNvrChannel() + "\r\n" + "                }\r\n" + "            }\r\n"
+                + "        }\r\n" + "    }\r\n" + "]";
+    }
+
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
@@ -436,19 +444,19 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 if (OnOffType.ON.equals(command)) {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetAudioAlarmV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetAudioAlarmV20\",\"param\":{\"Audio\" : {\"enable\" : 1}}}]");
+                                enableAlarmBuilder("SetAudioAlarmV20", "Audio", "1"));
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetAudioAlarm" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \" SetAudioAlarm\",\"param\": {\"Audio\": {\"schedule\": {\"enable\": 1,\"table\": \"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111\"}}}}]");
+                                enableAlarmBuilder("SetAudioAlarm", "Audio", "1"));
                     }
                 } else {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetAudioAlarmV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetAudioAlarmV20\",\"param\":{\"Audio\" : {\"enable\" : 0}}}]");
+                                enableAlarmBuilder("SetAudioAlarmV20", "Audio", "0"));
 
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetAudioAlarm" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \" SetAudioAlarm\",\"param\": {\"Audio\": {\"schedule\": {\"enable\": 0,\"table\": \"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111\"}}}}]");
+                                enableAlarmBuilder("SetAudioAlarm", "Audio", "0"));
                     }
                 }
                 break;
@@ -456,19 +464,19 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 if (OnOffType.ON.equals(command)) {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetFtpV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetFtpV20\",\"param\":{\"Ftp\" : {\"enable\" : 1}}}]");
+                                enableAlarmBuilder("SetFtpV20", "Ftp", "1"));
 
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetFtp" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetFtp\",\"param\":{\"Ftp\" : {\"schedule\" : {\"enable\" : 1}}}}]");
+                                enableAlarmBuilder("SetFtp", "Ftp", "1"));
                     }
                 } else {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetFtpV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetFtpV20\",\"param\":{\"Ftp\" : {\"enable\" : 0}}}]");
+                                enableAlarmBuilder("SetFtpV20", "Ftp", "0"));
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetFtp" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetFtp\",\"param\":{\"Ftp\" : {\"schedule\" : {\"enable\" : 0}}}}]");
+                                enableAlarmBuilder("SetFtp", "Ftp", "0"));
                     }
                 }
                 break;
@@ -476,7 +484,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 if (OnOffType.ON.equals(command)) {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetEmailV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetEmailV20\",\"param\": {\"Email\": {\"enable\": 1}}}]");
+                                enableAlarmBuilder("SetEmailV20", "Email", "1"));
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetEmail" + ipCameraHandler.reolinkAuth,
                                 "[{\"cmd\": \"SetEmail\",\"param\":{\"Email\" : {\"schedule\" : {\"enable\" : 1}}}}]");
@@ -484,7 +492,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 } else {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetEmailV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetEmailV20\",\"param\":{\"Email\" : {\"enable\" : 0}}}]");
+                                enableAlarmBuilder("SetEmailV20", "Email", "0"));
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetEmail" + ipCameraHandler.reolinkAuth,
                                 "[{\"cmd\": \"SetEmail\",\"param\":{\"Email\" : {\"schedule\" : {\"enable\" : 0}}}}]");
@@ -495,7 +503,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 if (OnOffType.ON.equals(command)) {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetPushV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetPushV20\",\"param\":{\"Push\":{\"enable\": 1}}}]");
+                                enableAlarmBuilder("SetPushV20", "Push", "1"));
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetPush" + ipCameraHandler.reolinkAuth,
                                 "[{\"cmd\": \"SetPush\",\"param\":{\"Push\" : {\"schedule\" : {\"enable\" : 1}}}}]");
@@ -503,7 +511,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 } else {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetPushV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetPushV20\",\"param\":{\"Push\":{\"enable\":0}}}]");
+                                enableAlarmBuilder("SetPushV20", "Push", "0"));
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetPush" + ipCameraHandler.reolinkAuth,
                                 "[{\"cmd\": \"SetPush\",\"param\":{\"Push\" : {\"schedule\" : {\"enable\" : 0}}}}]");
@@ -525,16 +533,26 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 break;
             case CHANNEL_ENABLE_MOTION_ALARM:
                 if (OnOffType.ON.equals(command)) {
-                    ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetMdAlarm" + ipCameraHandler.reolinkAuth);
+                    if (ipCameraHandler.reolinkScheduleVersion != 1) {
+                        ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetAlarm" + ipCameraHandler.reolinkAuth,
+                                "[{\"cmd\": \"SetAlarm\", \"action\": 0, \"param\": {\"Alarm\": {\"channel\": "
+                                        + ipCameraHandler.cameraConfig.getNvrChannel()
+                                        + ", \"motionDetectEnable\": 1 }}}]");
+                    }
                 } else {
-                    ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetMdAlarm" + ipCameraHandler.reolinkAuth);
+                    if (ipCameraHandler.reolinkScheduleVersion != 1) {
+                        ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetAlarm" + ipCameraHandler.reolinkAuth,
+                                "[{\"cmd\": \"SetAlarm\", \"action\": 0, \"param\": {\"Alarm\": {\"channel\": "
+                                        + ipCameraHandler.cameraConfig.getNvrChannel()
+                                        + ", \"motionDetectEnable\": 0 }}}]");
+                    }
                 }
                 break;
             case CHANNEL_ENABLE_RECORDINGS:
                 if (OnOffType.ON.equals(command)) {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetRecV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetRecV20\",\"param\":{\"Rec\":{\"enable\":1}}}]");
+                                enableAlarmBuilder("SetRecV20", "Rec", "1"));
 
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetRec" + ipCameraHandler.reolinkAuth,
@@ -545,7 +563,7 @@ public class ReolinkHandler extends ChannelDuplexHandler {
                 } else {
                     if (ipCameraHandler.reolinkScheduleVersion == 1) {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetRecV20" + ipCameraHandler.reolinkAuth,
-                                "[{\"cmd\": \"SetRecV20\",\"param\":{\"Rec\":{\"enable\":0}}}]");
+                                enableAlarmBuilder("SetRecV20", "Rec", "0"));
 
                     } else {
                         ipCameraHandler.sendHttpPOST("/api.cgi?cmd=SetRec" + ipCameraHandler.reolinkAuth,


### PR DESCRIPTION
Some of the Alarms would not enable/disable with newer versions of the Reolink firmware. These changes make the JSON be formatted in the way the camera wants. Tested on a Reolink 820A camera.