### PR TITLE
[ring] Fix for passwords with special characters

### DIFF
--- a/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
+++ b/bundles/org.openhab.binding.ring/src/main/java/org/openhab/binding/ring/internal/RestClient.java
@@ -191,7 +191,7 @@ public class RestClient {
     public Tokens getTokens(String username, String password, String refreshToken, String twofactorCode,
             String hardwareId) throws AuthenticationException, JsonParseException {
         Map<String, String> additionalHeaders = new HashMap<>();
-        ParamBuilder pb = new ParamBuilder(false);
+        ParamBuilder pb = new ParamBuilder(true);
         pb.add("client_id", "ring_official_android");
         pb.add("scope", "client");
         if (refreshToken.isBlank()) {


### PR DESCRIPTION
THe code in OH 5.0 does not let users login with complex passwords. See https://community.openhab.org/t/ring-binding-5-0-not-initializing-due-to-http-protocol-violation/165103/14

The PR attached uses URLEncode to allow these to work.
