### PR TITLE
[surepetcare] Fix hubRssi `NullPointerException`

### DIFF
--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
@@ -151,7 +151,7 @@ public class SurePetcareDeviceHandler extends SurePetcareBaseObjectHandler {
                             new QuantityType<>(signal.hubRssi, Units.DECIBEL_MILLIWATTS));
                 } else {
                     updateState(DEVICE_CHANNEL_HUB_RSSI, UnDefType.UNDEF);
-                }
+                } 
 
                 if (thing.getThingTypeUID().equals(THING_TYPE_FLAP_DEVICE)) {
                     updateThingCurfews(device);

--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
@@ -151,7 +151,7 @@ public class SurePetcareDeviceHandler extends SurePetcareBaseObjectHandler {
                             new QuantityType<>(signal.hubRssi, Units.DECIBEL_MILLIWATTS));
                 } else {
                     updateState(DEVICE_CHANNEL_HUB_RSSI, UnDefType.UNDEF);
-                } 
+                }
 
                 if (thing.getThingTypeUID().equals(THING_TYPE_FLAP_DEVICE)) {
                     updateThingCurfews(device);

--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
@@ -36,6 +36,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,16 +140,16 @@ public class SurePetcareDeviceHandler extends SurePetcareBaseObjectHandler {
                         (batVol - BATTERY_EMPTY_VOLTAGE) / (BATTERY_FULL_VOLTAGE - BATTERY_EMPTY_VOLTAGE) * 100.0f,
                         100.0f)));
                 updateState(DEVICE_CHANNEL_LOW_BATTERY, OnOffType.from(batVol < LOW_BATTERY_THRESHOLD));
-                Signal signal = device.status.signal;
-                if (signal != null && signal.deviceRssi != null) {
+                if (device.status.signal != null && device.status.signal.deviceRssi != null) {
                     updateState(DEVICE_CHANNEL_DEVICE_RSSI,
-                            new QuantityType<>(signal.deviceRssi, Units.DECIBEL_MILLIWATTS));
+                            new QuantityType<>(device.status.signal.deviceRssi, Units.DECIBEL_MILLIWATTS));
                 } else {
                     updateState(DEVICE_CHANNEL_DEVICE_RSSI, UnDefType.UNDEF);
                 }
-                if (signal != null && signal.hubRssi != null) {
+
+                if (device.status.signal != null && device.status.signal.hubRssi != null) {
                     updateState(DEVICE_CHANNEL_HUB_RSSI,
-                            new QuantityType<>(signal.hubRssi, Units.DECIBEL_MILLIWATTS));
+                            new QuantityType<>(device.status.signal.hubRssi, Units.DECIBEL_MILLIWATTS));
                 } else {
                     updateState(DEVICE_CHANNEL_HUB_RSSI, UnDefType.UNDEF);
                 }

--- a/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
+++ b/bundles/org.openhab.binding.surepetcare/src/main/java/org/openhab/binding/surepetcare/internal/handler/SurePetcareDeviceHandler.java
@@ -139,10 +139,19 @@ public class SurePetcareDeviceHandler extends SurePetcareBaseObjectHandler {
                         (batVol - BATTERY_EMPTY_VOLTAGE) / (BATTERY_FULL_VOLTAGE - BATTERY_EMPTY_VOLTAGE) * 100.0f,
                         100.0f)));
                 updateState(DEVICE_CHANNEL_LOW_BATTERY, OnOffType.from(batVol < LOW_BATTERY_THRESHOLD));
-                updateState(DEVICE_CHANNEL_DEVICE_RSSI,
-                        QuantityType.valueOf(device.status.signal.deviceRssi, Units.DECIBEL_MILLIWATTS));
-                updateState(DEVICE_CHANNEL_HUB_RSSI,
-                        QuantityType.valueOf(device.status.signal.hubRssi, Units.DECIBEL_MILLIWATTS));
+                Signal signal = device.status.signal;
+                if (signal != null && signal.deviceRssi != null) {
+                    updateState(DEVICE_CHANNEL_DEVICE_RSSI,
+                            new QuantityType<>(signal.deviceRssi, Units.DECIBEL_MILLIWATTS));
+                } else {
+                    updateState(DEVICE_CHANNEL_DEVICE_RSSI, UnDefType.UNDEF);
+                }
+                if (signal != null && signal.hubRssi != null) {
+                    updateState(DEVICE_CHANNEL_HUB_RSSI,
+                            new QuantityType<>(signal.hubRssi, Units.DECIBEL_MILLIWATTS));
+                } else {
+                    updateState(DEVICE_CHANNEL_HUB_RSSI, UnDefType.UNDEF);
+                }
 
                 if (thing.getThingTypeUID().equals(THING_TYPE_FLAP_DEVICE)) {
                     updateThingCurfews(device);


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

Add one or more appropriate labels to make your PR show up in the release notes.
E.g. enhancement, bug, documentation, new binding
This can only be done by yourself if you already contributed to this repo.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- [homematic] Improve communication with weak signal devices
- [timemachine][WIP] Initial contribution

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

# Testing

Your pull request will automatically be built and available under the following folder:
https://openhab.jfrog.io/ui/native/libs-pullrequest-local/org/openhab/addons/bundles/

It is a good practice to add a URL to your built JAR in this pull request description,
so it is easier for the community to test your Add-on.
If your pull request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Marketplace:
https://community.openhab.org/c/marketplace/69

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->

## Problem

NullPointerException occurs when `device.status.signal.hubRssi` or other signal values are null:

java.lang.NullPointerException: Cannot invoke "java.lang.Float.floatValue()" because "device.status.signal.hubRssi" is null
text

## Solution
- Added null checks for all signal fields (hubRssi, deviceRssi)
- Set channel state to `UnDefType.UNDEF` when values are missing
- Prevents the binding from returning an ERROR when API returns incomplete data
