### PR TITLE
[jinja] Remove jackson-datatype-jdk8 bundle from feature

### DIFF
--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -8,7 +8,6 @@
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.7.4</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.re2j.re2j/1.2</bundle>
 		<bundle dependency="true">mvn:ch.obermuhlner/big-math/2.3.2</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.immutables.immutables-exceptions/1.9</bundle>
 		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.jinja/${project.version}</bundle>
 	</feature>


### PR DESCRIPTION
To prevent upgrade issues it was added to the Jackson feature in openHAB Core.

Depends on https://github.com/openhab/openhab-core/pull/4943