### PR TITLE
[Groovy] Text about alternative, manual installation is outdated

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/README.md
+++ b/bundles/org.openhab.automation.groovyscripting/README.md
@@ -1,6 +1,6 @@
 # Groovy Scripting
 
-This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.28 that can be used as a scripting language within automation rules and which eliminates the need to manually install Groovy.
+This add-on provides support for [Groovy](https://groovy-lang.org/) 4.0.28 that can be used as a scripting language within automation rules.
 
 ## Creating Groovy Scripts
 


### PR DESCRIPTION
Cf. https://community.openhab.org/t/how-can-groovy-be-installed-manually-not-as-add-on/