### PR TITLE
[avmfritz] Fix boost and window open modes

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
@@ -172,6 +172,10 @@ public class HeatingModel implements BatteryModel {
         return boostactive;
     }
 
+    public void setBoostactive(BigDecimal boostActive) {
+        this.boostactive = boostActive;
+    }
+
     public @Nullable BigDecimal getBoostactiveendtime() {
         return boostactiveendtime;
     }

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
@@ -109,13 +109,14 @@ public class HeatingModel implements BatteryModel {
             return MODE_ON;
         } else if (TEMP_FRITZ_OFF.compareTo(tsoll) == 0) {
             return MODE_OFF;
-        } else if (BigDecimal.ONE.equals(getWindowopenactiv())) {
+        } else if (getWindowopenactiv() instanceof BigDecimal decimal && decimal.intValue() > 0) {
             return MODE_WINDOW_OPEN;
         } else if (komfort != null && komfort.compareTo(tsoll) == 0) {
             return MODE_COMFORT;
         } else if (absenk != null && absenk.compareTo(tsoll) == 0) {
             return MODE_ECO;
-        } else if (BigDecimal.ONE.equals(getBoostactive()) || TEMP_FRITZ_MAX.compareTo(tsoll) == 0) {
+        } else if ((getBoostactive() instanceof BigDecimal decimal && decimal.intValue() > 0)
+                || TEMP_FRITZ_MAX.compareTo(tsoll) == 0) {
             return MODE_BOOST;
         } else {
             return MODE_ON;

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
@@ -109,13 +109,13 @@ public class HeatingModel implements BatteryModel {
             return MODE_ON;
         } else if (TEMP_FRITZ_OFF.compareTo(tsoll) == 0) {
             return MODE_OFF;
-        } else if (getWindowopenactiv() instanceof BigDecimal decimal && decimal.intValue() > 0) {
+        } else if (getWindowopenactiv() instanceof BigDecimal decimal && decimal.doubleValue() > 0.5) {
             return MODE_WINDOW_OPEN;
         } else if (komfort != null && komfort.compareTo(tsoll) == 0) {
             return MODE_COMFORT;
         } else if (absenk != null && absenk.compareTo(tsoll) == 0) {
             return MODE_ECO;
-        } else if ((getBoostactive() instanceof BigDecimal decimal && decimal.intValue() > 0)
+        } else if ((getBoostactive() instanceof BigDecimal decimal && decimal.doubleValue() > 0.5)
                 || TEMP_FRITZ_MAX.compareTo(tsoll) == 0) {
             return MODE_BOOST;
         } else {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/dto/HeatingModel.java
@@ -92,8 +92,15 @@ public class HeatingModel implements BatteryModel {
         this.absenk = absenk;
     }
 
+    /**
+     * Helper to check if the value is equal to 1 regardless of the BigDecimal scale.
+     */
+    private static boolean isOne(@Nullable BigDecimal value) {
+        return (value != null) && (BigDecimal.ONE.compareTo(value) == 0);
+    }
+
     public String getMode() {
-        if (BigDecimal.ONE.equals(getHolidayactive())) {
+        if (isOne(getHolidayactive())) {
             return MODE_VACATION;
         } else if (getNextchange() != null && getNextchange().getEndperiod() != 0) {
             return MODE_AUTO;
@@ -103,21 +110,20 @@ public class HeatingModel implements BatteryModel {
     }
 
     public String getRadiatorMode() {
-        if (tsoll == null) {
+        if (isOne(getWindowopenactiv())) {
+            return MODE_WINDOW_OPEN;
+        } else if (isOne(getBoostactive()) || (tsoll != null && TEMP_FRITZ_MAX.compareTo(tsoll) == 0)) {
+            return MODE_BOOST;
+        } else if (tsoll == null) {
             return MODE_UNKNOWN;
         } else if (TEMP_FRITZ_ON.compareTo(tsoll) == 0) {
             return MODE_ON;
         } else if (TEMP_FRITZ_OFF.compareTo(tsoll) == 0) {
             return MODE_OFF;
-        } else if (getWindowopenactiv() instanceof BigDecimal decimal && decimal.doubleValue() > 0.5) {
-            return MODE_WINDOW_OPEN;
         } else if (komfort != null && komfort.compareTo(tsoll) == 0) {
             return MODE_COMFORT;
         } else if (absenk != null && absenk.compareTo(tsoll) == 0) {
             return MODE_ECO;
-        } else if ((getBoostactive() instanceof BigDecimal decimal && decimal.doubleValue() > 0.5)
-                || TEMP_FRITZ_MAX.compareTo(tsoll) == 0) {
-            return MODE_BOOST;
         } else {
             return MODE_ON;
         }

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/HeatingModelTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/HeatingModelTest.java
@@ -70,7 +70,14 @@ public class HeatingModelTest {
         heatingModel.setTsoll(BigDecimal.ONE);
         assertEquals(MODE_ON, heatingModel.getRadiatorMode());
 
+        heatingModel.setBoostactive(new BigDecimal(1.0));
+        assertEquals(MODE_BOOST, heatingModel.getRadiatorMode());
+
+        heatingModel.setBoostactive(new BigDecimal(0.0));
         heatingModel.setKomfort(BigDecimal.ONE);
         assertEquals(MODE_COMFORT, heatingModel.getRadiatorMode());
+
+        heatingModel.setWindowopenactiv(new BigDecimal(1.0));
+        assertEquals(MODE_WINDOW_OPEN, heatingModel.getRadiatorMode());
     }
 }

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/HeatingModelTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/HeatingModelTest.java
@@ -70,14 +70,15 @@ public class HeatingModelTest {
         heatingModel.setTsoll(BigDecimal.ONE);
         assertEquals(MODE_ON, heatingModel.getRadiatorMode());
 
-        heatingModel.setBoostactive(new BigDecimal(1.0));
-        assertEquals(MODE_BOOST, heatingModel.getRadiatorMode());
-
-        heatingModel.setBoostactive(new BigDecimal(0.0));
-        heatingModel.setKomfort(BigDecimal.ONE);
-        assertEquals(MODE_COMFORT, heatingModel.getRadiatorMode());
-
         heatingModel.setWindowopenactiv(new BigDecimal(1.0));
         assertEquals(MODE_WINDOW_OPEN, heatingModel.getRadiatorMode());
+        heatingModel.setWindowopenactiv(new BigDecimal(0.0));
+
+        heatingModel.setKomfort(BigDecimal.ONE);
+        assertEquals(MODE_COMFORT, heatingModel.getRadiatorMode());
+        heatingModel.setKomfort(null);
+
+        heatingModel.setBoostactive(new BigDecimal(1.0));
+        assertEquals(MODE_BOOST, heatingModel.getRadiatorMode());
     }
 }


### PR DESCRIPTION
See for https://community.openhab.org/t/fritz-binding-dect302-smartthermo302/165280/1

Fixes #17554 

Consider backporting to v4.3.x

Tip for reviewer: there seems to have been two issues
1. The result of `BigDecimal.equals()` depends on the scale of the two values .. so `1.00` is not the same as `1.0`. => The code has been changed to use `BigDecimal.compareTo()` which does not depend on scale.
2. The logic precedence sequence was returning on/off/comfort/eco before the boost or window open states could be evaluated. => The logic precedence has been changed.

Jar files for testing 
- [org.openhab.binding.avmfritz-5.1.0-SNAPSHOT.zip](https://github.com/user-attachments/files/21669394/org.openhab.binding.avmfritz-5.1.0-SNAPSHOT.zip)
- [org.openhab.binding.avmfritz-4.3.7-SNAPSHOT.zip](https://github.com/user-attachments/files/21669395/org.openhab.binding.avmfritz-4.3.7-SNAPSHOT.zip)

Test result:
- User has confirmed the functionality [here](https://community.openhab.org/t/fritz-binding-dect302-smartthermo302/165280/29)

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
