### PR TITLE
[openaitts] Add new voices, model and configuration

### DIFF
--- a/bundles/org.openhab.voice.openaitts/src/main/java/org/openhab/voice/openaitts/internal/OpenAITTSConfiguration.java
+++ b/bundles/org.openhab.voice.openaitts/src/main/java/org/openhab/voice/openaitts/internal/OpenAITTSConfiguration.java
@@ -23,5 +23,6 @@ public class OpenAITTSConfiguration {
     public String apiKey = "";
     public String apiUrl = "https://api.openai.com/v1/audio/speech";
     public String model = "tts-1";
-    public String speed = "1";
+    public Double speed = 1.0;
+    public String instructions = "";
 }

--- a/bundles/org.openhab.voice.openaitts/src/main/java/org/openhab/voice/openaitts/internal/OpenAITTSService.java
+++ b/bundles/org.openhab.voice.openaitts/src/main/java/org/openhab/voice/openaitts/internal/OpenAITTSService.java
@@ -126,8 +126,9 @@ public class OpenAITTSService extends AbstractCachedTTSService {
         content.addProperty("voice", voice.getLabel().toLowerCase());
         content.addProperty("speed", config.speed);
 
-        if (!"tts-1".equals(config.model) && !"tts-1-hd".equals(config.model))
+        if (!"tts-1".equals(config.model) && !"tts-1-hd".equals(config.model) && !config.instructions.isEmpty()) {
             content.addProperty("instructions", config.instructions);
+        }
 
         String queryJson = gson.toJson(content);
 

--- a/bundles/org.openhab.voice.openaitts/src/main/java/org/openhab/voice/openaitts/internal/OpenAITTSService.java
+++ b/bundles/org.openhab.voice.openaitts/src/main/java/org/openhab/voice/openaitts/internal/OpenAITTSService.java
@@ -68,7 +68,8 @@ public class OpenAITTSService extends AbstractCachedTTSService {
     private OpenAITTSConfiguration config = new OpenAITTSConfiguration();
     private final HttpClient httpClient;
     private final Gson gson = new Gson();
-    private static final Set<Voice> VOICES = Stream.of("nova", "alloy", "echo", "fable", "onyx", "shimmer")
+    private static final Set<Voice> VOICES = Stream
+            .of("nova", "alloy", "ash", "ballad", "coral", "sage", "echo", "fable", "onyx", "shimmer", "verse")
             .map(OpenAITTSVoice::new).collect(Collectors.toSet());
 
     @Activate
@@ -125,7 +126,12 @@ public class OpenAITTSService extends AbstractCachedTTSService {
         content.addProperty("voice", voice.getLabel().toLowerCase());
         content.addProperty("speed", config.speed);
 
+        if (!"tts-1".equals(config.model) && !"tts-1-hd".equals(config.model))
+            content.addProperty("instructions", config.instructions);
+
         String queryJson = gson.toJson(content);
+
+        logger.trace("Send query: {}", queryJson);
 
         try {
             ContentResponse response = httpClient.newRequest(config.apiUrl).method(HttpMethod.POST)
@@ -136,8 +142,7 @@ public class OpenAITTSService extends AbstractCachedTTSService {
             if (response.getStatus() == HttpStatus.OK_200) {
                 return new ByteArrayAudioStream(response.getContent(), requestedFormat);
             } else {
-                logger.error("Request resulted in HTTP {} with message: {}", response.getStatus(),
-                        response.getReason());
+                logger.error("Request failed with status {}: {}", response.getStatus(), response.getContentAsString());
                 throw new TTSException("Failed to generate audio data");
             }
         } catch (InterruptedException | TimeoutException | ExecutionException e) {

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
@@ -32,9 +32,16 @@
 			<options>
 				<option value="tts-1">tts-1</option>
 				<option value="tts-1-hd">tts-1-hd</option>
+				<option value="gpt-4o-mini-tts">gpt-4o-mini-tts</option>
 			</options>
 			<limitToOptions>false</limitToOptions>
-			<default>tts-1</default>
+			<default>gpt-4o-mini-tts</default>
+		</parameter>
+		<parameter name="instructions" type="text" groupName="tts">
+			<label>Instructions</label>
+			<description>Control the voice of your generated audio with additional instructions. Does not work with tts-1 or
+				tts-1-hd</description>
+			<default>Speak in a cheerful and positive tone.</default>
 		</parameter>
 		<parameter name="speed" type="decimal" min="0.25" max="4" groupName="tts">
 			<label>Speed</label>

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
@@ -30,9 +30,9 @@
 			<required>true</required>
 			<description>ID of the model to use.</description>
 			<options>
-				<option value="tts-1">tts-1</option>
-				<option value="tts-1-hd">tts-1-hd</option>
-				<option value="gpt-4o-mini-tts">gpt-4o-mini-tts</option>
+				<option value="tts-1">Standard TTS (fast)</option>
+				<option value="tts-1-hd">High-quality TTS</option>
+				<option value="gpt-4o-mini-tts">GPT-4o mini TTS</option>
 			</options>
 			<limitToOptions>false</limitToOptions>
 			<default>gpt-4o-mini-tts</default>

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/config/config.xml
@@ -41,7 +41,7 @@
 			<label>Instructions</label>
 			<description>Control the voice of your generated audio with additional instructions. Does not work with tts-1 or
 				tts-1-hd</description>
-			<default>Speak in a cheerful and positive tone.</default>
+			<default></default>
 		</parameter>
 		<parameter name="speed" type="decimal" min="0.25" max="4" groupName="tts">
 			<label>Speed</label>

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts.properties
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts.properties
@@ -15,3 +15,5 @@ voice.config.openaitts.model.label = Model
 voice.config.openaitts.model.description = ID of the model to use.
 voice.config.openaitts.speed.label = Speed
 voice.config.openaitts.speed.description = The speed of the generated audio. Select a value from 0.25 to 4.0.
+voice.config.openaitts.instructions.label=Instructions
+voice.config.openaitts.instructions.description=Control the voice of your generated audio with additional instructions. Does not work with tts-1 or tts-1-hd.

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts.properties
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts.properties
@@ -3,6 +3,8 @@
 addon.openaitts.name = OpenAI Text-to-Speech
 addon.openaitts.description = OpenAI TTS Service provides text-to-speech capabilities for openHAB.
 
+# add-on config
+
 voice.config.openaitts.apiKey.label = API Key
 voice.config.openaitts.apiKey.description = OpenAI API key.
 voice.config.openaitts.apiUrl.label = API URL
@@ -11,9 +13,12 @@ voice.config.openaitts.group.authentication.label = Authentication
 voice.config.openaitts.group.authentication.description = Authentication for connecting to OpenAI API.
 voice.config.openaitts.group.tts.label = TTS Configuration
 voice.config.openaitts.group.tts.description = Configure Text to Speech.
+voice.config.openaitts.instructions.label = Instructions
+voice.config.openaitts.instructions.description = Control the voice of your generated audio with additional instructions. Does not work with tts-1 or tts-1-hd
 voice.config.openaitts.model.label = Model
 voice.config.openaitts.model.description = ID of the model to use.
+voice.config.openaitts.model.option.tts-1 = Standard TTS (fast)
+voice.config.openaitts.model.option.tts-1-hd = High-quality TTS
+voice.config.openaitts.model.option.gpt-4o-mini-tts = GPT-4o mini TTS
 voice.config.openaitts.speed.label = Speed
 voice.config.openaitts.speed.description = The speed of the generated audio. Select a value from 0.25 to 4.0.
-voice.config.openaitts.instructions.label=Instructions
-voice.config.openaitts.instructions.description=Control the voice of your generated audio with additional instructions. Does not work with tts-1 or tts-1-hd.

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts_it.properties
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts_it.properties
@@ -15,5 +15,3 @@ voice.config.openaitts.model.label = Modello
 voice.config.openaitts.model.description = ID del modello da usare.
 voice.config.openaitts.speed.label = Velocità
 voice.config.openaitts.speed.description = La velocità dell'audio generato. Selezionare un valore da 0.25 a 4.0.
-voice.config.openaitts.instructions.label=Istruzioni
-voice.config.openaitts.instructions.description=Controlla la voce del tuo audio generato con istruzioni aggiuntive. Non funziona con tts-1 o tts-1-hd.

--- a/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts_it.properties
+++ b/bundles/org.openhab.voice.openaitts/src/main/resources/OH-INF/i18n/openaitts_it.properties
@@ -15,3 +15,5 @@ voice.config.openaitts.model.label = Modello
 voice.config.openaitts.model.description = ID del modello da usare.
 voice.config.openaitts.speed.label = Velocità
 voice.config.openaitts.speed.description = La velocità dell'audio generato. Selezionare un valore da 0.25 a 4.0.
+voice.config.openaitts.instructions.label=Istruzioni
+voice.config.openaitts.instructions.description=Controlla la voce del tuo audio generato con istruzioni aggiuntive. Non funziona con tts-1 o tts-1-hd.


### PR DESCRIPTION
Update for the OpenAI Speech-to-Text addon. New voices added, new model. Instruction field added to voice settings. You can now customize tone, accent, emotional style, intonation, etc.

These updates allow for much more fine-grained control over speech synthesis, enabling more natural and context-appropriate outputs.

Try it live: https://www.openai.fm/
