### PR TITLE
[matter] Fix computation of values for electricalenergymeasurement

### DIFF
--- a/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/devices/converter/ElectricalEnergyMeasurementConverter.java
+++ b/bundles/org.openhab.binding.matter/src/main/java/org/openhab/binding/matter/internal/controller/devices/converter/ElectricalEnergyMeasurementConverter.java
@@ -43,6 +43,8 @@ import org.openhab.core.types.UnDefType;
 @NonNullByDefault
 public class ElectricalEnergyMeasurementConverter extends GenericConverter<ElectricalEnergyMeasurementCluster> {
 
+    private static final Long ONE_HOUR_IN_MILLISECONDS = 3600000L;
+
     public ElectricalEnergyMeasurementConverter(ElectricalEnergyMeasurementCluster cluster,
             MatterBaseThingHandler handler, int endpointNumber, String labelPrefix) {
         super(cluster, handler, endpointNumber, labelPrefix);
@@ -106,16 +108,30 @@ public class ElectricalEnergyMeasurementConverter extends GenericConverter<Elect
                 }
                     break;
                 case ElectricalEnergyMeasurementCluster.ATTRIBUTE_PERIODIC_ENERGY_IMPORTED: {
-                    if (energyMeasurement.energy != null) {
+                    if (energyMeasurement.energy != null && energyMeasurement.startTimestamp != null
+                            && energyMeasurement.endTimestamp != null) {
                         updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYIMPORTED_ENERGY,
-                                activePowerToWatts(energyMeasurement.energy));
+                                activePowerToWatts(energyMeasurement.energy, (energyMeasurement.endTimestamp.longValue()
+                                        - energyMeasurement.startTimestamp.longValue()) * 1000));
+                    } else if (energyMeasurement.energy != null && energyMeasurement.startSystime != null
+                            && energyMeasurement.endSystime != null) {
+                        updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYIMPORTED_ENERGY,
+                                activePowerToWatts(energyMeasurement.energy, energyMeasurement.endSystime.longValue()
+                                        - energyMeasurement.startSystime.longValue()));
                     }
                 }
                     break;
                 case ElectricalEnergyMeasurementCluster.ATTRIBUTE_PERIODIC_ENERGY_EXPORTED: {
-                    if (energyMeasurement.energy != null) {
+                    if (energyMeasurement.energy != null && energyMeasurement.startTimestamp != null
+                            && energyMeasurement.endTimestamp != null) {
                         updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYEXPORTED_ENERGY,
-                                activePowerToWatts(energyMeasurement.energy));
+                                activePowerToWatts(energyMeasurement.energy, (energyMeasurement.endTimestamp.longValue()
+                                        - energyMeasurement.startTimestamp.longValue()) * 1000));
+                    } else if (energyMeasurement.energy != null && energyMeasurement.startSystime != null
+                            && energyMeasurement.endSystime != null) {
+                        updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYEXPORTED_ENERGY,
+                                activePowerToWatts(energyMeasurement.energy, energyMeasurement.endSystime.longValue()
+                                        - energyMeasurement.startSystime.longValue()));
                     }
                 }
                     break;
@@ -141,16 +157,40 @@ public class ElectricalEnergyMeasurementConverter extends GenericConverter<Elect
             updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_CUMULATIVEENERGYEXPORTED_ENERGY, UnDefType.NULL);
         }
         if (initializingCluster.periodicEnergyImported != null
-                && initializingCluster.periodicEnergyImported.energy != null) {
+                && initializingCluster.periodicEnergyImported.energy != null
+                && initializingCluster.periodicEnergyImported.startTimestamp != null
+                && initializingCluster.periodicEnergyImported.endTimestamp != null) {
             updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYIMPORTED_ENERGY,
-                    activePowerToWatts(initializingCluster.periodicEnergyImported.energy));
+                    activePowerToWatts(initializingCluster.periodicEnergyImported.energy,
+                            (initializingCluster.periodicEnergyImported.endTimestamp.longValue()
+                                    - initializingCluster.periodicEnergyImported.startTimestamp.longValue()) * 1000));
+        } else if (initializingCluster.periodicEnergyImported != null
+                && initializingCluster.periodicEnergyImported.energy != null
+                && initializingCluster.periodicEnergyImported.startSystime != null
+                && initializingCluster.periodicEnergyImported.endSystime != null) {
+            updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYIMPORTED_ENERGY,
+                    activePowerToWatts(initializingCluster.periodicEnergyImported.energy,
+                            initializingCluster.periodicEnergyImported.endSystime.longValue()
+                                    - initializingCluster.periodicEnergyImported.startSystime.longValue()));
         } else {
             updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYIMPORTED_ENERGY, UnDefType.NULL);
         }
         if (initializingCluster.periodicEnergyExported != null
-                && initializingCluster.periodicEnergyExported.energy != null) {
+                && initializingCluster.periodicEnergyExported.energy != null
+                && initializingCluster.periodicEnergyExported.startTimestamp != null
+                && initializingCluster.periodicEnergyExported.endTimestamp != null) {
             updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYEXPORTED_ENERGY,
-                    activePowerToWatts(initializingCluster.periodicEnergyExported.energy));
+                    activePowerToWatts(initializingCluster.periodicEnergyExported.energy,
+                            (initializingCluster.periodicEnergyExported.endTimestamp.longValue()
+                                    - initializingCluster.periodicEnergyExported.startTimestamp.longValue()) * 1000));
+        } else if (initializingCluster.periodicEnergyExported != null
+                && initializingCluster.periodicEnergyExported.energy != null
+                && initializingCluster.periodicEnergyExported.startSystime != null
+                && initializingCluster.periodicEnergyExported.endSystime != null) {
+            updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYEXPORTED_ENERGY,
+                    activePowerToWatts(initializingCluster.periodicEnergyExported.energy,
+                            initializingCluster.periodicEnergyExported.endSystime.longValue()
+                                    - initializingCluster.periodicEnergyExported.startSystime.longValue()));
         } else {
             updateState(CHANNEL_ID_ELECTRICALENERGYMEASUREMENT_PERIODICENERGYEXPORTED_ENERGY, UnDefType.NULL);
         }
@@ -158,5 +198,10 @@ public class ElectricalEnergyMeasurementConverter extends GenericConverter<Elect
 
     private QuantityType<Energy> activePowerToWatts(Number number) {
         return new QuantityType<Energy>(new BigDecimal(number.intValue() / 1000), Units.WATT_HOUR);
+    }
+
+    private QuantityType<Energy> activePowerToWatts(Number number, long periodMilli) {
+        return new QuantityType<Energy>(
+                new BigDecimal(number.intValue() / 1000 * ONE_HOUR_IN_MILLISECONDS / periodMilli), Units.WATT_HOUR);
     }
 }

--- a/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/ElectricalEnergyMeasurementConverterTest.java
+++ b/bundles/org.openhab.binding.matter/src/test/java/org/openhab/binding/matter/internal/controller/devices/converter/ElectricalEnergyMeasurementConverterTest.java
@@ -14,8 +14,7 @@ package org.openhab.binding.matter.internal.controller.devices.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -36,7 +35,7 @@ import org.openhab.core.types.StateDescription;
 
 /**
  * Test class for ElectricalEnergyMeasurementConverter
- * 
+ *
  * @author Dan Cunningham - Initial contribution
  */
 @NonNullByDefault
@@ -87,9 +86,12 @@ class ElectricalEnergyMeasurementConverterTest extends BaseMatterConverterTest {
     void testInitState() {
         ElectricalEnergyMeasurementCluster.EnergyMeasurementStruct measurement = mockCluster.new EnergyMeasurementStruct(
                 BigInteger.valueOf(1000), null, null, null, null);
+        ElectricalEnergyMeasurementCluster.EnergyMeasurementStruct measurement2 = mockCluster.new EnergyMeasurementStruct(
+                BigInteger.valueOf(1000), null, null, BigInteger.valueOf(123456789L),
+                BigInteger.valueOf(123456789L + 60000L));
 
         mockCluster.cumulativeEnergyImported = measurement;
-        mockCluster.periodicEnergyImported = measurement;
+        mockCluster.periodicEnergyImported = measurement2;
 
         converter.initState();
 
@@ -98,6 +100,6 @@ class ElectricalEnergyMeasurementConverterTest extends BaseMatterConverterTest {
                 eq(new QuantityType<>(1.0, Units.WATT_HOUR)));
         verify(mockHandler, times(1)).updateState(eq(1),
                 eq("electricalenergymeasurement-periodicenergyimported-energy"),
-                eq(new QuantityType<>(1.0, Units.WATT_HOUR)));
+                eq(new QuantityType<>(60.0, Units.WATT_HOUR)));
     }
 }


### PR DESCRIPTION
Fix computation of values for the channels electricalenergymeasurement-periodicenergyimported-energy and electricalenergymeasurement-periodicenergyexported-energy.

Takes into consideration fields startTimestamp, endTimestamp, startSystime and endSystime from ElectricalEnergyMeasurementCluster.EnergyMeasurementStruct
