### PR TITLE
[linky] WIP : Support for reading index instead of basic value,

### DIFF
--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/api/EnedisHttpApi.java
@@ -259,7 +259,7 @@ public class EnedisHttpApi {
     }
 
     private MeterReading getMeasures(ThingLinkyRemoteHandler handler, String apiUrl, String mps, String prmId,
-            LocalDate from, LocalDate to) throws LinkyException {
+            LocalDate from, LocalDate to, boolean useIndex) throws LinkyException {
         String dtStart = from.format(linkyBridgeHandler.getApiDateFormat());
         String dtEnd = to.format(linkyBridgeHandler.getApiDateFormat());
 
@@ -270,23 +270,28 @@ public class EnedisHttpApi {
         } else {
             String url = String.format(apiUrl, mps, prmId, dtStart, dtEnd);
             ConsumptionReport consomptionReport = getData(handler, url, ConsumptionReport.class);
-            return MeterReading.convertFromComsumptionReport(consomptionReport);
+            return MeterReading.convertFromComsumptionReport(consomptionReport, useIndex);
         }
     }
 
     public MeterReading getEnergyData(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
             LocalDate to) throws LinkyException {
-        return getMeasures(handler, linkyBridgeHandler.getDailyConsumptionUrl(), mps, prmId, from, to);
+        return getMeasures(handler, linkyBridgeHandler.getDailyConsumptionUrl(), mps, prmId, from, to, false);
+    }
+
+    public MeterReading getEnergyIndex(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
+            LocalDate to) throws LinkyException {
+        return getMeasures(handler, linkyBridgeHandler.getDailyIndexUrl(), mps, prmId, from, to, true);
     }
 
     public MeterReading getLoadCurveData(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
             LocalDate to) throws LinkyException {
-        return getMeasures(handler, linkyBridgeHandler.getLoadCurveUrl(), mps, prmId, from, to);
+        return getMeasures(handler, linkyBridgeHandler.getLoadCurveUrl(), mps, prmId, from, to, false);
     }
 
     public MeterReading getPowerData(ThingLinkyRemoteHandler handler, String mps, String prmId, LocalDate from,
             LocalDate to) throws LinkyException {
-        return getMeasures(handler, linkyBridgeHandler.getMaxPowerUrl(), mps, prmId, from, to);
+        return getMeasures(handler, linkyBridgeHandler.getMaxPowerUrl(), mps, prmId, from, to, false);
     }
 
     public ResponseTempo getTempoData(ThingBaseRemoteHandler handler, LocalDate from, LocalDate to)

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/Calendrier.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/Calendrier.java
@@ -12,18 +12,15 @@
  */
 package org.openhab.binding.linky.internal.dto;
 
-import java.time.LocalDateTime;
-
 /**
- * The {@link IntervalReading} holds informations for the energy consumption of a period
+ * The {@link Calendrier} holds informations about energy consumption
  *
  * @author Gaël L'hopital - Initial contribution
  * @author Laurent Arnal - Rewrite addon to use official dataconect API
  */
 
-public class IntervalReading {
-    public Double value = 0.0;
-    public Double[] valueFromFournisseur;
-    public Double[] valueFromDistributeur;
-    public LocalDateTime date;
+public class Calendrier {
+    public String idCalendrier;
+    public String libelleCalendrier;
+
 }

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/ClassesTemporelles.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/ClassesTemporelles.java
@@ -12,18 +12,15 @@
  */
 package org.openhab.binding.linky.internal.dto;
 
-import java.time.LocalDateTime;
-
 /**
- * The {@link IntervalReading} holds informations for the energy consumption of a period
+ * The {@link ClassesTemporelles} holds informations about energy consumption
  *
  * @author Gaël L'hopital - Initial contribution
  * @author Laurent Arnal - Rewrite addon to use official dataconect API
  */
 
-public class IntervalReading {
-    public Double value = 0.0;
-    public Double[] valueFromFournisseur;
-    public Double[] valueFromDistributeur;
-    public LocalDateTime date;
+public class ClassesTemporelles {
+    public String libelle;
+    public Double valeur = 0.0;
+
 }

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/ConsumptionReport.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/ConsumptionReport.java
@@ -31,6 +31,9 @@ public class ConsumptionReport {
         public LocalDateTime dateDebut;
         public LocalDateTime dateFin;
         public Double valeur;
+        public ClassesTemporelles[] classesTemporellesFournisseur;
+        public ClassesTemporelles[] classesTemporellesDistributeur;
+        public Calendrier[] calendrier;
     }
 
     public class Aggregate {

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/MeterReading.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/dto/MeterReading.java
@@ -44,30 +44,119 @@ public class MeterReading {
     public IntervalReading[] monthValue;
     public IntervalReading[] yearValue;
 
-    public static MeterReading convertFromComsumptionReport(ConsumptionReport comsumptionReport) {
+    public static MeterReading convertFromComsumptionReport(ConsumptionReport comsumptionReport, boolean useIndex) {
         MeterReading result = new MeterReading();
         result.readingType = new ReadingType();
 
         if (comsumptionReport.consumptions.aggregats != null) {
             if (comsumptionReport.consumptions.aggregats.days != null) {
-                result.baseValue = fromAgregat(comsumptionReport.consumptions.aggregats.days);
+                result.baseValue = fromAgregat(comsumptionReport.consumptions.aggregats.days, useIndex);
             } else if (comsumptionReport.consumptions.aggregats.heure != null) {
-                result.baseValue = fromAgregat(comsumptionReport.consumptions.aggregats.heure);
+                result.baseValue = fromAgregat(comsumptionReport.consumptions.aggregats.heure, useIndex);
             }
         }
 
         return result;
     }
 
-    public static IntervalReading[] fromAgregat(ConsumptionReport.Aggregate agregat) {
+    public static IntervalReading[] fromAgregat(ConsumptionReport.Aggregate agregat, boolean useIndex) {
         int size = agregat.datas.size();
         IntervalReading[] result = new IntervalReading[size];
 
-        for (int i = 0; i < size; i++) {
-            Data dataObj = agregat.datas.get(i);
-            result[i] = new IntervalReading();
-            result[i].value = Double.valueOf(dataObj.valeur);
-            result[i].date = dataObj.dateDebut;
+        if (!useIndex) {
+            for (int i = 0; i < size; i++) {
+                Data dataObj = agregat.datas.get(i);
+                result[i] = new IntervalReading();
+                result[i].value = Double.valueOf(dataObj.valeur);
+                result[i].date = dataObj.dateDebut;
+            }
+        } else {
+            Double lastVal = 0.0;
+            Double[] lastValFournisseur = new Double[6];
+            lastValFournisseur[0] = 0.0;
+            lastValFournisseur[1] = 0.0;
+            lastValFournisseur[2] = 0.0;
+            lastValFournisseur[3] = 0.0;
+            lastValFournisseur[4] = 0.0;
+            lastValFournisseur[5] = 0.0;
+
+            for (int i = 0; i < size; i++) {
+                Data dataObj = agregat.datas.get(i);
+                Double value = Double.valueOf(dataObj.valeur);
+                Double[] valueFournisseur = new Double[6];
+                valueFournisseur[0] = 0.0;
+                valueFournisseur[1] = 0.0;
+                valueFournisseur[2] = 0.0;
+                valueFournisseur[3] = 0.0;
+                valueFournisseur[4] = 0.0;
+                valueFournisseur[5] = 0.0;
+
+                if (i > 0) {
+                    result[i - 1] = new IntervalReading();
+                    result[i - 1].value = value - lastVal;
+                    result[i - 1].date = dataObj.dateDebut;
+                    result[i - 1].valueFromFournisseur = new Double[6];
+                    result[i - 1].valueFromDistributeur = new Double[4];
+
+                    result[i - 1].valueFromFournisseur[0] = 0.0;
+                    result[i - 1].valueFromFournisseur[1] = 0.0;
+                    result[i - 1].valueFromFournisseur[2] = 0.0;
+                    result[i - 1].valueFromFournisseur[3] = 0.0;
+                    result[i - 1].valueFromFournisseur[4] = 0.0;
+                    result[i - 1].valueFromFournisseur[5] = 0.0;
+
+                    result[i - 1].valueFromDistributeur[0] = 0.0;
+                    result[i - 1].valueFromDistributeur[1] = 0.0;
+                    result[i - 1].valueFromDistributeur[2] = 0.0;
+                    result[i - 1].valueFromDistributeur[3] = 0.0;
+
+                    if (dataObj.classesTemporellesFournisseur != null) {
+                        for (ClassesTemporelles ct : dataObj.classesTemporellesFournisseur) {
+                            int idxFournisseur = -1;
+                            if ("Base".equals(ct.libelle)) {
+                                idxFournisseur = 0;
+                            } else if ("Blanc Heures Creuses".equals(ct.libelle)) {
+                                idxFournisseur = 3;
+                            } else if ("Blanc Heures Pleines".equals(ct.libelle)) {
+                                idxFournisseur = 2;
+                            } else if ("Bleu Heures Creuses".equals(ct.libelle)) {
+                                idxFournisseur = 1;
+                            } else if ("Bleu Heures Pleines".equals(ct.libelle)) {
+                                idxFournisseur = 0;
+                            } else if ("Rouge Heures Creuses".equals(ct.libelle)) {
+                                idxFournisseur = 5;
+                            } else if ("Rouge Heures Pleines".equals(ct.libelle)) {
+                                idxFournisseur = 4;
+                            } else if ("Heures Pleines".equals(ct.libelle)) {
+                                idxFournisseur = 0;
+                            } else if ("Heures Creuses".equals(ct.libelle)) {
+                                idxFournisseur = 1;
+                            } else if ("Heures Creuses Hiver / Saison Haute".equals(ct.libelle)) {
+                                idxFournisseur = 4;
+                            } else if ("Heures Creuses Saison Basse".equals(ct.libelle)) {
+                                idxFournisseur = 4;
+                            } else if ("Heures Pleines Hiver / Saison Haute".equals(ct.libelle)) {
+                                idxFournisseur = 4;
+                            } else if ("Heures Pleines Saison Basse".equals(ct.libelle)) {
+                                idxFournisseur = 4;
+                            }
+
+                            if (idxFournisseur == -1) {
+                                continue;
+                            }
+
+                            valueFournisseur[idxFournisseur] = Double.valueOf(ct.valeur);
+                            result[i - 1].valueFromFournisseur[idxFournisseur] = (valueFournisseur[idxFournisseur]
+                                    - lastValFournisseur[idxFournisseur]);
+
+                        }
+                    }
+
+                }
+                lastVal = value;
+                lastValFournisseur = valueFournisseur;
+            }
+
         }
 
         return result;

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteBaseHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteBaseHandler.java
@@ -178,6 +178,8 @@ public abstract class BridgeRemoteBaseHandler extends BaseBridgeHandler {
 
     public abstract String getDailyConsumptionUrl();
 
+    public abstract String getDailyIndexUrl();
+
     public abstract String getMaxPowerUrl();
 
     public abstract String getLoadCurveUrl();

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteEnedisHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteEnedisHandler.java
@@ -51,6 +51,8 @@ public class BridgeRemoteEnedisHandler extends BridgeRemoteApiHandler {
     private static final String ADDRESS_URL = "customers_upa/v5/usage_points/addresses?usage_point_id=%s";
 
     private static final String MEASURE_DAILY_CONSUMPTION_URL = "metering_data_dc/v5/daily_consumption?usage_point_id=%s&start=%s&end=%s";
+    private static final String MEASURE_DAILY_INDEX_URL = MEASURE_DAILY_CONSUMPTION_URL;
+
     private static final String MEASURE_MAX_POWER_URL = "metering_data_dcmp/v5/daily_consumption_max_power?usage_point_id=%s&start=%s&end=%s";
     private static final String LOAD_CURVE_CONSUMPTION_URL = "metering_data_clc/v5/consumption_load_curve?usage_point_id=%s&start=%s&end=%s";
 
@@ -177,6 +179,11 @@ public class BridgeRemoteEnedisHandler extends BridgeRemoteApiHandler {
     @Override
     public String getDailyConsumptionUrl() {
         return getBaseUrl() + MEASURE_DAILY_CONSUMPTION_URL;
+    }
+
+    @Override
+    public String getDailyIndexUrl() {
+        return getBaseUrl() + MEASURE_DAILY_INDEX_URL;
     }
 
     @Override

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteEnedisWebHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteEnedisWebHandler.java
@@ -65,13 +65,16 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
     public static final String URL_COMPTE_PART = URL_MON_COMPTE.replace("compte", "compte-particulier");
     public static final URI COOKIE_URI = URI.create(URL_COMPTE_PART);
 
-    private static final String USER_INFO_CONTRACT_URL = BASE_URL + "/mon-compte-client/api/private/v1/userinfos";
+    private static final String USER_INFO_CONTRACT_URL = BASE_URL + "/mon-compte/api/private/v2/userinfos";
     private static final String USER_INFO_URL = BASE_URL + "/userinfos";
     private static final String PRM_INFO_BASE_URL = BASE_URL + "/mes-mesures-prm/api/private/v1/personnes/";
     private static final String PRM_INFO_URL = BASE_URL + "/mes-prms-part/api/private/v2/personnes/%s/prms";
 
     private static final String MEASURE_DAILY_CONSUMPTION_URL = PRM_INFO_BASE_URL
             + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=ENERGIE&mesuresCorrigees=false&typeDonnees=CONS";
+
+    private static final String MEASURE_DAILY_INDEX_URL = PRM_INFO_BASE_URL
+            + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=INDEX&mesuresCorrigees=false&typeDonnees=CONS";
 
     private static final String MEASURE_MAX_POWER_URL = PRM_INFO_BASE_URL
             + "%s/prms/%s/donnees-energetiques?mesuresTypeCode=PMAX&mesuresCorrigees=false&typeDonnees=CONS";
@@ -142,6 +145,11 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
     @Override
     public String getDailyConsumptionUrl() {
         return MEASURE_DAILY_CONSUMPTION_URL;
+    }
+
+    @Override
+    public String getDailyIndexUrl() {
+        return MEASURE_DAILY_INDEX_URL;
     }
 
     @Override
@@ -334,7 +342,7 @@ public class BridgeRemoteEnedisWebHandler extends BridgeRemoteBaseHandler {
             if (hashRes != null && hashRes.containsKey("cnAlex")) {
                 cookieKey = "personne_for_" + hashRes.get("cnAlex");
             } else {
-                throw new LinkyException("Connection failed step 7, missing cookieKey");
+                throw new LinkyException("Connection failed step 5, missing cookieKey");
             }
 
             List<HttpCookie> lCookie = httpClient.getCookieStore().getCookies();

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteMyElectricalDataHandler.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/handler/BridgeRemoteMyElectricalDataHandler.java
@@ -49,6 +49,8 @@ public class BridgeRemoteMyElectricalDataHandler extends BridgeRemoteApiHandler 
     private static final String CONTACT_URL = BASE_URL + "contact/%s/cache/";
     private static final String ADDRESS_URL = BASE_URL + "addresses/%s/cache/";
     private static final String MEASURE_DAILY_CONSUMPTION_URL = BASE_URL + "daily_consumption/%s/start/%s/end/%s/cache";
+    private static final String MEASURE_DAILY_INDEX_URL = MEASURE_DAILY_CONSUMPTION_URL;
+
     private static final String MEASURE_MAX_POWER_URL = BASE_URL
             + "daily_consumption_max_power/%s/start/%s/end/%s/cache";
     private static final String LOAD_CURVE_CONSUMPTION_URL = BASE_URL
@@ -190,6 +192,11 @@ public class BridgeRemoteMyElectricalDataHandler extends BridgeRemoteApiHandler 
     @Override
     public String getDailyConsumptionUrl() {
         return MEASURE_DAILY_CONSUMPTION_URL;
+    }
+
+    @Override
+    public String getDailyIndexUrl() {
+        return MEASURE_DAILY_INDEX_URL;
     }
 
     @Override

--- a/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/utils/DoubleTypeAdapter.java
+++ b/bundles/org.openhab.binding.linky/src/main/java/org/openhab/binding/linky/internal/utils/DoubleTypeAdapter.java
@@ -44,6 +44,9 @@ public class DoubleTypeAdapter extends TypeAdapter<Double> {
                 return Double.NaN;
             }
             String stringValue = reader.nextString();
+            if (stringValue != null) {
+                stringValue = stringValue.replace(',', '.');
+            }
             try {
                 Double value = Double.valueOf(stringValue);
                 return value;


### PR DESCRIPTION
# Support for reading index instead of basic value,

# Description

This PR is about to get consumption index from the api instead of consumption value.
With consumption index, we will be able to dispatch the consumption to a specific tarif, and have graph where you can see consumption of different time area in the day.

For exemple, it will support tarif like:
    Heure pleine / Heure creuse.
    Tempo tariff with 6 dispatch cadran : Red, White, Blue & HP/HC.

Note that it is currently a work in progress.
And the first version only implement EnedisWeb gateway.